### PR TITLE
[WIP]Optimized db storage

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -210,13 +210,17 @@ func initGenesis(ctx *cli.Context) error {
 		utils.Fatalf("invalid genesis file: %v", err)
 	}
 	// Open and initialise both full and light databases
-	stack, _ := makeConfigNode(ctx)
+	stack, cfg := makeConfigNode(ctx)
 	defer stack.Close()
 
 	for _, name := range []string{"chaindata", "lightchaindata"} {
-		chaindb, err := stack.OpenDatabase(name, 0, 0, "", false)
+		// chaindb, err := stack.OpenDatabase(name, 0, 0, "", false)
+		// if err != nil {
+		// 	utils.Fatalf("Failed to open database: %v", err)
+		// }
+		chaindb, err := stack.OpenDatabaseWithFreezer(name, cfg.Eth.DatabaseCache, cfg.Eth.DatabaseHandles, cfg.Eth.DatabaseFreezer, "eth/db/chaindata/", false)
 		if err != nil {
-			utils.Fatalf("Failed to open database: %v", err)
+			utils.Fatalf("Failed to open ancient database: %v", err)
 		}
 		_, hash, err := core.SetupGenesisBlock(chaindb, genesis)
 		if err != nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -738,12 +738,16 @@ func (bc *BlockChain) ResetWithGenesisBlock(genesis *types.Block) error {
 	defer bc.chainmu.Unlock()
 
 	// Prepare the genesis block and reinitialise the chain
-	batch := bc.db.NewBatch()
-	rawdb.WriteTd(batch, genesis.Hash(), genesis.NumberU64(), genesis.Difficulty())
-	rawdb.WriteBlock(batch, genesis)
-	if err := batch.Write(); err != nil {
-		log.Crit("Failed to write genesis block", "err", err)
-	}
+	//batch := bc.db.NewBatch()
+	//rawdb.WriteTd(batch, genesis.Hash(), genesis.NumberU64(), genesis.Difficulty())
+	//rawdb.WriteBlock(batch, genesis)
+	//rawdb.WriteHeader(bc.db, genesis.Header())
+	rawdb.WriteHeaderNumber(bc.db, genesis.Header().Hash(), genesis.Header().Number.Uint64())
+
+	rawdb.WriteAncientBlock(bc.db, genesis, nil, genesis.Difficulty())
+	// if err := batch.Write(); err != nil {
+	// 	log.Crit("Failed to write genesis block", "err", err)
+	// }
 	bc.writeHeadBlock(genesis)
 
 	// Last update all in-memory chain markers
@@ -1342,7 +1346,8 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 				}
 			}
 			// Write all the data out into the database
-			rawdb.WriteBody(batch, block.Hash(), block.NumberU64(), block.Body())
+			//rawdb.WriteBody(batch, block.Hash(), block.NumberU64(), block.Body())
+			rawdb.WriteAncientBlock(bc.db, block, receiptChain[i], bc.GetTd(block.Hash(), block.NumberU64()))
 			rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receiptChain[i])
 			rawdb.WriteTxLookupEntriesByBlock(batch, block) // Always write tx indices for live blocks, we assume they are needed
 
@@ -1438,7 +1443,10 @@ func (bc *BlockChain) writeBlockWithoutState(block *types.Block, td *big.Int) (e
 
 	batch := bc.db.NewBatch()
 	rawdb.WriteTd(batch, block.Hash(), block.NumberU64(), td)
-	rawdb.WriteBlock(batch, block)
+	//rawdb.WriteBlock(batch, block)
+	//rawdb.WriteHeader(bc.db, block.Header())
+	rawdb.WriteHeaderNumber(bc.db, block.Header().Hash(), block.Header().Number.Uint64())
+	rawdb.WriteAncientBlock(bc.db, block, nil, block.Difficulty())
 	if err := batch.Write(); err != nil {
 		log.Crit("Failed to write block into disk", "err", err)
 	}
@@ -1492,10 +1500,13 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
+		rawdb.WriteAncientBlock(bc.db, block, receipts, externTd)
 		blockBatch := bc.db.NewBatch()
-		rawdb.WriteTd(blockBatch, block.Hash(), block.NumberU64(), externTd)
-		rawdb.WriteBlock(blockBatch, block)
-		rawdb.WriteReceipts(blockBatch, block.Hash(), block.NumberU64(), receipts)
+		//rawdb.WriteTd(blockBatch, block.Hash(), block.NumberU64(), externTd)
+		//rawdb.WriteBlock(blockBatch, block)
+		//rawdb.WriteHeader(bc.db, block.Header())
+		//rawdb.WriteReceipts(blockBatch, block.Hash(), block.NumberU64(), receipts)
+		rawdb.WriteHeaderNumber(bc.db, block.Header().Hash(), block.Header().Number.Uint64())
 		rawdb.WritePreimages(blockBatch, state.Preimages())
 		if err := blockBatch.Write(); err != nil {
 			log.Crit("Failed to write block into disk", "err", err)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -318,9 +318,12 @@ func (g *Genesis) Commit(db ethdb.Database) (*types.Block, error) {
 	if err := config.CheckConfigForkOrder(); err != nil {
 		return nil, err
 	}
-	rawdb.WriteTd(db, block.Hash(), block.NumberU64(), g.Difficulty)
-	rawdb.WriteBlock(db, block)
-	rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), nil)
+	//rawdb.WriteTd(db, block.Hash(), block.NumberU64(), g.Difficulty)
+	//rawdb.WriteBlock(db, block)
+	//rawdb.WriteHeader(db, block.Header())
+	rawdb.WriteHeaderNumber(db, block.Header().Hash(), block.Header().Number.Uint64())
+	rawdb.WriteAncientBlock(db, block, nil, g.Difficulty)
+	//rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), nil)
 	rawdb.WriteCanonicalHash(db, block.Hash(), block.NumberU64())
 	rawdb.WriteHeadBlockHash(db, block.Hash())
 	rawdb.WriteHeadFastBlockHash(db, block.Hash())

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -34,16 +34,16 @@ import (
 // ReadCanonicalHash retrieves the hash assigned to a canonical block number.
 func ReadCanonicalHash(db ethdb.Reader, number uint64) common.Hash {
 	data, _ := db.Ancient(freezerHashTable, number)
-	if len(data) == 0 {
-		data, _ = db.Get(headerHashKey(number))
-		// In the background freezer is moving data from leveldb to flatten files.
-		// So during the first check for ancient db, the data is not yet in there,
-		// but when we reach into leveldb, the data was already moved. That would
-		// result in a not found error.
-		if len(data) == 0 {
-			data, _ = db.Ancient(freezerHashTable, number)
-		}
-	}
+	// if len(data) == 0 {
+	// 	data, _ = db.Get(headerHashKey(number))
+	// 	// In the background freezer is moving data from leveldb to flatten files.
+	// 	// So during the first check for ancient db, the data is not yet in there,
+	// 	// but when we reach into leveldb, the data was already moved. That would
+	// 	// result in a not found error.
+	// 	if len(data) == 0 {
+	// 		data, _ = db.Ancient(freezerHashTable, number)
+	// 	}
+	// }
 	if len(data) == 0 {
 		return common.Hash{}
 	}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -196,9 +196,9 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 		}
 	}
 	// Freezer is consistent with the key-value database, permit combining the two
-	if !frdb.readonly {
-		go frdb.freeze(db)
-	}
+	// if !frdb.readonly {
+	// 	go frdb.freeze(db)
+	// }
 	return &freezerdb{
 		KeyValueStore: db,
 		AncientStore:  frdb,

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -201,8 +201,11 @@ func (lc *LightChain) ResetWithGenesisBlock(genesis *types.Block) {
 
 	// Prepare the genesis block and reinitialise the chain
 	batch := lc.chainDb.NewBatch()
-	rawdb.WriteTd(batch, genesis.Hash(), genesis.NumberU64(), genesis.Difficulty())
-	rawdb.WriteBlock(batch, genesis)
+	//rawdb.WriteTd(batch, genesis.Hash(), genesis.NumberU64(), genesis.Difficulty())
+	//rawdb.WriteBlock(batch, genesis)
+	//rawdb.WriteHeader(lc.chainDb, genesis.Header())
+	rawdb.WriteHeaderNumber(lc.chainDb, genesis.Header().Hash(), genesis.Header().Number.Uint64())
+	rawdb.WriteAncientBlock(lc.chainDb, genesis, nil, genesis.Difficulty())
 	rawdb.WriteHeadHeaderHash(batch, genesis.Hash())
 	if err := batch.Write(); err != nil {
 		log.Crit("Failed to reset genesis block", "err", err)


### PR DESCRIPTION
### Description

This is the optimization for database storage

### Rationale
1. Block data is written to leveldb for two times. It occupied too much disk bandwidth. And as block data is sequential and less read operations, compaction to block data also takes disk bandwidth/ cpu/ memory.
2. State data in KV Store needs to do compaction in order to get better read performance. If block data and state data in the same KV Store, compaction will take more time(more data/ cpu/ memory/ disk bandwidth). Indeed we just need current world state(or latest world state) to execute. In future we needs other solution to get better performance.



### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
