### PR TITLE
ignore empty tx in GetDiffAccountsWithScope

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1185,7 +1185,10 @@ func (s *PublicBlockChainAPI) GetDiffAccountsWithScope(ctx context.Context, bloc
 					delete(diffTx.Accounts, account)
 				}
 			}
-			result.Transactions = append(result.Transactions, diffTx)
+
+			if len(diffTx.Accounts) != 0 {
+				result.Transactions = append(result.Transactions, diffTx)
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Keefe-Liu <bianze.kernel@gmail.com>

### Description

Ignore empty transaction in GetDiffAccountsWithScope.

### Rationale

The empty transaction is useless for user, ignore them to reduce iteration.

### Example


### Changes

Notable changes: 


### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
