### PR TITLE
[R4R]fix concurrent write seen of subfetcher

### DIFF
--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -105,7 +105,7 @@ func (p *triePrefetcher) abortLoop() {
 func (p *triePrefetcher) close() {
 	for _, fetcher := range p.fetchers {
 		p.abortChan <- fetcher // safe to do multiple times
-
+		<-fetcher.term
 		if metrics.Enabled {
 			if fetcher.root == p.root {
 				p.accountLoadMeter.Mark(int64(len(fetcher.seen)))


### PR DESCRIPTION
### Description
Fix the concurrent write of `seen` of subfetcher.

### Rationale
Currently, we do `fetcher.abort` in abortLoop.
`abort` will cause `subfetcher.loop` exit.

The `triePrefetcher` must wait for the subfetcher exit before it changing the `seen` of subfetcher.

### Example
Fix issue 
```
fatal error: concurrent map writes

goroutine 172 [running]:
runtime.throw({0x1548ace, 0xc02e4e0640})
	runtime/panic.go:1198 +0x71 fp=0xc01631bcd0 sp=0xc01631bca0 pc=0x44c491
runtime.mapassign_faststr(0xc02aa8db60, 0xc01cdfe140, {0xc0334c21e0, 0x20})
	runtime/map_faststr.go:211 +0x39c fp=0xc01631bd38 sp=0xc01631bcd0 pc=0x4297fc
github.com/ethereum/go-ethereum/core/state.(*subfetcher).loop(0xc01a0fcdd0)
	github.com/ethereum/go-ethereum/core/state/trie_prefetcher.go:361 +0x6cf fp=0xc01631bf70 sp=0xc01631bd38 pc=0xac89cf
github.com/ethereum/go-ethereum/core/state.newSubfetcher.func1()
	github.com/ethereum/go-ethereum/core/state/trie_prefetcher.go:261 +0x1d fp=0xc01631bf88 sp=0xc01631bf70 pc=0xac7f7d
github.com/panjf2000/ants/v2.(*goWorker).run.func1()
	github.com/panjf2000/ants/v2@v2.4.5/worker.go:70 +0x97 fp=0xc01631bfe0 sp=0xc01631bf88 pc=0x5f6b37
runtime.goexit()
	runtime/asm_amd64.s:1581 +0x1 fp=0xc01631bfe8 sp=0xc01631bfe0 pc=0x47fcc1
created by github.com/panjf2000/ants/v2.(*goWorker).run
	github.com/panjf2000/ants/v2@v2.4.5/worker.go:48 +0x68
```

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
