### PR TITLE
[R4R]fix cache key do not have hash func

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -267,7 +267,7 @@ func (db *cachingDB) CopyTrie(t Trie) Trie {
 
 // ContractCode retrieves a particular contract's code.
 func (db *cachingDB) ContractCode(addrHash, codeHash common.Hash) ([]byte, error) {
-	if cached, ok := db.codeCache.Get(codeHash.Bytes()); ok {
+	if cached, ok := db.codeCache.Get(codeHash); ok {
 		code := cached.([]byte)
 		if len(code) > 0 {
 			return code, nil
@@ -276,7 +276,7 @@ func (db *cachingDB) ContractCode(addrHash, codeHash common.Hash) ([]byte, error
 	code := rawdb.ReadCode(db.db.DiskDB(), codeHash)
 	if len(code) > 0 {
 
-		db.codeCache.Add(codeHash.Bytes(), code)
+		db.codeCache.Add(codeHash, code)
 		db.codeSizeCache.Add(codeHash, len(code))
 		return code, nil
 	}
@@ -289,7 +289,7 @@ func (db *cachingDB) ContractCode(addrHash, codeHash common.Hash) ([]byte, error
 func (db *cachingDB) ContractCodeWithPrefix(addrHash, codeHash common.Hash) ([]byte, error) {
 	if cached, ok := db.codeCache.Get(codeHash.Bytes()); ok {
 		code := cached.([]byte)
-		if len(code) >  0 {
+		if len(code) > 0 {
 			return code, nil
 		}
 	}


### PR DESCRIPTION
### Description

fix cache key do not have hash func

### Rationale

![image](https://user-images.githubusercontent.com/7310198/137461834-6395c2b9-7c0f-4042-8640-44eeb7fa82dd.png)
### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
