### PR TITLE
[R4R]fix downloader nil issue when the header is mising

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1028,8 +1028,8 @@ func (d *Downloader) findAncestorBinarySearch(p *peerConnection, mode SyncMode, 
 				}
 				header := d.lightchain.GetHeaderByHash(h) // Independent of sync mode, header surely exists
 				if header == nil {
-					p.log.Error("header not found", "number", header.Number, "hash", header.Hash(), "request", check)
-					return 0, fmt.Errorf("%w: header no found (%d)", errBadPeer, header.Number)
+					p.log.Error("header not found", "hash", h, "request", check)
+					return 0, fmt.Errorf("%w: header no found (%s)", errBadPeer, h)
 				}
 				if header.Number.Uint64() != check {
 					p.log.Warn("Received non requested header", "number", header.Number, "hash", header.Hash(), "request", check)


### PR DESCRIPTION
### Description

fix downloader nil issue when the header is mising
### Rationale

still refer to the header when the header is nil

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
