### PR TITLE
core: fix typo in blockchain_snapshot_test.go

### DIFF
--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -104,7 +104,7 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 		}
 		if basic.snapshotBlock > 0 && basic.snapshotBlock == point {
 			// Flushing the entire snap tree into the disk, the
-			// relavant (a) snapshot root and (b) snapshot generator
+			// relevant (a) snapshot root and (b) snapshot generator
 			// will be persisted atomically.
 			chain.snaps.Cap(blocks[point-1].Root(), 0)
 			diskRoot, blockRoot := chain.snaps.DiskRoot(), blocks[point-1].Root()


### PR DESCRIPTION

### Description
Fixed typo.


### Changes

```
relavant -> relevant
```
