### PR TITLE
[WIP]Separate Processing and State Verification on BSC: implement the framework of fast node

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -109,6 +109,7 @@ var (
 		utils.WhitelistFlag,
 		utils.BloomFilterSizeFlag,
 		utils.TriesInMemoryFlag,
+		utils.AllowInsecureNoTriesFlag,
 		utils.CacheFlag,
 		utils.CacheDatabaseFlag,
 		utils.CacheTrieFlag,

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -18,17 +18,22 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"os"
 	"time"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/state/pruner"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	cli "gopkg.in/urfave/cli.v1"
@@ -98,6 +103,32 @@ geth snapshot verify-state <state-root>
 will traverse the whole accounts and storages set based on the specified
 snapshot and recalculate the root hash of state for verification.
 In other words, this command does the snapshot to trie conversion.
+`,
+			},
+			{
+				Name: "insecure-prune-all",
+				Usage: "Prune all trie state data except genesis block, it will break storage for fullnode, only suitable for fast node " +
+					"who do not need trie storage at all",
+				ArgsUsage: "<genesisPath>",
+				Action:    utils.MigrateFlags(pruneAllState),
+				Category:  "MISCELLANEOUS COMMANDS",
+				Flags: []cli.Flag{
+					utils.DataDirFlag,
+					utils.AncientFlag,
+					utils.RopstenFlag,
+					utils.RinkebyFlag,
+					utils.GoerliFlag,
+				},
+				Description: `
+will prune all historical trie state data except genesis block.
+All trie nodes will be deleted from the database. 
+
+It expects the genesis file as argument.
+
+WARNING: It's necessary to delete the trie clean cache after the pruning.
+If you specify another directory for the trie clean cache via "--cache.trie.journal"
+during the use of Geth, please also specify it here for correct deletion. Otherwise
+the trie clean cache with default directory will be deleted.
 `,
 			},
 			{
@@ -178,6 +209,48 @@ func pruneState(ctx *cli.Context) error {
 	return nil
 }
 
+func pruneAllState(ctx *cli.Context) error {
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	genesisPath := ctx.Args().First()
+	if len(genesisPath) == 0 {
+		utils.Fatalf("Must supply path to genesis JSON file")
+	}
+	file, err := os.Open(genesisPath)
+	if err != nil {
+		utils.Fatalf("Failed to read genesis file: %v", err)
+	}
+	defer file.Close()
+
+	g := new(core.Genesis)
+	if err := json.NewDecoder(file).Decode(g); err != nil {
+		cfg := gethConfig{
+			Eth:     ethconfig.Defaults,
+			Node:    defaultNodeConfig(),
+			Metrics: metrics.DefaultConfig,
+		}
+
+		// Load config file.
+		if err := loadConfig(genesisPath, &cfg); err != nil {
+			utils.Fatalf("%v", err)
+		}
+		g = cfg.Eth.Genesis
+	}
+
+	chaindb := utils.MakeChainDatabase(ctx, stack, false)
+	pruner, err := pruner.NewAllPruner(chaindb)
+	if err != nil {
+		log.Error("Failed to open snapshot tree", "err", err)
+		return err
+	}
+	if err = pruner.PruneAll(g); err != nil {
+		log.Error("Failed to prune state", "err", err)
+		return err
+	}
+	return nil
+}
+
 func verifyState(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
@@ -188,7 +261,7 @@ func verifyState(ctx *cli.Context) error {
 		log.Error("Failed to load head block")
 		return errors.New("no head block")
 	}
-	snaptree, err := snapshot.New(chaindb, trie.NewDatabase(chaindb), 256, 128, headBlock.Root(), false, false, false)
+	snaptree, err := snapshot.New(chaindb, trie.NewDatabase(chaindb), 256, 128, headBlock.Root(), false, false, false, false)
 	if err != nil {
 		log.Error("Failed to open snapshot tree", "err", err)
 		return err

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -259,6 +259,10 @@ var (
 		Usage: "The layer of tries trees that keep in memory",
 		Value: 128,
 	}
+	AllowInsecureNoTriesFlag = cli.BoolTFlag{
+		Name:  "allow-insecure-no-tries",
+		Usage: `Disable the tries state root verification, the state consistency is no longer 100% guaranteed, diffsync is not allowed if enabled. Do not enable it unless you know exactly what the consequence it will cause.`,
+	}
 	OverrideBerlinFlag = cli.Uint64Flag{
 		Name:  "override.berlin",
 		Usage: "Manually specify Berlin fork-block, overriding the bundled setting",
@@ -1647,6 +1651,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.GlobalIsSet(TriesInMemoryFlag.Name) {
 		cfg.TriesInMemory = ctx.GlobalUint64(TriesInMemoryFlag.Name)
+	}
+	if ctx.GlobalIsSet(AllowInsecureNoTriesFlag.Name) {
+		cfg.NoTries = ctx.GlobalBool(AllowInsecureNoTriesFlag.Name)
 	}
 	if ctx.GlobalIsSet(CacheFlag.Name) || ctx.GlobalIsSet(CacheSnapshotFlag.Name) {
 		cfg.SnapshotCache = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheSnapshotFlag.Name) / 100

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -65,12 +65,6 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 
 	validateFuns := []func() error{
 		func() error {
-			if v.bc.HasBlockAndState(block.Hash(), block.NumberU64()) {
-				return ErrKnownBlock
-			}
-			return nil
-		},
-		func() error {
 			if hash := types.DeriveSha(block.Transactions(), trie.NewStackTrie(nil)); hash != header.TxHash {
 				return fmt.Errorf("transaction root hash mismatch: have %x, want %x", hash, header.TxHash)
 			}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -74,6 +74,9 @@ type Database interface {
 
 	// Purge cache
 	Purge()
+
+	// NoTries returns whether the database has tries storage.
+	NoTries() bool
 }
 
 // Trie is a Ethereum Merkle Patricia trie.
@@ -134,10 +137,12 @@ func NewDatabase(db ethdb.Database) Database {
 func NewDatabaseWithConfig(db ethdb.Database, config *trie.Config) Database {
 	csc, _ := lru.New(codeSizeCacheSize)
 	cc, _ := lru.New(codeCacheSize)
+	noTries := config != nil && config.NoTries
 	return &cachingDB{
 		db:            trie.NewDatabaseWithConfig(db, config),
 		codeSizeCache: csc,
 		codeCache:     cc,
+		noTries:       noTries,
 	}
 }
 
@@ -146,6 +151,7 @@ func NewDatabaseWithConfigAndCache(db ethdb.Database, config *trie.Config) Datab
 	cc, _ := lru.New(codeCacheSize)
 	atc, _ := lru.New(accountTrieCacheSize)
 	stc, _ := lru.New(storageTrieCacheSize)
+	noTries := config != nil && config.NoTries
 
 	database := &cachingDB{
 		db:               trie.NewDatabaseWithConfig(db, config),
@@ -153,8 +159,11 @@ func NewDatabaseWithConfigAndCache(db ethdb.Database, config *trie.Config) Datab
 		codeCache:        cc,
 		accountTrieCache: atc,
 		storageTrieCache: stc,
+		noTries:          noTries,
 	}
-	go database.purgeLoop()
+	if !noTries {
+		go database.purgeLoop()
+	}
 	return database
 }
 
@@ -164,6 +173,7 @@ type cachingDB struct {
 	codeCache        *lru.Cache
 	accountTrieCache *lru.Cache
 	storageTrieCache *lru.Cache
+	noTries          bool
 }
 
 type triePair struct {
@@ -187,6 +197,9 @@ func (db *cachingDB) purgeLoop() {
 
 // OpenTrie opens the main account trie at a specific root hash.
 func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
+	if db.noTries {
+		return trie.NewEmptyTrie(), nil
+	}
 	if db.accountTrieCache != nil {
 		if tr, exist := db.accountTrieCache.Get(root); exist {
 			return tr.(Trie).(*trie.SecureTrie).Copy(), nil
@@ -201,6 +214,9 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 
 // OpenStorageTrie opens the storage trie of an account.
 func (db *cachingDB) OpenStorageTrie(addrHash, root common.Hash) (Trie, error) {
+	if db.noTries {
+		return trie.NewEmptyTrie(), nil
+	}
 	if db.storageTrieCache != nil {
 		if tries, exist := db.storageTrieCache.Get(addrHash); exist {
 			triesPairs := tries.([3]*triePair)
@@ -246,6 +262,10 @@ func (db *cachingDB) CacheStorage(addrHash common.Hash, root common.Hash, t Trie
 	}
 }
 
+func (db *cachingDB) NoTries() bool {
+	return db.noTries
+}
+
 func (db *cachingDB) Purge() {
 	if db.storageTrieCache != nil {
 		db.storageTrieCache.Purge()
@@ -259,6 +279,8 @@ func (db *cachingDB) Purge() {
 func (db *cachingDB) CopyTrie(t Trie) Trie {
 	switch t := t.(type) {
 	case *trie.SecureTrie:
+		return t.Copy()
+	case *trie.EmptyTrie:
 		return t.Copy()
 	default:
 		panic(fmt.Errorf("unknown trie type %T", t))

--- a/core/state/snapshot/journal.go
+++ b/core/state/snapshot/journal.go
@@ -126,7 +126,7 @@ func loadAndParseJournal(db ethdb.KeyValueStore, base *diskLayer) (snapshot, jou
 }
 
 // loadSnapshot loads a pre-existing state snapshot backed by a key-value store.
-func loadSnapshot(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache int, root common.Hash, recovery bool) (snapshot, bool, error) {
+func loadSnapshot(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache int, root common.Hash, recovery, withoutTrie bool) (snapshot, bool, error) {
 	// If snapshotting is disabled (initial sync in progress), don't do anything,
 	// wait for the chain to permit us to do something meaningful
 	if rawdb.ReadSnapshotDisabled(diskdb) {
@@ -145,6 +145,7 @@ func loadSnapshot(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache int, 
 		root:   baseRoot,
 	}
 	snapshot, generator, err := loadAndParseJournal(diskdb, base)
+
 	if err != nil {
 		log.Warn("Failed to load new-format journal", "error", err)
 		return nil, false, err
@@ -158,6 +159,11 @@ func loadSnapshot(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache int, 
 	// which is below the snapshot. In this case the snapshot can be recovered
 	// by re-executing blocks but right now it's unavailable.
 	if head := snapshot.Root(); head != root {
+		log.Warn("Snapshot is not continuous with chain", "snaproot", head, "chainroot", root)
+
+		if withoutTrie {
+			return snapshot, false, nil
+		}
 		// If it's legacy snapshot, or it's new-format snapshot but
 		// it's not in recovery mode, returns the error here for
 		// rebuilding the entire snapshot forcibly.
@@ -168,7 +174,6 @@ func loadSnapshot(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache int, 
 		// the disk layer is always higher than chain head. It can
 		// be eventually recovered when the chain head beyonds the
 		// disk layer.
-		log.Warn("Snapshot is not continuous with chain", "snaproot", head, "chainroot", root)
 	}
 	// Everything loaded correctly, resume any suspended operations
 	if !generator.Done {

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -175,7 +175,7 @@ type Tree struct {
 // store, on a background thread. If the memory layers from the journal is not
 // continuous with disk layer or the journal is missing, all diffs will be discarded
 // iff it's in "recovery" mode, otherwise rebuild is mandatory.
-func New(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache, cap int, root common.Hash, async bool, rebuild bool, recovery bool) (*Tree, error) {
+func New(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache, cap int, root common.Hash, async bool, rebuild bool, recovery, withoutTrie bool) (*Tree, error) {
 	// Create a new, empty snapshot tree
 	snap := &Tree{
 		diskdb:   diskdb,
@@ -188,7 +188,7 @@ func New(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache, cap int, root
 		defer snap.waitBuild()
 	}
 	// Attempt to load a previously persisted snapshot and rebuild one if failed
-	head, disabled, err := loadSnapshot(diskdb, triedb, cache, root, recovery)
+	head, disabled, err := loadSnapshot(diskdb, triedb, cache, root, recovery, withoutTrie)
 	if disabled {
 		log.Warn("Snapshot maintenance disabled (syncing)")
 		return snap, nil

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -73,10 +73,13 @@ func (n *proofList) Delete(key []byte) error {
 // * Contracts
 // * Accounts
 type StateDB struct {
-	db             Database
-	prefetcher     *triePrefetcher
-	originalRoot   common.Hash // The pre-state root, before any changes were made
+	db           Database
+	prefetcher   *triePrefetcher
+	originalRoot common.Hash // The pre-state root, before any changes were made
+	currentRoot  common.Hash // only used when noTrie is true
+
 	trie           Trie
+	noTrie         bool
 	hasher         crypto.KeccakState
 	diffLayer      *types.DiffLayer
 	diffTries      map[common.Address]Trie
@@ -158,6 +161,7 @@ func newStateDB(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, 
 	if err != nil {
 		return nil, err
 	}
+	_, sdb.noTrie = tr.(*trie.EmptyTrie)
 	sdb.trie = tr
 	if sdb.snaps != nil {
 		if sdb.snap = sdb.snaps.Snapshot(root); sdb.snap != nil {
@@ -173,6 +177,9 @@ func newStateDB(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, 
 // state trie concurrently while the state is mutated so that when we reach the
 // commit phase, most of the needed data is already hot.
 func (s *StateDB) StartPrefetcher(namespace string) {
+	if s.noTrie {
+		return
+	}
 	if s.prefetcher != nil {
 		s.prefetcher.close()
 		s.prefetcher = nil
@@ -185,6 +192,9 @@ func (s *StateDB) StartPrefetcher(namespace string) {
 // StopPrefetcher terminates a running prefetcher and reports any leftover stats
 // from the gathered metrics.
 func (s *StateDB) StopPrefetcher() {
+	if s.noTrie {
+		return
+	}
 	if s.prefetcher != nil {
 		s.prefetcher.close()
 		s.prefetcher = nil
@@ -205,6 +215,14 @@ func (s *StateDB) setError(err error) {
 	if s.dbErr == nil {
 		s.dbErr = err
 	}
+}
+
+func (s *StateDB) NoTrie() bool {
+	return s.noTrie
+}
+
+func (s *StateDB) SetCurrentRoot(root common.Hash) {
+	s.currentRoot = root
 }
 
 func (s *StateDB) Error() error {
@@ -504,6 +522,9 @@ func (s *StateDB) Suicide(addr common.Address) bool {
 
 // updateStateObject writes the given object to the trie.
 func (s *StateDB) updateStateObject(obj *StateObject) {
+	if s.noTrie {
+		return
+	}
 	// Track the amount of time wasted on updating the account from the trie
 	if metrics.EnabledExpensive {
 		defer func(start time.Time) { s.AccountUpdates += time.Since(start) }(time.Now())
@@ -525,6 +546,9 @@ func (s *StateDB) updateStateObject(obj *StateObject) {
 
 // deleteStateObject removes the given object from the state trie.
 func (s *StateDB) deleteStateObject(obj *StateObject) {
+	if s.noTrie {
+		return
+	}
 	// Track the amount of time wasted on deleting the account from the trie
 	if metrics.EnabledExpensive {
 		defer func(start time.Time) { s.AccountUpdates += time.Since(start) }(time.Now())
@@ -957,6 +981,7 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 // It is called in between transactions to get the root hash that
 // goes into transaction receipts.
 func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+	// light process is not allowed when there is no trie
 	if s.lightProcessed {
 		s.StopPrefetcher()
 		return s.trie.Hash()
@@ -1042,16 +1067,18 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 		s.trie = tr
 	}
 	usedAddrs := make([][]byte, 0, len(s.stateObjectsPending))
-	for addr := range s.stateObjectsPending {
-		if obj := s.stateObjects[addr]; obj.deleted {
-			s.deleteStateObject(obj)
-		} else {
-			s.updateStateObject(obj)
+	if !s.noTrie {
+		for addr := range s.stateObjectsPending {
+			if obj := s.stateObjects[addr]; obj.deleted {
+				s.deleteStateObject(obj)
+			} else {
+				s.updateStateObject(obj)
+			}
+			usedAddrs = append(usedAddrs, common.CopyBytes(addr[:])) // Copy needed for closure
 		}
-		usedAddrs = append(usedAddrs, common.CopyBytes(addr[:])) // Copy needed for closure
-	}
-	if prefetcher != nil {
-		prefetcher.used(s.originalRoot, usedAddrs)
+		if prefetcher != nil {
+			prefetcher.used(s.originalRoot, usedAddrs)
+		}
 	}
 	if len(s.stateObjectsPending) > 0 {
 		s.stateObjectsPending = make(map[common.Address]struct{})
@@ -1060,8 +1087,11 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 	if metrics.EnabledExpensive {
 		defer func(start time.Time) { s.AccountHashes += time.Since(start) }(time.Now())
 	}
-	root := s.trie.Hash()
-	return root
+	if s.noTrie {
+		return s.currentRoot
+	} else {
+		return s.trie.Hash()
+	}
 }
 
 // Prepare sets the current transaction hash and index and block hash which is
@@ -1271,8 +1301,10 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, *types.DiffLayer
 							obj.dirtyCode = false
 						}
 						// Write any storage changes in the state object to its storage trie
-						if err := obj.CommitTrie(s.db); err != nil {
-							taskResults <- err
+						if !s.noTrie {
+							if err := obj.CommitTrie(s.db); err != nil {
+								taskResults <- err
+							}
 						}
 						taskResults <- nil
 					}
@@ -1299,24 +1331,26 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, *types.DiffLayer
 			}
 			// The onleaf func is called _serially_, so we can reuse the same account
 			// for unmarshalling every time.
-			var account Account
-			root, err := s.trie.Commit(func(_ [][]byte, _ []byte, leaf []byte, parent common.Hash) error {
-				if err := rlp.DecodeBytes(leaf, &account); err != nil {
+			if !s.noTrie {
+				var account Account
+				root, err := s.trie.Commit(func(_ [][]byte, _ []byte, leaf []byte, parent common.Hash) error {
+					if err := rlp.DecodeBytes(leaf, &account); err != nil {
+						return nil
+					}
+					if account.Root != emptyRoot {
+						s.db.TrieDB().Reference(account.Root, parent)
+					}
 					return nil
+				})
+				if err != nil {
+					return err
 				}
-				if account.Root != emptyRoot {
-					s.db.TrieDB().Reference(account.Root, parent)
+				if metrics.EnabledExpensive {
+					s.AccountCommits += time.Since(start)
 				}
-				return nil
-			})
-			if err != nil {
-				return err
-			}
-			if metrics.EnabledExpensive {
-				s.AccountCommits += time.Since(start)
-			}
-			if root != emptyRoot {
-				s.db.CacheAccount(root, s.trie)
+				if root != emptyRoot {
+					s.db.CacheAccount(root, s.trie)
+				}
 			}
 			wg.Wait()
 			return nil

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -400,6 +400,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 
 	// usually do have two tx, one for validator set contract, another for system reward contract.
 	systemTxs := make([]*types.Transaction, 0, 2)
+
 	for i, tx := range block.Transactions() {
 		if isPoSA {
 			if isSystemTx, err := posa.IsSystemTransaction(tx, block.Header()); err != nil {
@@ -415,11 +416,11 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 			return statedb, nil, nil, 0, err
 		}
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
+
 		receipt, err := applyTransaction(msg, p.config, p.bc, nil, gp, statedb, header, tx, usedGas, vmenv, bloomProcessors)
 		if err != nil {
 			return statedb, nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
-
 		commonTxs = append(commonTxs, tx)
 		receipts = append(receipts, receipt)
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -194,13 +194,14 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			TrieDirtyLimit:     config.TrieDirtyCache,
 			TrieDirtyDisabled:  config.NoPruning,
 			TrieTimeLimit:      config.TrieTimeout,
+			NoTries:            config.NoTries,
 			SnapshotLimit:      config.SnapshotCache,
 			TriesInMemory:      config.TriesInMemory,
 			Preimages:          config.Preimages,
 		}
 	)
 	bcOps := make([]core.BlockChainOption, 0)
-	if config.DiffSync {
+	if config.DiffSync && !config.NoTries {
 		bcOps = append(bcOps, core.EnableLightProcessor)
 	}
 	if config.PersistDiff {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -79,6 +79,7 @@ var Defaults = Config{
 	TrieDirtyCache:          256,
 	TrieTimeout:             60 * time.Minute,
 	TriesInMemory:           128,
+	NoTries:                 false,
 	SnapshotCache:           102,
 	DiffBlock:               uint64(86400),
 	Miner: miner.Config{
@@ -174,6 +175,7 @@ type Config struct {
 	TrieTimeout             time.Duration
 	SnapshotCache           int
 	TriesInMemory           uint64
+	NoTries                 bool
 	Preimages               bool
 
 	// Mining options

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -3,6 +3,7 @@
 package ethconfig
 
 import (
+	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -25,6 +26,10 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		SnapDiscoveryURLs       []string
 		NoPruning               bool
 		NoPrefetch              bool
+		DirectBroadcast         bool
+		DisableSnapProtocol     bool
+		DiffSync                bool
+		RangeLimit              bool
 		TxLookupLimit           uint64                 `toml:",omitempty"`
 		Whitelist               map[uint64]common.Hash `toml:"-"`
 		LightServ               int                    `toml:",omitempty"`
@@ -42,28 +47,30 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		DatabaseCache           int
 		DatabaseFreezer         string
 		DatabaseDiff            string
+		PersistDiff             bool
+		DiffBlock               uint64
 		TrieCleanCache          int
 		TrieCleanCacheJournal   string        `toml:",omitempty"`
 		TrieCleanCacheRejournal time.Duration `toml:",omitempty"`
 		TrieDirtyCache          int
 		TrieTimeout             time.Duration
-		TriesInMemory           uint64 `toml:",omitempty"`
 		SnapshotCache           int
+		TriesInMemory           uint64
+		NoTries                 bool
 		Preimages               bool
-		PersistDiff             bool
-		DiffBlock               uint64 `toml:",omitempty"`
 		Miner                   miner.Config
-		Ethash                  ethash.Config
+		Ethash                  ethash.Config `toml:",omitempty"`
 		TxPool                  core.TxPoolConfig
 		GPO                     gasprice.Config
 		EnablePreimageRecording bool
 		DocRoot                 string `toml:"-"`
 		EWASMInterpreter        string
 		EVMInterpreter          string
-		RPCGasCap               uint64                         `toml:",omitempty"`
-		RPCTxFeeCap             float64                        `toml:",omitempty"`
+		RPCGasCap               uint64
+		RPCTxFeeCap             float64
 		Checkpoint              *params.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle        *params.CheckpointOracleConfig `toml:",omitempty"`
+		OverrideBerlin          *big.Int                       `toml:",omitempty"`
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -73,6 +80,10 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.EthDiscoveryURLs = c.EthDiscoveryURLs
 	enc.SnapDiscoveryURLs = c.SnapDiscoveryURLs
 	enc.NoPruning = c.NoPruning
+	enc.DirectBroadcast = c.DirectBroadcast
+	enc.DisableSnapProtocol = c.DisableSnapProtocol
+	enc.DiffSync = c.DiffSync
+	enc.RangeLimit = c.RangeLimit
 	enc.TxLookupLimit = c.TxLookupLimit
 	enc.Whitelist = c.Whitelist
 	enc.LightServ = c.LightServ
@@ -90,16 +101,17 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.DatabaseCache = c.DatabaseCache
 	enc.DatabaseFreezer = c.DatabaseFreezer
 	enc.DatabaseDiff = c.DatabaseDiff
+	enc.PersistDiff = c.PersistDiff
+	enc.DiffBlock = c.DiffBlock
 	enc.TrieCleanCache = c.TrieCleanCache
 	enc.TrieCleanCacheJournal = c.TrieCleanCacheJournal
 	enc.TrieCleanCacheRejournal = c.TrieCleanCacheRejournal
 	enc.TrieDirtyCache = c.TrieDirtyCache
 	enc.TrieTimeout = c.TrieTimeout
-	enc.TriesInMemory = c.TriesInMemory
 	enc.SnapshotCache = c.SnapshotCache
+	enc.TriesInMemory = c.TriesInMemory
+	enc.NoTries = c.NoTries
 	enc.Preimages = c.Preimages
-	enc.PersistDiff = c.PersistDiff
-	enc.DiffBlock = c.DiffBlock
 	enc.Miner = c.Miner
 	enc.Ethash = c.Ethash
 	enc.TxPool = c.TxPool
@@ -112,6 +124,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
 	enc.Checkpoint = c.Checkpoint
 	enc.CheckpointOracle = c.CheckpointOracle
+	enc.OverrideBerlin = c.OverrideBerlin
 	return &enc, nil
 }
 
@@ -126,6 +139,10 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		SnapDiscoveryURLs       []string
 		NoPruning               *bool
 		NoPrefetch              *bool
+		DirectBroadcast         *bool
+		DisableSnapProtocol     *bool
+		DiffSync                *bool
+		RangeLimit              *bool
 		TxLookupLimit           *uint64                `toml:",omitempty"`
 		Whitelist               map[uint64]common.Hash `toml:"-"`
 		LightServ               *int                   `toml:",omitempty"`
@@ -144,27 +161,29 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		DatabaseFreezer         *string
 		DatabaseDiff            *string
 		PersistDiff             *bool
-		DiffBlock               *uint64 `toml:",omitempty"`
+		DiffBlock               *uint64
 		TrieCleanCache          *int
 		TrieCleanCacheJournal   *string        `toml:",omitempty"`
 		TrieCleanCacheRejournal *time.Duration `toml:",omitempty"`
 		TrieDirtyCache          *int
 		TrieTimeout             *time.Duration
-		TriesInMemory           *uint64 `toml:",omitempty"`
 		SnapshotCache           *int
+		TriesInMemory           *uint64
+		NoTries                 *bool
 		Preimages               *bool
 		Miner                   *miner.Config
-		Ethash                  *ethash.Config
+		Ethash                  *ethash.Config `toml:",omitempty"`
 		TxPool                  *core.TxPoolConfig
 		GPO                     *gasprice.Config
 		EnablePreimageRecording *bool
 		DocRoot                 *string `toml:"-"`
 		EWASMInterpreter        *string
 		EVMInterpreter          *string
-		RPCGasCap               *uint64                        `toml:",omitempty"`
-		RPCTxFeeCap             *float64                       `toml:",omitempty"`
+		RPCGasCap               *uint64
+		RPCTxFeeCap             *float64
 		Checkpoint              *params.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle        *params.CheckpointOracleConfig `toml:",omitempty"`
+		OverrideBerlin          *big.Int                       `toml:",omitempty"`
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -190,6 +209,18 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.NoPruning != nil {
 		c.NoPruning = *dec.NoPruning
+	}
+	if dec.DirectBroadcast != nil {
+		c.DirectBroadcast = *dec.DirectBroadcast
+	}
+	if dec.DisableSnapProtocol != nil {
+		c.DisableSnapProtocol = *dec.DisableSnapProtocol
+	}
+	if dec.DiffSync != nil {
+		c.DiffSync = *dec.DiffSync
+	}
+	if dec.RangeLimit != nil {
+		c.RangeLimit = *dec.RangeLimit
 	}
 	if dec.TxLookupLimit != nil {
 		c.TxLookupLimit = *dec.TxLookupLimit
@@ -263,11 +294,14 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.TrieTimeout != nil {
 		c.TrieTimeout = *dec.TrieTimeout
 	}
+	if dec.SnapshotCache != nil {
+		c.SnapshotCache = *dec.SnapshotCache
+	}
 	if dec.TriesInMemory != nil {
 		c.TriesInMemory = *dec.TriesInMemory
 	}
-	if dec.SnapshotCache != nil {
-		c.SnapshotCache = *dec.SnapshotCache
+	if dec.NoTries != nil {
+		c.NoTries = *dec.NoTries
 	}
 	if dec.Preimages != nil {
 		c.Preimages = *dec.Preimages
@@ -307,6 +341,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.CheckpointOracle != nil {
 		c.CheckpointOracle = dec.CheckpointOracle
+	}
+	if dec.OverrideBerlin != nil {
+		c.OverrideBerlin = dec.OverrideBerlin
 	}
 	return nil
 }

--- a/light/trie.go
+++ b/light/trie.go
@@ -49,6 +49,10 @@ type odrDatabase struct {
 	backend OdrBackend
 }
 
+func (db *odrDatabase) NoTries() bool {
+	return false
+}
+
 func (db *odrDatabase) OpenTrie(root common.Hash) (state.Trie, error) {
 	return &odrTrie{db: db, id: db.id}, nil
 }
@@ -176,6 +180,10 @@ func (t *odrTrie) do(key []byte, fn func() error) error {
 			return err
 		}
 	}
+}
+
+func (db *odrTrie) NoTries() bool {
+	return false
 }
 
 type nodeIterator struct {

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -230,7 +230,7 @@ func MakePreState(db ethdb.Database, accounts core.GenesisAlloc, snapshotter boo
 
 	var snaps *snapshot.Tree
 	if snapshotter {
-		snaps, _ = snapshot.New(db, sdb.TrieDB(), 1, 128, root, false, true, false)
+		snaps, _ = snapshot.New(db, sdb.TrieDB(), 1, 128, root, false, true, false, false)
 	}
 	statedb, _ = state.New(root, sdb, snaps)
 	return snaps, statedb

--- a/trie/database.go
+++ b/trie/database.go
@@ -282,6 +282,7 @@ type Config struct {
 	Cache     int    // Memory allowance (MB) to use for caching trie nodes in memory
 	Journal   string // Journal of clean cache to survive node restarts
 	Preimages bool   // Flag whether the preimage of trie key is recorded
+	NoTries   bool
 }
 
 // NewDatabase creates a new trie database to store ephemeral trie content before

--- a/trie/dummy_trie.go
+++ b/trie/dummy_trie.go
@@ -1,0 +1,96 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/ethdb"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type EmptyTrie struct{}
+
+func (t *EmptyTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error {
+	return nil
+}
+
+// NewSecure creates a dummy trie
+func NewEmptyTrie() *EmptyTrie {
+	return &EmptyTrie{}
+}
+
+func (t *EmptyTrie) Get(key []byte) []byte {
+	return nil
+}
+
+func (t *EmptyTrie) TryGet(key []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (t *EmptyTrie) TryGetNode(path []byte) ([]byte, int, error) {
+	return nil, 0, nil
+}
+func (t *EmptyTrie) Update(key, value []byte) {}
+
+func (t *EmptyTrie) TryUpdate(key, value []byte) error {
+	return nil
+}
+
+// Delete removes any existing value for key from the trie.
+func (t *EmptyTrie) Delete(key []byte) {
+	if err := t.TryDelete(key); err != nil {
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
+	}
+}
+
+func (t *EmptyTrie) TryDelete(key []byte) error {
+
+	return nil
+}
+
+func (t *EmptyTrie) GetKey(shaKey []byte) []byte {
+	return nil
+}
+
+func (t *EmptyTrie) Commit(onleaf LeafCallback) (root common.Hash, err error) {
+
+	return common.Hash{}, nil
+}
+
+func (t *EmptyTrie) Hash() common.Hash {
+	return common.Hash{}
+}
+
+// Copy returns a copy of SecureTrie.
+func (t *EmptyTrie) Copy() *EmptyTrie {
+	cpy := *t
+	return &cpy
+}
+
+func (t *EmptyTrie) ResetCopy() *EmptyTrie {
+	cpy := *t
+	return &cpy
+}
+
+// NodeIterator returns an iterator that returns nodes of the underlying trie. Iteration
+// starts at the key after the given start key.
+func (t *EmptyTrie) NodeIterator(start []byte) NodeIterator {
+	return nil
+}


### PR DESCRIPTION
## Summary
I am a developer from https://nodereal.io/ who focuses on building stable and powerful infrastructure in the cryptocurrency world. 

This PR tries to improve the syncing speed by separating the block processing and state verification in two different nodes: **fast node** and **verify node**. 

## Abstract
Currently a BSC node has two kinds of state world: MPT and snapshot.  MPT(Merkle Patricia Tries) is a tree-structured state world. The key function of MPT is to generate the state root to ensure state consistency, while the query/commit on MPT is quite slow. Snapshot is a flattened key-value-based state world. Snapshot provides fast queries and commit. The storage size of the snapshot increases slowly even with a large transaction volume. Snapshot is usually used for block processing, while MPT is used for state verification. 

To make full use of different storage, the **fast node** will do block processing with snapshot. It will do all verification against blocks except state root. The **verify node** receives the difflayer from **fast node** and does state verification, and response to **fast node**. All these are nonblocking process so that the syncing can be fast.

## Motivation
The increasing adoption of BSC leads to a more active network. On the other hand, the node maintainer had a hard time keeping their node catching up with the chain. A new syncing protocol to lower the hardware requirement is an urgent need.

## Specification
![image](https://user-images.githubusercontent.com/90668111/144979829-04003272-6b40-438a-84cd-53eebc43369c.png)

**Fast node** is a bsc client that does fullsync using only snapshot and generate difflayer. It needs the confirm message from the **verify node** before freezing the blocks, it has to wait if  1. it receives any negative message from the **verify node**; 2. it does not receive a positive message from the verified node for blocks at height **CurrentHeight-FreezeNumber**. 

**Verify node** receive difflayer that is generated by fast node and try to apply it into MPT and verify the state root. It sends back positive/negative messages to the **fast node**.

All the messages exchanged between **Fast node** and  **Verify node** are based on the diff p2p protocol. 

### Authentication
**Fast node** can only rely on trusted **verify node**, either deployed by the same developer or deployed by a trusted organization. We know the different peers will verify the peer id during the handshake, we will borrow this mechanism to do the authentication. We introduce **TrustVerifyNodes** settings, which is a list of encoded addresses, the **fast nodes** only build connections(based on diff protocol) with **TrustVerifyNodes**.

For organizations, they can deploy their own **verified node**.

For individual developers, they can connect to the **verify node** donated by the famous organization/validators.

### Chain Tools
Implement a new prune command to prune all MPT storage.

### Prototype verification
The performance improves x3 in fast node on mainnet.

### Command
Add `--allow-insecure-no-tries` to enable the feature, like  ` ./geth --config ./config.toml --datadir ./node --syncmode full --cache 5000 --allow-insecure-no-tries`

Prune the tires node:  `./geth snapshot insecure-prune-all --datadir ./node  ./genesis.json`