### PR TITLE
fixed direct db operation in trie database

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -396,8 +396,8 @@ func (db *Database) node(hash common.Hash) node {
 	memcacheDirtyMissMeter.Mark(1)
 
 	// Content unavailable in memory, attempt to retrieve from disk
-	enc, err := db.diskdb.Get(hash[:])
-	if err != nil || enc == nil {
+	enc := rawdb.ReadTrieNode(db.diskdb, hash)
+	if len(enc) == 0 {
 		return nil
 	}
 	if db.cleans != nil {


### PR DESCRIPTION
### Description

fixed direct diskdb read in node method

### Rationale

made it similar to Node method and others.

### Example

...

### Changes

Notable changes: 
* changed db.Get(hash[:]) to rawdb.ReadTrieNode(db, hash)

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

...

### Related issues

...
