### PR TITLE
gomod update uint256 to 1.2.0

### DIFF
--- a/consensus/ethash/difficulty.go
+++ b/consensus/ethash/difficulty.go
@@ -52,8 +52,7 @@ func CalcDifficultyFrontierU256(time uint64, parent *types.Header) *big.Int {
 		- num = block.number
 	*/
 
-	pDiff := uint256.NewInt()
-	pDiff.SetFromBig(parent.Difficulty) // pDiff: pdiff
+	pDiff, _ := uint256.FromBig(parent.Difficulty)
 	adjust := pDiff.Clone()
 	adjust.Rsh(adjust, difficultyBoundDivisor) // adjust: pDiff / 2048
 
@@ -96,8 +95,7 @@ func CalcDifficultyHomesteadU256(time uint64, parent *types.Header) *big.Int {
 		- num = block.number
 	*/
 
-	pDiff := uint256.NewInt()
-	pDiff.SetFromBig(parent.Difficulty) // pDiff: pdiff
+	pDiff, _ := uint256.FromBig(parent.Difficulty) // pDiff: pdiff
 	adjust := pDiff.Clone()
 	adjust.Rsh(adjust, difficultyBoundDivisor) // adjust: pDiff / 2048
 

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -568,11 +568,11 @@ func BenchmarkOpSHA3(bench *testing.B) {
 	env.interpreter = evmInterpreter
 	mem.Resize(32)
 	pc := uint64(0)
-	start := uint256.NewInt()
+	start := new(uint256.Int)
 
 	bench.ResetTimer()
 	for i := 0; i < bench.N; i++ {
-		stack.pushN(*uint256.NewInt().SetUint64(32), *start)
+		stack.pushN(*uint256.NewInt(32), *start)
 		opSha3(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
 	}
 }

--- a/core/vm/logger_test.go
+++ b/core/vm/logger_test.go
@@ -60,8 +60,8 @@ func TestStoreCapture(t *testing.T) {
 			Contract: contract,
 		}
 	)
-	scope.Stack.push(uint256.NewInt().SetUint64(1))
-	scope.Stack.push(uint256.NewInt())
+	scope.Stack.push(new(uint256.Int).SetUint64(1))
+	scope.Stack.push(new(uint256.Int))
 	var index common.Hash
 	logger.CaptureStart(env, common.Address{}, contract.Address(), false, nil, 0, nil)
 	logger.CaptureState(0, SSTORE, 0, 0, scope, nil, 0, nil)

--- a/eth/protocols/snap/range.go
+++ b/eth/protocols/snap/range.go
@@ -42,15 +42,15 @@ func newHashRange(start common.Hash, num uint64) *hashRange {
 	step256.SetFromBig(step)
 
 	return &hashRange{
-		current: uint256.NewInt().SetBytes32(start[:]),
+		current: new(uint256.Int).SetBytes32(start[:]),
 		step:    step256,
 	}
 }
 
 // Next pushes the hash range to the next interval.
 func (r *hashRange) Next() bool {
-	next := new(uint256.Int)
-	if overflow := next.AddOverflow(r.current, r.step); overflow {
+	next, overflow := new(uint256.Int).AddOverflow(r.current, r.step)
+	if overflow {
 		return false
 	}
 	r.current = next
@@ -65,16 +65,17 @@ func (r *hashRange) Start() common.Hash {
 // End returns the last hash in the current interval.
 func (r *hashRange) End() common.Hash {
 	// If the end overflows (non divisible range), return a shorter interval
-	next := new(uint256.Int)
-	if overflow := next.AddOverflow(r.current, r.step); overflow {
+	next, overflow := new(uint256.Int).AddOverflow(r.current, r.step)
+	if overflow {
 		return common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 	}
-	return new(uint256.Int).Sub(next, uint256.NewInt().SetOne()).Bytes32()
+	return next.SubUint64(next, 1).Bytes32()
 }
 
 // incHash returns the next hash, in lexicographical order (a.k.a plus one)
 func incHash(h common.Hash) common.Hash {
-	a := uint256.NewInt().SetBytes32(h[:])
-	a.Add(a, uint256.NewInt().SetOne())
+	var a uint256.Int
+	a.SetBytes32(h[:])
+	a.AddUint64(&a, 1)
 	return common.Hash(a.Bytes32())
 }

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/graph-gophers/graphql-go v0.0.0-20201113091052-beb923fada29
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
 	github.com/holiman/bloomfilter/v2 v2.0.3
-	github.com/holiman/uint256 v1.1.1
+	github.com/holiman/uint256 v1.2.0
 	github.com/huin/goupnp v1.0.1-0.20210310174557-0ca763054c88
 	github.com/influxdata/influxdb v1.8.3
 	github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZ
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
 github.com/holiman/uint256 v1.1.1 h1:4JywC80b+/hSfljFlEBLHrrh+CIONLDz9NuFl0af4Mw=
 github.com/holiman/uint256 v1.1.1/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
+github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=
+github.com/holiman/uint256 v1.2.0/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.0.1-0.20210310174557-0ca763054c88 h1:bcAj8KroPf552TScjFPIakjH2/tdIrIH8F+cc4v4SRo=
 github.com/huin/goupnp v1.0.1-0.20210310174557-0ca763054c88/go.mod h1:nNs7wvRfN1eKaMknBydLNQU6146XQim8t4h+q90biWo=


### PR DESCRIPTION


### Description

Update the dep uint256 version to v1.2.0

### Rationale

* https://github.com/ethereum/go-ethereum/pull/22745
* https://github.com/ethereum/go-ethereum/pull/22851

### Example


### Changes


