### PR TITLE
Ancient opt

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -125,6 +125,7 @@ var (
 		utils.CachePreimagesFlag,
 		utils.PersistDiffFlag,
 		utils.DiffBlockFlag,
+		utils.DelAncientDataFlag,
 		utils.ListenPortFlag,
 		utils.MaxPeersFlag,
 		utils.MaxPendingPeersFlag,

--- a/cmd/geth/pruneblock_test.go
+++ b/cmd/geth/pruneblock_test.go
@@ -93,7 +93,7 @@ func testOfflineBlockPruneWithAmountReserved(t *testing.T, amountReserved uint64
 		t.Fatalf("Failed to back up block: %v", err)
 	}
 
-	dbBack, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 0, 0, newAncientPath, "", false, true, false)
+	dbBack, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 0, 0, newAncientPath, "", false, true, false, false)
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}
@@ -139,7 +139,7 @@ func testOfflineBlockPruneWithAmountReserved(t *testing.T, amountReserved uint64
 
 func BlockchainCreator(t *testing.T, chaindbPath, AncientPath string, blockRemain uint64) (ethdb.Database, []*types.Block, []*types.Block, []types.Receipts, []*big.Int, uint64, *core.BlockChain) {
 	//create a database with ancient freezer
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 0, 0, AncientPath, "", false, false, false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 0, 0, AncientPath, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1627,8 +1627,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.GlobalIsSet(DelAncientDataFlag.Name) {
 		cfg.DelAncientData = ctx.GlobalBool(DelAncientDataFlag.Name)
-		if cfg.SyncMode != downloader.FullSync {
-			cfg.DelAncientData = false 
+		if cfg.SyncMode == downloader.FullSync {
+			cfg.DelAncientData = ctx.GlobalBool(DelAncientDataFlag.Name)
+		} else {
 			log.Crit("keepfixedblocks parameter take effect in full syncmode")
 		}
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -457,6 +457,10 @@ var (
 		Usage: "The number of blocks should be persisted in db (default = 86400)",
 		Value: uint64(86400),
 	}
+	DelAncientDataFlag = cli.BoolFlag{
+		Name:  "ancient.nodata",
+		Usage: "Enable ancientdb save no data, release more os resource",
+	}
 	// Miner settings
 	MiningEnabledFlag = cli.BoolFlag{
 		Name:  "mine",
@@ -1621,6 +1625,13 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.GlobalIsSet(DiffBlockFlag.Name) {
 		cfg.DiffBlock = ctx.GlobalUint64(DiffBlockFlag.Name)
 	}
+	if ctx.GlobalIsSet(DelAncientDataFlag.Name) {
+		cfg.DelAncientData = ctx.GlobalBool(DelAncientDataFlag.Name)
+		if cfg.SyncMode == downloader.LightSync {
+			cfg.DelAncientData = false 
+			log.Info("ancient.nodata not take effect, under light syncmode")
+		}
+	}
 	if gcmode := ctx.GlobalString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {
 		Fatalf("--%s must be either 'full' or 'archive'", GCModeFlag.Name)
 	}
@@ -1914,7 +1925,7 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, disableFree
 		chainDb, err = stack.OpenDatabase(name, cache, handles, "", readonly)
 	} else {
 		name := "chaindata"
-		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, disableFreeze, false)
+		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, disableFreeze, false, false)
 	}
 	if err != nil {
 		Fatalf("Could not open database: %v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -458,8 +458,8 @@ var (
 		Value: uint64(86400),
 	}
 	DelAncientDataFlag = cli.BoolFlag{
-		Name:  "ancient.nodata",
-		Usage: "Enable ancientdb save no data, release more os resource",
+		Name:  "keepfixedblocks",
+		Usage: "Keep a fixed number of blocks(9w) under full syncmode, enable release more os resources",
 	}
 	// Miner settings
 	MiningEnabledFlag = cli.BoolFlag{
@@ -1627,9 +1627,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.GlobalIsSet(DelAncientDataFlag.Name) {
 		cfg.DelAncientData = ctx.GlobalBool(DelAncientDataFlag.Name)
-		if cfg.SyncMode == downloader.LightSync {
+		if cfg.SyncMode != downloader.FullSync {
 			cfg.DelAncientData = false 
-			log.Info("ancient.nodata not take effect, under light syncmode")
+			log.Crit("keepfixedblocks parameter take effect in full syncmode")
 		}
 	}
 	if gcmode := ctx.GlobalString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -922,6 +922,7 @@ func (bc *BlockChain) ExportN(w io.Writer, first uint64, last uint64) error {
 // Note, this function assumes that the `mu` mutex is held!
 func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	// If the block is on a side chain or an unknown one, force other heads onto it too
+	// read from kvdb, has nothing to do with ancientdb type
 	updateHeads := rawdb.ReadCanonicalHash(bc.db, block.NumberU64()) != block.Hash()
 
 	// Add the block to the canonical chain number scheme and mark as the head
@@ -2350,6 +2351,9 @@ func (bc *BlockChain) insertSideChain(block *types.Block, it *insertIterator) (i
 	for i := len(hashes) - 1; i >= 0; i-- {
 		// Append the next block to our batch
 		block := bc.GetBlock(hashes[i], numbers[i])
+		if block == nil {
+			continue
+		}
 
 		blocks = append(blocks, block)
 		memory += block.Size()

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -1762,7 +1762,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	}
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}
@@ -1832,7 +1832,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	db.Close()
 
 	// Start a new blockchain back up and see where the repait leads us
-	db, err = rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
+	db, err = rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to reopen persistent database: %v", err)
 	}

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -1961,7 +1961,7 @@ func testSetHead(t *testing.T, tt *rewindTest, snapshots bool) {
 	}
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -64,7 +64,7 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 	}
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}
@@ -248,7 +248,7 @@ func (snaptest *crashSnapshotTest) test(t *testing.T) {
 	db.Close()
 
 	// Start a new blockchain back up and see where the repair leads us
-	newdb, err := rawdb.NewLevelDBDatabaseWithFreezer(snaptest.datadir, 0, 0, snaptest.datadir, "", false, false, false)
+	newdb, err := rawdb.NewLevelDBDatabaseWithFreezer(snaptest.datadir, 0, 0, snaptest.datadir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to reopen persistent database: %v", err)
 	}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -761,7 +761,7 @@ func TestFastVsFullChains(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -835,7 +835,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 			t.Fatalf("failed to create temp freezer dir: %v", err)
 		}
 		defer os.Remove(dir)
-		db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false, false, false)
+		db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false, false, false, false)
 		if err != nil {
 			t.Fatalf("failed to create temp freezer db: %v", err)
 		}
@@ -1702,7 +1702,7 @@ func TestBlockchainRecovery(t *testing.T) {
 	}
 	defer os.Remove(frdir)
 
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -1759,7 +1759,7 @@ func TestIncompleteAncientReceiptChainInsertion(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -1958,7 +1958,7 @@ func testInsertKnownChainData(t *testing.T, typ string) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(dir)
-	chaindb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false, false, false)
+	chaindb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -2238,7 +2238,7 @@ func TestTransactionIndices(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -2266,7 +2266,7 @@ func TestTransactionIndices(t *testing.T) {
 	// Init block chain with external ancients, check all needed indices has been indexed.
 	limit := []uint64{0, 32, 64, 128}
 	for _, l := range limit {
-		ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
+		ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false, false)
 		if err != nil {
 			t.Fatalf("failed to create temp freezer db: %v", err)
 		}
@@ -2286,7 +2286,7 @@ func TestTransactionIndices(t *testing.T) {
 	}
 
 	// Reconstruct a block chain which only reserves HEAD-64 tx indices
-	ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
+	ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -2365,7 +2365,7 @@ func TestSkipStaleTxIndicesInFastSync(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -250,6 +250,10 @@ func (hc *HeaderChain) writeHeaders(headers []*types.Header) (result *headerWrit
 				headHeader = hc.GetHeader(headHash, headNumber)
 			)
 			for rawdb.ReadCanonicalHash(hc.chainDb, headNumber) != headHash {
+				// backtracking to ancientdb
+				if frozen, _ := hc.chainDb.Ancients(); frozen == headNumber {
+					break
+				}
 				rawdb.WriteCanonicalHash(markerBatch, headHash, headNumber)
 				headHash = headHeader.ParentHash
 				headNumber = headHeader.Number.Uint64() - 1

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -440,7 +440,7 @@ func TestAncientStorage(t *testing.T) {
 	}
 	defer os.Remove(frdir)
 
-	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false, false, false)
+	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -95,7 +95,11 @@ func iterateTransactions(db ethdb.Database, from uint64, to uint64, reverse bool
 		number uint64
 		rlp    rlp.RawValue
 	}
-	if to == from {
+
+	if offset := db.AncientOffSet(); offset >= from {
+		from = offset
+	}
+	if to <= from {
 		return nil
 	}
 	threads := to - from

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -222,12 +222,6 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 			return nil, err
 		}
 
-		if frozen, _ := frdb.Ancients(); frozen != 0 {
-			if kvhash, _ := db.Get(headerHashKey(frozen)); len(kvhash) == 0 {
-				return nil, fmt.Errorf("gap (#%d) in the chain between ancients(no data mode) and leveldb", frozen)
-			}
-		}
-
 		go frdb.freeze()
 		return &freezerdb{
 			KeyValueStore: db,
@@ -324,12 +318,6 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 			}
 			// Otherwise, the head header is still the genesis, we're allowed to init a new
 			// feezer.
-		}
-	}
-
-	if frozen, _ := frdb.Ancients(); frozen != 0 {
-		if kvhash, _ := db.Get(headerHashKey(frozen)); len(kvhash) == 0 {
-			return nil, fmt.Errorf("gap (#%d) in the chain between ancients and leveldb", frozen)
 		}
 	}
 

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -175,6 +175,14 @@ func ReadOffSetOfLastAncientFreezer(db ethdb.KeyValueReader) uint64 {
 	return new(big.Int).SetBytes(offset).Uint64()
 }
 
+func ReadFrozenOfAncientFreezer(db ethdb.KeyValueReader) uint64 {
+	fozen, _ := db.Get(frozenOfAncientDBKey)
+	if fozen == nil {
+		return 0
+	}
+	return new(big.Int).SetBytes(fozen).Uint64()
+}
+
 func WriteOffSetOfCurrentAncientFreezer(db ethdb.KeyValueWriter, offset uint64) {
 	if err := db.Put(offSetOfCurrentAncientFreezer, new(big.Int).SetUint64(offset).Bytes()); err != nil {
 		log.Crit("Failed to store offSetOfAncientFreezer", "err", err)
@@ -182,6 +190,12 @@ func WriteOffSetOfCurrentAncientFreezer(db ethdb.KeyValueWriter, offset uint64) 
 }
 func WriteOffSetOfLastAncientFreezer(db ethdb.KeyValueWriter, offset uint64) {
 	if err := db.Put(offSetOfLastAncientFreezer, new(big.Int).SetUint64(offset).Bytes()); err != nil {
+		log.Crit("Failed to store offSetOfAncientFreezer", "err", err)
+	}
+}
+
+func WriteFrozenOfAncientFreezer(db ethdb.KeyValueWriter, frozen uint64) {
+	if err := db.Put(frozenOfAncientDBKey, new(big.Int).SetUint64(frozen).Bytes()); err != nil {
 		log.Crit("Failed to store offSetOfAncientFreezer", "err", err)
 	}
 }
@@ -201,7 +215,30 @@ func NewFreezerDb(db ethdb.KeyValueStore, frz, namespace string, readonly bool, 
 // NewDatabaseWithFreezer creates a high level database on top of a given key-
 // value data store with a freezer moving immutable chain segments into cold
 // storage.
-func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace string, readonly, disableFreeze, isLastOffset bool) (ethdb.Database, error) {
+func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace string, readonly, disableFreeze, isLastOffset, noAncientData bool) (ethdb.Database, error) {
+	if noAncientData && !disableFreeze && !readonly {
+		frdb, err := newNoDataFreezer(freezer, db)
+		if err != nil {
+			return nil, err
+		}
+
+		if frozen, _ := frdb.Ancients(); frozen != 0 {
+			if kvhash, _ := db.Get(headerHashKey(frozen)); len(kvhash) == 0 {
+				return nil, fmt.Errorf("gap (#%d) in the chain between ancients(no data mode) and leveldb", frozen)
+			}
+		}
+
+		go frdb.freeze()
+		return &freezerdb{
+			KeyValueStore: db,
+			AncientStore:  frdb,
+		}, nil
+	}
+
+	if noAncientData {
+		log.Error("ancient.nodata not take effect, disableFreezer or readonly be set")
+	}
+
 	// Create the idle freezer instance
 	frdb, err := newFreezer(freezer, namespace, readonly)
 	if err != nil {
@@ -290,6 +327,12 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 		}
 	}
 
+	if frozen, _ := frdb.Ancients(); frozen != 0 {
+		if kvhash, _ := db.Get(headerHashKey(frozen)); len(kvhash) == 0 {
+			return nil, fmt.Errorf("gap (#%d) in the chain between ancients and leveldb", frozen)
+		}
+	}
+
 	// Freezer is consistent with the key-value database, permit combining the two
 	if !disableFreeze && !frdb.readonly {
 		go frdb.freeze(db)
@@ -325,12 +368,12 @@ func NewLevelDBDatabase(file string, cache int, handles int, namespace string, r
 
 // NewLevelDBDatabaseWithFreezer creates a persistent key-value database with a
 // freezer moving immutable chain segments into cold storage.
-func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer string, namespace string, readonly, disableFreeze, isLastOffset bool) (ethdb.Database, error) {
+func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer string, namespace string, readonly, disableFreeze, isLastOffset, noAncientData bool) (ethdb.Database, error) {
 	kvdb, err := leveldb.New(file, cache, handles, namespace, readonly)
 	if err != nil {
 		return nil, err
 	}
-	frdb, err := NewDatabaseWithFreezer(kvdb, freezer, namespace, readonly, disableFreeze, isLastOffset)
+	frdb, err := NewDatabaseWithFreezer(kvdb, freezer, namespace, readonly, disableFreeze, isLastOffset, noAncientData)
 	if err != nil {
 		kvdb.Close()
 		return nil, err

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -399,83 +399,6 @@ func (f *freezer) freeze(db ethdb.KeyValueStore) {
 		}
 
 		backoff = gcKvStore(db, ancients, first, f.frozen, start)
-		// // Wipe out all data from the active database
-		// batch := db.NewBatch()
-		// for i := 0; i < len(ancients); i++ {
-		// 	// Always keep the genesis block in active database
-		// 	if first+uint64(i) != 0 {
-		// 		DeleteBlockWithoutNumber(batch, ancients[i], first+uint64(i))
-		// 		DeleteCanonicalHash(batch, first+uint64(i))
-		// 	}
-		// }
-		// if err := batch.Write(); err != nil {
-		// 	log.Crit("Failed to delete frozen canonical blocks", "err", err)
-		// }
-		// batch.Reset()
-
-		// // Wipe out side chains also and track dangling side chians
-		// var dangling []common.Hash
-		// for number := first; number < f.frozen; number++ {
-		// 	// Always keep the genesis block in active database
-		// 	if number != 0 {
-		// 		dangling = ReadAllHashes(db, number)
-		// 		for _, hash := range dangling {
-		// 			log.Trace("Deleting side chain", "number", number, "hash", hash)
-		// 			DeleteBlock(batch, hash, number)
-		// 		}
-		// 	}
-		// }
-		// if err := batch.Write(); err != nil {
-		// 	log.Crit("Failed to delete frozen side blocks", "err", err)
-		// }
-		// batch.Reset()
-
-		// // Step into the future and delete and dangling side chains
-		// if f.frozen > 0 {
-		// 	tip := f.frozen
-		// 	for len(dangling) > 0 {
-		// 		drop := make(map[common.Hash]struct{})
-		// 		for _, hash := range dangling {
-		// 			log.Debug("Dangling parent from freezer", "number", tip-1, "hash", hash)
-		// 			drop[hash] = struct{}{}
-		// 		}
-		// 		children := ReadAllHashes(db, tip)
-		// 		for i := 0; i < len(children); i++ {
-		// 			// Dig up the child and ensure it's dangling
-		// 			child := ReadHeader(nfdb, children[i], tip)
-		// 			if child == nil {
-		// 				log.Error("Missing dangling header", "number", tip, "hash", children[i])
-		// 				continue
-		// 			}
-		// 			if _, ok := drop[child.ParentHash]; !ok {
-		// 				children = append(children[:i], children[i+1:]...)
-		// 				i--
-		// 				continue
-		// 			}
-		// 			// Delete all block data associated with the child
-		// 			log.Debug("Deleting dangling block", "number", tip, "hash", children[i], "parent", child.ParentHash)
-		// 			DeleteBlock(batch, children[i], tip)
-		// 		}
-		// 		dangling = children
-		// 		tip++
-		// 	}
-		// 	if err := batch.Write(); err != nil {
-		// 		log.Crit("Failed to delete dangling side blocks", "err", err)
-		// 	}
-		// }
-		// // Log something friendly for the user
-		// context := []interface{}{
-		// 	"blocks", f.frozen - first, "elapsed", common.PrettyDuration(time.Since(start)), "number", f.frozen - 1,
-		// }
-		// if n := len(ancients); n > 0 {
-		// 	context = append(context, []interface{}{"hash", ancients[n-1]}...)
-		// }
-		// log.Info("Deep froze chain segment", context...)
-
-		// // Avoid database thrashing with tiny writes
-		// if f.frozen-first < freezerBatchLimit {
-		// 	backoff = true
-		// }
 	}
 }
 
@@ -497,7 +420,7 @@ func (f *freezer) repair() error {
 	return nil
 }
 
-// delete leveldb data that save to ancientdb
+// delete leveldb data that save to ancientdb, split from func freeze
 func gcKvStore(db ethdb.KeyValueStore, ancients []common.Hash, first uint64, frozen uint64, start time.Time) bool {
 	// Wipe out all data from the active database
 	batch := db.NewBatch()

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -397,83 +397,85 @@ func (f *freezer) freeze(db ethdb.KeyValueStore) {
 		if err := f.Sync(); err != nil {
 			log.Crit("Failed to flush frozen tables", "err", err)
 		}
-		// Wipe out all data from the active database
-		batch := db.NewBatch()
-		for i := 0; i < len(ancients); i++ {
-			// Always keep the genesis block in active database
-			if first+uint64(i) != 0 {
-				DeleteBlockWithoutNumber(batch, ancients[i], first+uint64(i))
-				DeleteCanonicalHash(batch, first+uint64(i))
-			}
-		}
-		if err := batch.Write(); err != nil {
-			log.Crit("Failed to delete frozen canonical blocks", "err", err)
-		}
-		batch.Reset()
 
-		// Wipe out side chains also and track dangling side chians
-		var dangling []common.Hash
-		for number := first; number < f.frozen; number++ {
-			// Always keep the genesis block in active database
-			if number != 0 {
-				dangling = ReadAllHashes(db, number)
-				for _, hash := range dangling {
-					log.Trace("Deleting side chain", "number", number, "hash", hash)
-					DeleteBlock(batch, hash, number)
-				}
-			}
-		}
-		if err := batch.Write(); err != nil {
-			log.Crit("Failed to delete frozen side blocks", "err", err)
-		}
-		batch.Reset()
+		backoff = gcKvStore(db, ancients, first, f.frozen, start)
+		// // Wipe out all data from the active database
+		// batch := db.NewBatch()
+		// for i := 0; i < len(ancients); i++ {
+		// 	// Always keep the genesis block in active database
+		// 	if first+uint64(i) != 0 {
+		// 		DeleteBlockWithoutNumber(batch, ancients[i], first+uint64(i))
+		// 		DeleteCanonicalHash(batch, first+uint64(i))
+		// 	}
+		// }
+		// if err := batch.Write(); err != nil {
+		// 	log.Crit("Failed to delete frozen canonical blocks", "err", err)
+		// }
+		// batch.Reset()
 
-		// Step into the future and delete and dangling side chains
-		if f.frozen > 0 {
-			tip := f.frozen
-			for len(dangling) > 0 {
-				drop := make(map[common.Hash]struct{})
-				for _, hash := range dangling {
-					log.Debug("Dangling parent from freezer", "number", tip-1, "hash", hash)
-					drop[hash] = struct{}{}
-				}
-				children := ReadAllHashes(db, tip)
-				for i := 0; i < len(children); i++ {
-					// Dig up the child and ensure it's dangling
-					child := ReadHeader(nfdb, children[i], tip)
-					if child == nil {
-						log.Error("Missing dangling header", "number", tip, "hash", children[i])
-						continue
-					}
-					if _, ok := drop[child.ParentHash]; !ok {
-						children = append(children[:i], children[i+1:]...)
-						i--
-						continue
-					}
-					// Delete all block data associated with the child
-					log.Debug("Deleting dangling block", "number", tip, "hash", children[i], "parent", child.ParentHash)
-					DeleteBlock(batch, children[i], tip)
-				}
-				dangling = children
-				tip++
-			}
-			if err := batch.Write(); err != nil {
-				log.Crit("Failed to delete dangling side blocks", "err", err)
-			}
-		}
-		// Log something friendly for the user
-		context := []interface{}{
-			"blocks", f.frozen - first, "elapsed", common.PrettyDuration(time.Since(start)), "number", f.frozen - 1,
-		}
-		if n := len(ancients); n > 0 {
-			context = append(context, []interface{}{"hash", ancients[n-1]}...)
-		}
-		log.Info("Deep froze chain segment", context...)
+		// // Wipe out side chains also and track dangling side chians
+		// var dangling []common.Hash
+		// for number := first; number < f.frozen; number++ {
+		// 	// Always keep the genesis block in active database
+		// 	if number != 0 {
+		// 		dangling = ReadAllHashes(db, number)
+		// 		for _, hash := range dangling {
+		// 			log.Trace("Deleting side chain", "number", number, "hash", hash)
+		// 			DeleteBlock(batch, hash, number)
+		// 		}
+		// 	}
+		// }
+		// if err := batch.Write(); err != nil {
+		// 	log.Crit("Failed to delete frozen side blocks", "err", err)
+		// }
+		// batch.Reset()
 
-		// Avoid database thrashing with tiny writes
-		if f.frozen-first < freezerBatchLimit {
-			backoff = true
-		}
+		// // Step into the future and delete and dangling side chains
+		// if f.frozen > 0 {
+		// 	tip := f.frozen
+		// 	for len(dangling) > 0 {
+		// 		drop := make(map[common.Hash]struct{})
+		// 		for _, hash := range dangling {
+		// 			log.Debug("Dangling parent from freezer", "number", tip-1, "hash", hash)
+		// 			drop[hash] = struct{}{}
+		// 		}
+		// 		children := ReadAllHashes(db, tip)
+		// 		for i := 0; i < len(children); i++ {
+		// 			// Dig up the child and ensure it's dangling
+		// 			child := ReadHeader(nfdb, children[i], tip)
+		// 			if child == nil {
+		// 				log.Error("Missing dangling header", "number", tip, "hash", children[i])
+		// 				continue
+		// 			}
+		// 			if _, ok := drop[child.ParentHash]; !ok {
+		// 				children = append(children[:i], children[i+1:]...)
+		// 				i--
+		// 				continue
+		// 			}
+		// 			// Delete all block data associated with the child
+		// 			log.Debug("Deleting dangling block", "number", tip, "hash", children[i], "parent", child.ParentHash)
+		// 			DeleteBlock(batch, children[i], tip)
+		// 		}
+		// 		dangling = children
+		// 		tip++
+		// 	}
+		// 	if err := batch.Write(); err != nil {
+		// 		log.Crit("Failed to delete dangling side blocks", "err", err)
+		// 	}
+		// }
+		// // Log something friendly for the user
+		// context := []interface{}{
+		// 	"blocks", f.frozen - first, "elapsed", common.PrettyDuration(time.Since(start)), "number", f.frozen - 1,
+		// }
+		// if n := len(ancients); n > 0 {
+		// 	context = append(context, []interface{}{"hash", ancients[n-1]}...)
+		// }
+		// log.Info("Deep froze chain segment", context...)
+
+		// // Avoid database thrashing with tiny writes
+		// if f.frozen-first < freezerBatchLimit {
+		// 	backoff = true
+		// }
 	}
 }
 
@@ -493,4 +495,89 @@ func (f *freezer) repair() error {
 	}
 	atomic.StoreUint64(&f.frozen, min)
 	return nil
+}
+
+// delete leveldb data that save to ancientdb
+func gcKvStore(db ethdb.KeyValueStore, ancients []common.Hash, first uint64, frozen uint64, start time.Time) bool {
+	// Wipe out all data from the active database
+	batch := db.NewBatch()
+	for i := 0; i < len(ancients); i++ {
+		// Always keep the genesis block in active database
+		if first+uint64(i) != 0 {
+			DeleteBlockWithoutNumber(batch, ancients[i], first+uint64(i))
+			DeleteCanonicalHash(batch, first+uint64(i))
+		}
+	}
+	if err := batch.Write(); err != nil {
+		log.Crit("Failed to delete frozen canonical blocks", "err", err)
+	}
+	batch.Reset()
+
+	// Wipe out side chains also and track dangling side chians
+	var dangling []common.Hash
+	for number := first; number < frozen; number++ {
+		// Always keep the genesis block in active database
+		if number != 0 {
+			dangling = ReadAllHashes(db, number)
+			for _, hash := range dangling {
+				log.Trace("Deleting side chain", "number", number, "hash", hash)
+				DeleteBlock(batch, hash, number)
+			}
+		}
+	}
+	if err := batch.Write(); err != nil {
+		log.Crit("Failed to delete frozen side blocks", "err", err)
+	}
+	batch.Reset()
+
+	// Step into the future and delete and dangling side chains
+	if frozen > 0 {
+		tip := frozen
+		nfdb := &nofreezedb{KeyValueStore: db}
+		for len(dangling) > 0 {
+			drop := make(map[common.Hash]struct{})
+			for _, hash := range dangling {
+				log.Debug("Dangling parent from freezer", "number", tip-1, "hash", hash)
+				drop[hash] = struct{}{}
+			}
+			children := ReadAllHashes(db, tip)
+			for i := 0; i < len(children); i++ {
+				// Dig up the child and ensure it's dangling
+				child := ReadHeader(nfdb, children[i], tip)
+				if child == nil {
+					log.Error("Missing dangling header", "number", tip, "hash", children[i])
+					continue
+				}
+				if _, ok := drop[child.ParentHash]; !ok {
+					children = append(children[:i], children[i+1:]...)
+					i--
+					continue
+				}
+				// Delete all block data associated with the child
+				log.Debug("Deleting dangling block", "number", tip, "hash", children[i], "parent", child.ParentHash)
+				DeleteBlock(batch, children[i], tip)
+			}
+			dangling = children
+			tip++
+		}
+		if err := batch.Write(); err != nil {
+			log.Crit("Failed to delete dangling side blocks", "err", err)
+		}
+	}
+
+	// Log something friendly for the user
+	context := []interface{}{
+		"blocks", frozen - first, "elapsed", common.PrettyDuration(time.Since(start)), "number", frozen - 1,
+	}
+	if n := len(ancients); n > 0 {
+		context = append(context, []interface{}{"hash", ancients[n-1]}...)
+	}
+	log.Info("Deep froze chain segment", context...)
+
+	// Avoid database thrashing with tiny writes
+	if frozen-first < freezerBatchLimit {
+		return true
+	}
+
+	return false
 }

--- a/core/rawdb/nodatafreezer.go
+++ b/core/rawdb/nodatafreezer.go
@@ -59,18 +59,11 @@ func newNoDataFreezer(datadir string, db ethdb.KeyValueStore) (*nodatafreezer, e
 }
 
 // repair init frozen , compatible disk-ancientdb and pruner-block-tool.
-func (f *nodatafreezer) repair(datadir string) error {	
-	currentOffset := ReadOffSetOfCurrentAncientFreezer(f.db)
-	lastOffset := ReadOffSetOfLastAncientFreezer(f.db)
+func (f *nodatafreezer) repair(datadir string) error {
+	// compatible prune-block-tool
+	offset := ReadOffSetOfCurrentAncientFreezer(f.db)
 
-	var offset uint64
-	if currentOffset > lastOffset {
-		atomic.StoreUint64(&f.frozen, currentOffset)
-		offset = currentOffset
-	} else {
-		offset = lastOffset
-	}
-	
+	// compatible freezer
 	min := uint64(math.MaxUint64)
 	for name, disableSnappy := range FreezerNoSnappy {
 		table, err := NewFreezerTable(datadir, name, disableSnappy)

--- a/core/rawdb/nodatafreezer.go
+++ b/core/rawdb/nodatafreezer.go
@@ -38,7 +38,7 @@ func newNoDataFreezer(datadir string, db ethdb.KeyValueStore) (*nodatafreezer, e
 		}
 	}
 
-	lock, _, err := fileutil.Flock(filepath.Join(datadir, "NODATA_ANCIENT_FLOCK"))
+	lock, _, err := fileutil.Flock(filepath.Join(datadir, "../NODATA_ANCIENT_FLOCK"))
 	if err != nil {
 		return nil, err
 	} 
@@ -59,13 +59,7 @@ func newNoDataFreezer(datadir string, db ethdb.KeyValueStore) (*nodatafreezer, e
 }
 
 // repair init frozen , compatible disk-ancientdb and pruner-block-tool.
-func (f *nodatafreezer) repair(datadir string) error {
-	if frozen := ReadFrozenOfAncientFreezer(f.db); frozen != 0 {
-		atomic.StoreUint64(&f.frozen, frozen)
-		return nil
-	}
-
-	
+func (f *nodatafreezer) repair(datadir string) error {	
 	currentOffset := ReadOffSetOfCurrentAncientFreezer(f.db)
 	lastOffset := ReadOffSetOfLastAncientFreezer(f.db)
 
@@ -90,6 +84,10 @@ func (f *nodatafreezer) repair(datadir string) error {
 		table.Close()
 	}
 	offset += min
+
+	if frozen := ReadFrozenOfAncientFreezer(f.db); frozen > offset {
+		offset = frozen
+	}
 
 	atomic.StoreUint64(&f.frozen, offset)
 	if err := f.Sync(); err != nil {
@@ -163,6 +161,11 @@ func (f *nodatafreezer) AppendAncient(number uint64, hash, header, body, receipt
 
 // TruncateAncients discards any recent data above the provided threshold number, always success.
 func (f *nodatafreezer) TruncateAncients(items uint64) error {
+	if atomic.LoadUint64(&f.frozen) <= items {
+		return nil
+	}
+	atomic.StoreUint64(&f.frozen, items)
+	WriteFrozenOfAncientFreezer(f.db, atomic.LoadUint64(&f.frozen))
 	return nil
 }
 

--- a/core/rawdb/nodatafreezer.go
+++ b/core/rawdb/nodatafreezer.go
@@ -1,0 +1,239 @@
+package rawdb
+
+import (
+	"os"
+	"math"
+	"sync"
+	"time"
+	"sync/atomic"
+	"path/filepath"
+	
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/prometheus/tsdb/fileutil"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+type nodatafreezer struct {
+	db 			ethdb.KeyValueStore 	// Meta database
+	frozen    	uint64 					// Number of next frozen block
+	threshold 	uint64					// Number of recent blocks not to freeze (params.FullImmutabilityThreshold apart from tests)
+
+	instanceLock 	fileutil.Releaser        // File-system lock to prevent double opens
+	quit 			chan struct{}
+	closeOnce 		sync.Once
+}
+
+func newNoDataFreezer(datadir string, db ethdb.KeyValueStore) (*nodatafreezer, error) {
+	if info, err := os.Lstat(datadir); !os.IsNotExist(err) {
+		if info.Mode()&os.ModeSymlink != 0 {
+			log.Warn("Symbolic link ancient database is not supported", "path", datadir)
+			return nil, errSymlinkDatadir
+		}
+	}
+
+	lock, _, err := fileutil.Flock(filepath.Join(datadir, "NODATA_ANCIENT_FLOCK"))
+	if err != nil {
+		return nil, err
+	} 
+	
+	freezer := &nodatafreezer{
+		db 			: db,
+		threshold 	: params.FullImmutabilityThreshold,
+		instanceLock: lock,
+		quit 		: make(chan struct{}),
+	}
+
+	if err := freezer.repair(datadir); err != nil {
+		return nil, err
+	}
+	
+	log.Info("Opened ancientdb with nodata mode", "database", datadir, "frozen", freezer.frozen)
+	return freezer, nil
+}
+
+
+func (f *nodatafreezer) repair(datadir string) error {
+	if frozen := ReadFrozenOfAncientFreezer(f.db); frozen != 0 {
+		atomic.StoreUint64(&f.frozen, frozen)
+		return nil
+	}
+
+	
+	currentOffset := ReadOffSetOfCurrentAncientFreezer(f.db)
+	lastOffset := ReadOffSetOfLastAncientFreezer(f.db)
+
+	var offset uint64
+	if currentOffset > lastOffset {
+		atomic.StoreUint64(&f.frozen, currentOffset)
+		offset = currentOffset
+	} else {
+		offset = lastOffset
+	}
+	
+	min := uint64(math.MaxUint64)
+	for name, disableSnappy := range FreezerNoSnappy {
+		table, err := NewFreezerTable(datadir, name, disableSnappy)
+		if err != nil {
+			return err
+		}
+		items := atomic.LoadUint64(&table.items)
+		if min > items {
+			min = items
+		}
+		table.Close()
+	}
+	offset += min
+
+	atomic.StoreUint64(&f.frozen, offset)
+	if err := f.Sync(); err != nil {
+		return nil
+	}
+	return nil
+}
+
+func (f *nodatafreezer) Close() error {
+	var err error
+	f.closeOnce.Do(func() {
+		close(f.quit)
+		f.Sync()
+		err = f.instanceLock.Release()
+	})
+	return err
+}
+
+func (f *nodatafreezer) HasAncient(kind string, number uint64) (bool, error) {
+	return false, nil
+}
+
+func (f *nodatafreezer) Ancient(kind string, number uint64) ([]byte, error) {
+	if _, ok := FreezerNoSnappy[kind]; ok {
+		if number >= atomic.LoadUint64(&f.frozen) {
+			return nil, errOutOfBounds
+		}
+		return nil, nil
+	}
+	return nil, errUnknownTable
+}
+
+func (f *nodatafreezer) Ancients() (uint64, error) {
+	return atomic.LoadUint64(&f.frozen), nil
+}
+
+func (f *nodatafreezer) ItemAmountInAncient() (uint64, error) {
+	return 0, nil
+}
+
+func (f *nodatafreezer) AncientOffSet() uint64 {
+	return atomic.LoadUint64(&f.frozen)
+}
+
+func (f *nodatafreezer) AncientSize(kind string) (uint64, error) {
+	if _, ok := FreezerNoSnappy[kind]; ok {
+		return 0, nil
+	}
+	return 0, errUnknownTable
+}
+
+func (f *nodatafreezer) AppendAncient(number uint64, hash, header, body, receipts, td []byte) (err error) {
+	if atomic.LoadUint64(&f.frozen) != number {
+		return errOutOrderInsertion
+	}
+	atomic.AddUint64(&f.frozen, 1)
+	return nil
+}
+
+func (f *nodatafreezer) TruncateAncients(items uint64) error {
+	return nil
+}
+
+func (f *nodatafreezer) Sync() error {
+	WriteFrozenOfAncientFreezer(f.db, atomic.LoadUint64(&f.frozen))
+	return nil
+}
+
+func (f *nodatafreezer) freeze() {
+	nfdb := &nofreezedb{KeyValueStore: f.db}
+
+	var (
+		backoff   bool
+	)
+	for {
+		select {
+		case <-f.quit:
+			log.Info("Freezer shutting down")
+			return
+		default:
+		}
+		if backoff {
+			select {
+			case <-time.NewTimer(freezerRecheckInterval).C:
+				backoff = false
+			case <-f.quit:
+				return
+			}
+		}
+		// Retrieve the freezing threshold.
+		hash := ReadHeadBlockHash(nfdb)
+		if hash == (common.Hash{}) {
+			log.Debug("Current full block hash unavailable") // new chain, empty database
+			backoff = true
+			continue
+		}
+		number := ReadHeaderNumber(nfdb, hash)
+		threshold := atomic.LoadUint64(&f.threshold)
+
+		switch {
+		case number == nil:
+			log.Error("Current full block number unavailable", "hash", hash)
+			backoff = true
+			continue
+
+		case *number < threshold:
+			log.Debug("Current full block not old enough", "number", *number, "hash", hash, "delay", threshold)
+			backoff = true
+			continue
+
+		case *number-threshold <= f.frozen:
+			log.Debug("Ancient blocks frozen already", "number", *number, "hash", hash, "frozen", f.frozen)
+			backoff = true
+			continue
+		}
+		head := ReadHeader(nfdb, hash, *number)
+		if head == nil {
+			log.Error("Current full block unavailable", "number", *number, "hash", hash)
+			backoff = true
+			continue
+		}
+		// Seems we have data ready to be frozen, process in usable batches
+		limit := *number - threshold
+		if limit-f.frozen > freezerBatchLimit {
+			limit = f.frozen + freezerBatchLimit
+		}
+		var (
+			start    = time.Now()
+			first    = f.frozen
+			ancients = make([]common.Hash, 0, limit-f.frozen)
+		)
+		for f.frozen <= limit {
+			// Retrieves all the components of the canonical block
+			hash := ReadCanonicalHash(nfdb, f.frozen)
+			if hash == (common.Hash{}) {
+				log.Error("Canonical hash missing, can't freeze", "number", f.frozen)
+				break
+			}
+			log.Trace("Deep froze ancient block", "number", f.frozen, "hash", hash)
+			// Inject all the components into the relevant data tables
+			if err := f.AppendAncient(f.frozen, nil, nil, nil, nil, nil); err != nil {
+				break
+			}
+			ancients = append(ancients, hash)
+		}
+		// Batch of blocks have been frozen, flush them before wiping from leveldb
+		if err := f.Sync(); err != nil {
+			log.Crit("Failed to flush frozen tables", "err", err)
+		}
+		backoff = gcKvStore(f.db, ancients, first, f.frozen, start)
+	}
+}

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -75,6 +75,9 @@ var (
 	//offSet of the ancientDB before updated version.
 	offSetOfLastAncientFreezer = []byte("offSetOfLastAncientFreezer")
 
+	//frozenOfAncientDBKey tracks the block number for ancientDB to save.
+	frozenOfAncientDBKey = []byte("FrozenOfAncientDB")
+
 	// badBlockKey tracks the list of bad blocks seen by local
 	badBlockKey = []byte("InvalidBlock")
 

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -258,7 +258,7 @@ func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, sta
 
 func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace string, readonly, interrupt bool) error {
 	// Open old db wrapper.
-	chainDb, err := p.node.OpenDatabaseWithFreezer(name, cache, handles, p.oldAncientPath, namespace, readonly, true, interrupt)
+	chainDb, err := p.node.OpenDatabaseWithFreezer(name, cache, handles, p.oldAncientPath, namespace, readonly, true, interrupt, false)
 	if err != nil {
 		log.Error("Failed to open ancient database", "err=", err)
 		return err

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -130,7 +130,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 
 	// Assemble the Ethereum object
 	chainDb, err := stack.OpenAndMergeDatabase("chaindata", config.DatabaseCache, config.DatabaseHandles,
-		config.DatabaseFreezer, config.DatabaseDiff, "eth/db/chaindata/", false, config.PersistDiff)
+		config.DatabaseFreezer, config.DatabaseDiff, "eth/db/chaindata/", false, config.PersistDiff, config.DelAncientData)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -81,6 +81,7 @@ var Defaults = Config{
 	TriesInMemory:           128,
 	SnapshotCache:           102,
 	DiffBlock:               uint64(86400),
+	DelAncientData: 		 false,
 	Miner: miner.Config{
 		GasFloor:      8000000,
 		GasCeil:       8000000,
@@ -167,6 +168,7 @@ type Config struct {
 	DatabaseDiff       string
 	PersistDiff        bool
 	DiffBlock          uint64
+	DelAncientData 	   bool
 
 	TrieCleanCache          int
 	TrieCleanCacheJournal   string        `toml:",omitempty"` // Disk journal directory for trie cache to survive node restarts

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -81,7 +81,6 @@ var Defaults = Config{
 	TriesInMemory:           128,
 	SnapshotCache:           102,
 	DiffBlock:               uint64(86400),
-	DelAncientData: 		 false,
 	Miner: miner.Config{
 		GasFloor:      8000000,
 		GasCeil:       8000000,
@@ -168,7 +167,7 @@ type Config struct {
 	DatabaseDiff       string
 	PersistDiff        bool
 	DiffBlock          uint64
-	DelAncientData 	   bool
+	DelAncientData     bool
 
 	TrieCleanCache          int
 	TrieCleanCacheJournal   string        `toml:",omitempty"` // Disk journal directory for trie cache to survive node restarts

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -52,6 +52,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		Preimages               bool
 		PersistDiff             bool
 		DiffBlock               uint64 `toml:",omitempty"`
+		DelAncientData          bool
 		Miner                   miner.Config
 		Ethash                  ethash.Config
 		TxPool                  core.TxPoolConfig
@@ -100,6 +101,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.Preimages = c.Preimages
 	enc.PersistDiff = c.PersistDiff
 	enc.DiffBlock = c.DiffBlock
+	enc.DelAncientData = c.DelAncientData
 	enc.Miner = c.Miner
 	enc.Ethash = c.Ethash
 	enc.TxPool = c.TxPool
@@ -145,6 +147,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		DatabaseDiff            *string
 		PersistDiff             *bool
 		DiffBlock               *uint64 `toml:",omitempty"`
+		DelAncientData          *bool
 		TrieCleanCache          *int
 		TrieCleanCacheJournal   *string        `toml:",omitempty"`
 		TrieCleanCacheRejournal *time.Duration `toml:",omitempty"`
@@ -247,6 +250,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.DiffBlock != nil {
 		c.DiffBlock = *dec.DiffBlock
+	}
+	if dec.DelAncientData != nil {
+		c.DelAncientData = *dec.DelAncientData
 	}
 	if dec.TrieCleanCache != nil {
 		c.TrieCleanCache = *dec.TrieCleanCache

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -74,6 +74,9 @@ func (eth *Ethereum) stateAtBlock(block *types.Block, reexec uint64, base *state
 		// The optional base statedb is given, mark the start point as parent block
 		statedb, database, report = base, base.Database(), false
 		current = eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
+		if current == nil {
+			return nil, fmt.Errorf("missing parent block %v %d", block.ParentHash(), block.NumberU64()-1)
+		}
 	} else {
 		// Otherwise try to reexec blocks until we find a state or reach our limit
 		current = block

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1774,9 +1774,15 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceiptsByBlockNumber(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	if receipts == nil {
+		return nil, fmt.Errorf("block %d receipts not found", blockNumber)
+	}
 	block, err := s.b.BlockByHash(ctx, blockHash)
 	if err != nil {
 		return nil, err
+	}
+	if block == nil {
+		return nil, fmt.Errorf("block %d not found", blockNumber)
 	}
 	txs := block.Transactions()
 	if len(txs) != len(receipts) {

--- a/node/node.go
+++ b/node/node.go
@@ -582,7 +582,7 @@ func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, r
 	return db, err
 }
 
-func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, diff, namespace string, readonly, persistDiff , noAncientData bool) (ethdb.Database, error) {
+func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, diff, namespace string, readonly, persistDiff, noAncientData bool) (ethdb.Database, error) {
 	chainDataHandles := handles
 	if persistDiff {
 		chainDataHandles = handles * chainDataHandlesPercentage / 100

--- a/node/node.go
+++ b/node/node.go
@@ -582,12 +582,12 @@ func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, r
 	return db, err
 }
 
-func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, diff, namespace string, readonly, persistDiff bool) (ethdb.Database, error) {
+func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, diff, namespace string, readonly, persistDiff , noAncientData bool) (ethdb.Database, error) {
 	chainDataHandles := handles
 	if persistDiff {
 		chainDataHandles = handles * chainDataHandlesPercentage / 100
 	}
-	chainDB, err := n.OpenDatabaseWithFreezer(name, cache, chainDataHandles, freezer, namespace, readonly, false, false)
+	chainDB, err := n.OpenDatabaseWithFreezer(name, cache, chainDataHandles, freezer, namespace, readonly, false, false, noAncientData)
 	if err != nil {
 		return nil, err
 	}
@@ -607,7 +607,7 @@ func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, di
 // also attaching a chain freezer to it that moves ancient chain data from the
 // database to immutable append-only files. If the node is an ephemeral one, a
 // memory database is returned.
-func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly, disableFreeze, isLastOffset bool) (ethdb.Database, error) {
+func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly, disableFreeze, isLastOffset, noAncientData bool) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 	if n.state == closedState {
@@ -626,7 +626,7 @@ func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer,
 		case !filepath.IsAbs(freezer):
 			freezer = n.ResolvePath(freezer)
 		}
-		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly, disableFreeze, isLastOffset)
+		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly, disableFreeze, isLastOffset, noAncientData)
 	}
 
 	if err == nil {


### PR DESCRIPTION
### Description

Block Data no longer transfer to AncientDB when delete from KVStore.
Save more os resources, disk space, disk bandwidth, cpu.

### Rationale

Release more disk space, disk bandwidth resources.

### Example

"./geth" start command add "--keepfixedblocks" parameter

### Changes

Notable changes: 
* add nodatafreezer struct inherit AncientStore interface, implement not save to AncientDB when delete from KVStore
* fix puner-block tool bug, “Failed to decode block body” error when restart
