### PR TITLE
[R4R]Prefetch state data on mining process

### DIFF
--- a/core/gaspool.go
+++ b/core/gaspool.go
@@ -27,9 +27,6 @@ type GasPool uint64
 
 // SetGas set an initial value for gaspool
 func (gp *GasPool) SetGas(amount uint64) *GasPool {
-	if amount > math.MaxUint64 {
-		panic("gas pool pushed above uint64")
-	}
 	*(*uint64)(gp) = amount
 	return gp
 }

--- a/core/gaspool.go
+++ b/core/gaspool.go
@@ -25,12 +25,6 @@ import (
 // in a block. The zero value is a pool with zero gas available.
 type GasPool uint64
 
-// SetGas set an initial value for gaspool
-func (gp *GasPool) SetGas(amount uint64) *GasPool {
-	*(*uint64)(gp) = amount
-	return gp
-}
-
 // AddGas makes gas available for execution.
 func (gp *GasPool) AddGas(amount uint64) *GasPool {
 	if uint64(*gp) > math.MaxUint64-amount {

--- a/core/gaspool.go
+++ b/core/gaspool.go
@@ -25,6 +25,15 @@ import (
 // in a block. The zero value is a pool with zero gas available.
 type GasPool uint64
 
+// SetGas set an initial value for gaspool
+func (gp *GasPool) SetGas(amount uint64) *GasPool {
+	if amount > math.MaxUint64 {
+		panic("gas pool pushed above uint64")
+	}
+	*(*uint64)(gp) = amount
+	return gp
+}
+
 // AddGas makes gas available for execution.
 func (gp *GasPool) AddGas(amount uint64) *GasPool {
 	if uint64(*gp) > math.MaxUint64-amount {

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -27,6 +27,7 @@ import (
 )
 
 const prefetchThread = 2
+const checkInterval = 10
 
 // statePrefetcher is a basic Prefetcher, which blindly executes a block on top
 // of an arbitrary state with the goal of prefetching potentially useful state
@@ -133,7 +134,7 @@ func (p *statePrefetcher) PrefetchMining(txs *types.TransactionsByPriceAndNonce,
 				return
 			default:
 			}
-			if count++; count%10 == 0 {
+			if count++; count%checkInterval == 0 {
 				if *txCurr == nil {
 					return
 				}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -108,7 +108,7 @@ func (p *statePrefetcher) PrefetchMining(txs *types.TransactionsByPriceAndNonce,
 				select {
 				case tx := <-startCh:
 					// Convert the transaction into an executable message and pre-cache its sender
-					msg, err := tx.AsMessagePrefetch(signer)
+					msg, err := tx.AsMessageNoNonceCheck(signer)
 					if err != nil {
 						return // Also invalid block, bail out
 					}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -108,14 +108,14 @@ func (p *statePrefetcher) PrefetchMining(txs *types.TransactionsByPriceAndNonce,
 				select {
 				case tx := <-txCh:
 					// Convert the transaction into an executable message and pre-cache its sender
-					msg, err := tx.AsMessage(signer)
+					msg, err := tx.AsMessagePrefetch(signer)
 					if err != nil {
 						return // Also invalid block, bail out
 					}
 					idx++
 					newStatedb.Prepare(tx.Hash(), header.Hash(), idx)
 					precacheTransaction(msg, p.config, gaspool, newStatedb, header, evm)
-					gaspool.SetGas(gasLimit)
+					gaspool = new(GasPool).AddGas(gasLimit)
 				case <-stopCh:
 					return
 				}

--- a/core/types.go
+++ b/core/types.go
@@ -40,6 +40,8 @@ type Prefetcher interface {
 	// the transaction messages using the statedb, but any changes are discarded. The
 	// only goal is to pre-cache transaction signatures and state trie nodes.
 	Prefetch(block *types.Block, statedb *state.StateDB, cfg vm.Config, interrupt *uint32)
+	// PrefetchMining used for pre-caching transaction signatures and state trie nodes. Only used for mining stage.
+	PrefetchMining(txs *types.TransactionsByPriceAndNonce, header *types.Header, gasLimit uint64, statedb *state.StateDB, cfg vm.Config, interruptCh <-chan struct{}, txCurr **types.Transaction)
 }
 
 // Processor is an interface for processing blocks using a given initial state.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -591,7 +591,9 @@ func (tx *Transaction) AsMessage(s Signer) (Message, error) {
 // AsMessageNoNonceCheck returns the transaction with checkNonce field set to be false.
 func (tx *Transaction) AsMessageNoNonceCheck(s Signer) (Message, error) {
 	msg, err := tx.AsMessage(s)
-	msg.checkNonce = false
+	if err == nil {
+		msg.checkNonce = false
+	}
 	return msg, err
 }
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -503,7 +503,7 @@ func (t *TransactionsByPriceAndNonce) CurrentSize() int {
 	return len(t.heads)
 }
 
-//Forward move t to be one index after tx
+//Forward moves current transaction to be the one which is one index after tx
 func (t *TransactionsByPriceAndNonce) Forward(tx *Transaction) {
 	if tx == nil {
 		t.heads = t.heads[0:0]

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -458,7 +458,7 @@ func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transa
 	}
 }
 
-// Copy copy a new TransactionsPriceAndNonce with the same *transaction
+// Copy copys a new TransactionsPriceAndNonce with the same *transaction
 func (t *TransactionsByPriceAndNonce) Copy() *TransactionsByPriceAndNonce {
 	heads := make([]*Transaction, len(t.heads))
 	copy(heads, t.heads)
@@ -505,6 +505,10 @@ func (t *TransactionsByPriceAndNonce) CurrentSize() int {
 
 //Forward move t to be one index behind tx, param tx cant be nil
 func (t *TransactionsByPriceAndNonce) Forward(tx *Transaction) {
+	if tx == nil {
+		t.heads = t.heads[0:0]
+		return
+	}
 	//get the sender address of tx
 	acc, _ := Sender(t.signer, tx)
 	for _, head := range t.heads {
@@ -583,6 +587,24 @@ func (tx *Transaction) AsMessage(s Signer) (Message, error) {
 	var err error
 	msg.from, err = Sender(s, tx)
 	return msg, err
+}
+
+func (tx *Transaction) AsMessagePrefetch(s Signer) (Message, error) {
+	msg := Message{
+		nonce:      tx.Nonce(),
+		gasLimit:   tx.Gas(),
+		gasPrice:   new(big.Int).Set(tx.GasPrice()),
+		to:         tx.To(),
+		amount:     tx.Value(),
+		data:       tx.Data(),
+		accessList: tx.AccessList(),
+		checkNonce: false,
+	}
+
+	var err error
+	msg.from, err = Sender(s, tx)
+	return msg, err
+
 }
 
 func (m Message) From() common.Address   { return m.from }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -588,7 +588,8 @@ func (tx *Transaction) AsMessage(s Signer) (Message, error) {
 	return msg, err
 }
 
-func (tx *Transaction) AsMessagePrefetch(s Signer) (Message, error) {
+// AsMessageNoNonceCheck returns the transaction with checkNonce field set to be false.
+func (tx *Transaction) AsMessageNoNonceCheck(s Signer) (Message, error) {
 	msg := Message{
 		nonce:      tx.Nonce(),
 		gasLimit:   tx.Gas(),
@@ -603,7 +604,6 @@ func (tx *Transaction) AsMessagePrefetch(s Signer) (Message, error) {
 	var err error
 	msg.from, err = Sender(s, tx)
 	return msg, err
-
 }
 
 func (m Message) From() common.Address   { return m.from }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -503,23 +503,13 @@ func (t *TransactionsByPriceAndNonce) CurrentSize() int {
 	return len(t.heads)
 }
 
-//Forward move t to be one index behind tx, tx cant be nil
+//Forward move t to be one index behind tx, param tx cant be nil
 func (t *TransactionsByPriceAndNonce) Forward(tx *Transaction) {
-	if tx == nil {
-		txTmp := t.Peek()
-		for txTmp != nil {
-			t.Shift()
-			txTmp = t.Peek()
-		}
-		return
-	}
-
-	l := len(t.heads)
 	acc, _ := Sender(t.signer, tx)
-	for i := 0; i < l; i++ {
-		accTmp, _ := Sender(t.signer, t.heads[i])
+	for _, head := range t.heads {
+		accTmp, _ := Sender(t.signer, head)
 		if acc == accTmp {
-			if tx == t.heads[i] {
+			if tx == head {
 				txTmp := t.Peek()
 				for txTmp != tx {
 					t.Shift()

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -505,11 +505,14 @@ func (t *TransactionsByPriceAndNonce) CurrentSize() int {
 
 //Forward move t to be one index behind tx, param tx cant be nil
 func (t *TransactionsByPriceAndNonce) Forward(tx *Transaction) {
+	//get the sender address of tx
 	acc, _ := Sender(t.signer, tx)
 	for _, head := range t.heads {
 		accTmp, _ := Sender(t.signer, head)
 		if acc == accTmp {
+			//found element in t.headers euqals to tx which means they point to the same transaction
 			if tx == head {
+				//shift t to the position one after tx
 				txTmp := t.Peek()
 				for txTmp != tx {
 					t.Shift()
@@ -519,6 +522,7 @@ func (t *TransactionsByPriceAndNonce) Forward(tx *Transaction) {
 				return
 			}
 			for _, txTmp := range t.txs[accTmp] {
+				//found the same pointer in t.txs as tx and then shift t to the position one after tx
 				if txTmp == tx {
 					txTmp = t.Peek()
 					for txTmp != tx {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -590,19 +590,8 @@ func (tx *Transaction) AsMessage(s Signer) (Message, error) {
 
 // AsMessageNoNonceCheck returns the transaction with checkNonce field set to be false.
 func (tx *Transaction) AsMessageNoNonceCheck(s Signer) (Message, error) {
-	msg := Message{
-		nonce:      tx.Nonce(),
-		gasLimit:   tx.Gas(),
-		gasPrice:   new(big.Int).Set(tx.GasPrice()),
-		to:         tx.To(),
-		amount:     tx.Value(),
-		data:       tx.Data(),
-		accessList: tx.AccessList(),
-		checkNonce: false,
-	}
-
-	var err error
-	msg.from, err = Sender(s, tx)
+	msg, err := tx.AsMessage(s)
+	msg.checkNonce = false
 	return msg, err
 }
 

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -358,6 +358,75 @@ func TestTransactionTimeSort(t *testing.T) {
 	}
 }
 
+func TestTransactionForward(t *testing.T) {
+	// Generate a batch of accounts to start with
+	keys := make([]*ecdsa.PrivateKey, 5)
+	for i := 0; i < len(keys); i++ {
+		keys[i], _ = crypto.GenerateKey()
+	}
+	signer := HomesteadSigner{}
+
+	// Generate a batch of transactions with overlapping prices, but different creation times
+	groups := map[common.Address]Transactions{}
+	for start, key := range keys {
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+
+		tx, _ := SignTx(NewTransaction(0, common.Address{}, big.NewInt(100), 100, big.NewInt(1), nil), signer, key)
+		tx2, _ := SignTx(NewTransaction(1, common.Address{}, big.NewInt(100), 100, big.NewInt(1), nil), signer, key)
+
+		tx.time = time.Unix(0, int64(len(keys)-start))
+		tx2.time = time.Unix(1, int64(len(keys)-start))
+
+		groups[addr] = append(groups[addr], tx)
+		groups[addr] = append(groups[addr], tx2)
+
+	}
+	// Sort the transactions
+	txset := NewTransactionsByPriceAndNonce(signer, groups)
+	txsetCpy := txset.Copy()
+
+	txs := Transactions{}
+	for tx := txsetCpy.Peek(); tx != nil; tx = txsetCpy.Peek() {
+		txs = append(txs, tx)
+		txsetCpy.Shift()
+	}
+
+	tmp := txset.Copy()
+	for j := 0; j < 10; j++ {
+		txset = tmp.Copy()
+		txsetCpy = tmp.Copy()
+		i := 0
+		for ; i < j; i++ {
+			txset.Shift()
+		}
+		tx := txset.Peek()
+		txsetCpy.Forward(tx)
+		txCpy := txsetCpy.Peek()
+		if txCpy == nil {
+			if tx == nil {
+				continue
+			}
+			txset.Shift()
+			if txset.Peek() != nil {
+				t.Errorf("forward got an incorrect result, got %v, want %v", txCpy, tx)
+			} else {
+				continue
+			}
+		}
+		txset.Shift()
+		for ; i < len(txs)-1; i++ {
+			tx = txset.Peek()
+			txCpy = txsetCpy.Peek()
+			if txCpy != tx {
+				t.Errorf("forward got an incorrect result, got %v, want %v", txCpy, tx)
+			}
+			txsetCpy.Shift()
+			txset.Shift()
+		}
+
+	}
+}
+
 // TestTransactionCoding tests serializing/de-serializing to/from rlp and JSON.
 func TestTransactionCoding(t *testing.T) {
 	key, err := crypto.GenerateKey()

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -780,7 +780,6 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 	}
 	bloomProcessors := core.NewAsyncReceiptBloomGenerator(processorCapacity)
 
-	//	var interruptPrefetch uint32
 	interruptCh := make(chan struct{})
 	defer close(interruptCh)
 	tx := &types.Transaction{}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -782,7 +782,8 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 
 	//	var interruptPrefetch uint32
 	interruptCh := make(chan struct{})
-	var txCurr **types.Transaction
+	var tx *types.Transaction
+	txCurr := &tx
 	//prefetch txs from all pending txs
 	txsPrefetch := txs.Copy()
 	w.prefetcher.PrefetchMining(txsPrefetch, w.current.header, w.current.gasPool.Gas(), w.current.state.Copy(), *w.chain.GetVMConfig(), interruptCh, txCurr)
@@ -824,8 +825,7 @@ LOOP:
 			}
 		}
 		// Retrieve the next transaction and abort if all done
-		tx := txs.Peek()
-		txCurr = &tx
+		tx = txs.Peek()
 		if tx == nil {
 			break
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -782,7 +782,8 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 
 	//	var interruptPrefetch uint32
 	interruptCh := make(chan struct{})
-	var tx *types.Transaction
+	defer close(interruptCh)
+	tx := &types.Transaction{}
 	txCurr := &tx
 	//prefetch txs from all pending txs
 	txsPrefetch := txs.Copy()
@@ -808,7 +809,6 @@ LOOP:
 					inc:   true,
 				}
 			}
-			close(interruptCh)
 			return atomic.LoadInt32(interrupt) == commitInterruptNewHead
 		}
 		// If we don't have enough gas for any further transactions then we're done
@@ -879,7 +879,6 @@ LOOP:
 			txs.Shift()
 		}
 	}
-	close(interruptCh)
 	bloomProcessors.Close()
 
 	if !w.isRunning() && len(coalescedLogs) > 0 {


### PR DESCRIPTION
### Description

When miner process mining work, there would be some hard disk access wich are quite time consuming processes.

### Rationale

- Add some prefetch routines to warm up touched data slots by apply transactions concurrently to the given individual state database copy.
![mining-prefetcher-design](https://user-images.githubusercontent.com/26671219/159983026-509c9cb5-59d7-40ef-9b69-e31c5984d14c.jpg)


### Changes

Notable changes:

- Modify `Prefetch` inteface so that it would be compatible with mining `prefetcher`
- Add `PrefetchMining` method for state_prefetcher just like `Prefetch` but a mining version