### PR TITLE
[R4R]fix code of difflayer not assgin before return

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1333,19 +1333,6 @@ func (s *StateDB) Commit(failPostCommitFunc func(), postCommitFuncs ...func() er
 				}()
 			}
 
-			if s.snap != nil {
-				for addr := range s.stateObjectsDirty {
-					if obj := s.stateObjects[addr]; !obj.deleted {
-						if obj.code != nil && obj.dirtyCode {
-							diffLayer.Codes = append(diffLayer.Codes, types.DiffCode{
-								Hash: common.BytesToHash(obj.CodeHash()),
-								Code: obj.code,
-							})
-						}
-					}
-				}
-			}
-
 			for addr := range s.stateObjectsDirty {
 				if obj := s.stateObjects[addr]; !obj.deleted {
 					// Write any contract code associated with the state object
@@ -1422,6 +1409,12 @@ func (s *StateDB) Commit(failPostCommitFunc func(), postCommitFuncs ...func() er
 					if obj.code != nil && obj.dirtyCode {
 						rawdb.WriteCode(codeWriter, common.BytesToHash(obj.CodeHash()), obj.code)
 						obj.dirtyCode = false
+						if s.snap != nil {
+							diffLayer.Codes = append(diffLayer.Codes, types.DiffCode{
+								Hash: common.BytesToHash(obj.CodeHash()),
+								Code: obj.code,
+							})
+						}
 						if codeWriter.ValueSize() > ethdb.IdealBatchSize {
 							if err := codeWriter.Write(); err != nil {
 								return err


### PR DESCRIPTION
### Description
Bugfix for diff layer may have nil code even there is a new smart contract created in the block.

### Rationale
The bug is introduced in pipecommit PR. 
When doing `Commit` of `StateDB`,  the difflayer is returned while the `commmitTrie` routine may assign the code of difflayer in the future.

This bug will impact the diff sync: difflayer may not contains the all changed codes.

### Example
No

### Changes
After this patch, the node can always get the same difflayers. 
