### PR TITLE
[R4R] skip verification on account storage root to tolerate with fastnode when doing diffsync

### DIFF
--- a/core/blockchain_diff_test.go
+++ b/core/blockchain_diff_test.go
@@ -314,6 +314,11 @@ func TestProcessDiffLayer(t *testing.T) {
 			if diff == nil {
 				continue
 			}
+			// change the storage root into emptyRoot
+			for idx, account := range diff.Accounts {
+				latestAccount, _ := snapshot.FullAccount(account.Blob)
+				diff.Accounts[idx].Blob = snapshot.SlimAccountRLP(latestAccount.Nonce, latestAccount.Balance, types.EmptyRootHash, latestAccount.CodeHash)
+			}
 			lightBackend.Chain().HandleDiffLayer(diff, "testpid", true)
 		}
 		_, err := lightBackend.chain.insertChain([]*types.Block{block}, true)


### PR DESCRIPTION
### Description
The developer proposes a fast node in these PR https://github.com/bnb-chain/bsc/pull/640.

And the fast node is adopted by many developers, there is some adaptive work to do to make fast node serve diffsync well.

### Rationale
A fast node is a node without  MPT(Merkle Patricia Tries, which means the account inside the generated difflayer will not have the correct `storageRoot`. 

Currently, diffsync will check the calculated `storageRoot` of each account against the `storageRoot` within the untrusted difflaayer.  While this is not necessary to guarantee the correctness of each account, since diffsync will verify the state root of the biggest account MPT, which already guarantees the data consistency. We will remove the redundant check in this PR to be compatible with fast node.
### Example
No API changes.

### Changes
No 
