### PR TITLE
[R4R]fix pruner block tool bug, add some check logic

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -278,7 +278,8 @@ func pruneBlock(ctx *cli.Context) error {
 	var newAncientPath string
 	oldAncientPath := ctx.GlobalString(utils.AncientFlag.Name)
 	if !filepath.IsAbs(oldAncientPath) {
-		oldAncientPath = stack.ResolvePath(oldAncientPath)
+		// force absolute paths, which often fail due to the splicing of relative paths
+		return errors.New("datadir.ancient not abs path")
 	}
 
 	path, _ := filepath.Split(oldAncientPath)

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -250,6 +250,9 @@ func (hc *HeaderChain) writeHeaders(headers []*types.Header) (result *headerWrit
 				headHeader = hc.GetHeader(headHash, headNumber)
 			)
 			for rawdb.ReadCanonicalHash(hc.chainDb, headNumber) != headHash {
+				if frozen, _ := hc.chainDb.Ancients(); frozen == headNumber {
+					break
+				}
 				rawdb.WriteCanonicalHash(markerBatch, headHash, headNumber)
 				headHash = headHeader.ParentHash
 				headNumber = headHeader.Number.Uint64() - 1

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -95,7 +95,10 @@ func iterateTransactions(db ethdb.Database, from uint64, to uint64, reverse bool
 		number uint64
 		rlp    rlp.RawValue
 	}
-	if to == from {
+	if offset := db.AncientOffSet(); offset > from {
+		from = offset
+	}
+	if to <= from {
 		return nil
 	}
 	threads := to - from

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -74,6 +74,9 @@ func (eth *Ethereum) stateAtBlock(block *types.Block, reexec uint64, base *state
 		// The optional base statedb is given, mark the start point as parent block
 		statedb, database, report = base, base.Database(), false
 		current = eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
+		if current == nil {
+			return nil, fmt.Errorf("missing parent block %v %d", block.ParentHash(), block.NumberU64()-1)
+		}
 	} else {
 		// Otherwise try to reexec blocks until we find a state or reach our limit
 		current = block

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1774,9 +1774,15 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceiptsByBlockNumber(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	if receipts == nil {
+		return nil, fmt.Errorf("block %d receipts not found", blockNumber)
+	}
 	block, err := s.b.BlockByHash(ctx, blockHash)
 	if err != nil {
 		return nil, err
+	}
+	if block == nil {
+		return nil, fmt.Errorf("block %d not found", blockNumber)
 	}
 	txs := block.Transactions()
 	if len(txs) != len(receipts) {


### PR DESCRIPTION
### Description

fix prune-block-tool bugs

### Rationale

fix bugs:
1. When the prune-block-tool  is executed, "Failed to decode block body" error may be reported due to txloopuplimit setting.
2. Added some verification logic, because some data related to the block may be deleted after the prune-block-tool is executed.
3. Force the input of ‘--datadir.ancient’ to be an absolute path. Many users always fail to execute because they are caught in the splicing of relative paths of ‘--datadir’ and ‘--datadir.ancient’

