### PR TITLE
change prefetch thread num

### DIFF
--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-const prefetchThread = 2
+const prefetchThread = 3
 const checkInterval = 10
 
 // statePrefetcher is a basic Prefetcher, which blindly executes a block on top


### PR DESCRIPTION
### Description

since the main thread has become faster after using sharedStorage , we need more prefetch thread num to make the prefetch is faster than main process.

### Rationale

After after adding some metric on prefetch therad ,   the metric shows that the prefetcher with two threads has 5-20% faster than main process while  prefetcher with three threads has become 20-40% faster than main process .

The yellow line is using 3 thread
<img width="728" alt="image" src="https://user-images.githubusercontent.com/19421226/161216810-b78b97d2-bb4a-4f66-a7e3-0527418e940a.png">

### Performance

The two test machine is on AWS , the two nodes has worked in fullsync mode and has caught up to the latest block

The cost of process a block show that the processing cost of main process with three prefetch threads  has become 3%-10% faster than two prefetch threads

<img width="701" alt="image" src="https://user-images.githubusercontent.com/19421226/161217727-dc0d1234-aa9e-437d-b641-9006a491bc7e.png">


Compare to the processing cost of main process prefetcher with 3 thread  and 4 thread ,  the cost of process a block is nearly same , so 3 thread is enough for prefetcher
<img width="702" alt="image" src="https://user-images.githubusercontent.com/19421226/161215869-2e9304e6-af81-4b0b-8e6a-fe46792fda1c.png">

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
