### PR TITLE
[R4R]fix deadlock on miner module when failed to commit trie

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1366,10 +1366,8 @@ func (s *StateDB) Commit(failPostCommitFunc func(), postCommitFuncs ...func() er
 					// Write any contract code associated with the state object
 					tasks <- func() {
 						// Write any storage changes in the state object to its storage trie
-						if err := obj.CommitTrie(s.db); err != nil {
-							taskResults <- err
-						}
-						taskResults <- nil
+						err := obj.CommitTrie(s.db)
+						taskResults <- err
 					}
 					tasksNum++
 				}


### PR DESCRIPTION
### Description
A possible deadlock when commit trie failed

### Rationale
A node stuck and failed to import any blocks, the go routine profile is:  [routine.txt](https://github.com/bnb-chain/bsc/files/8401973/routine.txt)

```
github.com/ethereum/go-ethereum/core/state.(*StateDB).Commit.func1.1(0x40eefc8fc0, 0x0, 0x420496c2f8, 0x1, 0x1, 0x572e056600a67eff, 0x99b123d0825edb78)
	/ext-go/1/src/github.com/ethereum/go-ethereum/core/state/statedb.go:1367 +0x2d4
github.com/ethereum/go-ethereum/core/state.(*StateDB).Commit.func1(0x0, 0x0)
	/ext-go/1/src/github.com/ethereum/go-ethereum/core/state/statedb.go:1413 +0x5c
github.com/ethereum/go-ethereum/core/state.(*StateDB).Commit.func4(0x429104c180, 0x4316b0ec80)
	/ext-go/1/src/github.com/ethereum/go-ethereum/core/state/statedb.go:1502 +0x28
created by github.com/ethereum/go-ethereum/core/state.(*StateDB).Commit
	/ext-go/1/src/github.com/ethereum/go-ethereum/core/state/statedb.go:1501 +0x200
```
<img width="772" alt="image" src="https://user-images.githubusercontent.com/7310198/161370724-faa9b5f8-0762-49ff-85d8-fa5a5d6a4ee5.png">

Blocked in sending task to `tasks` channel. 

The task itself will send response to `taskResults`, if `CommitTrie` failed, `taskResults` will get two signal, while the size of `taskResults` is `len(s.stateObjectsDirty)`, which will cause the routine blocked.


### Example
No
### Changes

No
