### PR TITLE
Fixed disconnect reason check

### DIFF
--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -89,7 +89,7 @@ var discReasonToString = [...]string{
 }
 
 func (d DiscReason) String() string {
-	if len(discReasonToString) < int(d) {
+	if len(discReasonToString) <= int(d) {
 		return fmt.Sprintf("unknown disconnect reason %d", d)
 	}
 	return discReasonToString[d]


### PR DESCRIPTION
### Description

To avoid a runtime error when the reason ID is equal to a length of discReasonToString (`runtime error: index out of range [17] with length 17`)

### Rationale

It crashes when it comes with reason ID = 17

### Example

`runtime error: index out of range [17] with length 17`

### Changes

Changed a comparison operator from `<` to `<=`