### PR TITLE
[R4R]Fix miningprefetcher

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -782,10 +782,10 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 
 	interruptCh := make(chan struct{})
 	defer close(interruptCh)
-	tx := &types.Transaction{}
-	txCurr := &tx
 	//prefetch txs from all pending txs
 	txsPrefetch := txs.Copy()
+	tx := txsPrefetch.Peek()
+	txCurr := &tx
 	w.prefetcher.PrefetchMining(txsPrefetch, w.current.header, w.current.gasPool.Gas(), w.current.state.Copy(), *w.chain.GetVMConfig(), interruptCh, txCurr)
 
 LOOP:


### PR DESCRIPTION
### Description

panic with nil pointer of `Transaction.inner`

### Rationale
If `PrefetchMining` run fast enough that sub-prefetcher-routines checked `txCurr` before transaction had been peeked from `TransactionByPriceAndNonce` at the main worker routine, it would get an empty `Transaction` struct with nil `inner` filed which would cause panic in `func (s EIP155Signer) Sender(tx *Transaction) (common.Address, error)`
<img width="676" alt="截屏2022-04-06 15 23 08" src="https://user-images.githubusercontent.com/26671219/161918690-9f5d0ef3-0fea-44de-974b-5103b745255a.png">


### Example

N/A

### Changes

Notable changes: 
* Instead of using empty `Transaction` for tx initialization, `Peek` the first `transaction` from `TransactionByPriceAndNonce` for current transaction `txCurr` at `miner/worker.go:line787` which would be accessed in mining-prefetcher-routine
