### PR TITLE
[R4R] prepare for release of v1.1.9

### DIFF
--- a/.github/release.env
+++ b/.github/release.env
@@ -1,2 +1,2 @@
-MAINNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.7/mainnet.zip"
-TESTNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.7/testnet.zip"
+MAINNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.8/mainnet.zip"
+TESTNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.8/testnet.zip"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ IMPROVEMENT
 * [\#792](https://github.com/binance-chain/bsc/pull/792) add shared storage for prefetching state data
 * [\#795](https://github.com/binance-chain/bsc/pull/795) implement state verification pipeline in pipecommit
 * [\#803](https://github.com/binance-chain/bsc/pull/803) prefetch state data during the mining process
-* [\#812](https://github.com/bnb-chain/bsc/pull/818) skip verification on account storage root to tolerate with fastnode when doing diffsync
+* [\#812](https://github.com/bnb-chain/bsc/pull/812) skip verification on account storage root to tolerate with fastnode when doing diffsync
 * [\#818](https://github.com/bnb-chain/bsc/pull/818) add shared storage to the prefetcher of miner
 * [\#820](https://github.com/bnb-chain/bsc/pull/820) disable diffsync when pipecommit is enabled
 * [\#830](https://github.com/bnb-chain/bsc/pull/830) change the number of prefetch threads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.1.9
+
+IMPROVEMENT
+* [\#792](https://github.com/binance-chain/bsc/pull/792) add shared storage for prefetching state data
+* [\#795](https://github.com/binance-chain/bsc/pull/795) implement state verification pipeline in pipecommit
+* [\#803](https://github.com/binance-chain/bsc/pull/803) prefetch state data during the mining process
+* [\#812](https://github.com/bnb-chain/bsc/pull/818) skip verification on account storage root to tolerate with fastnode when doing diffsync
+* [\#818](https://github.com/bnb-chain/bsc/pull/818) add shared storage to the prefetcher of miner
+* [\#820](https://github.com/bnb-chain/bsc/pull/820) disable diffsync when pipecommit is enabled
+* [\#830](https://github.com/bnb-chain/bsc/pull/830) change the number of prefetch threads
+
+BUGFIX
+* [\#797](https://github.com/bnb-chain/bsc/pull/797) fix race condition on preimage in pipecommit
+* [\#808](https://github.com/bnb-chain/bsc/pull/808) fix code of difflayer not assgin when new smart contract created
+* [\#817](https://github.com/bnb-chain/bsc/pull/817) fix bugs of prune block tool
+* [\#834](https://github.com/bnb-chain/bsc/pull/834) fix deadlock when failed to verify state root in pipecommit
+* [\#835](https://github.com/bnb-chain/bsc/pull/835) fix deadlock on miner module when failed to commit trie
+* [\#842](https://github.com/bnb-chain/bsc/pull/842) fix invalid nil check of statedb in diffsync
+
 ## v1.1.8
 FEATURES
 * [\#668](https://github.com/binance-chain/bsc/pull/668) implement State Verification && Snapshot Commit pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ IMPROVEMENT
 
 BUGFIX
 * [\#797](https://github.com/bnb-chain/bsc/pull/797) fix race condition on preimage in pipecommit
-* [\#808](https://github.com/bnb-chain/bsc/pull/808) fix code of difflayer not assgin when new smart contract created
+* [\#808](https://github.com/bnb-chain/bsc/pull/808) fix code of difflayer not assign when new smart contract created
 * [\#817](https://github.com/bnb-chain/bsc/pull/817) fix bugs of prune block tool
 * [\#834](https://github.com/bnb-chain/bsc/pull/834) fix deadlock when failed to verify state root in pipecommit
 * [\#835](https://github.com/bnb-chain/bsc/pull/835) fix deadlock on miner module when failed to commit trie

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 8  // Patch version component of the current release
+	VersionPatch = 9  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description

Prepare for the release v1.1.9.

### Rationale
IMPROVEMENT
* [\#792](https://github.com/binance-chain/bsc/pull/792) add shared storage for prefetching state data
* [\#795](https://github.com/binance-chain/bsc/pull/795) implement state verification pipeline in pipecommit
* [\#803](https://github.com/binance-chain/bsc/pull/803) prefetch state data during the mining process
* [\#812](https://github.com/bnb-chain/bsc/pull/818) skip verification on account storage root to tolerate with fastnode when doing diffsync
* [\#818](https://github.com/bnb-chain/bsc/pull/818) add shared storage to the prefetcher of miner
* [\#820](https://github.com/bnb-chain/bsc/pull/820) disable diffsync when pipecommit is enabled
* [\#830](https://github.com/bnb-chain/bsc/pull/830) change the number of prefetch threads

BUGFIX
* [\#797](https://github.com/bnb-chain/bsc/pull/797) fix race condition on preimage in pipecommit
* [\#808](https://github.com/bnb-chain/bsc/pull/808) fix code of difflayer not assign when new smart contract created
* [\#817](https://github.com/bnb-chain/bsc/pull/817) fix bugs of prune block tool
* [\#834](https://github.com/bnb-chain/bsc/pull/834) fix deadlock when failed to verify state root in pipecommit
* [\#835](https://github.com/bnb-chain/bsc/pull/835) fix deadlock on miner module when failed to commit trie
* [\#842](https://github.com/bnb-chain/bsc/pull/842) fix invalid nil check of statedb in diffsync

### Example

NA

### Changes
NA

