### PR TITLE
[R4R] fix:defer bloomprocessor close

### DIFF
--- a/core/receipt_processor.go
+++ b/core/receipt_processor.go
@@ -60,6 +60,9 @@ func (p *AsyncReceiptBloomGenerator) Apply(receipt *types.Receipt) {
 }
 
 func (p *AsyncReceiptBloomGenerator) Close() {
+	if _, ok := <-p.receipts; !ok {
+		return
+	}
 	close(p.receipts)
 	p.isClosed = true
 	p.wg.Wait()

--- a/core/receipt_processor.go
+++ b/core/receipt_processor.go
@@ -60,7 +60,7 @@ func (p *AsyncReceiptBloomGenerator) Apply(receipt *types.Receipt) {
 }
 
 func (p *AsyncReceiptBloomGenerator) Close() {
-	if _, ok := <-p.receipts; !ok {
+	if p.isClosed {
 		return
 	}
 	close(p.receipts)

--- a/core/receipt_processor.go
+++ b/core/receipt_processor.go
@@ -60,9 +60,6 @@ func (p *AsyncReceiptBloomGenerator) Apply(receipt *types.Receipt) {
 }
 
 func (p *AsyncReceiptBloomGenerator) Close() {
-	if p.isClosed {
-		return
-	}
 	close(p.receipts)
 	p.isClosed = true
 	p.wg.Wait()

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -403,6 +403,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 
 	// initilise bloom processors
 	bloomProcessors := NewAsyncReceiptBloomGenerator(txNum)
+	defer bloomProcessors.Close()
 	statedb.MarkFullProcessed()
 
 	// usually do have two tx, one for validator set contract, another for system reward contract.

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -403,7 +403,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 
 	// initilise bloom processors
 	bloomProcessors := NewAsyncReceiptBloomGenerator(txNum)
-	defer bloomProcessors.Close()
 	statedb.MarkFullProcessed()
 
 	// usually do have two tx, one for validator set contract, another for system reward contract.
@@ -411,6 +410,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	for i, tx := range block.Transactions() {
 		if isPoSA {
 			if isSystemTx, err := posa.IsSystemTransaction(tx, block.Header()); err != nil {
+				bloomProcessors.Close()
 				return statedb, nil, nil, 0, err
 			} else if isSystemTx {
 				systemTxs = append(systemTxs, tx)
@@ -420,11 +420,13 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 
 		msg, err := tx.AsMessage(signer)
 		if err != nil {
+			bloomProcessors.Close()
 			return statedb, nil, nil, 0, err
 		}
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
 		receipt, err := applyTransaction(msg, p.config, p.bc, nil, gp, statedb, header, tx, usedGas, vmenv, bloomProcessors)
 		if err != nil {
+			bloomProcessors.Close()
 			return statedb, nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
 


### PR DESCRIPTION
### Description

There's risk of memory leak for channel in `bloomProcessors` in `Process` when an early return happen.

### Rationale

We need to ensure closing channel (`bloomProcessors.Close()`) before return

### Example

N/A

### Changes

Notable changes: 
* user defer to make sure `bloomProcessors.Close()` be executed before `Process` return
* keep current `bloomProcessors.Close()` for efficiency.
