### PR TITLE
x = append(y) is equivalent to x = y

### DIFF
--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -188,7 +188,7 @@ func blockReceiptsKey(number uint64, hash common.Hash) []byte {
 
 // diffLayerKey = diffLayerKeyPrefix + hash
 func diffLayerKey(hash common.Hash) []byte {
-	return append(append(diffLayerPrefix, hash.Bytes()...))
+	return append(diffLayerPrefix, hash.Bytes()...)
 }
 
 // txLookupKey = txLookupPrefix + hash


### PR DESCRIPTION
I noticed this redundant operation.

So I removed the unnecessary append.

Less operation - faster node :)