### PR TITLE
[R4R]fix:Shift panic for zero length of heads

### DIFF
--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -127,6 +127,13 @@ func (p *statePrefetcher) PrefetchMining(txs *types.TransactionsByPriceAndNonce,
 	go func(txset *types.TransactionsByPriceAndNonce) {
 		count := 0
 		for {
+			if count++; count%checkInterval == 0 {
+				txTmp := *txCurr
+				if txTmp == nil {
+					return
+				}
+				txset.Forward(txTmp)
+			}
 			tx := txset.Peek()
 			if tx == nil {
 				return
@@ -135,13 +142,6 @@ func (p *statePrefetcher) PrefetchMining(txs *types.TransactionsByPriceAndNonce,
 			case <-interruptCh:
 				return
 			default:
-			}
-			if count++; count%checkInterval == 0 {
-				txTmp := *txCurr
-				if txTmp == nil {
-					return
-				}
-				txset.Forward(txTmp)
 			}
 			txCh <- tx
 			txset.Shift()

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -127,20 +127,21 @@ func (p *statePrefetcher) PrefetchMining(txs *types.TransactionsByPriceAndNonce,
 	go func(txset *types.TransactionsByPriceAndNonce) {
 		count := 0
 		for {
-			if count++; count%checkInterval == 0 {
-				txset.Forward(*txCurr)
-			}
-			tx := txset.Peek()
-			if tx == nil {
-				return
-			}
 			select {
 			case <-interruptCh:
 				return
 			default:
+				if count++; count%checkInterval == 0 {
+					txset.Forward(*txCurr)
+				}
+				tx := txset.Peek()
+				if tx == nil {
+					return
+				}
+				txCh <- tx
+				txset.Shift()
+
 			}
-			txCh <- tx
-			txset.Shift()
 		}
 	}(txs)
 }

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -137,10 +137,11 @@ func (p *statePrefetcher) PrefetchMining(txs *types.TransactionsByPriceAndNonce,
 			default:
 			}
 			if count++; count%checkInterval == 0 {
-				if *txCurr == nil {
+				txTmp := *txCurr
+				if txTmp == nil {
 					return
 				}
-				txset.Forward(*txCurr)
+				txset.Forward(txTmp)
 			}
 			txCh <- tx
 			txset.Shift()

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -128,11 +128,7 @@ func (p *statePrefetcher) PrefetchMining(txs *types.TransactionsByPriceAndNonce,
 		count := 0
 		for {
 			if count++; count%checkInterval == 0 {
-				txTmp := *txCurr
-				if txTmp == nil {
-					return
-				}
-				txset.Forward(txTmp)
+				txset.Forward(*txCurr)
 			}
 			tx := txset.Peek()
 			if tx == nil {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -505,10 +505,6 @@ func (t *TransactionsByPriceAndNonce) CurrentSize() int {
 
 //Forward moves current transaction to be the one which is one index after tx
 func (t *TransactionsByPriceAndNonce) Forward(tx *Transaction) {
-	if tx == nil {
-		t.heads = t.heads[0:0]
-		return
-	}
 	//check whether target tx exists in t.heads
 	for _, head := range t.heads {
 		if tx == head {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -505,6 +505,12 @@ func (t *TransactionsByPriceAndNonce) CurrentSize() int {
 
 //Forward moves current transaction to be the one which is one index after tx
 func (t *TransactionsByPriceAndNonce) Forward(tx *Transaction) {
+	if tx == nil {
+		if len(t.heads) > 0 {
+			t.heads = t.heads[0:0]
+		}
+		return
+	}
 	//check whether target tx exists in t.heads
 	for _, head := range t.heads {
 		if tx == head {

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -392,7 +392,7 @@ func TestTransactionForward(t *testing.T) {
 	}
 
 	tmp := txset.Copy()
-	for j := 0; j < 10; j++ {
+	for j := 0; j < 11; j++ {
 		txset = tmp.Copy()
 		txsetCpy = tmp.Copy()
 		i := 0
@@ -400,6 +400,9 @@ func TestTransactionForward(t *testing.T) {
 			txset.Shift()
 		}
 		tx := txset.Peek()
+		if tx == nil {
+			continue
+		}
 		txsetCpy.Forward(tx)
 		txCpy := txsetCpy.Peek()
 		if txCpy == nil {


### PR DESCRIPTION
### Description

panic when length of heads equal to zero when `shift`

### Rationale

- `TransactionsByPriceAndNonce.Shift` should only be called after `TransactionsByPriceAndNonce.Peek` directly and void invoke on `TransactionsByPriceAndNonce.Shift` when `Peek` show a nil result, otherwise might cause a panic for zero length `TransactionsByPriceAndNonce.heads` when doing `Shift`
- `func (p *statePrefetcher) PrefetchMining(...)` invoked `TransactionsByPriceAndNonce.Forward` before `TransactionsByPriceAndNonce.Shift` with no `TransactionsByPriceAndNoncePeek` check while `TransactionsByPriceAndNonce.Forward` might change `TransactionsByPriceAndNonce.heads` to zero length.
### Example

N/A

### Changes

Notable changes: 
* rearrange calling sequence in the dispatcher of `prefechmining`, make sure `Peek` be checked before `Shift`
    * `func (p *statePrefetcher) PrefetchMining(...)`
