### PR TITLE
[R4R] fix validator pipecommit issue

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/common"
 	"time"
 
 	"github.com/ethereum/go-ethereum/consensus"
@@ -140,10 +141,8 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 			if err := statedb.WaitPipeVerification(); err != nil {
 				return err
 			}
-			statedb.CorrectAccountsRoot()
+			statedb.CorrectAccountsRoot(common.Hash{})
 			statedb.Finalise(v.config.IsEIP158(header.Number))
-			// State verification pipeline - accounts root are not calculated here, just populate needed fields for process
-			statedb.PopulateSnapAccountAndStorage()
 			return nil
 		})
 	} else {

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -18,9 +18,9 @@ package core
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -975,12 +975,21 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 }
 
 //CorrectAccountsRoot will fix account roots in pipecommit mode
-func (s *StateDB) CorrectAccountsRoot() {
-	if accounts, err := s.snap.Accounts(); err == nil && accounts != nil {
+func (s *StateDB) CorrectAccountsRoot(blockRoot common.Hash) {
+	var snapshot snapshot.Snapshot
+	if blockRoot == (common.Hash{}) {
+		snapshot = s.snap
+	} else {
+		if snapshot = s.snaps.Snapshot(blockRoot); snapshot == nil {
+			return
+		}
+	}
+	if accounts, err := snapshot.Accounts(); err == nil && accounts != nil {
 		for _, obj := range s.stateObjects {
 			if !obj.deleted && !obj.rootCorrected && obj.data.Root == dummyRoot {
 				if account, exist := accounts[crypto.Keccak256Hash(obj.address[:])]; exist && len(account.Root) != 0 {
 					obj.data.Root = common.BytesToHash(account.Root)
+					obj.rootCorrected = true
 				}
 			}
 		}
@@ -1465,6 +1474,8 @@ func (s *StateDB) Commit(failPostCommitFunc func(), postCommitFuncs ...func() er
 				}
 				if s.pipeCommit {
 					defer close(snapUpdated)
+					// State verification pipeline - accounts root are not calculated here, just populate needed fields for process
+					s.PopulateSnapAccountAndStorage()
 				}
 				diffLayer.Destructs, diffLayer.Accounts, diffLayer.Storages = s.SnapToDiffLayer()
 				// Only update if there's a state transition (skip empty Clique blocks)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -983,9 +983,9 @@ func (s *StateDB) CorrectAccountsRoot(blockRoot common.Hash) {
 		if s.snaps != nil {
 			snapshot = s.snaps.Snapshot(blockRoot)
 		}
-		if snapshot == nil {
-			return
-		}
+	}
+	if snapshot == nil {
+		return
 	}
 	if accounts, err := snapshot.Accounts(); err == nil && accounts != nil {
 		for _, obj := range s.stateObjects {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -980,7 +980,10 @@ func (s *StateDB) CorrectAccountsRoot(blockRoot common.Hash) {
 	if blockRoot == (common.Hash{}) {
 		snapshot = s.snap
 	} else {
-		if snapshot = s.snaps.Snapshot(blockRoot); snapshot == nil {
+		if s.snaps != nil {
+			snapshot = s.snaps.Snapshot(blockRoot)
+		}
+		if snapshot == nil {
 			return
 		}
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -979,11 +979,10 @@ func (s *StateDB) CorrectAccountsRoot(blockRoot common.Hash) {
 	var snapshot snapshot.Snapshot
 	if blockRoot == (common.Hash{}) {
 		snapshot = s.snap
-	} else {
-		if s.snaps != nil {
-			snapshot = s.snaps.Snapshot(blockRoot)
-		}
+	} else if s.snaps != nil {
+		snapshot = s.snaps.Snapshot(blockRoot)
 	}
+
 	if snapshot == nil {
 		return
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1009,6 +1009,9 @@ func (w *worker) commit(uncles []*types.Header, interval func(), update bool, st
 	if err != nil {
 		return err
 	}
+
+	s.CorrectAccountsRoot(w.chain.CurrentBlock().Root())
+
 	block, receipts, err := w.engine.FinalizeAndAssemble(w.chain, types.CopyHeader(w.current.header), s, w.current.txs, uncles, w.current.receipts)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Description

If a validator runs 1.1.9 with `pipecommit` enabled, sometimes it will fail to write block due to incorrect account roots, like this:
```
t=2022-04-25T05:11:48+0000 lvl=info msg=“Sealing block with”                    number=17,244,681 delay=2.740279174s  headerDifficulty=2 val=0x70F657164e5b75689b64B7fd1fA275F334f28e18
t=2022-04-25T05:11:51+0000 lvl=eror msg=“Failed writing block to chain”         err=“can’t create storage trie: missing trie node 542e5fc2709de84248e9bce43a9c0c8943a608029001360f8ab55bf113b23d28 (path )”
```

This pr fix this issue by calling `CorrectAccountsRoot` before commit the block in mining.

### Rationale
In `pipecommit`, the account roots are populated with dummy data, in the importing process the account roots are corrected, however, they are not corrected in the mining process. If the miner uses dummy roots to commit block, there will be errors. 


### Example

Fix with this pr, validators can commit block successfully.

```
t=2022-04-27T08:58:03+0000 lvl=info msg="Commit new mining work"                 number=17,306,482 sealhash=0xd73b981fe17df5e509a7bb9187f3bc7aa605b060691ab83175adbd9aeaa093f6 uncles=0 txs=0    gas=24428   elapsed=19.800ms
t=2022-04-27T08:58:03+0000 lvl=info msg="Sealing block with"                     number=17,306,482 delay=-132.915737ms headerDifficulty=1 val=0x0075E536980C629619a44d489De40837551f82FF
t=2022-04-27T08:58:03+0000 lvl=info msg="Successfully sealed new block"          number=17,306,482 sealhash=0xd73b981fe17df5e509a7bb9187f3bc7aa605b060691ab83175adbd9aeaa093f6 hash=0x8eba9ca7775c565d621acad75333da58a2c7bd85dbf70fd9cb686c514938f6d5 elapsed="697.7µs"
t=2022-04-27T08:58:03+0000 lvl=info msg="🔨 mined potential block"                number=17,306,482 hash=0x8eba9ca7775c565d621acad75333da58a2c7bd85dbf70fd9cb686c514938f6d5
```
### Changes

Notable changes: 
* fix account roots during mining
