### PR TITLE
[R4R] prepare for release v1.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.1.10
+
+FEATURE
+* [\#885](https://github.com/binance-chain/bsc/pull/885) add Euler Hardfork, including BEP-127 and BEP-131
+
+
+BUGFIX
+* [\#856](https://github.com/binance-chain/bsc/pull/856) fix logic issue: handlers.removePeer() is called twice
+* [\#860](https://github.com/binance-chain/bsc/pull/860) fix:defer bloomprocessor close
+* [\#877](https://github.com/binance-chain/bsc/pull/877) fix validator pipecommit issue
+* [\#870](https://github.com/binance-chain/bsc/pull/870) fix:Shift panic for zero length of heads
+
 ## v1.1.9
 
 IMPROVEMENT

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This command will:
 
 Steps:
 
-1. Download the binary, config and genesis files from [release](https://github.com/binance-chain/bsc/releases/download/v1.0.0-alpha.0/binary.zip), or compile the binary by `make geth`. 
+1. Download the binary, config and genesis files from [release](https://github.com/bnb-chain/bsc/releases/tag/v1.1.10), or compile the binary by `make geth`. 
 2. Init genesis state: `./geth --datadir node init genesis.json`.
 3. Start your fullnode: `./geth --config ./config.toml --datadir ./node`.
 4. Or start a validator node: `./geth --config ./config.toml --datadir ./node -unlock ${validatorAddr} --mine --allow-insecure-unlock`. The ${validatorAddr} is the wallet account address of your running validator node. 

--- a/params/config.go
+++ b/params/config.go
@@ -280,9 +280,7 @@ var (
 		NielsBlock:          big.NewInt(1014369),
 		MirrorSyncBlock:     big.NewInt(5582500),
 		BrunoBlock:          big.NewInt(13837000),
-
-		// TODO modify blockNumber
-		EulerBlock: nil,
+		EulerBlock:          big.NewInt(19203503),
 
 		Parlia: &ParliaConfig{
 			Period: 3,

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 9  // Patch version component of the current release
+	VersionPatch = 10 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
It is a maintenance release.


### Rationale
FEATURE
* [\#885](https://github.com/binance-chain/bsc/pull/885) add Euler Hardfork, including BEP-127 and BEP-131


BUGFIX
* [\#856](https://github.com/binance-chain/bsc/pull/856) fix logic issue: handlers.removePeer() is called twice
* [\#860](https://github.com/binance-chain/bsc/pull/860) fix:defer bloomprocessor close
* [\#877](https://github.com/binance-chain/bsc/pull/877) fix validator pipecommit issue
* [\#870](https://github.com/binance-chain/bsc/pull/870) fix:Shift panic for zero length of heads

### Example

add an example CLI or API response...

### Changes
The Euler upgrade height for testnet is 19203503.