### PR TITLE
BUG:pending snapshot block and state cannot update

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -487,7 +487,7 @@ func (w *worker) mainLoop() {
 				start := time.Now()
 				if err := w.commitUncle(w.current, ev.Block.Header()); err == nil {
 					var uncles []*types.Header
-					w.commit(uncles, nil, false, start)
+					w.commit(uncles, nil, true, start)
 				}
 			}
 
@@ -998,7 +998,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		commitTxsTimer.UpdateSince(start)
 		log.Info("Gas pool", "height", header.Number.String(), "pool", w.current.gasPool.String())
 	}
-	w.commit(uncles, w.fullTaskHook, false, tstart)
+	w.commit(uncles, w.fullTaskHook, true, tstart)
 }
 
 // commit runs any post-transaction state modifications, assembles the final block


### PR DESCRIPTION
### Description
Pending snapshot block and state cannot update when txs or block header is changed

### Rationale

If the block environment required by EVM is not synchronized, the estimation of gas will be completely different from the actual use.

### Example

EstimateGas -> StateAndHeaderByNumberOrHash -> miner.Pending()
