### PR TITLE
[R4R] improve snap mutex

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -412,7 +412,7 @@ func (s *StateObject) updateTrie(db Database) Trie {
 		}
 		// If state snapshotting is active, cache the data til commit
 		if s.db.snap != nil {
-			s.db.snapMux.Lock()
+			s.db.snapStorageMux.Lock()
 			if storage == nil {
 				// Retrieve the old storage map, if available, create a new one otherwise
 				if storage = s.db.snapStorage[s.address]; storage == nil {
@@ -421,7 +421,7 @@ func (s *StateObject) updateTrie(db Database) Trie {
 				}
 			}
 			storage[string(key[:])] = v // v will be nil if value is 0x00
-			s.db.snapMux.Unlock()
+			s.db.snapStorageMux.Unlock()
 		}
 		usedStorage = append(usedStorage, common.CopyBytes(key[:])) // Copy needed for closure
 	}


### PR DESCRIPTION
### Description

This pr tries to improve block importing by splitting mutex for snap account and storage.

### Rationale

The access to snap accounts and snap storage could use different locks to avoid unnecessary race.

### Result

* Before


```
Dropped 546 nodes (cum <= 0.02mins)
Showing top 40 nodes out of 106
      flat  flat%   sum%        cum   cum%
  3.59mins 90.44% 90.44%   3.59mins 90.44%  sync.(*Mutex).Unlock (partial-inline)
  0.37mins  9.26% 99.71%   2.17mins 54.68%  sync.(*RWMutex).Unlock
         0     0% 99.71%   0.03mins  0.74%  github.com/VictoriaMetrics/fastcache.(*Cache).Set
         0     0% 99.71%   0.03mins  0.74%  github.com/VictoriaMetrics/fastcache.(*bucket).Set
         0     0% 99.71%   0.51mins 12.93%  github.com/ethereum/go-ethereum/core.(*BlockChain).InsertChain
         0     0% 99.71%   0.02mins  0.58%  github.com/ethereum/go-ethereum/core.(*BlockChain).insertChain
         0     0% 99.71%   0.08mins  2.02%  github.com/ethereum/go-ethereum/core.(*StateTransition).TransitionDb
         0     0% 99.71%   0.04mins     1%  github.com/ethereum/go-ethereum/core.(*TxPool).AddRemotes
         0     0% 99.71%   0.04mins     1%  github.com/ethereum/go-ethereum/core.(*TxPool).addTxs
         0     0% 99.71%   0.34mins  8.47%  github.com/ethereum/go-ethereum/core.(*TxPool).runReorg
         0     0% 99.71%   0.05mins  1.14%  github.com/ethereum/go-ethereum/core.(*statePrefetcher).Prefetch.func1
         0     0% 99.71%   0.08mins  1.97%  github.com/ethereum/go-ethereum/core.ApplyMessage
         0     0% 99.71%   0.06mins  1.48%  github.com/ethereum/go-ethereum/core.precacheTransaction
         0     0% 99.71%   0.11mins  2.70%  github.com/ethereum/go-ethereum/core/rawdb.ReadStorageSnapshot
         0     0% 99.71%   0.11mins  2.72%  github.com/ethereum/go-ethereum/core/state.(*StateDB).AccountsIntermediateRoot.func1
         0     0% 99.71%   0.11mins  2.72%  github.com/ethereum/go-ethereum/core/state.(*StateDB).AccountsIntermediateRoot.func2
```

* After

```
Dropped 571 nodes (cum <= 0.02mins)
Showing top 40 nodes out of 111
      flat  flat%   sum%        cum   cum%
  4.54mins 91.33% 91.33%   4.54mins 91.33%  sync.(*Mutex).Unlock (partial-inline)
  0.42mins  8.38% 99.70%   2.28mins 45.96%  sync.(*RWMutex).Unlock
         0     0% 99.70%   0.04mins  0.76%  github.com/VictoriaMetrics/fastcache.(*Cache).Set
         0     0% 99.70%   0.04mins  0.76%  github.com/VictoriaMetrics/fastcache.(*bucket).Set
         0     0% 99.70%   0.45mins  9.08%  github.com/ethereum/go-ethereum/core.(*BlockChain).InsertChain
         0     0% 99.70%   0.03mins  0.55%  github.com/ethereum/go-ethereum/core.(*BlockChain).insertChain
         0     0% 99.70%   0.08mins  1.57%  github.com/ethereum/go-ethereum/core.(*StateTransition).TransitionDb
         0     0% 99.70%   0.04mins  0.81%  github.com/ethereum/go-ethereum/core.(*TxPool).AddRemotes
         0     0% 99.70%   0.04mins  0.81%  github.com/ethereum/go-ethereum/core.(*TxPool).addTxs
         0     0% 99.70%   0.40mins  8.12%  github.com/ethereum/go-ethereum/core.(*TxPool).runReorg
         0     0% 99.70%   0.04mins  0.85%  github.com/ethereum/go-ethereum/core.(*statePrefetcher).Prefetch.func1
         0     0% 99.70%   0.08mins  1.54%  github.com/ethereum/go-ethereum/core.ApplyMessage
         0     0% 99.70%   0.06mins  1.12%  github.com/ethereum/go-ethereum/core.precacheTransaction
         0     0% 99.70%   0.11mins  2.20%  github.com/ethereum/go-ethereum/core/rawdb.ReadStorageSnapshot
         0     0% 99.70%   0.06mins  1.16%  github.com/ethereum/go-ethereum/core/state.(*StateDB).AccountsIntermediateRoot.func1
         0     0% 99.70%   0.06mins  1.17%  github.com/ethereum/go-ethereum/core/state.(*StateDB).AccountsIntermediateRoot.func2
```

We can see that `AccountsIntermediateRoot`'s block duration has been reduced.

### Changes

Notable changes: 
* use different locks for snap account and snap storage 
