### PR TITLE
[R4R] Release For BSC v1.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.1.11
+
+UPGRADE
+* [\#927](https://github.com/bnb-chain/bsc/pull/927) add readme for validators about how to enter/exit maintenance
+* [\#942](https://github.com/bnb-chain/bsc/pull/942) update the blockNumber of Euler Fork upgrade on BSC Mainnet
+
+
 ## v1.1.10
 
 FEATURE

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This command will:
 
 Steps:
 
-1. Download the binary, config and genesis files from [release](https://github.com/bnb-chain/bsc/releases/tag/v1.1.10), or compile the binary by `make geth`. 
+1. Download the binary, config and genesis files from [release](https://github.com/bnb-chain/bsc/releases/tag/v1.1.11), or compile the binary by `make geth`. 
 2. Init genesis state: `./geth --datadir node init genesis.json`.
 3. Start your fullnode: `./geth --config ./config.toml --datadir ./node`.
 4. Or start a validator node: `./geth --config ./config.toml --datadir ./node -unlock ${validatorAddr} --mine --allow-insecure-unlock`. The ${validatorAddr} is the wallet account address of your running validator node. 

--- a/params/config.go
+++ b/params/config.go
@@ -255,9 +255,7 @@ var (
 		NielsBlock:          big.NewInt(0),
 		MirrorSyncBlock:     big.NewInt(5184000),
 		BrunoBlock:          big.NewInt(13082000),
-
-		// TODO modify blockNumber
-		EulerBlock: nil,
+		EulerBlock:          big.NewInt(18907621),
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -303,9 +301,7 @@ var (
 		NielsBlock:          big.NewInt(0),
 		MirrorSyncBlock:     big.NewInt(400),
 		BrunoBlock:          big.NewInt(400),
-
-		// TODO
-		EulerBlock: nil,
+		EulerBlock:          nil,
 
 		Parlia: &ParliaConfig{
 			Period: 3,

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 10 // Patch version component of the current release
+	VersionPatch = 11 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
V1.1.11 is a is a hard fork release that contains the update about the block number of `Euler Fork` upgrade. 
The upgrade will start at block number `18907621`,  approximately at 2022-06-22 08:00:00 UTC.

### Rationale

UPGRADE
* [\#927](https://github.com/bnb-chain/bsc/pull/927) add readme for validators about how to enter/exit maintenance
* [\#942](https://github.com/bnb-chain/bsc/pull/942) update the blockNumber of Euler Fork upgrade on BSC Mainnet

### Example
No

### Changes
Notable changes: 
* Update the blockNumber of `Euler Fork` upgrade to `18907621` on mainnet
* More details about `Euler Fork`, please refer to https://github.com/bnb-chain/bsc/pull/885