### PR TITLE
[R4R][Feature]: Improve trie prefetch

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -237,6 +237,9 @@ func (s *StateDB) StopPrefetcher() {
 }
 
 func (s *StateDB) TriePrefetchInAdvance(block *types.Block, signer types.Signer) {
+	if s.prefetcher == nil {
+		return
+	}
 	accounts := make(map[common.Address]struct{}, block.Transactions().Len()<<1)
 	for _, tx := range block.Transactions() {
 		from, err := types.Sender(signer, tx)
@@ -254,7 +257,7 @@ func (s *StateDB) TriePrefetchInAdvance(block *types.Block, signer types.Signer)
 		addressesToPrefetch = append(addressesToPrefetch, common.CopyBytes(addr[:])) // Copy needed for closure
 	}
 
-	if s.prefetcher != nil && len(addressesToPrefetch) > 0 {
+	if len(addressesToPrefetch) > 0 {
 		s.prefetcher.prefetch(s.originalRoot, addressesToPrefetch, emptyAddr)
 	}
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -237,7 +237,11 @@ func (s *StateDB) StopPrefetcher() {
 }
 
 func (s *StateDB) TriePrefetchInAdvance(block *types.Block, signer types.Signer) {
-	if s.prefetcher == nil {
+	s.prefetcherLock.Lock()
+	prefetcher := s.prefetcher // s.prefetcher could be resetted to nil
+	s.prefetcherLock.Unlock()
+
+	if prefetcher == nil {
 		return
 	}
 	accounts := make(map[common.Address]struct{}, block.Transactions().Len()<<1)
@@ -258,7 +262,7 @@ func (s *StateDB) TriePrefetchInAdvance(block *types.Block, signer types.Signer)
 	}
 
 	if len(addressesToPrefetch) > 0 {
-		s.prefetcher.prefetch(s.originalRoot, addressesToPrefetch, emptyAddr)
+		prefetcher.prefetch(s.originalRoot, addressesToPrefetch, emptyAddr)
 	}
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -236,6 +236,29 @@ func (s *StateDB) StopPrefetcher() {
 	}
 }
 
+func (s *StateDB) TriePrefetchInAdvance(block *types.Block, signer types.Signer) {
+	accounts := make(map[common.Address]struct{}, block.Transactions().Len()<<1)
+	for _, tx := range block.Transactions() {
+		from, err := types.Sender(signer, tx)
+		if err != nil {
+			// invalid block, skip prefetch
+			return
+		}
+		accounts[from] = struct{}{}
+		if tx.To() != nil {
+			accounts[*tx.To()] = struct{}{}
+		}
+	}
+	addressesToPrefetch := make([][]byte, 0, len(accounts))
+	for addr := range accounts {
+		addressesToPrefetch = append(addressesToPrefetch, common.CopyBytes(addr[:])) // Copy needed for closure
+	}
+
+	if s.prefetcher != nil && len(addressesToPrefetch) > 0 {
+		s.prefetcher.prefetch(s.originalRoot, addressesToPrefetch, emptyAddr)
+	}
+}
+
 // Mark that the block is processed by diff layer
 func (s *StateDB) SetExpectedStateRoot(root common.Hash) {
 	s.expectedRoot = root

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -26,8 +26,10 @@ import (
 )
 
 const (
-	abortChanSize      = 64
-	concurrentChanSize = 10
+	abortChanSize                 = 64
+	concurrentChanSize            = 10
+	parallelTriePrefetchThreshold = 50
+	parallelTriePrefetchCapacity  = 100
 )
 
 var (
@@ -113,6 +115,10 @@ func (p *triePrefetcher) mainLoop() {
 				p.fetchersMutex.Unlock()
 			}
 			fetcher.schedule(pMsg.keys)
+			// no need to run parallel trie prefetch if threshold is not reached.
+			if fetcher.pendingSize() > parallelTriePrefetchThreshold {
+				fetcher.scheduleParallel(pMsg.keys)
+			}
 
 		case <-p.closeMainChan:
 			for _, fetcher := range p.fetchers {
@@ -166,6 +172,14 @@ func (p *triePrefetcher) abortLoop() {
 		select {
 		case fetcher := <-p.abortChan:
 			fetcher.abort()
+			// stop fetcher's parallel children
+			fetcher.childrenLock.Lock()
+			children := fetcher.children
+			fetcher.children = nil
+			fetcher.childrenLock.Unlock()
+			for _, child := range children {
+				child.abort()
+			}
 		case <-p.closeAbortChan:
 			return
 		}
@@ -310,8 +324,10 @@ type subfetcher struct {
 	root common.Hash // Root hash of the trie to prefetch
 	trie Trie        // Trie being populated with nodes
 
-	tasks [][]byte   // Items queued up for retrieval
-	lock  sync.Mutex // Lock protecting the task queue
+	tasks          [][]byte   // Items queued up for retrieval
+	lock           sync.Mutex // Lock protecting the task queue
+	totalSize      uint32
+	processedIndex uint32
 
 	wake chan struct{}  // Wake channel if a new task is scheduled
 	stop chan struct{}  // Channel to interrupt processing
@@ -322,7 +338,9 @@ type subfetcher struct {
 	dups int                 // Number of duplicate preload tasks
 	used [][]byte            // Tracks the entries used in the end
 
-	accountHash common.Hash
+	accountHash  common.Hash
+	children     []*subfetcher
+	childrenLock sync.Mutex
 }
 
 // newSubfetcher creates a goroutine to prefetch state items belonging to a
@@ -342,18 +360,60 @@ func newSubfetcher(db Database, root common.Hash, accountHash common.Hash) *subf
 	return sf
 }
 
+func (sf *subfetcher) pendingSize() uint32 {
+	return sf.totalSize - atomic.LoadUint32(&sf.processedIndex)
+}
+
 // schedule adds a batch of trie keys to the queue to prefetch.
 func (sf *subfetcher) schedule(keys [][]byte) {
 	// Append the tasks to the current queue
 	sf.lock.Lock()
 	sf.tasks = append(sf.tasks, keys...)
 	sf.lock.Unlock()
-
 	// Notify the prefetcher, it's fine if it's already terminated
 	select {
 	case sf.wake <- struct{}{}:
 	default:
 	}
+	sf.totalSize += uint32(len(keys))
+}
+
+func (sf *subfetcher) scheduleParallel(keys [][]byte) {
+	// To feed the children first, if they are hungry.
+	// A child can handle keys with capacity of parallelTriePrefetchCapacity.
+	var curKeyIndex uint32 = 0
+	for _, child := range sf.children {
+		feedNum := parallelTriePrefetchCapacity - child.pendingSize()
+		if feedNum == 0 { // the child is full, can't process more tasks
+			continue
+		}
+		if curKeyIndex+feedNum > uint32(len(keys)) {
+			feedNum = uint32(len(keys)) - curKeyIndex
+		}
+		child.schedule(keys[curKeyIndex : curKeyIndex+feedNum])
+		curKeyIndex += feedNum
+		if curKeyIndex == uint32(len(keys)) {
+			return // the new arrived keys were all consumed by children.
+		}
+	}
+	// Children did not comsume all the keys, to create new subfetch to handle left keys.
+	keysLeft := keys[curKeyIndex:]
+
+	// the pending tasks exceed the threshold and have not been consumed up by its children
+	dispatchSize := len(keysLeft)
+	children := []*subfetcher{}
+	for i := 0; i*parallelTriePrefetchCapacity < dispatchSize; i++ {
+		child := newSubfetcher(sf.db, sf.root, sf.accountHash)
+		endIndex := (i + 1) * parallelTriePrefetchCapacity
+		if endIndex > dispatchSize {
+			endIndex = dispatchSize
+		}
+		child.schedule(keysLeft[i*parallelTriePrefetchCapacity : endIndex])
+		children = append(children, child)
+	}
+	sf.childrenLock.Lock()
+	sf.children = append(sf.children, children...)
+	sf.childrenLock.Unlock()
 }
 
 // peek tries to retrieve a deep copy of the fetcher's trie in whatever form it
@@ -450,6 +510,7 @@ func (sf *subfetcher) loop() {
 						sf.trie.TryGet(task)
 						sf.seen[string(task)] = struct{}{}
 					}
+					atomic.AddUint32(&sf.processedIndex, 1)
 				}
 			}
 

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -398,7 +398,7 @@ func (sf *subfetcher) scheduleParallel(keys [][]byte) {
 			keyIndex += feedNum
 		}
 	}
-	// Children did not comsume all the keys, to create new subfetch to handle left keys.
+	// Children did not consume all the keys, to create new subfetch to handle left keys.
 	keysLeft := keys[keyIndex:]
 	keysLeftSize := len(keysLeft)
 	for i := 0; i*parallelTriePrefetchCapacity < keysLeftSize; i++ {

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -28,8 +28,8 @@ import (
 const (
 	abortChanSize                 = 64
 	concurrentChanSize            = 10
-	parallelTriePrefetchThreshold = 100
-	parallelTriePrefetchCapacity  = 200
+	parallelTriePrefetchThreshold = 10
+	parallelTriePrefetchCapacity  = 20
 )
 
 var (

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -403,9 +403,12 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	posa, isPoSA := p.engine.(consensus.PoSA)
 	commonTxs := make([]*types.Transaction, 0, txNum)
 
-	// initilise bloom processors
+	// initialise bloom processors
 	bloomProcessors := NewAsyncReceiptBloomGenerator(txNum)
 	statedb.MarkFullProcessed()
+
+	// do trie prefetch for the big state trie tree in advance based transaction's From/To address.
+	statedb.TriePrefetchInAdvance(block, signer)
 
 	// usually do have two tx, one for validator set contract, another for system reward contract.
 	systemTxs := make([]*types.Transaction, 0, 2)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -407,11 +407,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	bloomProcessors := NewAsyncReceiptBloomGenerator(txNum)
 	statedb.MarkFullProcessed()
 	signer := types.MakeSigner(p.config, header.Number)
-	// do trie prefetch for the big state trie tree in advance based transaction's From/To address.
-	go func() {
-		// trie prefetcher is thread safe now, ok now to prefetch in a separate routine
-		statedb.TriePrefetchInAdvance(block, signer)
-	}()
 
 	// usually do have two tx, one for validator set contract, another for system reward contract.
 	systemTxs := make([]*types.Transaction, 0, 2)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -408,7 +408,10 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	statedb.MarkFullProcessed()
 
 	// do trie prefetch for the big state trie tree in advance based transaction's From/To address.
-	statedb.TriePrefetchInAdvance(block, signer)
+	go func() {
+		// trie prefetcher is thread safe now, ok now to prefetch in a separate routine
+		statedb.TriePrefetchInAdvance(block, signer)
+	}()
 
 	// usually do have two tx, one for validator set contract, another for system reward contract.
 	systemTxs := make([]*types.Transaction, 0, 2)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -406,7 +406,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	// initialise bloom processors
 	bloomProcessors := NewAsyncReceiptBloomGenerator(txNum)
 	statedb.MarkFullProcessed()
-
+	signer := types.MakeSigner(p.config, header.Number)
 	// do trie prefetch for the big state trie tree in advance based transaction's From/To address.
 	go func() {
 		// trie prefetcher is thread safe now, ok now to prefetch in a separate routine
@@ -427,7 +427,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 			}
 		}
 
-		msg, err := tx.AsMessage(types.MakeSigner(p.config, header.Number), header.BaseFee)
+		msg, err := tx.AsMessage(signer, header.BaseFee)
 		if err != nil {
 			bloomProcessors.Close()
 			return statedb, nil, nil, 0, err


### PR DESCRIPTION
### Description
We found that the current trie prefetch could be not fast enough, especially trie prefetch of the outer big state trie tree. When processing a big block, thousands of accounts's root hash could be changed. In this PR, we try to optimize it in 2 approaches.


### Rationale
#### 1.Trie prefetch From/To address in advance
Instead of do trie prefetch until a transaction is finalized, we could do trie prefetch in advance. Try to prefetch the trie node of the From/To accounts, since their root hash are most likely to be changed.
The bellow tracing image shows, the trieprefetch has several idle state.
<img width="1194" alt="image" src="https://user-images.githubusercontent.com/98502954/174550518-7c8fb50f-9a83-4262-b447-1c189af8f6e2.png">
After trie prefetch From/To in advance, it will be busy.
<img width="1186" alt="image" src="https://user-images.githubusercontent.com/98502954/174550557-ad1762f8-ea8c-4484-9d8f-c9446f724cdd.png">
#### 2.Parallel TriePrefetch
Currently, we create a subfetcher for each account address to do trie prefetch. But if the number of changed account or updated KV is too large, the subfetcher would not be able to fetch all the trie node  in time. In this case, we will create child subfetchers to do parallel trie prefetch for it.
Child subfetcher will be created on demand, when the pending task size exceed the threshold of `parallelTriePrefetchThreshold` and each has a capacity of `parallelTriePrefetchCapacity`. The created child subfetchers can be reused, we will try to dispatch tasks to these hungry child first before start new child subfecther. If the parent subfetcher is stopped, the child subfecthers will be stopped too.
The general workflow of parallel trie prefetch is shown by the following diagram.
![image](https://user-images.githubusercontent.com/92799281/175246845-5e970e71-6b5b-44a6-be6e-79b4dd31fbba.png)


### Performance Result
This PR would be more beneficial if the validation phase occupies more time. 
I tested based on BNB chain traffics of April 18th 2022, during that time, the peek validation could cost ~1.65 second on my test device. The hardware configuration of the device is: `4TB SSD, 16 core, 60GB memory`.
And I tested for different configuration of `parallelTriePrefetchThreshold` and `parallelTriePrefetchCapacity`, the results of peek insert and validation cost are:
**peek insert**
- v1.1.11:   ~2.30s
- this PR with threshold == 100 capacity == 200 : ~1.65s ==> improved: ~28%
- this PR with threshold == 100 capacity == 100 : ~1.48s ==> improved: ~36%
- this PR with threshold == 50  capacity == 100 : ~1.34s  ==> improved: ~42%
- this PR with threshold == 50  capacity == 50 : ~1.23s ==> improved: ~47%
- this PR with threshold == 25  capacity == 50 : ~1.13s  ==> improved: ~51%
- this PR with threshold == 25 capacity == 25 : ~1.05s ==> improved: ~54%
- this PR with threshold == 10 capacity == 20 : ~0.92s  ==> improved: ~60%
- this PR with threshold == 10 capacity == 10 : ~0.94s ==> improved: ~59%
- this PR with threshold == 5 capacity == 10 : ~0.87s  ==> improved: ~62%

**peek validation**
- v1.1.11:   ~1.65s
- this PR with threshold == 100 capacity == 200 : ~1.10s ==> improved: ~33%
- this PR with threshold == 100 capacity == 100 : ~0.85s ==> improved: ~48%
- this PR with threshold == 50 capacity == 100 : ~0.74s  ==> improved: ~55%
- this PR with threshold == 50 capacity == 50 : ~0.60s ==> improved: ~64%
- this PR with threshold == 25 capacity == 50 : ~0.52s ==> improved: ~68%
- this PR with threshold == 25 capacity == 25 : ~0.41s ==> improved: ~75%
- this PR with threshold == 10 capacity == 20 : ~0.33s ==> improved: ~80%
- this PR with threshold == 10 capacity == 10 : ~0.30s ==> improved: ~82%
- this PR with threshold == 5 capacity == 10 : ~0.26s ==> improved: ~84%

It seems `parallelTriePrefetchThreshold = 10` and `parallelTriePrefetchCapacity = 20` could be good enough

I also did a long run test for more the 14hours, the PR even have observable benefit for general traffic load, I saw ~60% reduce of the validation cost. 
<img width="1179" alt="image" src="https://user-images.githubusercontent.com/98502954/178645300-cb344ebc-4e93-4991-9fb5-347d275bf1f8.png">

### Changes
No impact to users.
