### PR TITLE
[R4R] correct logic for eip check of NewEVMInterpreter

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -122,15 +122,16 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 		default:
 			jt = frontierInstructionSet
 		}
-		for i := 0; i < len(cfg.ExtraEips); i++ {
-			if err := EnableEIP(cfg.ExtraEips[i], &jt); err != nil {
+		var extraEips []int
+		for _, eip := range cfg.ExtraEips {
+			if err := EnableEIP(eip, &jt); err != nil {
 				// Disable it, so caller can check if it's activated or not
-				cfg.ExtraEips = append(cfg.ExtraEips[:i], cfg.ExtraEips[i+1:]...)
-				i--
-				log.Error("EIP activation failed", "eip", cfg.ExtraEips[i], "error", err)
+				log.Error("EIP activation failed", "eip", eip, "error", err)
+			} else {
+				extraEips = append(extraEips, eip)
 			}
 		}
-
+		cfg.ExtraEips = extraEips
 		cfg.JumpTable = jt
 	}
 	evmInterpreter := EVMInterpreterPool.Get().(*EVMInterpreter)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -122,13 +122,15 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 		default:
 			jt = frontierInstructionSet
 		}
-		for i, eip := range cfg.ExtraEips {
-			if err := EnableEIP(eip, &jt); err != nil {
+		for i := 0; i < len(cfg.ExtraEips); i++ {
+			if err := EnableEIP(cfg.ExtraEips[i], &jt); err != nil {
 				// Disable it, so caller can check if it's activated or not
 				cfg.ExtraEips = append(cfg.ExtraEips[:i], cfg.ExtraEips[i+1:]...)
-				log.Error("EIP activation failed", "eip", eip, "error", err)
+				i--
+				log.Error("EIP activation failed", "eip", cfg.ExtraEips[i], "error", err)
 			}
 		}
+
 		cfg.JumpTable = jt
 	}
 	evmInterpreter := EVMInterpreterPool.Get().(*EVMInterpreter)


### PR DESCRIPTION
### Description
current code logic of for...range...check to delete elements in slice is not correct, would skip checking the element next to the element be deleted of which error was detected.
```
for i, v := range slice{
   // check slice[i]
    slice = append(slice[:i], slice[i+1:]...)
}
```
### Rationale
declare a new slice for left eipIDs
### Changes
core/vm/interpreter.go : NewEVMInterpreter(...)