### PR TITLE
[R4R]: Redesign triePrefetcher to make it thread safe

### DIFF
--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -193,11 +193,9 @@ func (p *triePrefetcher) copy() *triePrefetcher {
 	// If the prefetcher is already a copy, duplicate the data
 	if p.fetches != nil {
 		fetcherCopied := &triePrefetcher{
-			db:             p.db,
-			root:           p.root,
-			fetches:        make(map[common.Hash]Trie, len(p.fetches)),
-			abortChan:      make(chan *subfetcher),
-			closeAbortChan: make(chan struct{}),
+			db:      p.db,
+			root:    p.root,
+			fetches: make(map[common.Hash]Trie, len(p.fetches)),
 		}
 		// p.fetches is safe to be accessed outside of mainloop
 		// if the triePrefetcher is active, fetches will not be used in mainLoop


### PR DESCRIPTION
### Description
There are 2 types of triePrefetcher instances.
1.New created `triePrefetcher`: it is the one to do trie prefetch to speed up validation phase.
2.Copied `triePrefetcher`: it just do a copy of the prefetched trie,  it won't do prefetch at all. The copied tries are all kept in p.fetches.

In thie PR, we try to improve the new created one, to make it concurrent safe, while the copied one's behavior stay unchanged(its logic is very simple).

### Rationale
As commented in `triePrefetcher` struct, its APIs are not thread safe. So callers should make sure the created triePrefetcher should be used within a single routine. As we are trying to improve triePrefetcher, we would use it concurrently, so it is necessary to redesign it for concurrent access.

The redesigned workflow:
1.start a mainLoop to do the real trie prefetch work, caller could schedule prefetch request through channel message.
2.as the trie prefetch close operation is only allowed to do once and will be processed in the mainLoop too, since it will update the fetchers informantion.
3.The other operations will be done outside of the mainLoop for performance concern, since mainLoop could be too busy if all the works are done within the mainLoop. The action lists are: trie(),used(), copy(), these actions can be done in parallel with a simple read lock.

There is no obvious performance impact.
<img width="1708" alt="image" src="https://user-images.githubusercontent.com/92799281/177265276-318ab870-a41b-49b7-94b9-4507b2c11324.png">


### Changes
No impact to users.
