### PR TITLE
[R4R] fix nil pointer issue when stopping mining new block

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -919,7 +919,7 @@ LOOP:
 		if stopTimer != nil {
 			select {
 			case <-stopTimer.C:
-				log.Info("Not enough time for further transactions", "txs", len(w.current.txs))
+				log.Info("Not enough time for further transactions", "txs", len(env.txs))
 				break LOOP
 			default:
 			}


### PR DESCRIPTION
### Description

```
t=2022-07-07T12:38:34+0000 lvl=info msg="Mining aborted due to sync"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0xff0ffd]

goroutine 110 [running]:
github.com/ethereum/go-ethereum/miner.(*worker).commitTransactions(0xc000269b80, 0xc01db799a0, 0xc076245840, 0xc01cdc87e0, 0xc076245800)
        github.com/ethereum/go-ethereum@/miner/worker.go:922 +0xc2d
github.com/ethereum/go-ethereum/miner.(*worker).fillTransactions(0xc000269b80, 0xc01cdc87e0, 0xc01db799a0)
        github.com/ethereum/go-ethereum@/miner/worker.go:1121 +0x219
github.com/ethereum/go-ethereum/miner.(*worker).commitWork(0xc000269b80, 0xc01cdc87e0, 0x1, 0x62c6d3ca)
        github.com/ethereum/go-ethereum@/miner/worker.go:1168 +0x150
github.com/ethereum/go-ethereum/miner.(*worker).mainLoop(0xc000269b80)
        github.com/ethereum/go-ethereum@/miner/worker.go:546 +0x110f
created by github.com/ethereum/go-ethereum/miner.newWorker
        github.com/ethereum/go-ethereum@/miner/worker.go:290 +0x61d
```

### Rationale

After merging #816, miners use `env` instead of `w.current` for mining information.

### Example

N/A

### Changes

Notable changes: 
* miner/worker.go
