### PR TITLE
[R4R] Pipecommit enable trie prefetcher

### DIFF
--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -118,9 +118,8 @@ type diffLayer struct {
 	storageList map[common.Hash][]common.Hash          // List of storage slots for iterated retrievals, one per account. Any existing lists are sorted if non-nil
 	storageData map[common.Hash]map[common.Hash][]byte // Keyed storage slots for direct retrieval. one per account (nil means deleted)
 
-	verifiedCh       chan struct{} // the difflayer is verified when verifiedCh is nil or closed
-	valid            bool          // mark the difflayer is valid or not.
-	accountCorrected bool          // mark the accountData has been corrected ort not
+	verifiedCh chan struct{} // the difflayer is verified when verifiedCh is nil or closed
+	valid      bool          // mark the difflayer is valid or not.
 
 	diffed *bloomfilter.Filter // Bloom filter tracking all the diffed items up to the disk layer
 
@@ -294,14 +293,6 @@ func (dl *diffLayer) CorrectAccounts(accounts map[common.Hash][]byte) {
 	defer dl.lock.Unlock()
 
 	dl.accountData = accounts
-	dl.accountCorrected = true
-}
-
-func (dl *diffLayer) AccountsCorrected() bool {
-	dl.lock.RLock()
-	defer dl.lock.RUnlock()
-
-	return dl.accountCorrected
 }
 
 // Parent returns the subsequent layer of a diff layer.

--- a/core/state/snapshot/disklayer.go
+++ b/core/state/snapshot/disklayer.go
@@ -62,10 +62,6 @@ func (dl *diskLayer) Verified() bool {
 func (dl *diskLayer) CorrectAccounts(map[common.Hash][]byte) {
 }
 
-func (dl *diskLayer) AccountsCorrected() bool {
-	return true
-}
-
 // Parent always returns nil as there's no layer below the disk.
 func (dl *diskLayer) Parent() snapshot {
 	return nil

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -113,9 +113,6 @@ type Snapshot interface {
 	// CorrectAccounts updates account data for storing the correct data during pipecommit
 	CorrectAccounts(map[common.Hash][]byte)
 
-	// AccountsCorrected checks whether the account data has been corrected during pipecommit
-	AccountsCorrected() bool
-
 	// Account directly retrieves the account associated with a particular hash in
 	// the snapshot slim data format.
 	Account(hash common.Hash) (*Account, error)

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -128,19 +128,16 @@ type Snapshot interface {
 	// Storage directly retrieves the storage data associated with a particular hash,
 	// within a particular account.
 	Storage(accountHash, storageHash common.Hash) ([]byte, error)
+
+	// Parent returns the subsequent layer of a snapshot, or nil if the base was
+	// reached.
+	Parent() snapshot
 }
 
 // snapshot is the internal version of the snapshot data layer that supports some
 // additional methods compared to the public API.
 type snapshot interface {
 	Snapshot
-
-	// Parent returns the subsequent layer of a snapshot, or nil if the base was
-	// reached.
-	//
-	// Note, the method is an internal helper to avoid type switching between the
-	// disk and diff layers. There is no locking involved.
-	Parent() snapshot
 
 	// Update creates a new layer on top of the existing snapshot diff tree with
 	// the specified data items.

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -365,16 +365,6 @@ func (s *StateObject) finalise(prefetch bool) {
 		}
 	}
 
-	// The account root need to be updated before prefetch, otherwise the account root is empty
-	//	if s.db.pipeCommit && s.data.Root == dummyRoot && !s.rootCorrected && s.db.snap.AccountsCorrected() {
-	//		if acc, err := s.db.snap.Account(crypto.HashData(s.db.hasher, s.address.Bytes())); err == nil {
-	//			if acc != nil && len(acc.Root) != 0 {
-	//				s.data.Root = common.BytesToHash(acc.Root)
-	//				s.rootCorrected = true
-	//			}
-	//		}
-	//	}
-
 	if s.db.prefetcher != nil && prefetch && len(slotsToPrefetch) > 0 && s.data.Root != emptyRoot {
 		s.db.prefetcher.prefetch(s.data.Root, slotsToPrefetch, s.addrHash)
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -366,14 +366,14 @@ func (s *StateObject) finalise(prefetch bool) {
 	}
 
 	// The account root need to be updated before prefetch, otherwise the account root is empty
-	if s.db.pipeCommit && s.data.Root == dummyRoot && !s.rootCorrected && s.db.snap.AccountsCorrected() {
-		if acc, err := s.db.snap.Account(crypto.HashData(s.db.hasher, s.address.Bytes())); err == nil {
-			if acc != nil && len(acc.Root) != 0 {
-				s.data.Root = common.BytesToHash(acc.Root)
-				s.rootCorrected = true
-			}
-		}
-	}
+	//	if s.db.pipeCommit && s.data.Root == dummyRoot && !s.rootCorrected && s.db.snap.AccountsCorrected() {
+	//		if acc, err := s.db.snap.Account(crypto.HashData(s.db.hasher, s.address.Bytes())); err == nil {
+	//			if acc != nil && len(acc.Root) != 0 {
+	//				s.data.Root = common.BytesToHash(acc.Root)
+	//				s.rootCorrected = true
+	//			}
+	//		}
+	//	}
 
 	if s.db.prefetcher != nil && prefetch && len(slotsToPrefetch) > 0 && s.data.Root != emptyRoot && s.data.Root != dummyRoot {
 		s.db.prefetcher.prefetch(s.data.Root, slotsToPrefetch, s.addrHash)

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -375,7 +375,7 @@ func (s *StateObject) finalise(prefetch bool) {
 	//		}
 	//	}
 
-	if s.db.prefetcher != nil && prefetch && len(slotsToPrefetch) > 0 && s.data.Root != emptyRoot && s.data.Root != dummyRoot {
+	if s.db.prefetcher != nil && prefetch && len(slotsToPrefetch) > 0 && s.data.Root != emptyRoot {
 		s.db.prefetcher.prefetch(s.data.Root, slotsToPrefetch, s.addrHash)
 	}
 	if len(s.dirtyStorage) > 0 {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1034,7 +1034,11 @@ func (s *StateDB) CorrectAccountsRoot(blockRoot common.Hash) {
 		for _, obj := range s.stateObjects {
 			if !obj.deleted {
 				if account, exist := accounts[crypto.Keccak256Hash(obj.address[:])]; exist {
-					obj.data.Root = common.BytesToHash(account.Root)
+					if len(account.Root) == 0 {
+						obj.data.Root = emptyRoot
+					} else {
+						obj.data.Root = common.BytesToHash(account.Root)
+					}
 					obj.rootCorrected = true
 				}
 			}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1036,7 +1036,8 @@ func (s *StateDB) CorrectAccountsRoot(blockRoot common.Hash) {
 	}
 	if accounts, err := snapshot.Accounts(); err == nil && accounts != nil {
 		for _, obj := range s.stateObjects {
-			if !obj.deleted && !obj.rootCorrected && obj.data.Root == dummyRoot {
+			//			if !obj.deleted && !obj.rootCorrected && obj.data.Root == dummyRoot {
+			if !obj.deleted {
 				if account, exist := accounts[crypto.Keccak256Hash(obj.address[:])]; exist {
 					obj.data.Root = common.BytesToHash(account.Root)
 					obj.rootCorrected = true
@@ -1051,12 +1052,13 @@ func (s *StateDB) PopulateSnapAccountAndStorage() {
 	for addr := range s.stateObjectsPending {
 		if obj := s.stateObjects[addr]; !obj.deleted {
 			if s.snap != nil {
-				root := obj.data.Root
-				storageChanged := s.populateSnapStorage(obj)
-				if storageChanged {
-					root = dummyRoot
-				}
-				s.snapAccounts[obj.address] = snapshot.SlimAccountRLP(obj.data.Nonce, obj.data.Balance, root, obj.data.CodeHash)
+				//root := obj.data.Root
+				s.populateSnapStorage(obj)
+				//storageChanged := s.populateSnapStorage(obj)
+				//if storageChanged {
+				//	root = dummyRoot
+				//}
+				s.snapAccounts[obj.address] = snapshot.SlimAccountRLP(obj.data.Nonce, obj.data.Balance, obj.data.Root, obj.data.CodeHash)
 			}
 		}
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -50,10 +50,6 @@ var (
 	// emptyRoot is the known root hash of an empty trie.
 	emptyRoot = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 
-	// dummyRoot is the dummy account root before corrected in pipecommit sync mode,
-	// the value is 542e5fc2709de84248e9bce43a9c0c8943a608029001360f8ab55bf113b23d28
-	dummyRoot = crypto.Keccak256Hash([]byte("dummy_account_root"))
-
 	emptyAddr = crypto.Keccak256Hash(common.Address{}.Bytes())
 )
 
@@ -1036,7 +1032,6 @@ func (s *StateDB) CorrectAccountsRoot(blockRoot common.Hash) {
 	}
 	if accounts, err := snapshot.Accounts(); err == nil && accounts != nil {
 		for _, obj := range s.stateObjects {
-			//			if !obj.deleted && !obj.rootCorrected && obj.data.Root == dummyRoot {
 			if !obj.deleted {
 				if account, exist := accounts[crypto.Keccak256Hash(obj.address[:])]; exist {
 					obj.data.Root = common.BytesToHash(account.Root)
@@ -1052,12 +1047,7 @@ func (s *StateDB) PopulateSnapAccountAndStorage() {
 	for addr := range s.stateObjectsPending {
 		if obj := s.stateObjects[addr]; !obj.deleted {
 			if s.snap != nil {
-				//root := obj.data.Root
 				s.populateSnapStorage(obj)
-				//storageChanged := s.populateSnapStorage(obj)
-				//if storageChanged {
-				//	root = dummyRoot
-				//}
 				s.snapAccounts[obj.address] = snapshot.SlimAccountRLP(obj.data.Nonce, obj.data.Balance, obj.data.Root, obj.data.CodeHash)
 			}
 		}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1004,8 +1004,8 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 	if s.prefetcher != nil && len(addressesToPrefetch) > 0 {
 		if s.snap.Verified() {
 			s.prefetcher.prefetch(s.originalRoot, addressesToPrefetch, emptyAddr)
-		} else if s.prefetcher.rootPrefetch != (common.Hash{}) {
-			s.prefetcher.prefetch(s.prefetcher.rootPrefetch, addressesToPrefetch, emptyAddr)
+		} else if s.prefetcher.rootParent != (common.Hash{}) {
+			s.prefetcher.prefetch(s.prefetcher.rootParent, addressesToPrefetch, emptyAddr)
 		}
 	}
 	// Invalidate journal because reverting across transactions is not allowed.

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -49,10 +49,11 @@ type prefetchMsg struct {
 //
 // Note, the prefetcher's API is not thread safe.
 type triePrefetcher struct {
-	db       Database                    // Database to fetch trie nodes through
-	root     common.Hash                 // Root hash of theaccount trie for metrics
-	fetches  map[common.Hash]Trie        // Partially or fully fetcher tries
-	fetchers map[common.Hash]*subfetcher // Subfetchers for each trie
+	db           Database    // Database to fetch trie nodes through
+	root         common.Hash // Root hash of theaccount trie for metrics
+	rootPrefetch common.Hash
+	fetches      map[common.Hash]Trie        // Partially or fully fetcher tries
+	fetchers     map[common.Hash]*subfetcher // Subfetchers for each trie
 
 	abortChan         chan *subfetcher // to abort a single subfetcher and its children
 	closed            int32
@@ -70,10 +71,15 @@ type triePrefetcher struct {
 	storageDupMeter   metrics.Meter
 	storageSkipMeter  metrics.Meter
 	storageWasteMeter metrics.Meter
+
+	accountStaleLoadMeter  metrics.Meter
+	accountStaleDupMeter   metrics.Meter
+	accountStaleSkipMeter  metrics.Meter
+	accountStaleWasteMeter metrics.Meter
 }
 
 // newTriePrefetcher
-func newTriePrefetcher(db Database, root common.Hash, namespace string) *triePrefetcher {
+func newTriePrefetcher(db Database, root, rootPrefetch common.Hash, namespace string) *triePrefetcher {
 	prefix := triePrefetchMetricsPrefix + namespace
 	p := &triePrefetcher{
 		db:        db,
@@ -94,6 +100,11 @@ func newTriePrefetcher(db Database, root common.Hash, namespace string) *triePre
 		storageDupMeter:   metrics.GetOrRegisterMeter(prefix+"/storage/dup", nil),
 		storageSkipMeter:  metrics.GetOrRegisterMeter(prefix+"/storage/skip", nil),
 		storageWasteMeter: metrics.GetOrRegisterMeter(prefix+"/storage/waste", nil),
+
+		accountStaleLoadMeter:  metrics.GetOrRegisterMeter(prefix+"/accountst/load", nil),
+		accountStaleDupMeter:   metrics.GetOrRegisterMeter(prefix+"/accountst/dup", nil),
+		accountStaleSkipMeter:  metrics.GetOrRegisterMeter(prefix+"/accountst/skip", nil),
+		accountStaleWasteMeter: metrics.GetOrRegisterMeter(prefix+"/accountst/waste", nil),
 	}
 	go p.mainLoop()
 	return p
@@ -144,7 +155,8 @@ func (p *triePrefetcher) mainLoop() {
 				}
 
 				if metrics.EnabledExpensive {
-					if fetcher.root == p.root {
+					switch fetcher.root {
+					case p.root:
 						p.accountLoadMeter.Mark(int64(len(fetcher.seen)))
 						p.accountDupMeter.Mark(int64(fetcher.dups))
 						p.accountSkipMeter.Mark(int64(len(fetcher.tasks)))
@@ -154,7 +166,19 @@ func (p *triePrefetcher) mainLoop() {
 						}
 						fetcher.lock.Unlock()
 						p.accountWasteMeter.Mark(int64(len(fetcher.seen)))
-					} else {
+
+					case p.rootPrefetch:
+						p.accountStaleLoadMeter.Mark(int64(len(fetcher.seen)))
+						p.accountStaleDupMeter.Mark(int64(fetcher.dups))
+						p.accountStaleSkipMeter.Mark(int64(len(fetcher.tasks)))
+						fetcher.lock.Lock()
+						for _, key := range fetcher.used {
+							delete(fetcher.seen, string(key))
+						}
+						fetcher.lock.Unlock()
+						p.accountStaleWasteMeter.Mark(int64(len(fetcher.seen)))
+
+					default:
 						p.storageLoadMeter.Mark(int64(len(fetcher.seen)))
 						p.storageDupMeter.Mark(int64(fetcher.dups))
 						p.storageSkipMeter.Mark(int64(len(fetcher.tasks)))
@@ -165,6 +189,7 @@ func (p *triePrefetcher) mainLoop() {
 						}
 						fetcher.lock.Unlock()
 						p.storageWasteMeter.Mark(int64(len(fetcher.seen)))
+
 					}
 				}
 			}

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -82,10 +82,11 @@ type triePrefetcher struct {
 func newTriePrefetcher(db Database, root, rootPrefetch common.Hash, namespace string) *triePrefetcher {
 	prefix := triePrefetchMetricsPrefix + namespace
 	p := &triePrefetcher{
-		db:        db,
-		root:      root,
-		fetchers:  make(map[common.Hash]*subfetcher), // Active prefetchers use the fetchers map
-		abortChan: make(chan *subfetcher, abortChanSize),
+		db:           db,
+		root:         root,
+		rootPrefetch: rootPrefetch,
+		fetchers:     make(map[common.Hash]*subfetcher), // Active prefetchers use the fetchers map
+		abortChan:    make(chan *subfetcher, abortChanSize),
 
 		closeMainChan:     make(chan struct{}),
 		closeMainDoneChan: make(chan struct{}),

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -49,9 +49,9 @@ type prefetchMsg struct {
 //
 // Note, the prefetcher's API is not thread safe.
 type triePrefetcher struct {
-	db         Database    // Database to fetch trie nodes through
-	root       common.Hash // Root hash of theaccount trie for metrics
-	rootParent common.Hash
+	db         Database                    // Database to fetch trie nodes through
+	root       common.Hash                 // Root hash of theaccount trie for metrics
+	rootParent common.Hash                 //Root has of the account trie from block before the prvious one, designed for pipecommit mode
 	fetches    map[common.Hash]Trie        // Partially or fully fetcher tries
 	fetchers   map[common.Hash]*subfetcher // Subfetchers for each trie
 

--- a/core/state/trie_prefetcher_test.go
+++ b/core/state/trie_prefetcher_test.go
@@ -55,7 +55,7 @@ func prefetchGuaranteed(prefetcher *triePrefetcher, root common.Hash, keys [][]b
 
 func TestCopyAndClose(t *testing.T) {
 	db := filledStateDB()
-	prefetcher := newTriePrefetcher(db.db, db.originalRoot, "")
+	prefetcher := newTriePrefetcher(db.db, db.originalRoot, common.Hash{}, "")
 	skey := common.HexToHash("aaa")
 	prefetchGuaranteed(prefetcher, db.originalRoot, [][]byte{skey.Bytes()}, common.Hash{})
 	prefetchGuaranteed(prefetcher, db.originalRoot, [][]byte{skey.Bytes()}, common.Hash{})
@@ -80,7 +80,7 @@ func TestCopyAndClose(t *testing.T) {
 
 func TestUseAfterClose(t *testing.T) {
 	db := filledStateDB()
-	prefetcher := newTriePrefetcher(db.db, db.originalRoot, "")
+	prefetcher := newTriePrefetcher(db.db, db.originalRoot, common.Hash{}, "")
 	skey := common.HexToHash("aaa")
 	prefetchGuaranteed(prefetcher, db.originalRoot, [][]byte{skey.Bytes()}, common.Hash{})
 	a := prefetcher.trie(db.originalRoot)
@@ -96,7 +96,7 @@ func TestUseAfterClose(t *testing.T) {
 
 func TestCopyClose(t *testing.T) {
 	db := filledStateDB()
-	prefetcher := newTriePrefetcher(db.db, db.originalRoot, "")
+	prefetcher := newTriePrefetcher(db.db, db.originalRoot, common.Hash{}, "")
 	skey := common.HexToHash("aaa")
 	prefetchGuaranteed(prefetcher, db.originalRoot, [][]byte{skey.Bytes()}, common.Hash{})
 	cpy := prefetcher.copy()


### PR DESCRIPTION
### Description
current `pipecommit` mode would use dummyRoot as account storageRoot before previous block had done commit. This would lead `trirePrefetcher` not able to work.

### Rationale
Remove dummyRoot to keep previous storage root while doing triePrefetch and recover stateRoot to enable effective triePrefetch in `pipecommit` mode
It's fine to do `triePrefetch` on previous `stateRoot/storageRoot` and would do a lot help for all the `accounts/storages` which are not modified during previous block.
And this would cause no harm since we use the corrected root when we do updateTrie and commit, which would ignore the stale node prefetched and the path node in cache would still help even though they were prefetched from a stale root.
tell us why we need these changes...

### Test
#### metrics on `verifystate` stage under `pipecommit` mode
<img width="1234" alt="verifystate-metrics" src="https://user-images.githubusercontent.com/26671219/181664503-d762cbb2-b68b-497f-8975-98e44f733c0a.png">
<img width="1469" alt="metrics" src="https://user-images.githubusercontent.com/26671219/181664749-9cf11c27-4ff1-4cec-82d5-c7c9ae532aa1.png">
green-line: before<br/> 
yellow-line: after


#### triePrefetch efficiency:
- on Account &emsp; **up from 0% to 100%**
  - before: 0%
   <img width="440" alt="accountPrefetch_before" src="https://user-images.githubusercontent.com/26671219/180361260-f06e98b1-9d02-4bf6-ae46-2a1001721f50.png">

  - after: 100%
   <img width="1280" alt="accountPrefetch_after" src="https://user-images.githubusercontent.com/26671219/180361372-d4e224eb-dfbf-480a-960a-5d8414385c30.png">

 
- on Storage
  - before: about 70%
  <img width="314" alt="storagePrefetch_before" src="https://user-images.githubusercontent.com/26671219/180361602-48664ffe-b367-47e8-a4b9-d0667bf2bc91.png">


  - after: about 84%
  <img width="370" alt="storagePrefetch_after" src="https://user-images.githubusercontent.com/26671219/180361619-ce880d0a-d8ec-4f1d-a898-da41eabcfeac.png">



### Changes

Notable changes: 
* remove `dummyroot`, keep root before previous block for `triePrefetch` on `storage`
* use `stateRoot` of block before previous one for `triePrefetch`on `account`