### PR TITLE
[R4R] Pipecommit trieprefetchenhance

### DIFF
--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -131,6 +131,8 @@ type Snapshot interface {
 	// Storage directly retrieves the storage data associated with a particular hash,
 	// within a particular account.
 	Storage(accountHash, storageHash common.Hash) ([]byte, error)
+
+	Parent() snapshot
 }
 
 // snapshot is the internal version of the snapshot data layer that supports some
@@ -143,7 +145,7 @@ type snapshot interface {
 	//
 	// Note, the method is an internal helper to avoid type switching between the
 	// disk and diff layers. There is no locking involved.
-	Parent() snapshot
+	//	Parent() snapshot
 
 	// Update creates a new layer on top of the existing snapshot diff tree with
 	// the specified data items.

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -132,6 +132,7 @@ type Snapshot interface {
 	// within a particular account.
 	Storage(accountHash, storageHash common.Hash) ([]byte, error)
 
+	//Parent used to get parent layer
 	Parent() snapshot
 }
 
@@ -139,13 +140,6 @@ type Snapshot interface {
 // additional methods compared to the public API.
 type snapshot interface {
 	Snapshot
-
-	// Parent returns the subsequent layer of a snapshot, or nil if the base was
-	// reached.
-	//
-	// Note, the method is an internal helper to avoid type switching between the
-	// disk and diff layers. There is no locking involved.
-	//	Parent() snapshot
 
 	// Update creates a new layer on top of the existing snapshot diff tree with
 	// the specified data items.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1001,7 +1001,11 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 		}
 	}
 	if s.prefetcher != nil && len(addressesToPrefetch) > 0 {
-		s.prefetcher.prefetch(s.originalRoot, addressesToPrefetch, emptyAddr)
+		if !s.snap.AccountsCorrected() {
+			s.prefetcher.prefetch(s.snap.Parent().Root(), addressesToPrefetch, emptyAddr)
+		} else {
+			s.prefetcher.prefetch(s.originalRoot, addressesToPrefetch, emptyAddr)
+		}
 	}
 	// Invalidate journal because reverting across transactions is not allowed.
 	s.clearJournalAndRefund()

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -224,7 +224,6 @@ func (s *StateDB) StartPrefetcher(namespace string) {
 		} else {
 			s.prefetcher = newTriePrefetcher(s.db, s.originalRoot, common.Hash{}, namespace)
 		}
-		//		s.prefetcher = newTriePrefetcher(s.db, s.originalRoot, namespace)
 	}
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1006,12 +1006,10 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 		}
 	}
 	if s.prefetcher != nil && len(addressesToPrefetch) > 0 {
-		if !s.snap.AccountsCorrected() {
-			if s.prefetcher.rootPrefetch != (common.Hash{}) {
-				s.prefetcher.prefetch(s.prefetcher.rootPrefetch, addressesToPrefetch, emptyAddr)
-			}
-		} else {
+		if s.snap.Verified() {
 			s.prefetcher.prefetch(s.originalRoot, addressesToPrefetch, emptyAddr)
+		} else if s.prefetcher.rootPrefetch != (common.Hash{}) {
+			s.prefetcher.prefetch(s.prefetcher.rootPrefetch, addressesToPrefetch, emptyAddr)
 		}
 	}
 	// Invalidate journal because reverting across transactions is not allowed.

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -49,10 +49,11 @@ type prefetchMsg struct {
 //
 // Note, the prefetcher's API is not thread safe.
 type triePrefetcher struct {
-	db       Database                    // Database to fetch trie nodes through
-	root     common.Hash                 // Root hash of theaccount trie for metrics
-	fetches  map[common.Hash]Trie        // Partially or fully fetcher tries
-	fetchers map[common.Hash]*subfetcher // Subfetchers for each trie
+	db           Database    // Database to fetch trie nodes through
+	root         common.Hash // Root hash of theaccount trie for metrics
+	rootPrefetch common.Hash
+	fetches      map[common.Hash]Trie        // Partially or fully fetcher tries
+	fetchers     map[common.Hash]*subfetcher // Subfetchers for each trie
 
 	abortChan         chan *subfetcher // to abort a single subfetcher and its children
 	closed            int32
@@ -70,16 +71,22 @@ type triePrefetcher struct {
 	storageDupMeter   metrics.Meter
 	storageSkipMeter  metrics.Meter
 	storageWasteMeter metrics.Meter
+
+	accountStaleLoadMeter  metrics.Meter
+	accountStaleDupMeter   metrics.Meter
+	accountStaleSkipMeter  metrics.Meter
+	accountStaleWasteMeter metrics.Meter
 }
 
 // newTriePrefetcher
-func newTriePrefetcher(db Database, root common.Hash, namespace string) *triePrefetcher {
+func newTriePrefetcher(db Database, root, rootPrefetch common.Hash, namespace string) *triePrefetcher {
 	prefix := triePrefetchMetricsPrefix + namespace
 	p := &triePrefetcher{
-		db:        db,
-		root:      root,
-		fetchers:  make(map[common.Hash]*subfetcher), // Active prefetchers use the fetchers map
-		abortChan: make(chan *subfetcher, abortChanSize),
+		db:           db,
+		root:         root,
+		rootPrefetch: rootPrefetch,
+		fetchers:     make(map[common.Hash]*subfetcher), // Active prefetchers use the fetchers map
+		abortChan:    make(chan *subfetcher, abortChanSize),
 
 		closeMainChan:     make(chan struct{}),
 		closeMainDoneChan: make(chan struct{}),
@@ -94,6 +101,11 @@ func newTriePrefetcher(db Database, root common.Hash, namespace string) *triePre
 		storageDupMeter:   metrics.GetOrRegisterMeter(prefix+"/storage/dup", nil),
 		storageSkipMeter:  metrics.GetOrRegisterMeter(prefix+"/storage/skip", nil),
 		storageWasteMeter: metrics.GetOrRegisterMeter(prefix+"/storage/waste", nil),
+
+		accountStaleLoadMeter:  metrics.GetOrRegisterMeter(prefix+"/accountst/load", nil),
+		accountStaleDupMeter:   metrics.GetOrRegisterMeter(prefix+"/accountst/dup", nil),
+		accountStaleSkipMeter:  metrics.GetOrRegisterMeter(prefix+"/accountst/skip", nil),
+		accountStaleWasteMeter: metrics.GetOrRegisterMeter(prefix+"/accountstwaste", nil),
 	}
 	go p.mainLoop()
 	return p
@@ -144,7 +156,8 @@ func (p *triePrefetcher) mainLoop() {
 				}
 
 				if metrics.EnabledExpensive {
-					if fetcher.root == p.root {
+					switch fetcher.root {
+					case p.root:
 						p.accountLoadMeter.Mark(int64(len(fetcher.seen)))
 						p.accountDupMeter.Mark(int64(fetcher.dups))
 						p.accountSkipMeter.Mark(int64(len(fetcher.tasks)))
@@ -154,7 +167,19 @@ func (p *triePrefetcher) mainLoop() {
 						}
 						fetcher.lock.Unlock()
 						p.accountWasteMeter.Mark(int64(len(fetcher.seen)))
-					} else {
+
+					case p.rootPrefetch:
+						p.accountStaleLoadMeter.Mark(int64(len(fetcher.seen)))
+						p.accountStaleDupMeter.Mark(int64(fetcher.dups))
+						p.accountStaleSkipMeter.Mark(int64(len(fetcher.tasks)))
+						fetcher.lock.Lock()
+						for _, key := range fetcher.used {
+							delete(fetcher.seen, string(key))
+						}
+						fetcher.lock.Unlock()
+						p.accountStaleWasteMeter.Mark(int64(len(fetcher.seen)))
+
+					default:
 						p.storageLoadMeter.Mark(int64(len(fetcher.seen)))
 						p.storageDupMeter.Mark(int64(fetcher.dups))
 						p.storageSkipMeter.Mark(int64(len(fetcher.tasks)))
@@ -165,7 +190,30 @@ func (p *triePrefetcher) mainLoop() {
 						}
 						fetcher.lock.Unlock()
 						p.storageWasteMeter.Mark(int64(len(fetcher.seen)))
+
 					}
+					//					if fetcher.root == p.root {
+					//						p.accountLoadMeter.Mark(int64(len(fetcher.seen)))
+					//						p.accountDupMeter.Mark(int64(fetcher.dups))
+					//						p.accountSkipMeter.Mark(int64(len(fetcher.tasks)))
+					//						fetcher.lock.Lock()
+					//						for _, key := range fetcher.used {
+					//							delete(fetcher.seen, string(key))
+					//						}
+					//						fetcher.lock.Unlock()
+					//						p.accountWasteMeter.Mark(int64(len(fetcher.seen)))
+					//					} else {
+					//						p.storageLoadMeter.Mark(int64(len(fetcher.seen)))
+					//						p.storageDupMeter.Mark(int64(fetcher.dups))
+					//						p.storageSkipMeter.Mark(int64(len(fetcher.tasks)))
+					//
+					//						fetcher.lock.Lock()
+					//						for _, key := range fetcher.used {
+					//							delete(fetcher.seen, string(key))
+					//						}
+					//						fetcher.lock.Unlock()
+					//						p.storageWasteMeter.Mark(int64(len(fetcher.seen)))
+					//					}
 				}
 			}
 			close(p.closeMainDoneChan)

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -192,28 +192,6 @@ func (p *triePrefetcher) mainLoop() {
 						p.storageWasteMeter.Mark(int64(len(fetcher.seen)))
 
 					}
-					//					if fetcher.root == p.root {
-					//						p.accountLoadMeter.Mark(int64(len(fetcher.seen)))
-					//						p.accountDupMeter.Mark(int64(fetcher.dups))
-					//						p.accountSkipMeter.Mark(int64(len(fetcher.tasks)))
-					//						fetcher.lock.Lock()
-					//						for _, key := range fetcher.used {
-					//							delete(fetcher.seen, string(key))
-					//						}
-					//						fetcher.lock.Unlock()
-					//						p.accountWasteMeter.Mark(int64(len(fetcher.seen)))
-					//					} else {
-					//						p.storageLoadMeter.Mark(int64(len(fetcher.seen)))
-					//						p.storageDupMeter.Mark(int64(fetcher.dups))
-					//						p.storageSkipMeter.Mark(int64(len(fetcher.tasks)))
-					//
-					//						fetcher.lock.Lock()
-					//						for _, key := range fetcher.used {
-					//							delete(fetcher.seen, string(key))
-					//						}
-					//						fetcher.lock.Unlock()
-					//						p.storageWasteMeter.Mark(int64(len(fetcher.seen)))
-					//					}
 				}
 			}
 			close(p.closeMainDoneChan)


### PR DESCRIPTION
### Description

current `pipecommit` mode would use dummyRoot as account storageRoot before previous block had done commit. This would lead `trirePrefetcher` not able to work.

### Rationale
Recover `dummyRoot` as previous storage root when came across `dummyRoot` while doing `triePrefetch` as well as `stateRoot` to enable effective `triePrefetch` in `pipecommit` mode
It's fine to do `triePrefetch` on previous `stateRoot/storageRoot` and would do a lot help for all the `accounts/storages` which are not modified during previous block. 
And this would cause no harm since we use the corrected `root` when we do `updateTrie` and `commit`, which would ignore the stale node prefetched and the `path node` in cache would still help even though they were prefetched from a stale root.

comparison of commit time(AccountsIntermediateRoot, StateIntermediateRoot, commit)
<img width="1263" alt="截屏2022-07-20 13 19 26" src="https://user-images.githubusercontent.com/26671219/179902956-41cbf79f-3501-4c1f-8f62-843cdb8e23cc.png">
green line: `pipecommit` with dummyRoot (no effective `triePrefetcher` work) <br \>
yellow line: `pipecommit` with previous root to do `triePrefetch`

logs shown `triePrefetcher` hit rate from 0 up to about 100%
before:
<img width="1004" alt="截屏2022-07-20 14 22 11" src="https://user-images.githubusercontent.com/26671219/179911398-74eb49a1-4c4b-481a-83f6-e5f224b72abc.png">
after:
<img width="1640" alt="截屏2022-07-20 14 23 05" src="https://user-images.githubusercontent.com/26671219/179911411-d00f3a9d-e5b0-415e-8288-3d5b327e7f8f.png">
explain: total count of accounts is : unchanged(329)+changed(8)=337; fetched 294 accounts on stale root, and 43 accounts on corrected root; `294+43==337`, all accounts has been `prefetched` correctly. 

### Example

N/A

### Changes

Notable changes: 
* add field `rootPrefetch` in `triePrefetcher` to store previous block's state root
* recover dummyRoot as previous storage root for `triePrefetch`
