### PR TITLE
[R4R]: Trie prefetch on state pretch

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1892,7 +1892,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 			// do Prefetch in a separate goroutine to avoid blocking the critical path
 
 			// 1.do state prefetch for snapshot cache
-			throwaway := statedb.Copy()
+			throwaway := statedb.CopyDoPrefetch()
 			go bc.prefetcher.Prefetch(block, throwaway, &bc.vmConfig, interruptCh)
 
 			// 2.do trie prefetch for MPT trie node cache

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1898,7 +1898,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 			// 2.do trie prefetch for MPT trie node cache
 			// it is for the big state trie tree, prefetch based on transaction's From/To address.
 			// trie prefetcher is thread safe now, ok to prefetch in a separate routine
-			go statedb.TriePrefetchInAdvance(block, signer)
+			go throwaway.TriePrefetchInAdvance(block, signer)
 		}
 
 		//Process block using the parent state as reference point

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -237,10 +237,9 @@ func (s *StateDB) StopPrefetcher() {
 }
 
 func (s *StateDB) TriePrefetchInAdvance(block *types.Block, signer types.Signer) {
-	s.prefetcherLock.Lock()
-	prefetcher := s.prefetcher // s.prefetcher could be resetted to nil
-	s.prefetcherLock.Unlock()
-
+	// s is a temporary throw away StateDB, s.prefetcher won't be resetted to nil
+	// so no need to add lock for s.prefetcher
+	prefetcher := s.prefetcher
 	if prefetcher == nil {
 		return
 	}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -58,7 +58,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 	// No need to execute the first batch, since the main processor will do it.
 	for i := 0; i < prefetchThread; i++ {
 		go func() {
-			newStatedb := statedb.Copy()
+			newStatedb := statedb.CopyDoPrefetch()
 			newStatedb.EnableWriteOnSharedStorage()
 			gaspool := new(GasPool).AddGas(block.GasLimit())
 			blockContext := NewEVMBlockContext(header, p.bc, nil)
@@ -100,7 +100,7 @@ func (p *statePrefetcher) PrefetchMining(txs *types.TransactionsByPriceAndNonce,
 	for i := 0; i < prefetchThread; i++ {
 		go func(startCh <-chan *types.Transaction, stopCh <-chan struct{}) {
 			idx := 0
-			newStatedb := statedb.Copy()
+			newStatedb := statedb.CopyDoPrefetch()
 			newStatedb.EnableWriteOnSharedStorage()
 			gaspool := new(GasPool).AddGas(gasLimit)
 			blockContext := NewEVMBlockContext(header, p.bc, nil)
@@ -153,5 +153,8 @@ func precacheTransaction(msg types.Message, config *params.ChainConfig, gaspool 
 	// Update the evm with the new transaction context.
 	evm.Reset(NewEVMTxContext(msg), statedb)
 	// Add addresses to access list if applicable
-	ApplyMessage(evm, msg, gaspool)
+	if _, err := ApplyMessage(evm, msg, gaspool); err == nil {
+		statedb.Finalise(true)
+	}
+
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -899,7 +899,7 @@ func (w *worker) commitTransactions(env *environment, txs *types.TransactionsByP
 	txsPrefetch := txs.Copy()
 	tx := txsPrefetch.Peek()
 	txCurr := &tx
-	w.prefetcher.PrefetchMining(txsPrefetch, env.header, env.gasPool.Gas(), env.state.Copy(), *w.chain.GetVMConfig(), interruptCh, txCurr)
+	w.prefetcher.PrefetchMining(txsPrefetch, env.header, env.gasPool.Gas(), env.state.CopyDoPrefetch(), *w.chain.GetVMConfig(), interruptCh, txCurr)
 
 LOOP:
 	for {


### PR DESCRIPTION
### Description
This is another PR to enhance the trie prefetch, try to reuse the execution results of state prefetch.

### Rationale
Currently, state prefetch just pre-execute the transactions and discard the results. It is helpful to increase the snapshot cache hit rate. It would be more helpful, if it can do trie prefetch at the same time, since the it will preload the trie node and build the trie tree in advance.
This PR is to implement it, by reusing the main trie prefetch and doing finalize after transaction is executed.

### Test Result
With this PR, the peek validation of the BSC 2022.04.18 burst traffic reduced by ~39% even based on the previous trie prefetch optimizations.
<img width="1732" alt="image" src="https://user-images.githubusercontent.com/92799281/179381848-18639354-2d22-43ed-88c8-50e96558257c.png">


### Changes
No impact to user.
