### PR TITLE
config: overwrite HTTPHost in config.toml via cli flag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1050,8 +1050,10 @@ func SplitAndTrim(input string) (ret []string) {
 // setHTTP creates the HTTP RPC listener interface string from the set
 // command line flags, returning empty if the HTTP endpoint is disabled.
 func setHTTP(ctx *cli.Context, cfg *node.Config) {
-	if ctx.GlobalBool(HTTPEnabledFlag.Name) && cfg.HTTPHost == "" {
-		cfg.HTTPHost = "127.0.0.1"
+	if ctx.GlobalBool(HTTPEnabledFlag.Name) {
+		if cfg.HTTPHost == "" {
+			cfg.HTTPHost = "127.0.0.1"
+		}
 		if ctx.GlobalIsSet(HTTPListenAddrFlag.Name) {
 			cfg.HTTPHost = ctx.GlobalString(HTTPListenAddrFlag.Name)
 		}


### PR DESCRIPTION
### Description

Overwrites `HTTPHost` in config.toml via cli flag when starting a node.

```
 ./geth --config ./config.toml --datadir ./node  --cache 8000 --http --http.addr 0.0.0.0 
```

When starting a node with flag `http` and `http.addr`, the config `HTTPHost` will be overwrite by the flag `http.addr`.

### Rationale

It's reasonable to overwrite the config in config.toml via cli flag.

### Example

Start a node with command:

```
 ./geth --config ./config.toml --datadir ./node  --cache 8000 --http --http.addr 0.0.0.0 
```

### Changes

This pr will allow overwriting `HTTPHost` in config.toml via cli flag.
