### PR TITLE
[R4R] Fix pipecommit active statedb

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -455,9 +455,11 @@ func (s *StateObject) updateTrie(db Database) Trie {
 	}
 	wg.Wait()
 
-	if s.db.prefetcher != nil {
-		s.db.prefetcher.used(s.data.Root, usedStorage)
+	prefetcher := s.db.prefetcher
+	if prefetcher != nil {
+		prefetcher.used(s.data.Root, usedStorage)
 	}
+
 	if len(s.pendingStorage) > 0 {
 		s.pendingStorage = make(Storage)
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -169,10 +169,11 @@ func (s *StateObject) getTrie(db Database) Trie {
 	if s.trie == nil {
 		// Try fetching from prefetcher first
 		// We don't prefetch empty tries
-		if s.data.Root != emptyRoot && s.db.prefetcher != nil {
+		prefetcher := s.db.prefetcher
+		if s.data.Root != emptyRoot && prefetcher != nil {
 			// When the miner is creating the pending state, there is no
 			// prefetcher
-			s.trie = s.db.prefetcher.trie(s.data.Root)
+			s.trie = prefetcher.trie(s.data.Root)
 		}
 		if s.trie == nil {
 			var err error
@@ -375,8 +376,9 @@ func (s *StateObject) finalise(prefetch bool) {
 		}
 	}
 
-	if s.db.prefetcher != nil && prefetch && len(slotsToPrefetch) > 0 && s.data.Root != emptyRoot && s.data.Root != dummyRoot {
-		s.db.prefetcher.prefetch(s.data.Root, slotsToPrefetch, s.addrHash)
+	prefetcher := s.db.prefetcher
+	if prefetcher != nil && prefetch && len(slotsToPrefetch) > 0 && s.data.Root != emptyRoot && s.data.Root != dummyRoot {
+		prefetcher.prefetch(s.data.Root, slotsToPrefetch, s.addrHash)
 	}
 	if len(s.dirtyStorage) > 0 {
 		s.dirtyStorage = make(Storage)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -857,8 +857,9 @@ func (s *StateDB) Copy() *StateDB {
 	// If there's a prefetcher running, make an inactive copy of it that can
 	// only access data but does not actively preload (since the user will not
 	// know that they need to explicitly terminate an active copy).
-	if s.prefetcher != nil {
-		state.prefetcher = s.prefetcher.copy()
+	prefetcher := s.prefetcher
+	if prefetcher != nil {
+		state.prefetcher = prefetcher.copy()
 	}
 	if s.snaps != nil {
 		// In order for the miner to be able to use and make additions
@@ -970,8 +971,9 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 			addressesToPrefetch = append(addressesToPrefetch, common.CopyBytes(addr[:])) // Copy needed for closure
 		}
 	}
-	if s.prefetcher != nil && len(addressesToPrefetch) > 0 {
-		s.prefetcher.prefetch(s.originalRoot, addressesToPrefetch, emptyAddr)
+	prefetcher := s.prefetcher
+	if prefetcher != nil && len(addressesToPrefetch) > 0 {
+		prefetcher.prefetch(s.originalRoot, addressesToPrefetch, emptyAddr)
 	}
 	// Invalidate journal because reverting across transactions is not allowed.
 	s.clearJournalAndRefund()


### PR DESCRIPTION
### Description

`prefetcher` be accessed after non-nil condition as a field of `statedb` is not safe.
eg: as in `pipecommit` mode, `statedb` might be used as `activestatedb` to `StopPrefetcher`, which would `panic` during:
```
if prefetcher != nil {
    prefetcher.used(s.data.Root, usedStorage)
 }
```

### Rationale

get `prefetcher` from `statedb` before check nil condition

### Example

N/A

### Changes
-
