### PR TITLE
[R4R]db: freezer batch compatible offline prunblock command

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -337,18 +337,37 @@ func pruneBlock(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	var newAncientPath string
-	oldAncientPath := ctx.GlobalString(utils.AncientFlag.Name)
-	if !filepath.IsAbs(oldAncientPath) {
-		// force absolute paths, which often fail due to the splicing of relative paths
-		return errors.New("datadir.ancient not abs path")
+
+	// Most of the problems reported by many users when using the prune-block
+	// tool are due to incorrect directory settings. Here, the default directory
+	// and relative directory are canceled, and the user is forced to formulate
+	// an absolute path to guide the user to run the prune-block command correctly.
+	if !ctx.GlobalIsSet(utils.DataDirFlag.Name) {
+		return errors.New("datadir must be set")
+	} else {
+		datadir := ctx.GlobalString(utils.DataDirFlag.Name)
+		if !filepath.IsAbs(datadir) {
+			// force absolute paths, which often fail due to the splicing of relative paths
+			return errors.New("datadir not abs path")
+		}
+	}
+
+	var oldAncientPath string
+	if !ctx.GlobalIsSet(utils.AncientFlag.Name) {
+		return errors.New("datadir.ancient must be set")
+	} else {
+		oldAncientPath = ctx.GlobalString(utils.AncientFlag.Name)
+		if !filepath.IsAbs(oldAncientPath) {
+			// force absolute paths, which often fail due to the splicing of relative paths
+			return errors.New("datadir.ancient not abs path")
+		}
 	}
 
 	path, _ := filepath.Split(oldAncientPath)
 	if path == "" {
 		return errors.New("prune failed, did not specify the AncientPath")
 	}
-	newAncientPath = filepath.Join(path, "ancient_back")
+	newAncientPath := filepath.Join(path, "ancient_back")
 
 	blockpruner := pruner.NewBlockPruner(chaindb, stack, oldAncientPath, newAncientPath, blockAmountReserved)
 

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -351,7 +351,7 @@ func pruneBlock(ctx *cli.Context) error {
 	}
 
 	// Most of the problems reported by users when first using the prune-block
-	// tool are due to incorrect directory settings. Here, the default directory
+	// tool are due to incorrect directory settings.Here, the default directory
 	// and relative directory are canceled, and the user is forced to formulate
 	// an absolute path to guide users to run the prune-block command correctly.
 	if !ctx.GlobalIsSet(utils.DataDirFlag.Name) {

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -350,10 +350,10 @@ func pruneBlock(ctx *cli.Context) error {
 		return err
 	}
 
-	// Most of the problems reported by many users when using the prune-block
+	// Most of the problems reported by users when first using the prune-block
 	// tool are due to incorrect directory settings. Here, the default directory
 	// and relative directory are canceled, and the user is forced to formulate
-	// an absolute path to guide the user to run the prune-block command correctly.
+	// an absolute path to guide users to run the prune-block command correctly.
 	if !ctx.GlobalIsSet(utils.DataDirFlag.Name) {
 		return errors.New("datadir must be set")
 	} else {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -147,7 +147,7 @@ var (
 	}
 	AncientFlag = DirectoryFlag{
 		Name:  "datadir.ancient",
-		Usage: "Data directory for ancient chain segments (default = inside chaindata)",
+		Usage: "Data directory for ancient chain segments (default = inside chaindata, '${datadir}/geth/chaindata/ancient/')",
 	}
 	DiffFlag = DirectoryFlag{
 		Name:  "datadir.diff",

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -94,7 +94,7 @@ func TestFreezerBasicsClosing(t *testing.T) {
 	// In-between writes, the table is closed and re-opened.
 	for x := 0; x < 255; x++ {
 		data := getChunk(15, x)
-		batch := f.newBatch()
+		batch := f.newBatch(0)
 		require.NoError(t, batch.AppendRaw(uint64(x), data))
 		require.NoError(t, batch.commit())
 		f.Close()
@@ -222,7 +222,7 @@ func TestFreezerRepairDanglingHeadLarge(t *testing.T) {
 			t.Errorf("Expected error for missing index entry")
 		}
 		// We should now be able to store items again, from item = 1
-		batch := f.newBatch()
+		batch := f.newBatch(0)
 		for x := 1; x < 0xff; x++ {
 			require.NoError(t, batch.AppendRaw(uint64(x), getChunk(15, ^x)))
 		}
@@ -412,7 +412,7 @@ func TestFreezerRepairFirstFile(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Write 80 bytes, splitting out into two files
-		batch := f.newBatch()
+		batch := f.newBatch(0)
 		require.NoError(t, batch.AppendRaw(0, getChunk(40, 0xFF)))
 		require.NoError(t, batch.AppendRaw(1, getChunk(40, 0xEE)))
 		require.NoError(t, batch.commit())
@@ -450,7 +450,7 @@ func TestFreezerRepairFirstFile(t *testing.T) {
 		}
 
 		// Write 40 bytes
-		batch := f.newBatch()
+		batch := f.newBatch(0)
 		require.NoError(t, batch.AppendRaw(1, getChunk(40, 0xDD)))
 		require.NoError(t, batch.commit())
 
@@ -507,7 +507,7 @@ func TestFreezerReadAndTruncate(t *testing.T) {
 		f.truncate(0)
 
 		// Write the data again
-		batch := f.newBatch()
+		batch := f.newBatch(0)
 		for x := 0; x < 30; x++ {
 			require.NoError(t, batch.AppendRaw(uint64(x), getChunk(15, ^x)))
 		}
@@ -529,7 +529,7 @@ func TestFreezerOffset(t *testing.T) {
 		}
 
 		// Write 6 x 20 bytes, splitting out into three files
-		batch := f.newBatch()
+		batch := f.newBatch(0)
 		require.NoError(t, batch.AppendRaw(0, getChunk(20, 0xFF)))
 		require.NoError(t, batch.AppendRaw(1, getChunk(20, 0xEE)))
 
@@ -592,7 +592,7 @@ func TestFreezerOffset(t *testing.T) {
 		t.Log(f.dumpIndexString(0, 100))
 
 		// It should allow writing item 6.
-		batch := f.newBatch()
+		batch := f.newBatch(0)
 		require.NoError(t, batch.AppendRaw(6, getChunk(20, 0x99)))
 		require.NoError(t, batch.commit())
 
@@ -710,7 +710,7 @@ func getChunk(size int, b int) []byte {
 func writeChunks(t *testing.T, ft *freezerTable, n int, length int) {
 	t.Helper()
 
-	batch := ft.newBatch()
+	batch := ft.newBatch(0)
 	for i := 0; i < n; i++ {
 		if err := batch.AppendRaw(uint64(i), getChunk(length, i)); err != nil {
 			t.Fatalf("AppendRaw(%d, ...) returned error: %v", i, err)
@@ -906,7 +906,7 @@ func TestFreezerReadonly(t *testing.T) {
 
 	// Case 5: Now write some data via a batch.
 	// This should fail either during AppendRaw or Commit
-	batch := f.newBatch()
+	batch := f.newBatch(0)
 	writeErr := batch.AppendRaw(32, make([]byte, 1))
 	if writeErr == nil {
 		writeErr = batch.commit()

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -115,7 +115,7 @@ func TestFreezerModifyRollback(t *testing.T) {
 
 	// Reopen and check that the rolled-back data doesn't reappear.
 	tables := map[string]bool{"test": true}
-	f2, err := newFreezer(dir, "", false, 2049, tables)
+	f2, err := newFreezer(dir, "", false, 0, 2049, tables)
 	if err != nil {
 		t.Fatalf("can't reopen freezer after failed ModifyAncients: %v", err)
 	}
@@ -262,17 +262,17 @@ func TestFreezerReadonlyValidate(t *testing.T) {
 	defer os.RemoveAll(dir)
 	// Open non-readonly freezer and fill individual tables
 	// with different amount of data.
-	f, err := newFreezer(dir, "", false, 2049, tables)
+	f, err := newFreezer(dir, "", false, 0, 2049, tables)
 	if err != nil {
 		t.Fatal("can't open freezer", err)
 	}
 	var item = make([]byte, 1024)
-	aBatch := f.tables["a"].newBatch()
+	aBatch := f.tables["a"].newBatch(0)
 	require.NoError(t, aBatch.AppendRaw(0, item))
 	require.NoError(t, aBatch.AppendRaw(1, item))
 	require.NoError(t, aBatch.AppendRaw(2, item))
 	require.NoError(t, aBatch.commit())
-	bBatch := f.tables["b"].newBatch()
+	bBatch := f.tables["b"].newBatch(0)
 	require.NoError(t, bBatch.AppendRaw(0, item))
 	require.NoError(t, bBatch.commit())
 	if f.tables["a"].items != 3 {
@@ -285,7 +285,7 @@ func TestFreezerReadonlyValidate(t *testing.T) {
 
 	// Re-openening as readonly should fail when validating
 	// table lengths.
-	f, err = newFreezer(dir, "", true, 2049, tables)
+	f, err = newFreezer(dir, "", true, 0, 2049, tables)
 	if err == nil {
 		t.Fatal("readonly freezer should fail with differing table lengths")
 	}
@@ -300,7 +300,7 @@ func newFreezerForTesting(t *testing.T, tables map[string]bool) (*freezer, strin
 	}
 	// note: using low max table size here to ensure the tests actually
 	// switch between multiple files.
-	f, err := newFreezer(dir, "", false, 2049, tables)
+	f, err := newFreezer(dir, "", false, 0, 2049, tables)
 	if err != nil {
 		t.Fatal("can't open freezer", err)
 	}

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -62,11 +62,12 @@ func newPrunedFreezer(datadir string, db ethdb.KeyValueStore) (*prunedfreezer, e
 func (f *prunedfreezer) repair(datadir string) error {
 	// compatible prune-block-tool
 	offset := ReadOffSetOfCurrentAncientFreezer(f.db)
+	log.Info("Read last offline prune-block start block number", "offset", offset)
 
 	// compatible freezer
 	min := uint64(math.MaxUint64)
 	for name, disableSnappy := range FreezerNoSnappy {
-		table, err := NewFreezerTable(datadir, name, disableSnappy, true)
+		table, err := NewFreezerTable(datadir, name, disableSnappy, false)
 		if err != nil {
 			return err
 		}
@@ -76,6 +77,7 @@ func (f *prunedfreezer) repair(datadir string) error {
 		}
 		table.Close()
 	}
+	log.Info("Read ancientdb item counts", "items", min)
 	offset += min
 
 	if frozen := ReadFrozenOfAncientFreezer(f.db); frozen > offset {

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -436,7 +436,11 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 			return consensus.ErrUnknownAncestor
 		}
 		// Write into new ancient_back db.
-		rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td)
+		_, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td)
+		if err != nil {
+			log.Error("write new ancient error", "error", err)
+			return err
+		}
 		// Print the log every 5s for better trace.
 		if common.PrettyDuration(time.Since(start)) > common.PrettyDuration(5*time.Second) {
 			log.Info("block backup process running successfully", "current blockNumber for backup", blockNumber)

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -437,7 +437,7 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 		}
 		// Write into new ancient_back db.
 		if _, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td); err != nil {
-			log.Error("write new ancient error", "error", err)
+			log.Error("failed to write new ancient", "error", err)
 			return err
 		}
 		// Print the log every 5s for better trace.

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -436,8 +436,7 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 			return consensus.ErrUnknownAncestor
 		}
 		// Write into new ancient_back db.
-		_, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td)
-		if err != nil {
+		if _, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td); err != nil {
 			log.Error("write new ancient error", "error", err)
 			return err
 		}


### PR DESCRIPTION
### Description

* Freezer batch compatible offline prune tool.
* Normalized the prune-block command parameters to avoid the first execution failure for new users due to parameter problems.


### Changes

Usage
* geth snapshot prune-block --datadir $datadir_var --datadir.ancient $ancientdir_var
| --datadir and --datadir.ancient parameters are required options and uses absolute path

Code changes: 
* add offset(after offline prune tool running, offset stands the start block number in ancient) to freezer batch.
* batch reset and commit will consider offset.
