### PR TITLE
statedb: get rid of activestate, stopPrefetcher manually

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1356,19 +1356,17 @@ func (s *StateDB) Commit(failPostCommitFunc func(), postCommitFuncs ...func() er
 	}
 	// Finalize any pending changes and merge everything into the tries
 	if s.lightProcessed {
+		defer s.StopPrefetcher()
 		root, diff, err := s.LightCommit()
 		if err != nil {
-			s.StopPrefetcher()
 			return root, diff, err
 		}
 		for _, postFunc := range postCommitFuncs {
 			err = postFunc()
 			if err != nil {
-				s.StopPrefetcher()
 				return root, diff, err
 			}
 		}
-		s.StopPrefetcher()
 		return root, diff, nil
 	}
 	var diffLayer *types.DiffLayer

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1154,15 +1154,7 @@ func (s *StateDB) StateIntermediateRoot() common.Hash {
 	// the remainder without, but pre-byzantium even the initial prefetcher is
 	// useless, so no sleep lost.
 	prefetcher := s.prefetcher
-	defer func() {
-		s.prefetcherLock.Lock()
-		if s.prefetcher != nil {
-			s.prefetcher.close()
-			s.prefetcher = nil
-		}
-		// try not use defer inside defer
-		s.prefetcherLock.Unlock()
-	}()
+	defer s.StopPrefetcher()
 
 	// Now we're about to start to write changes to the trie. The trie is so far
 	// _untouched_. We can check with the prefetcher, if it can give us a trie

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -229,7 +229,11 @@ func (s *StateDB) StopPrefetcher() {
 	if s.noTrie {
 		return
 	}
-	s.prefetcher.close()
+	s.prefetcherLock.Lock()
+	if s.prefetcher != nil {
+		s.prefetcher.close()
+	}
+	s.prefetcherLock.Unlock()
 }
 
 func (s *StateDB) TriePrefetchInAdvance(block *types.Block, signer types.Signer) {


### PR DESCRIPTION
### Description

- Since `statedb` would be accessed concurrently in different routine, it's not proper to use defer with `activeState` in the `insertchain`
- `triePrefetcher` is safe to be accessed like `trie` to get cached node when stopped, and since `triePrefetcher` had been redesigned to concurrency safe, there's no need to use `Lock`.

### Rationale

`StopPrefetcher` manually

### Example

N/A

### Changes

Notable changes: 
* `StopPrefetcher` manually
*  Modify `StopPrefetcher` to keep stopped prefetcher in `statedb`
