### PR TITLE
[R4R] fix: missing contract upgrades and incorrect behavior when miners enable pipecommit

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/parlia"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/systemcontracts"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -577,7 +578,7 @@ func (w *worker) mainLoop() {
 			if w.isRunning() && w.current != nil && len(w.current.uncles) < 2 {
 				start := time.Now()
 				if err := w.commitUncle(w.current, ev.Block.Header()); err == nil {
-					w.commit(w.current.copy(), nil, false, start)
+					w.commit(w.current, nil, false, start)
 				}
 			}
 
@@ -1075,6 +1076,10 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		log.Error("Failed to create sealing context", "err", err)
 		return nil, err
 	}
+
+	// Handle upgrade build-in system contract code
+	systemcontracts.UpgradeBuildInSystemContract(w.chainConfig, header.Number, env.state)
+
 	// Accumulate the uncles for the sealing work only if it's allowed.
 	if !genParams.noUncle {
 		commitUncles := func(blocks map[common.Hash]*types.Block) {
@@ -1162,11 +1167,11 @@ func (w *worker) commitWork(interrupt *int32, noempty bool, timestamp int64) {
 	// Create an empty block based on temporary copied state for
 	// sealing in advance without waiting block execution finished.
 	if !noempty && atomic.LoadUint32(&w.noempty) == 0 {
-		w.commit(work.copy(), nil, false, start)
+		w.commit(work, nil, false, start)
 	}
 	// Fill pending transactions from the txpool
 	w.fillTransactions(interrupt, work)
-	w.commit(work.copy(), w.fullTaskHook, true, start)
+	w.commit(work, w.fullTaskHook, true, start)
 
 	// Swap out the old work with the new one, terminating any leftover
 	// prefetcher processes in the mean time and starting a new one.
@@ -1185,16 +1190,17 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 		if interval != nil {
 			interval()
 		}
+
+		err := env.state.WaitPipeVerification()
+		if err != nil {
+			return err
+		}
+		env.state.CorrectAccountsRoot(w.chain.CurrentBlock().Root())
+
 		// Create a local environment copy, avoid the data race with snapshot state.
 		// https://github.com/ethereum/go-ethereum/issues/24299
 		env := env.copy()
 		s := env.state
-		err := s.WaitPipeVerification()
-		if err != nil {
-			return err
-		}
-		s.CorrectAccountsRoot(w.chain.CurrentBlock().Root())
-
 		block, receipts, err := w.engine.FinalizeAndAssemble(w.chain, types.CopyHeader(env.header), s, env.txs, env.unclelist(), env.receipts)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Description

1. The code for the mining block upgrade system contract is missing. https://github.com/bnb-chain/bsc/blob/de4abf9d09afac7ad54d3268647d1c8f5aa61e95/miner/worker.go#L966
2. Incorrect update of `stateb` when miner enables `pipecommit`.

### Rationale

1. Missed when merging ethereum versions.
2. When a miner does a `commit`, a new `*environment` is copied to work, but when `pipecommit` is enabled, `CorrectAccountsRoot` should be called to correct the root hash of the accounts in the snapshot, which results in only the copied ones be updated, and the continuously running `statedb` is not properly updated.

### Example

N/A

### Changes

Notable changes: 
* miner/worker.go
