### PR TITLE
[R4R]fix: resolve the concurrent cache read and write issue for fast node

### DIFF
--- a/core/remote_state_verifier.go
+++ b/core/remote_state_verifier.go
@@ -211,8 +211,9 @@ func (vm *remoteVerifyManager) cacheBlockVerified(hash common.Hash) {
 func (vm *remoteVerifyManager) AncestorVerified(header *types.Header) bool {
 	// find header of H-11 block.
 	header = vm.bc.GetHeaderByNumber(header.Number.Uint64() - maxForkHeight)
-	// If start from genesis block, there has not a H-11 block.
-	if header == nil {
+	// If start from genesis block, there has not a H-11 block,return true.
+	// Either if the block is an empty block, return true.
+	if header == nil || header.TxHash == types.EmptyRootHash {
 		return true
 	}
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	// chainHeadChanSize is the size of channel listening to ChainHeadEvent.
-	chainHeadChanSize = 10
+	chainHeadChanSize = 9
 
 	// txSlotSize is used to calculate how many data slots a single transaction
 	// takes up based on its size. The slots are used as DoS protection, ensuring


### PR DESCRIPTION
Signed-off-by: cryyl <yl.on.the.way@gmail.com>

### Description

When fast node insert a block, it will judge whether the 11 ahead of current block has been verified. While, if a block is an empty block, it must be verified. So if the 11 ahead block is an empty block, the AncestorVerified function will return true.

### Rationale



### Example



### Changes

Notable changes: 
* In the AncestorVerified function, if the 11 ahead of current block is an empty block, return true.
