### PR TITLE
fix: Incorrect merkle root issue when enabling pipecommit with miner

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1009,6 +1009,9 @@ func (s *StateDB) CorrectAccountsRoot(blockRoot common.Hash) {
 			if !obj.deleted && !obj.rootCorrected && obj.data.Root == dummyRoot {
 				if account, exist := accounts[crypto.Keccak256Hash(obj.address[:])]; exist {
 					obj.data.Root = common.BytesToHash(account.Root)
+					if obj.data.Root == (common.Hash{}) {
+						obj.data.Root = emptyRoot
+					}
 					obj.rootCorrected = true
 				}
 			}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1197,14 +1197,15 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 		}
 		env.state.CorrectAccountsRoot(w.chain.CurrentBlock().Root())
 
-		// Create a local environment copy, avoid the data race with snapshot state.
-		// https://github.com/ethereum/go-ethereum/issues/24299
-		env := env.copy()
-		s := env.state
-		block, receipts, err := w.engine.FinalizeAndAssemble(w.chain, types.CopyHeader(env.header), s, env.txs, env.unclelist(), env.receipts)
+		block, receipts, err := w.engine.FinalizeAndAssemble(w.chain, types.CopyHeader(env.header), env.state, env.txs, env.unclelist(), env.receipts)
 		if err != nil {
 			return err
 		}
+
+		// Create a local environment copy, avoid the data race with snapshot state.
+		// https://github.com/ethereum/go-ethereum/issues/24299
+		env := env.copy()
+
 		// If we're post merge, just ignore
 		if !w.isTTDReached(block.Header()) {
 			select {


### PR DESCRIPTION
### Description

1. Trie data is incorrect when enabling `pipecommit` with miner.
<img width="1781" alt="image" src="https://user-images.githubusercontent.com/25412254/180356752-cb1ed428-7a96-45dd-a0f4-3062b9f11924.png">
2. Account root hash is incorrect when doing `statedb. CorrectAccountsRoot `.

### Rationale

1. 1. Because the `parlia` consensus will call the system contract in `FinalizeAndAssemble`, and change the state of the world. But before that, the `statedb` is copied, but this copied `statedb` will not be used when writing blocks, resulting in incorrect writing of the world state.
2. 1. When `account root` is an empty hash, the correct `emptyhash` value is not assigned.

### Example

N/A

### Changes

Notable changes: 
* miner/worker.go
