### PR TITLE
[R4R]fix: fast node can not recover from force kill or panic

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -258,6 +258,9 @@ func (bc *BlockChain) GetTd(hash common.Hash, number uint64) *big.Int {
 
 // HasState checks if state trie is fully present in the database or not.
 func (bc *BlockChain) HasState(hash common.Hash) bool {
+	if bc.stateCache.NoTries() {
+		return bc.snaps != nil && bc.snaps.Snapshot(hash) != nil
+	}
 	if bc.pipeCommit && bc.snaps != nil {
 		// If parent snap is pending on verification, treat it as state exist
 		if s := bc.snaps.Snapshot(hash); s != nil && !s.Verified() {


### PR DESCRIPTION
### Description
This PR tries to fix the issue that the fast node can not been recovered after being force kill.

### Rationale
The logic of `HasBlockAndState` on develop branch is different from the [fastnode](https://github.com/bnb-chain/bsc/tree/fastnode) branch, which cause the problem.

### Example
We tried to force kill a fast node, and bring it back again, we will get the following logs to ensure the patch works:

```
=2022-07-25T12:30:30+0000 lvl=info msg="Importing sidechain segment"            start=915,482 end=916,833
t=2022-07-25T12:30:30+0000 lvl=eror msg="Expired request does not exist"         peer=c10f40b516f6b4deb81c0a03e9f35fbe77a5e782c283946653f54832540e22ff
t=2022-07-25T12:30:30+0000 lvl=eror msg="Expired request does not exist"         peer=6ce892615c659728db873e6367d026272816a6b5136a40fcefd9ab3343fdb92f
t=2022-07-25T12:30:30+0000 lvl=warn msg="Inserted known block"                   number=915,504 hash=0x6429b586608c0154dd7d85485550d276f07f2cd8d642d9a62bc1b882ded6bc43 uncles=0 txs=0 gas=0 root=0x412eb6a584fd458d1c90af93a44d0e7b5197f4ccfcca18a020fc0149870be039
t=2022-07-25T12:30:30+0000 lvl=eror msg="Impossible reorg, please file an issue" oldnum=915,504 oldhash=0x6429b586608c0154dd7d85485550d276f07f2cd8d642d9a62bc1b882ded6bc43 oldblocks=1323 newnum=915,504 newhash=0x6429b586608c0154dd7d85485550d276f07f2cd8d642d9a62bc1b882ded6bc43 newblocks=0t=2022-07-25T12:30:31+0000 lvl=warn msg="Inserted known block"                   number=915,513 hash=0xf190ed09f537e75b425f5058131e3877d776da1ac3b9f1b5922adffe2d81dce3 uncles=0 txs=0 gas=0 root=0xe98bca1cf99628719eac9734f9c1192dba60ecb8f6f407044fd6295e552b00f6t=2022-07-25T12:30:31+0000 lvl=warn msg="Inserted known block"                   number=915,521 hash=0x313053fe688e95c22cf53e29737ab17dff48761007580890ef37ee857f5cd2f1 uncles=0 txs=0 gas=0 root=0x638bbe4ca0e92cf84521e1f1321c8b3ca9d6d51b2506f9b94efd9ef133fb9276
```

### Changes
No impact to userrs.
