### PR TITLE
[R4R] Prepare for v1.1.12

### DIFF
--- a/.github/release.env
+++ b/.github/release.env
@@ -1,2 +1,2 @@
-MAINNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.8/mainnet.zip"
-TESTNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.8/testnet.zip"
+MAINNET_FILE_URL="https://github.com/binance-chain/bsc/releases/latest/download/mainnet.zip"
+TESTNET_FILE_URL="https://github.com/binance-chain/bsc/releases/latest/download/testnet.zip"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v1.1.12
+
+FEATURE
+* [\#862](https://github.com/bnb-chain/bsc/pull/862) Pruning AncientDB inline at runtime
+* [\#926](https://github.com/bnb-chain/bsc/pull/926) Separate Processing and State Verification on BSC
+
+IMPROVEMENT
+* [\#816](https://github.com/bnb-chain/bsc/pull/816) merge go-ethereum v1.10.15
+* [\#950](https://github.com/bnb-chain/bsc/pull/950) code optimizations for state prefetcher
+* [\#972](https://github.com/bnb-chain/bsc/pull/972) redesign triePrefetcher to make it thread safe
+* [\#998](https://github.com/bnb-chain/bsc/pull/998) update dockerfile with a few enhancement
+* [\#1015](https://github.com/bnb-chain/bsc/pull/1015) disable noisy logs since system transaction will cause gas capping
+
+BUGFIX
+* [\#932](https://github.com/bnb-chain/bsc/pull/932) fix account root was not set correctly when committing mpt during pipeline commit
+* [\#953](https://github.com/bnb-chain/bsc/pull/953) correct logic for eip check of NewEVMInterpreter
+* [\#958](https://github.com/bnb-chain/bsc/pull/958) define DiscReason as uint8
+* [\#959](https://github.com/bnb-chain/bsc/pull/959) update some packages' version
+* [\#983](https://github.com/bnb-chain/bsc/pull/983) fix nil pointer issue when stopping mining new block
+* [\#1002](https://github.com/bnb-chain/bsc/pull/1002) Fix pipecommit active statedb
+* [\#1005](https://github.com/bnb-chain/bsc/pull/1005) freezer batch compatible offline prunblock command
+* [\#1007](https://github.com/bnb-chain/bsc/pull/1007) missing contract upgrades and incorrect behavior when miners enable pipecommit
+* [\#1009](https://github.com/bnb-chain/bsc/pull/1009) resolve the concurrent cache read and write issue for fast node
+* [\#1011](https://github.com/bnb-chain/bsc/pull/1011) Incorrect merkle root issue when enabling pipecommit with miner
+* [\#1013](https://github.com/bnb-chain/bsc/pull/1013) tools broken because of writting metadata when open a readyonly db
+* [\#1014](https://github.com/bnb-chain/bsc/pull/1014) fast node can not recover from force kill or panic
+* [\#1019](https://github.com/bnb-chain/bsc/pull/1019) memory leak issue with diff protocol
+* [\#1020](https://github.com/bnb-chain/bsc/pull/1020) remove diffhash patch introduced from separate node
+* [\#1024](https://github.com/bnb-chain/bsc/pull/1024) verify node is not treated as verify node
+
 ## v1.1.11
 
 UPGRADE

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 11 // Patch version component of the current release
+	VersionPatch = 12 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.1.12 is a performance release. the following two features are introduced in this release.
1. `Separate Processing and State Verification.`
2. `Pruning AncientDB inline at runtime.` 

#### Separate Processing and State Verification 
Separate Processing and State Verification is introduced in https://github.com/bnb-chain/bsc/pull/926. it introduces two type nodes to make full use of different storage, one is named fast node, and the other is named verify node. The fast node will do block processing with snapshot, it will do all verification against blocks except state root. The verify node receives diffhash from the fast node and then responds MPT root to the fast node.

If you want to use this feature, See more details [here](https://docs.bnbchain.org/docs/BSC-separate-node)

#### Pruning AncientDB inline at runtime
A new flag is introduced to prune ancient undesired block data at runtime, it will discard `block`, `receipt`, `header` in the ancient DB to save space. 

Example: `geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0 --puneancient`.

*Note: once turned on, the ancient data will not be recovered again*

### Command Changes
After merging the Ethereum version, some Flag parameters have changed, please refer to the following list.
#### Removed
1. `--yolov3`
2. `--vm.ewasm`
3. `--vm.evm`
4. `--rpc`  (use --http)
5. `--rpcaddr` (use --http.addr)
6. `--rpccorsdomain` (use --http.port)
7. `--rpcvhosts`(use --http.corsdomain)
8. `--rpcapi` (use --http.vhosts)

#### Added
1. `--dev.gaslimit` Initial block gas limit
2. `--sepolia` Sepolia network: pre-configured proof-of-work test network
9. `--override.arrowglacier` Manually specify Arrow Glacier fork-block, overriding the bundled setting
10. `--override.terminaltotaldifficulty` Manually specify TerminalTotalDifficulty, overriding the bundled setting
11. `--rpc.evmtimeout` Sets a timeout used for eth_call (0=infinite)
12. `--gpo.ignoreprice` Gas price below which gpo will ignore transactions
13. `--metrics.influxdbv2` Enable metrics export/push to an external InfluxDB v2 database
14. `--metrics.influxdb.token` Token to authorize access to the database (v2 only)
15. `--metrics.influxdb.bucket` InfluxDB bucket name to push reported metrics to (v2 only)
16. `--metrics.influxdb.organization` InfluxDB organization name (v2 only)

#### Changed
1. `--syncemode` removed the `fast` mode

### Rationale

N/A

### Example

N/A

### Changes

FEATURE
* [\#862](https://github.com/bnb-chain/bsc/pull/862) Pruning AncientDB inline at runtime
* [\#926](https://github.com/bnb-chain/bsc/pull/926) Separate Processing and State Verification on BSC

IMPROVEMENT
* [\#816](https://github.com/bnb-chain/bsc/pull/816) merge go-ethereum v1.10.15
* [\#950](https://github.com/bnb-chain/bsc/pull/950) code optimizations for state prefetcher
* [\#972](https://github.com/bnb-chain/bsc/pull/972) redesign triePrefetcher to make it thread safe
* [\#998](https://github.com/bnb-chain/bsc/pull/998) update dockerfile with a few enhancement
* [\#1015](https://github.com/bnb-chain/bsc/pull/1015) disable noisy logs since system transaction will cause gas capping

BUGFIX
* [\#932](https://github.com/bnb-chain/bsc/pull/932) fix account root was not set correctly when committing mpt during pipeline commit
* [\#953](https://github.com/bnb-chain/bsc/pull/953) correct logic for eip check of NewEVMInterpreter
* [\#958](https://github.com/bnb-chain/bsc/pull/958) define DiscReason as uint8
* [\#959](https://github.com/bnb-chain/bsc/pull/959) update some packages' version
* [\#983](https://github.com/bnb-chain/bsc/pull/983) fix nil pointer issue when stopping mining new block
* [\#1002](https://github.com/bnb-chain/bsc/pull/1002) Fix pipecommit active statedb
* [\#1005](https://github.com/bnb-chain/bsc/pull/1005) freezer batch compatible offline prunblock command
* [\#1007](https://github.com/bnb-chain/bsc/pull/1007) missing contract upgrades and incorrect behavior when miners enable pipecommit
* [\#1009](https://github.com/bnb-chain/bsc/pull/1009) resolve the concurrent cache read and write issue for fast node
* [\#1011](https://github.com/bnb-chain/bsc/pull/1011) Incorrect merkle root issue when enabling pipecommit with miner
* [\#1013](https://github.com/bnb-chain/bsc/pull/1013) tools broken because of writting metadata when open a readyonly db
* [\#1014](https://github.com/bnb-chain/bsc/pull/1014) fast node can not recover from force kill or panic
* [\#1019](https://github.com/bnb-chain/bsc/pull/1019) memory leak issue with diff protocol
* [\#1020](https://github.com/bnb-chain/bsc/pull/1020) remove diffhash patch introduced from separate node
* [\#1024](https://github.com/bnb-chain/bsc/pull/1024) verify node is not treated as verify node

