### PR TITLE
[R4R]fix: verify node is not treated as verify node

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -947,7 +947,7 @@ func (srv *Server) checkInboundConn(remoteIP net.IP) error {
 func (srv *Server) SetupConn(fd net.Conn, flags connFlag, dialDest *enode.Node) error {
 	// If dialDest is verify node, set verifyConn flags.
 	for _, n := range srv.VerifyNodes {
-		if dialDest == n {
+		if dialDest.ID() == n.ID() {
 			flags |= verifyConn
 		}
 	}


### PR DESCRIPTION
### Description
For the fast node, verify node is a special setting that can do remove state root verification.

The development branch does have bugs in mark verify nodes. This PR aims to fix the bug.

### Rationale
![image](https://user-images.githubusercontent.com/7310198/181430275-0af7c0c7-52ab-4f69-8ecf-97d34b7c6397.png)
Both `dialDest` and `n` here is pointers, we shall just compare whether the ID equals.

### Example
After the patch, fast node can work smoothly in `full` and `insecure` mode.

### Changes

No
