### PR TITLE
add --pruneancient flag for snapshot prune-state cmd

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -429,7 +430,7 @@ func pruneBlock(ctx *cli.Context) error {
 
 func pruneState(ctx *cli.Context) error {
 	if ctx.GlobalIsSet(utils.PruneAncientDataFlag.Name) { // prune ancient only take effect on full sync.
-		if err := ctx.GlobalSet(utils.SyncModeFlag.Name, "full"); err != nil {
+		if err := ctx.GlobalSet(utils.SyncModeFlag.Name, downloader.FullSync.String()); err != nil {
 			return err
 		}
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2020,7 +2020,7 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, disableFree
 		chainDb, err = stack.OpenDatabase(name, cache, handles, "", readonly)
 	} else {
 		name := "chaindata"
-		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, disableFreeze, false, false)
+		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, disableFreeze, false, ctx.GlobalIsSet(PruneAncientDataFlag.Name))
 	}
 	if err != nil {
 		Fatalf("Could not open database: %v", err)


### PR DESCRIPTION
### Description

suppliment missing flag `--pruneancient` to snapshot sub-command prune-state.

### Rationale

To make sure the command `geth snapshot prune-state --datadir <datadir> --pruneancient` work as expectation after ancient db was pruned inline at runtime.

### Example


### Changes
