### PR TITLE
ci: add commit message lint

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -1,14 +1,16 @@
-const maxTypeNumber = 3
-
 const validateTypeNums = (parsedCommit) => {
     if (!parsedCommit.type) {
         return [false, 'invalid commit message']
     }
 
-    return [
-        parsedCommit.type.split(' ').length <= maxTypeNumber,
-      `type must not be more than ${maxTypeNumber}`,
-    ]
+    const types = parsedCommit.type.split(' ')
+    for (var i=0;i<types.length;i++){
+        if ((types[i].toLowerCase() == "wip") || (types[i].toLowerCase() == "r4r")) {
+            return [false, 'R4R  or WIP is not acceptable, no matter upper case or lower case']
+        }
+    }
+
+    return [true,'']
   }
 
 
@@ -25,7 +27,6 @@ module.exports = {
     'scope-empty':[2, 'always'],
     'type-enum': [2, 'never'],
     'function-rules/type-case': [2, 'always', validateTypeNums],
-    'type-max-length': [2, 'always', 20],
     'header-max-length': [
       2,
       'always',

--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -1,0 +1,37 @@
+const maxTypeNumber = 3
+
+const validateTypeNums = (parsedCommit) => {
+    if (!parsedCommit.type) {
+        return [false, 'invalid commit message']
+    }
+
+    return [
+        parsedCommit.type.split(' ').length <= maxTypeNumber,
+      `type must not be more than ${maxTypeNumber}`,
+    ]
+  }
+
+
+module.exports = {
+  parserPreset: {
+    parserOpts: {
+      headerPattern: /^(.*): .*/,
+    }
+  },
+  extends: ['@commitlint/config-conventional'],
+  plugins: ['commitlint-plugin-function-rules'],
+  rules: {
+    'subject-empty':[2, 'always'],
+    'scope-empty':[2, 'always'],
+    'type-enum': [2, 'never'],
+    'function-rules/type-case': [2, 'always', validateTypeNums],
+    'type-max-length': [2, 'always', 20],
+    'header-max-length': [
+      2,
+      'always',
+      72,
+    ],
+  },
+  helpUrl:
+    'https://github.com/bnb-chain/bsc/tree/develop/docs/lint/commit.md',
+}

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,45 @@
+name: Lint Commit Messages
+
+on:
+  push:
+    branches: 
+      - master
+      - develop
+
+  pull_request:
+    branches: 
+      - master
+      - develop
+
+jobs:
+  commitlint:
+    strategy:
+      matrix:
+        node-version: [14.x]
+        os: [ubuntu-18.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.npm
+            **/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install Deps
+        run: |
+          npm install -g commitlint-plugin-function-rules @commitlint/cli
+          npm install --save-dev commitlint-plugin-function-rules @commitlint/cli
+      - uses: wagoid/commitlint-github-action@v5
+        id: commitlint
+        env:
+          NODE_PATH: ${{ github.workspace }}/node_modules
+        with:
+          configFile: /github/workspace/.github/commitlint.config.js

--- a/docs/lint/commit.md
+++ b/docs/lint/commit.md
@@ -1,0 +1,26 @@
+## Commit Format Requirements
+1. The head line should contain no more than 72 characters
+2. head line is composed by  scope : subject 
+3. multi-scope is supported, separated by a space, such as scope1 scope2 scope3: subject 
+   it is better that scope number =<3 , scope length <= 20 char , but not mandatory
+4. keyword, such as  R4R  or WIP is not acceptable in the scope, no matter upper case or lower case.
+
+#### Example: Single Scope
+```
+evm: optimize opcode mload
+```
+
+#### Example: Multi Scope
+```
+rpc core db: refactor the interface of trie access
+```
+
+#### Example: Big Scope
+if the change is too big, impact several scopes, the scope name can be bep, feat or fix
+```
+bep130: implement parallel evm
+
+feat: implement parallel trie prefetch
+
+fix: stack overflow on GetCommitState
+```


### PR DESCRIPTION
### Description

Added Commit Lint Checker, which will automatically check the commit message format when submitting PR.
Docs: https://github.com/j75689/bsc/blob/ci/commitlint/docs/lint/commit.md

### Rationale

1. https://commitlint.js.org/#/reference-configuration
2. https://github.com/wagoid/commitlint-github-action

### Example
Success: 
<img width="962" alt="image" src="https://user-images.githubusercontent.com/25412254/183647187-40f1ce28-4372-4665-9642-e974625ee02c.png">

Fails:
<img width="855" alt="image" src="https://user-images.githubusercontent.com/25412254/183646174-4fe6b309-af8a-4dab-a2dc-6cfcf3e47535.png">
<img width="579" alt="image" src="https://user-images.githubusercontent.com/25412254/183648991-c1f39c97-3d1c-450d-ac9f-b4e3ea814fcd.png">


### Changes

N/A
