### PR TITLE
ci: no type-case check for scope.

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -26,6 +26,7 @@ module.exports = {
     'subject-empty':[2, 'always'],
     'scope-empty':[2, 'always'],
     'type-enum': [2, 'never'],
+    'type-case': [0, 'always'],
     'function-rules/type-case': [2, 'always', validateTypeNums],
     'header-max-length': [
       2,


### PR DESCRIPTION
### Description
The commitlint will check scope's case by default, only lower-case is allowed, e.g. the following commit message will fail:
"BEP100:  implement xxx"

Just remove this check.

### Rationale
None

### Example
None

### Changes
No impact to users
