### PR TITLE
test: fix TestOfflineBlockPrune

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -311,7 +311,7 @@ func doTest(cmdline []string) {
 	packages := []string{"./accounts/...", "./common/...", "./consensus/...", "./console/...", "./core/...",
 		"./crypto/...", "./eth/...", "./ethclient/...", "./ethdb/...", "./event/...", "./graphql/...", "./les/...",
 		"./light/...", "./log/...", "./metrics/...", "./miner/...", "./mobile/...", "./node/...",
-		"./p2p/...", "./params/...", "./rlp/...", "./rpc/...", "./tests/...", "./trie/..."}
+		"./p2p/...", "./params/...", "./rlp/...", "./rpc/...", "./tests/...", "./trie/...", "./cmd/geth/..."}
 	if len(flag.CommandLine.Args()) > 0 {
 		packages = flag.CommandLine.Args()
 	}

--- a/cmd/geth/pruneblock_test.go
+++ b/cmd/geth/pruneblock_test.go
@@ -49,8 +49,8 @@ var (
 	blockPruneBackUpBlockNumber = 128
 	key, _                      = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	address                     = crypto.PubkeyToAddress(key.PublicKey)
-	balance                     = big.NewInt(10000000)
-	gspec                       = &core.Genesis{Config: params.TestChainConfig, Alloc: core.GenesisAlloc{address: {Balance: balance}}}
+	balance                     = big.NewInt(100000000000000000)
+	gspec                       = &core.Genesis{Config: params.TestChainConfig, Alloc: core.GenesisAlloc{address: {Balance: balance}}, BaseFee: big.NewInt(params.InitialBaseFee)}
 	signer                      = types.LatestSigner(gspec.Config)
 	config                      = &core.CacheConfig{
 		TrieCleanLimit: 256,
@@ -154,7 +154,7 @@ func BlockchainCreator(t *testing.T, chaindbPath, AncientPath string, blockRemai
 	// Make chain starting from genesis
 	blocks, _ := core.GenerateChain(gspec.Config, genesis, ethash.NewFaker(), db, 500, func(i int, block *core.BlockGen) {
 		block.SetCoinbase(common.Address{0: byte(canonicalSeed), 19: byte(i)})
-		tx, err := types.SignTx(types.NewTransaction(block.TxNonce(address), common.Address{0x00}, big.NewInt(1000), params.TxGas, nil, nil), signer, key)
+		tx, err := types.SignTx(types.NewTransaction(block.TxNonce(address), common.Address{0x00}, big.NewInt(1000), params.TxGas, big.NewInt(params.InitialBaseFee), nil), signer, key)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
### Description

1. fix TestOfflineBlockPrune
2. trigger unit case for testing cmd in ci

### Rationale

1. This test case is broken after merging go-ethereum

https://github.com/bnb-chain/bsc/issues/1046

### Example

`make test`

### Changes

N/A
