### PR TITLE
ci: fix the pattern of commit lint

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -22,7 +22,7 @@ const validateTypeNums = (parsedCommit) => {
 module.exports = {
   parserPreset: {
     parserOpts: {
-      headerPattern: /^(.*): .*/,
+      headerPattern: /^(.*):.*/,
     }
   },
   extends: ['@commitlint/config-conventional'],


### PR DESCRIPTION
### Description

Fix the pattern of commit lint

### Rationale

changed parser pattern from `/^(.*): .*/` to `/^(.*):.*/`, allow the message formats like `(scope):(subject)`.

### Example

N/A

### Changes

Notable changes: 
* .github/commitlint.config.js
