### PR TITLE
metrics: add global txpool metrics

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -131,6 +131,12 @@ var (
 	slotsGauge   = metrics.NewRegisteredGauge("txpool/slots", nil)
 
 	reheapTimer = metrics.NewRegisteredTimer("txpool/reheap", nil)
+
+	pricedUrgentGauge   = metrics.NewRegisteredGauge("txpool/priced/urgent", nil)
+	pricedFloatingGauge = metrics.NewRegisteredGauge("txpool/priced/floating", nil)
+	pricedStalesGauge   = metrics.NewRegisteredGauge("txpool/priced/stale", nil)
+	pendingGaugeTotal   = metrics.NewRegisteredGauge("txpool/pending/total", nil)
+	queuedGaugeTotal    = metrics.NewRegisteredGauge("txpool/queued/total", nil)
 )
 
 // TxStatus is the current status of a transaction as seen by the pool.
@@ -383,6 +389,13 @@ func (pool *TxPool) loop() {
 		case <-report.C:
 			pool.mu.RLock()
 			pending, queued := pool.stats()
+
+			pricedUrgentGauge.Update(int64(len(pool.priced.urgent.list)))
+			pricedFloatingGauge.Update(int64(len(pool.priced.floating.list)))
+			pricedStalesGauge.Update(int64(pool.priced.stales))
+			pendingGaugeTotal.Update(int64(pending))
+			queuedGaugeTotal.Update(int64(queued))
+
 			pool.mu.RUnlock()
 			stales := int(atomic.LoadInt64(&pool.priced.stales))
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -392,7 +392,7 @@ func (pool *TxPool) loop() {
 
 			pricedUrgentGauge.Update(int64(len(pool.priced.urgent.list)))
 			pricedFloatingGauge.Update(int64(len(pool.priced.floating.list)))
-			pricedStalesGauge.Update(int64(pool.priced.stales))
+			pricedStalesGauge.Update(pool.priced.stales)
 			pendingGaugeTotal.Update(int64(pending))
 			queuedGaugeTotal.Update(int64(queued))
 


### PR DESCRIPTION
### Description
we found an oom issue from bsc v1.1.12, and it's probably caused by https://github.com/ethereum/go-ethereum/issues/23690
so add global txpool metrics to monitor.

### Rationale

N/A

### Example

N/A

### Changes

N/A
