### PR TITLE
txpool: reheap the priced list if london fork not enabled

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1224,10 +1224,17 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 	// because of another transaction (e.g. higher gas price).
 	if reset != nil {
 		pool.demoteUnexecutables()
-		if reset.newHead != nil && pool.chainconfig.IsLondon(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
-			pendingBaseFee := misc.CalcBaseFee(pool.chainconfig, reset.newHead)
-			pool.priced.SetBaseFee(pendingBaseFee)
+		if reset.newHead != nil {
+			if pool.chainconfig.IsLondon(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
+				// london fork enabled, reset given the base fee
+				pendingBaseFee := misc.CalcBaseFee(pool.chainconfig, reset.newHead)
+				pool.priced.SetBaseFee(pendingBaseFee)
+			} else {
+				// london fork not enabled, reheap to "reset" the priced list
+				pool.priced.Reheap()
+			}
 		}
+
 		// Update all accounts to the latest known pending nonce
 		nonces := make(map[common.Address]uint64, len(pool.pending))
 		for addr, list := range pool.pending {


### PR DESCRIPTION
### Description

issue: https://github.com/ethereum/go-ethereum/issues/23690

### Rationale

force calls Reheap periodically on the txpool to evict old transactions from the priced list when London fork is not enabled. Otherwise, it calls setBaseFee that internally calls Reheap.

The patch refer to https://github.com/maticnetwork/bor/pull/201/files 

### Example

pending...

### Changes

N/A
