### PR TITLE
release: prepare for release v1.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.1.15
+* [\#1109](https://github.com/bnb-chain/bsc/pull/1109) nanofork: block exploitation accounts and suspend cross chain bridge related precompile contracts
+
 ## v1.1.14
 IMPROVEMENT
 * [\#1057](https://github.com/bnb-chain/bsc/pull/1057) ci: allow merge pull request

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 14 // Patch version component of the current release
+	VersionPatch = 15 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
This PR introduce an emergency nano hard fork, all clients must upgrade to this version.

### Rationale
The cross-chain bridge-related precompile contracts have been exploited, this release aims to suspend the precompile contract and block the hacker's account.

* [\#1109](https://github.com/bnb-chain/bsc/pull/1109) nanofork: block exploitation accounts and suspend cross chain bridge related precompile contracts

### Example
Account `"0x489A8756C18C0b8B24EC2a2b9FF3D4d447F79BEc", "0xFd6042Df3D74ce9959922FeC559d7995F3933c55"` are blocked.

### Changes
It is an emergency hardfork, all client must upgrade to this release.
