### PR TITLE
typo: fix Merkel to Merkle

### DIFF
--- a/core/types/blacklist.go
+++ b/core/types/blacklist.go
@@ -2,7 +2,7 @@ package types
 
 import "github.com/ethereum/go-ethereum/common"
 
-// This is introduced because of the Tendermint IAVL Merkel Proof verification exploitation.
+// This is introduced because of the Tendermint IAVL Merkle Proof verification exploitation.
 var NanoBlackList = []common.Address{
 	common.HexToAddress("0x489A8756C18C0b8B24EC2a2b9FF3D4d447F79BEc"),
 	common.HexToAddress("0xFd6042Df3D74ce9959922FeC559d7995F3933c55"),


### PR DESCRIPTION
### Description

fix typo Merkel to Merkle

### Rationale


### Example


### Changes

