### PR TITLE
typo: fix Merkel to Merkle

### DIFF
--- a/core/types/blacklist.go
+++ b/core/types/blacklist.go
@@ -2,7 +2,7 @@ package types
 
 import "github.com/ethereum/go-ethereum/common"
 
-// This is introduced because of the Tendermint IAVL Merkel Proof verification exploitation.
+// This is introduced because of the Tendermint IAVL Merkle Proof verification exploitation.
 var NanoBlackList = []common.Address{
 	common.HexToAddress("0x489A8756C18C0b8B24EC2a2b9FF3D4d447F79BEc"),
 	common.HexToAddress("0xFd6042Df3D74ce9959922FeC559d7995F3933c55"),

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -169,7 +169,7 @@ type bytecodeResponse struct {
 // to actual requests and to validate any security constraints.
 //
 // Concurrency note: storage requests and responses are handled concurrently from
-// the main runloop to allow Merkel proof verifications on the peer's thread and
+// the main runloop to allow Merkle proof verifications on the peer's thread and
 // to drop on invalid response. The request struct must contain all the data to
 // construct the response without accessing runloop internals (i.e. tasks). That
 // is only included to allow the runloop to match a response to the task being


### PR DESCRIPTION
### Description

fix typo Merkel to Merkle

More Info: 
[https://en.wikipedia.org/wiki/Merkle_tree](url)

### Changes
core/types/blacklist.go
eth/protocols/snap/sync.go

