### PR TITLE
parlia: miner may not applies newHead to parlia.Snapshot ASAP

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -929,8 +929,8 @@ func (p *Parlia) IsLocalBlock(header *types.Header) bool {
 	return p.val == header.Coinbase
 }
 
-func (p *Parlia) SignRecently(chain consensus.ChainReader, parent *types.Header) (bool, error) {
-	snap, err := p.snapshot(chain, parent.Number.Uint64(), parent.ParentHash, nil)
+func (p *Parlia) SignRecently(chain consensus.ChainReader, parent *types.Block) (bool, error) {
+	snap, err := p.snapshot(chain, parent.NumberU64(), parent.Hash(), nil)
 	if err != nil {
 		return true, err
 	}
@@ -941,7 +941,7 @@ func (p *Parlia) SignRecently(chain consensus.ChainReader, parent *types.Header)
 	}
 
 	// If we're amongst the recent signers, wait for the next block
-	number := parent.Number.Uint64() + 1
+	number := parent.NumberU64() + 1
 	for seen, recent := range snap.Recents {
 		if recent == p.val {
 			// Signer is among recents, only wait if the current block doesn't shift it out

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -470,7 +470,7 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 			clearPending(head.Block.NumberU64())
 			timestamp = time.Now().Unix()
 			if p, ok := w.engine.(*parlia.Parlia); ok {
-				signedRecent, err := p.SignRecently(w.chain, head.Block.Header())
+				signedRecent, err := p.SignRecently(w.chain, head.Block)
 				if err != nil {
 					log.Info("Not allowed to propose block", "err", err)
 					continue


### PR DESCRIPTION
### Description

`parlia.SignRecently()` is the first function be called when `miner.worker` getting NewChainHead signal.

```go
            case head := <-w.chainHeadCh:
			if !w.isRunning() {
				continue
			}
			clearPending(head.Block.NumberU64())
			timestamp = time.Now().Unix()
			if p, ok := w.engine.(*parlia.Parlia); ok {
				signedRecent, err := p.SignRecently(w.chain, head.Block.Header())
				if err != nil {
					log.Info("Not allowed to propose block", "err", err)
					continue
				}
				if signedRecent {
					log.Info("Signed recently, must wait")
					continue
				}
			}
			commit(true, commitInterruptNewHead)
```

I believe we should import this new head to parlia.Snapshot as soon as the newChainHead is heard by miner.worker.

But [inside `parlia.SignRecently()`](https://github.com/bnb-chain/bsc/blob/cb131fabe5fb9570180e7030a293a984f17c2446/consensus/parlia/parlia.go#L933) there is a bug of loading current snapshot.

```go
func (p *Parlia) SignRecently(chain consensus.ChainReader, parent *types.Header) (bool, error) {
	snap, err := p.snapshot(chain, parent.Number.Uint64(), parent.ParentHash, nil)
```

Obviously we cannot find a block by mismatched blockNumber and blockHash. In the line above they are `parent.Number.Uint64()` and `parent.ParentHash`.

However we are very lucky that parlia.Snapshot has a cache, which can help us to find the `currentNewHead's parent's snapshot` by `parent.ParentHash`.
The recent-sign-checking job is done by this snapshot.

It works, but the new head was not imported to snapshot. 
I don't believe we doing this intentionally.

```go
if s, ok := p.recentSnaps.Get(hash); ok {
	snap = s.(*Snapshot)
	break
}
```

The newHead is actually imported to parlia.Snapshot when worker prepare packing stage. The heads that need to be imported to parlia.Snapshot may accumulate. It obviously slows the worker's progress.


### Example

When log `Signed recently, must wait` pops up, the newHead is not imported to parlia.Snapshot.
When a validator just passed a RecentSign stage, it imports all missed heads when prepareWork.

### Changes

```go
func (p *Parlia) SignRecently(chain consensus.ChainReader, parent *types.Block) (bool, error) {
	snap, err := p.snapshot(chain, parent.NumberU64(), parent.Hash(), nil)
```

### Note

It might changes the SignRecently() result because the `snap` found by pre-modify and after-modify are different. 
Verify this first.