### PR TITLE
parlia urgent: BEP-131 bug. Cause new validators on blockNumber%Epoch = 11 are slashed often. 

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -929,8 +929,8 @@ func (p *Parlia) IsLocalBlock(header *types.Header) bool {
 	return p.val == header.Coinbase
 }
 
-func (p *Parlia) SignRecently(chain consensus.ChainReader, parent *types.Header) (bool, error) {
-	snap, err := p.snapshot(chain, parent.Number.Uint64(), parent.ParentHash, nil)
+func (p *Parlia) SignRecently(chain consensus.ChainReader, parent *types.Block) (bool, error) {
+	snap, err := p.snapshot(chain, parent.NumberU64(), parent.Hash(), nil)
 	if err != nil {
 		return true, err
 	}
@@ -941,7 +941,7 @@ func (p *Parlia) SignRecently(chain consensus.ChainReader, parent *types.Header)
 	}
 
 	// If we're amongst the recent signers, wait for the next block
-	number := parent.Number.Uint64() + 1
+	number := parent.NumberU64() + 1
 	for seen, recent := range snap.Recents {
 		if recent == p.val {
 			// Signer is among recents, only wait if the current block doesn't shift it out

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -470,7 +470,7 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 			clearPending(head.Block.NumberU64())
 			timestamp = time.Now().Unix()
 			if p, ok := w.engine.(*parlia.Parlia); ok {
-				signedRecent, err := p.SignRecently(w.chain, head.Block.Header())
+				signedRecent, err := p.SignRecently(w.chain, head.Block)
 				if err != nil {
 					log.Info("Not allowed to propose block", "err", err)
 					continue


### PR DESCRIPTION
#### Please review and merge this PR ASAP. It continually makes mistake for all validators.

### Description

Inside parlia snapshot, BEP-131 validator set is updated at `number%s.config.Epoch == uint64(len(snap.Validators)/2)`.

Simplify it is `blockNumber%200 = 10`

`parlia.SignRecently()` is the first function be called when `miner.worker` getting NewChainHead signal, which controls the starting of the packing tasks.

```go
            case head := <-w.chainHeadCh:
			if !w.isRunning() {
				continue
			}
			clearPending(head.Block.NumberU64())
			timestamp = time.Now().Unix()
			if p, ok := w.engine.(*parlia.Parlia); ok {
				signedRecent, err := p.SignRecently(w.chain, head.Block.Header())
				if err != nil {
					log.Info("Not allowed to propose block", "err", err)
					continue
				}
				if signedRecent {
					log.Info("Signed recently, must wait")
					continue
				}
			}
			commit(true, commitInterruptNewHead)
```

But there is bug inside the `parlia.SignRecently()` causes the newValidatorSet is not updated on `blockNumber%200 = 10`


```go
func (p *Parlia) SignRecently(chain consensus.ChainReader, parent *types.Header) (bool, error) {
	snap, err := p.snapshot(chain, parent.Number.Uint64(), parent.ParentHash, nil)
```

Obviously we cannot find a block by mismatched blockNumber and blockHash. In the line above they are `parent.Number.Uint64()` and `parent.ParentHash`.

However the `parent.ParentHash` hits a cache of parlia.Snapshot. The cached snapshot cannot `snap.apply` the latest chain head.

Thus the very import part [*ChangeValidatorSet*](https://github.com/BNB48Club/bsc/blob/6e08fc046ab4a7ee3aa0c9780310a1cbf1b5f884/consensus/parlia/snapshot.go#L191) doesn't run on a RecentSigned validator and new imported validator of current Epoch.


### Rationale

 BNB48 Club reported some related cases. 

### Example

![slashlist](https://user-images.githubusercontent.com/17488831/196654318-276fd7f2-09a2-4169-8416-4e27e74460ec.jpg)

#### recent slash list, `blockNumber%Epoch = 11` occur frequently

![slashrecord](https://user-images.githubusercontent.com/17488831/196654930-5f08fc98-ef14-40cd-8cef-0518d548ffb3.jpg)
#### The slashed validator 

![epoch](https://user-images.githubusercontent.com/17488831/196655082-21889988-822b-4f22-8e5a-7a361629caef.jpg)
#### This was a new imported validator on Epoch of 22243800, it was a candidate in last Epoch. He was in-turn at 22243811.
#### But he didn't loaded the newValidatorSet at 22243810 so he missed 22243811.



### Changes

```go
func (p *Parlia) SignRecently(chain consensus.ChainReader, parent *types.Block) (bool, error) {
	snap, err := p.snapshot(chain, parent.NumberU64(), parent.Hash(), nil)
```
