### PR TITLE
fair: a hotfix to include more txs before seal block

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -800,11 +800,6 @@ func (p *Parlia) Delay(chain consensus.ChainReader, header *types.Header) *time.
 		return nil
 	}
 	delay := p.delayForRamanujanFork(snap, header)
-	// The blocking time should be no more than half of period
-	half := time.Duration(p.config.Period) * time.Second / 2
-	if delay > half {
-		delay = half
-	}
 	return &delay
 }
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -89,7 +89,7 @@ var Defaults = Config{
 		GasCeil:       8000000,
 		GasPrice:      big.NewInt(params.GWei),
 		Recommit:      3 * time.Second,
-		DelayLeftOver: 50 * time.Millisecond,
+		DelayLeftOver: 300 * time.Millisecond,
 	},
 	TxPool:        core.DefaultTxPoolConfig,
 	RPCGasCap:     50000000,

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -89,7 +89,7 @@ var Defaults = Config{
 		GasCeil:       8000000,
 		GasPrice:      big.NewInt(params.GWei),
 		Recommit:      3 * time.Second,
-		DelayLeftOver: 300 * time.Millisecond,
+		DelayLeftOver: 400 * time.Millisecond,
 	},
 	TxPool:        core.DefaultTxPoolConfig,
 	RPCGasCap:     50000000,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -649,6 +649,8 @@ func (w *worker) mainLoop() {
 			return
 		case <-w.txsSub.Err():
 			return
+		case <-w.txs2Sub.Err():
+			return
 		case <-w.chainHeadSub.Err():
 			return
 		case <-w.chainSideSub.Err():

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1127,7 +1127,7 @@ func (w *worker) fillTransactions(interrupt *int32, env *environment) {
 	if delay != nil {
 		left := *delay - w.config.DelayLeftOver
 		if left <= 0 {
-			log.Info("Not enough time for further fillTransactions", "delay", *delay, "DelayLeftOver", w.config.DelayLeftOver)
+			log.Info("Not enough time for fillTransactions", "delay", *delay, "DelayLeftOver", w.config.DelayLeftOver)
 			return
 		}
 		stopTimer = time.NewTimer(left)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -272,6 +272,7 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 		unconfirmed:        newUnconfirmedBlocks(eth.BlockChain(), sealingLogAtDepth),
 		pendingTasks:       make(map[common.Hash]*task),
 		txsCh:              make(chan core.NewTxsEvent, txChanSize),
+		txs2Ch:             make(chan core.NewTxsEvent, txChanSize),
 		chainHeadCh:        make(chan core.ChainHeadEvent, chainHeadChanSize),
 		chainSideCh:        make(chan core.ChainSideEvent, chainSideChanSize),
 		newWorkCh:          make(chan *newWorkReq),


### PR DESCRIPTION
### Description
As the mining phase, the only criteria for a validator is to broadcast the block on time.
It can keep mining as long as the 3s deadline and GasLimit are not reached.

This is a temporary hot fix to give validator more time to commit transactions, especially when network is not busy.

And the complete network fairness is an open topic, more efforts are need to settle it.

### Changes
It changes the logic of packing transaction in mine phase.
It would be better for validator to apply this change, it helps for APR.

