### PR TITLE
worker: remove pre-seal empty block

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -240,23 +240,6 @@ func (miner *Miner) SetGasCeil(ceil uint64) {
 	miner.worker.setGasCeil(ceil)
 }
 
-// EnablePreseal turns on the preseal mining feature. It's enabled by default.
-// Note this function shouldn't be exposed to API, it's unnecessary for users
-// (miners) to actually know the underlying detail. It's only for outside project
-// which uses this library.
-func (miner *Miner) EnablePreseal() {
-	miner.worker.enablePreseal()
-}
-
-// DisablePreseal turns off the preseal mining feature. It's necessary for some
-// fake consensus engine which can seal blocks instantaneously.
-// Note this function shouldn't be exposed to API, it's unnecessary for users
-// (miners) to actually know the underlying detail. It's only for outside project
-// which uses this library.
-func (miner *Miner) DisablePreseal() {
-	miner.worker.disablePreseal()
-}
-
 // GetSealingBlock retrieves a sealing block based on the given parameters.
 // The returned block is not sealed but all other fields should be filled.
 func (miner *Miner) GetSealingBlock(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash) (*types.Block, error) {


### PR DESCRIPTION
### Description
`pre-seal` empty block is for PoW to deliver an empty block ASAP to gain the block mine reward.
It is useless for PoS consensus and it does not work for BSC either.
Delete the code to make worker simpler.

### Rationale
NA

### Example
NA

### Changes
NA
