### PR TITLE
worker: fix a bug of the delay timer.

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -809,6 +809,7 @@ LOOP:
 			select {
 			case <-stopTimer.C:
 				log.Info("Not enough time for further transactions", "txs", len(env.txs))
+				stopTimer.Reset(0) // re-active the timer, in case it will be used later.
 				break LOOP
 			default:
 			}


### PR DESCRIPTION
### Description
`fillTransactions` will call `commitTransactions` twice, if the delay timer is expired during the first call, it will make the delay timer never be triggered in the second commitTransactions call. Pseudo code:
    x := time.NewTimer(time.Second)
    <-x.C
    fmt.Println("read delay 1")
    <-x.C
    fmt.Println("read delay 2")  // will never hit

### Rationale
NA

### Example
NA

### Changes
NA