### PR TITLE
Prune some useless code

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -136,8 +136,7 @@ func (h *Hash) SetBytes(b []byte) {
 	if len(b) > len(h) {
 		b = b[len(b)-HashLength:]
 	}
-
-	copy(h[HashLength-len(b):], b)
+	copy(h[:], b)
 }
 
 // Generate implements testing/quick.Generator.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1423,11 +1423,8 @@ func (s *StateDB) Commit(failPostCommitFunc func(), postCommitFuncs ...func() er
 			finishCh := make(chan struct{})
 
 			threads := gopool.Threads(len(s.stateObjectsDirty))
-			wg := sync.WaitGroup{}
 			for i := 0; i < threads; i++ {
-				wg.Add(1)
 				go func() {
-					defer wg.Done()
 					for {
 						select {
 						case task := <-tasks:
@@ -1492,7 +1489,6 @@ func (s *StateDB) Commit(failPostCommitFunc func(), postCommitFuncs ...func() er
 					return err
 				}
 			}
-			wg.Wait()
 			return nil
 		}()
 

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -142,9 +142,7 @@ func (c *Contract) isCode(udest uint64) bool {
 	// in state trie. In that case, we do an analysis, and save it locally, so
 	// we don't have to recalculate it for every JUMP instruction in the execution
 	// However, we don't save it within the parent context
-	if c.analysis == nil {
-		c.analysis = codeBitmap(c.Code)
-	}
+	c.analysis = codeBitmap(c.Code)
 	return c.analysis.codeSegment(udest)
 }
 


### PR DESCRIPTION
### Description

This pr is about some code prunning.

### Rationale

Mainly remove some useless code.

### Example

N/A

### Changes

Notable changes: 
* remove useless `waitgroup`
* remove useless `nil` check
