### PR TITLE
metrics: add build info into metrics server

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -50,12 +50,8 @@ jobs:
 
       - name: Build Binary for ARM
         if: matrix.os == 'ubuntu-18.04'
-        env:
-          GOPATH: /home/runner/work/woodpecker/go
         run: |
-          mkdir -p $GOPATH/src/github.com/bnb-chain/bsc/
-          cp -r ./* $GOPATH/src/github.com/bnb-chain/bsc/
-          cd $GOPATH/src/github.com/bnb-chain/bsc/ && make geth-linux-arm
+          make geth-linux-arm
       # ==============================
       #       Upload artifacts
       # ==============================
@@ -86,28 +82,28 @@ jobs:
         if: matrix.os == 'ubuntu-18.04'
         with:
           name: arm5
-          path: /home/runner/work/woodpecker/go/src/github.com/bnb-chain/bsc/build/bin/geth-linux-arm-5
+          path: ./build/bin/geth-linux-arm-5
       
       - name: Upload ARM-6 Build
         uses: actions/upload-artifact@v2
         if: matrix.os == 'ubuntu-18.04'
         with:
           name: arm6
-          path: /home/runner/work/woodpecker/go/src/github.com/bnb-chain/bsc/build/bin/geth-linux-arm-6
+          path: ./build/bin/geth-linux-arm-6
 
       - name: Upload ARM-7 Build
         uses: actions/upload-artifact@v2
         if: matrix.os == 'ubuntu-18.04'
         with:
           name: arm7
-          path: /home/runner/work/woodpecker/go/src/github.com/bnb-chain/bsc/build/bin/geth-linux-arm-7
+          path: ./build/bin/geth-linux-arm-7
 
       - name: Upload ARM-64 Build
         uses: actions/upload-artifact@v2
         if: matrix.os == 'ubuntu-18.04'
         with:
           name: arm64
-          path: /home/runner/work/woodpecker/go/src/github.com/bnb-chain/bsc/build/bin/geth-linux-arm64
+          path: ./build/bin/geth-linux-arm64
 
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,8 @@ jobs:
 
       - name: Build Binary for ARM
         if: matrix.os == 'ubuntu-18.04'
-        env:
-          GOPATH: /home/runner/work/woodpecker/go
         run: |
-          mkdir -p $GOPATH/src/github.com/bnb-chain/bsc/
-          cp -r ./* $GOPATH/src/github.com/bnb-chain/bsc/
-          cd $GOPATH/src/github.com/bnb-chain/bsc/ && make geth-linux-arm
+          make geth-linux-arm
       # ==============================
       #       Upload artifacts
       # ==============================
@@ -87,28 +83,28 @@ jobs:
         if: matrix.os == 'ubuntu-18.04'
         with:
           name: arm5
-          path: /home/runner/work/woodpecker/go/src/github.com/bnb-chain/bsc/build/bin/geth-linux-arm-5
+          path: ./build/bin/geth-linux-arm-5
       
       - name: Upload ARM-6 Build
         uses: actions/upload-artifact@v2
         if: matrix.os == 'ubuntu-18.04'
         with:
           name: arm6
-          path: /home/runner/work/woodpecker/go/src/github.com/bnb-chain/bsc/build/bin/geth-linux-arm-6
+          path: ./build/bin/geth-linux-arm-6
 
       - name: Upload ARM-7 Build
         uses: actions/upload-artifact@v2
         if: matrix.os == 'ubuntu-18.04'
         with:
           name: arm7
-          path: /home/runner/work/woodpecker/go/src/github.com/bnb-chain/bsc/build/bin/geth-linux-arm-7
+          path: ./build/bin/geth-linux-arm-7
 
       - name: Upload ARM-64 Build
         uses: actions/upload-artifact@v2
         if: matrix.os == 'ubuntu-18.04'
         with:
           name: arm64
-          path: /home/runner/work/woodpecker/go/src/github.com/bnb-chain/bsc/build/bin/geth-linux-arm64
+          path: ./build/bin/geth-linux-arm64
 
   release:
     name: Release

--- a/Makefile
+++ b/Makefile
@@ -9,25 +9,30 @@
 GOBIN = ./build/bin
 GO ?= latest
 GORUN = env GO111MODULE=on go run
+GIT_COMMIT=$(shell git rev-parse HEAD)
+GIT_COMMIT_DATE=$(shell git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
 
 geth:
 	$(GORUN) build/ci.go install ./cmd/geth
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
+ldflags = -X main.gitCommit=$(GIT_COMMIT) \
+          -X main.gitDate=$(GIT_COMMIT_DATE)
+
 geth-linux-arm: geth-linux-arm5 geth-linux-arm6 geth-linux-arm7 geth-linux-arm64
 
 geth-linux-arm5:
-	env GO111MODULE=on GOARCH=arm GOARM=5 GOOS=linux go build -o build/bin/geth-linux-arm-5  ./cmd/geth
+	env GO111MODULE=on GOARCH=arm GOARM=5 GOOS=linux go build -ldflags="$(ldflags)" -o build/bin/geth-linux-arm-5 ./cmd/geth
 
 geth-linux-arm6:
-	env GO111MODULE=on GOARCH=arm GOARM=6 GOOS=linux go build -o build/bin/geth-linux-arm-6  ./cmd/geth
+	env GO111MODULE=on GOARCH=arm GOARM=6 GOOS=linux go build -ldflags="$(ldflags)" -o build/bin/geth-linux-arm-6 ./cmd/geth
 
 geth-linux-arm7:
-	env GO111MODULE=on GOARCH=arm GOARM=7 GOOS=linux go build -o build/bin/geth-linux-arm-7  ./cmd/geth
+	env GO111MODULE=on GOARCH=arm GOARM=7 GOOS=linux go build -ldflags="$(ldflags)" -o build/bin/geth-linux-arm-7 ./cmd/geth
 
 geth-linux-arm64:
-	env GO111MODULE=on GOARCH=arm64 GOOS=linux go build -o build/bin/geth-linux-arm64  ./cmd/geth
+	env GO111MODULE=on GOARCH=arm64 GOOS=linux go build -ldflags="$(ldflags)" -o build/bin/geth-linux-arm64 ./cmd/geth
 
 all:
 	$(GORUN) build/ci.go install

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -324,7 +324,7 @@ func prepare(ctx *cli.Context) {
 	}
 
 	// Start metrics export if enabled
-	utils.SetupMetrics(ctx)
+	utils.SetupMetrics(ctx, utils.EnableBuildInfo(gitCommit, gitDate))
 
 	// Start system runtime metrics collection
 	go metrics.CollectProcessMetrics(3 * time.Second)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -26,6 +26,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"runtime"
 	godebug "runtime/debug"
 	"strconv"
 	"strings"
@@ -1931,7 +1932,23 @@ func RegisterGraphQLService(stack *node.Node, backend ethapi.Backend, cfg node.C
 	}
 }
 
-func SetupMetrics(ctx *cli.Context) {
+type SetupMetricsOption func()
+
+func EnableBuildInfo(gitCommit, gitDate string) SetupMetricsOption {
+	return func() {
+		// register build info into metrics
+		metrics.NewRegisteredLabel("build-info", nil).Mark(map[string]interface{}{
+			"version":          params.VersionWithMeta,
+			"git-commit":       gitCommit,
+			"git-commit-date":  gitDate,
+			"go-version":       runtime.Version(),
+			"operating-system": runtime.GOOS,
+			"architecture":     runtime.GOARCH,
+		})
+	}
+}
+
+func SetupMetrics(ctx *cli.Context, options ...SetupMetricsOption) {
 	if metrics.Enabled {
 		log.Info("Enabling metrics collection")
 
@@ -1986,6 +2003,10 @@ func SetupMetrics(ctx *cli.Context) {
 			address := fmt.Sprintf("%s:%d", ctx.GlobalString(MetricsHTTPFlag.Name), ctx.GlobalInt(MetricsPortFlag.Name))
 			log.Info("Enabling stand-alone metrics HTTP endpoint", "address", address)
 			exp.Setup(address)
+		}
+
+		for _, opt := range options {
+			opt()
 		}
 	}
 }

--- a/metrics/label.go
+++ b/metrics/label.go
@@ -1,0 +1,48 @@
+package metrics
+
+import "encoding/json"
+
+// Label hold an map[string]interface{} value that can be set arbitrarily.
+type Label interface {
+	Value() map[string]interface{}
+	String() string
+	Mark(map[string]interface{})
+}
+
+// NewRegisteredLabel constructs and registers a new StandardLabel.
+func NewRegisteredLabel(name string, r Registry) Label {
+	c := NewStandardLabel()
+	if nil == r {
+		r = DefaultRegistry
+	}
+	r.Register(name, c)
+	return c
+}
+
+// NewStandardLabel constructs a new StandardLabel.
+func NewStandardLabel() *StandardLabel {
+	return &StandardLabel{}
+}
+
+// StandardLabel is the standard implementation of a Label.
+type StandardLabel struct {
+	value   map[string]interface{}
+	jsonStr string
+}
+
+// Value returns label values.
+func (l *StandardLabel) Value() map[string]interface{} {
+	return l.value
+}
+
+// Mark records the label.
+func (l *StandardLabel) Mark(value map[string]interface{}) {
+	buf, _ := json.Marshal(value)
+	l.jsonStr = string(buf)
+	l.value = value
+}
+
+// String returns label by JSON format.
+func (l *StandardLabel) String() string {
+	return l.jsonStr
+}

--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -31,6 +31,7 @@ var (
 	typeSummaryTpl         = "# TYPE %s summary\n"
 	keyValueTpl            = "%s %v\n\n"
 	keyQuantileTagValueTpl = "%s {quantile=\"%s\"} %v\n"
+	keyLabelValueTpl       = "%s%s %v\n\n"
 )
 
 // collector is a collection of byte buffers that aggregate Prometheus reports
@@ -96,6 +97,15 @@ func (c *collector) addResettingTimer(name string, m metrics.ResettingTimer) {
 	c.writeSummaryPercentile(name, "0.95", ps[1])
 	c.writeSummaryPercentile(name, "0.99", ps[2])
 	c.buff.WriteRune('\n')
+}
+
+func (c *collector) addLabel(name string, m metrics.Label) {
+	c.writeLabel(mutateKey(name), m.String())
+}
+
+func (c *collector) writeLabel(name string, value interface{}) {
+	c.buff.WriteString(fmt.Sprintf(typeGaugeTpl, name))
+	c.buff.WriteString(fmt.Sprintf(keyLabelValueTpl, name, value, 1))
 }
 
 func (c *collector) writeGaugeCounter(name string, value interface{}) {

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -57,6 +57,8 @@ func Handler(reg metrics.Registry) http.Handler {
 				c.addTimer(name, m.Snapshot())
 			case metrics.ResettingTimer:
 				c.addResettingTimer(name, m.Snapshot())
+			case metrics.Label:
+				c.addLabel(name, m)
 			default:
 				log.Warn("Unknown Prometheus metric type", "type", fmt.Sprintf("%T", i))
 			}

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -196,7 +196,7 @@ func (r *StandardRegistry) register(name string, i interface{}) error {
 		return DuplicateMetric(name)
 	}
 	switch i.(type) {
-	case Counter, Gauge, GaugeFloat64, Healthcheck, Histogram, Meter, Timer, ResettingTimer:
+	case Counter, Gauge, GaugeFloat64, Healthcheck, Histogram, Meter, Timer, ResettingTimer, Label:
 		r.metrics[name] = i
 	}
 	return nil


### PR DESCRIPTION
### Description

1. metrics: add build info into metrics server
2. metrics: add label type in metrics package
3. ci: add git info to cross-compile
4. ci: fix build cmd of arm binary

### Rationale

implement a `Label` type in the metrics package, and set build-info into metrics server.

### Example

1. /debug/metrics
<img width="614" alt="image" src="https://user-images.githubusercontent.com/25412254/204302188-0d9d18c5-9e0a-4a6a-b119-6cf92a05aea9.png">

2. /debug/metrics/prometheus
<img width="1678" alt="image" src="https://user-images.githubusercontent.com/25412254/204302258-dc3a107b-122a-4579-b2c5-af9e15309c28.png">


### Changes

Notable changes: 
* metrics package
