### PR TITLE
release: prepare for v1.1.18 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.1.18
+IMPROVEMENT
+
+* [\#1209](https://github.com/bnb-chain/bsc/pull/1209) metrics: add build info into metrics server
+* [\#1204](https://github.com/bnb-chain/bsc/pull/1204) worker: NewTxsEvent and triePrefetch reuse in mining task
+* [\#1195](https://github.com/bnb-chain/bsc/pull/1195) hardfork: update Gibbs fork height and system contract code
+* [\#1192](https://github.com/bnb-chain/bsc/pull/1192) all: sync with upstream v1.10.22
+* [\#1186](https://github.com/bnb-chain/bsc/pull/1186) worker: improvement of the current block generation logic to get more rewards
+* [\#1184](https://github.com/bnb-chain/bsc/pull/1184) worker: remove pre-seal empty block
+* [\#1182](https://github.com/bnb-chain/bsc/pull/1182) Parlia: Some updates of the miner worker
+* [\#1181](https://github.com/bnb-chain/bsc/pull/1181) all: sync with upstream v1.10.21
+* [\#1177](https://github.com/bnb-chain/bsc/pull/1177) core/forkid: refactor nextForkHash function
+* [\#1174](https://github.com/bnb-chain/bsc/pull/1174) worker: some code enhancement on work.go
+* [\#1166](https://github.com/bnb-chain/bsc/pull/1166) miner: disable enforceTip when get txs from txpool
+
+BUGFIX
+* [\#1201](https://github.com/bnb-chain/bsc/pull/1201) worker: add double sign check for safety
+* [\#1185](https://github.com/bnb-chain/bsc/pull/1185) worker: fix a bug of the delay timer
+
 ## v1.1.17
 IMPROVEMENT
 

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 17 // Patch version component of the current release
+	VersionPatch = 18 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
v1.1.18 is a hard-fork release.  The mainnet is expected to have a scheduled hardfork upgrade named Gibbs at block height 23,846,001. The current block generation speed forecasts this to occur around 12th Dec. 2022 at 10:00 AM (UTC). The validators and full node operators on Mainnet should switch their software version to  [v1.1.18](https://github.com/bnb-chain/bsc/releases/tag/v1.1.18) by 12th Dec.

Besides, a critical issue has been patched in this release to fix theoretically non-maliciously, double-sign issue, all validators are encouraged to upgrade to the latest version as soon as possible.

### Rationale

IMPROVEMENT

* [\#1209](https://github.com/bnb-chain/bsc/pull/1209) metrics: add build info into metrics server
* [\#1204](https://github.com/bnb-chain/bsc/pull/1204) worker: NewTxsEvent and triePrefetch reuse in mining task
* [\#1195](https://github.com/bnb-chain/bsc/pull/1195) hardfork: update Gibbs fork height and system contract code
* [\#1192](https://github.com/bnb-chain/bsc/pull/1192) all: sync with upstream v1.10.22
* [\#1186](https://github.com/bnb-chain/bsc/pull/1186) worker: improvement of the current block generation logic to get more rewards
* [\#1184](https://github.com/bnb-chain/bsc/pull/1184) worker: remove pre-seal empty block
* [\#1182](https://github.com/bnb-chain/bsc/pull/1182) Parlia: Some updates of the miner worker
* [\#1181](https://github.com/bnb-chain/bsc/pull/1181) all: sync with upstream v1.10.21
* [\#1177](https://github.com/bnb-chain/bsc/pull/1177) core/forkid: refactor nextForkHash function
* [\#1174](https://github.com/bnb-chain/bsc/pull/1174) worker: some code enhancement on work.go
* [\#1166](https://github.com/bnb-chain/bsc/pull/1166) miner: disable enforceTip when get txs from txpool

BUGFIX
* [\#1201](https://github.com/bnb-chain/bsc/pull/1201) worker: add double sign check for safety
* [\#1185](https://github.com/bnb-chain/bsc/pull/1185) worker: fix a bug of the delay timer


### Example
No API or Command changes.

### Changes
The validators and full node operators on Mainnet should switch their software version to  [v1.1.18](https://github.com/bnb-chain/bsc/releases/tag/v1.1.18) by 12th Dec.  
