### PR TITLE
metrics: fix the label format of prometheus server

### DIFF
--- a/metrics/label.go
+++ b/metrics/label.go
@@ -1,11 +1,8 @@
 package metrics
 
-import "encoding/json"
-
 // Label hold an map[string]interface{} value that can be set arbitrarily.
 type Label interface {
 	Value() map[string]interface{}
-	String() string
 	Mark(map[string]interface{})
 }
 
@@ -26,8 +23,7 @@ func NewStandardLabel() *StandardLabel {
 
 // StandardLabel is the standard implementation of a Label.
 type StandardLabel struct {
-	value   map[string]interface{}
-	jsonStr string
+	value map[string]interface{}
 }
 
 // Value returns label values.
@@ -37,12 +33,5 @@ func (l *StandardLabel) Value() map[string]interface{} {
 
 // Mark records the label.
 func (l *StandardLabel) Mark(value map[string]interface{}) {
-	buf, _ := json.Marshal(value)
-	l.jsonStr = string(buf)
 	l.value = value
-}
-
-// String returns label by JSON format.
-func (l *StandardLabel) String() string {
-	return l.jsonStr
 }

--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -100,7 +100,11 @@ func (c *collector) addResettingTimer(name string, m metrics.ResettingTimer) {
 }
 
 func (c *collector) addLabel(name string, m metrics.Label) {
-	c.writeLabel(mutateKey(name), m.String())
+	labels := make([]string, 0, len(m.Value()))
+	for k, v := range m.Value() {
+		labels = append(labels, fmt.Sprintf(`%s="%s"`, mutateKey(k), fmt.Sprint(v)))
+	}
+	c.writeLabel(mutateKey(name), "{"+strings.Join(labels, ", ")+"}")
 }
 
 func (c *collector) writeLabel(name string, value interface{}) {


### PR DESCRIPTION
### Description
1. the label in `prometheus` must match the regex [a-zA-Z_:][a-zA-Z0-9_:]*.
ex. api_http_requests_total{method="POST", handler="/messages"}

### Rationale

fix the printer in `metrics/prometheus`

### Example

<img width="1513" alt="image" src="https://user-images.githubusercontent.com/25412254/205009649-be282e60-ec96-41a9-bc87-f3541ea272b8.png">

### Changes

Notable changes: 
* metrics/label
* metrics/prometheus
