### PR TITLE
hotfix: fix the incorrect format of prometheus label

### DIFF
--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -126,5 +126,7 @@ func (c *collector) writeSummaryPercentile(name, p string, value interface{}) {
 }
 
 func mutateKey(key string) string {
-	return strings.Replace(key, "/", "_", -1)
+	key = strings.Replace(key, "/", "_", -1)
+	key = strings.Replace(key, "-", "_", -1)
+	return key
 }


### PR DESCRIPTION
### Description

fix the incorrect format of prometheus label
1. https://github.com/bnb-chain/bsc/pull/1217
2. https://github.com/bnb-chain/bsc/pull/1222

### Rationale

N/A

### Example

N/A

### Changes

BUGFIX
* [\#1217](https://github.com/bnb-chain/bsc/pull/1201) metrics: build-info causes prom error
* [\#1222](https://github.com/bnb-chain/bsc/pull/1185) fix the label format of prometheus server

