### PR TITLE
pruneancient_comments

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -34,11 +34,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/fatih/structs"
-	pcsclite "github.com/gballet/go-libpcsclite"
-	gopsutil "github.com/shirou/gopsutil/mem"
-	"gopkg.in/urfave/cli.v1"
-
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
@@ -74,6 +69,9 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/fatih/structs"
+	pcsclite "github.com/gballet/go-libpcsclite"
+	gopsutil "github.com/shirou/gopsutil/mem"
 )
 
 func init() {
@@ -503,8 +501,10 @@ var (
 		Value: uint64(86400),
 	}
 	PruneAncientDataFlag = cli.BoolFlag{
-		Name:  "pruneancient",
-		Usage: "Prune ancient data, recommends to the user who don't care about the ancient data. Note that once be turned on, the ancient data will not be recovered again",
+		Name: "pruneancient",
+		Usage: "Prune ancient data, is an optional config and disabled by default." +
+			"only keep the latest 9w blocks' data, the older blocks' data will be permanently pruned." +
+			"recommends to the user who don't care about the ancient data.",
 	}
 	// Miner settings
 	MiningEnabledFlag = cli.BoolFlag{

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -174,7 +174,13 @@ type Config struct {
 	DatabaseDiff       string
 	PersistDiff        bool
 	DiffBlock          uint64
-	PruneAncientData   bool
+	// PruneAncientData is an optional config and disabled by default, and usually you do not need it.
+	// When this flag is enabled, only keep the latest 9w blocks' data, the older blocks' data will be
+	// pruned instead of being dumped to freezerdb, the pruned data includes CanonicalHash, Header, Block,
+	// Receipt and TotalDifficulty.
+	// Notice: the PruneAncientData is an irreversible operation, once be turned on, the ancient data
+	// will not be recovered again.
+	PruneAncientData bool
 
 	TrieCleanCache          int
 	TrieCleanCacheJournal   string        `toml:",omitempty"` // Disk journal directory for trie cache to survive node restarts


### PR DESCRIPTION
### Description

In this pr, some comments about ancient data prune are added.
* Enriched the description of the pruneancient startup parameter, emphasizing that it is not enabled by default, and only the latest 9w block data is kept.
*  Enriched the note of the PruneAncientData confg, emphasizing that irreversible and what kinds of data will be pruned,

### Rationale

Currently, some node operators misunderstand pruneancient flag, which leads to difficulty of maintaining nodes. By adding these comments, it will be easier for them to maintain nodes.

### Example

NA

### Changes

Notable changes: 
* add comments
