### PR TITLE
fix comments: makes the  ‘pruneancient’ clearer, prune ancient compatibility, add comments for pruneancient

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -504,8 +504,10 @@ var (
 	PruneAncientDataFlag = cli.BoolFlag{
 		Name: "pruneancient",
 		Usage: "Prune ancient data, is an optional config and disabled by default." +
-			"only keep the latest 9w blocks' data, the older blocks' data will be permanently pruned." +
-			"recommends to the user who don't care about the ancient data.",
+      		 "Only keep the latest 9w blocks' data, the older blocks' data will be permanently pruned." +
+      		 "Notice:the geth/chaindata/ancient dir will be removed, if restart without the flag," +
+      		 "the ancient data will start with the previous point that the oldest unpruned block number." +
+      		 "Recommends to the user who don't care about the ancient data.",
 	}
 	// Miner settings
 	MiningEnabledFlag = cli.BoolFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -34,6 +34,11 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/fatih/structs"
+	pcsclite "github.com/gballet/go-libpcsclite"
+	gopsutil "github.com/shirou/gopsutil/mem"
+	"gopkg.in/urfave/cli.v1"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
@@ -69,10 +74,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/fatih/structs"
-	pcsclite "github.com/gballet/go-libpcsclite"
-	gopsutil "github.com/shirou/gopsutil/mem"
-	"gopkg.in/urfave/cli.v1"
 )
 
 func init() {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -34,11 +34,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/fatih/structs"
-	pcsclite "github.com/gballet/go-libpcsclite"
-	gopsutil "github.com/shirou/gopsutil/mem"
-	"gopkg.in/urfave/cli.v1"
-
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
@@ -74,6 +69,10 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/fatih/structs"
+	pcsclite "github.com/gballet/go-libpcsclite"
+	gopsutil "github.com/shirou/gopsutil/mem"
+	"gopkg.in/urfave/cli.v1"
 )
 
 func init() {
@@ -503,8 +502,10 @@ var (
 		Value: uint64(86400),
 	}
 	PruneAncientDataFlag = cli.BoolFlag{
-		Name:  "pruneancient",
-		Usage: "Prune ancient data, recommends to the user who don't care about the ancient data. Note that once be turned on, the ancient data will not be recovered again",
+		Name: "pruneancient",
+		Usage: "Prune ancient data, is an optional config and disabled by default." +
+			"only keep the latest 9w blocks' data, the older blocks' data will be permanently pruned." +
+			"recommends to the user who don't care about the ancient data.",
 	}
 	// Miner settings
 	MiningEnabledFlag = cli.BoolFlag{

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -178,8 +178,9 @@ type Config struct {
 	// When this flag is enabled, only keep the latest 9w blocks' data, the older blocks' data will be
 	// pruned instead of being dumped to freezerdb, the pruned data includes CanonicalHash, Header, Block,
 	// Receipt and TotalDifficulty.
-	// Notice: the PruneAncientData is an irreversible operation, once be turned on, the ancient data
-	// will not be recovered again.
+	// Notice: the PruneAncientData once be turned on, the get/chaindata/ancient dir will be removed, if 
+	// restart without the pruneancient flag, the ancient data will start with the previous point that 
+	// the oldest unpruned block number.
 	PruneAncientData bool
 
 	TrieCleanCache          int

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -174,7 +174,13 @@ type Config struct {
 	DatabaseDiff       string
 	PersistDiff        bool
 	DiffBlock          uint64
-	PruneAncientData   bool
+	// PruneAncientData is an optional config and disabled by default, and usually you do not need it.
+	// When this flag is enabled, only keep the latest 9w blocks' data, the older blocks' data will be
+	// pruned instead of being dumped to freezerdb, the pruned data includes CanonicalHash, Header, Block,
+	// Receipt and TotalDifficulty.
+	// Notice: the PruneAncientData is an irreversible operation, once be turned on, the ancient data
+	// will not be recovered again.
+	PruneAncientData bool
 
 	TrieCleanCache          int
 	TrieCleanCacheJournal   string        `toml:",omitempty"` // Disk journal directory for trie cache to survive node restarts


### PR DESCRIPTION
### Description

This PR, optimized the behavior of the pruneancient flag, making the meaning of 'pruneancient' clearer, and fixed the compatibility issue between pruneancient flag and the snap prune-blocks tool, the changes include the following points:

1. If set the pruneancient flag, the ${datadir}/geth/chaindata/ancient dir will be removed. Restart without the pruneancient flag, the ancient data will start with the previous point that the oldest unpruned block number. This change makes the  ‘pruneancient’ clearer and better compatible with the snap prune-blocks tool.
2. Before this PR once the pruneancient flag is set, it needs to be set every time it starts. Since the ancient data still exists, it will be regarded as part of the blockchain database, but it will destroy the continuity of the database, so the startup will fail. With the implementation of the first point, this problem is solved. There are no restrictions on whether a user enabled the pruneancient flag or not.
3.  The snap prune-blocks tool will change the frozen number, causing compatibility issues with the pruneancient flag. It is resolved by tracking the frozen number.
4. The behavior of the pruneancient flag and the applicable audience are described in detail in code comments and command line notes.



### Rationale

Some maintainers of bsc nodes feel confused by the ancient data still exists after enable the pruneancient flag, and the reserved ancient data also introduces the incompatibility with snap prune-blocks tool. It is necessary to delete ancient data that is no longer needed.

Some maintainers of bsc nodes may switch between using the pruneancient flag and not using, while using the snap prune-blocks tool, so they  must be compatible.

The pruneancient flag adds the behavior of deleting ancient data, and the compatibility has been specifically improved, so it is necessary to describe in detail in code comments and command line notes.

### Example

NA

### Changes

Notable changes: 
* delete the ancient dir in newPrunedFreezer.
* add frozen number compatibility in NewDatabaseWithFreezer.
* add WriteOffSetOfCurrentAncientFreezer in prunedfreezer TruncateAncients to tracking the offset for snap prune-blocks tool.
