### PR TITLE
ci: disable CGO_ENABLED when building binary

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -44,6 +44,8 @@ jobs:
       # ==============================
 
       - name: Build Binary for ${{matrix.os}}
+        env:
+          CGO_ENABLED: "0"
         run: make geth
 
       # ==============================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
       # ==============================
 
       - name: Build Binary for ${{matrix.os}}
+        env:
+          CGO_ENABLED: "0"
         run: make geth
 
       # ==============================


### PR DESCRIPTION
### Description

ci: disable CGO_ENABLED when building binary

### Rationale
The current release binary will depend on `GLIBC`, which may make some Users not easy to use, so disable `CGO_ENABLED` in the official release version to remove the dependency on C lib.

<img width="635" alt="image" src="https://user-images.githubusercontent.com/25412254/209775287-5f95877c-b538-41e5-bc67-270ff5b9087f.png">

### Example

https://github.com/j75689/bsc/releases/tag/v1.1.19-rc3

### Changes

Notable changes: 
* ci(release)
