### PR TITLE
docs: minor fix about the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ running web servers, so malicious web pages could try to subvert locally availab
 APIs!**
 
 ### Operating a private network
-- [BSC-Deploy](https://github.com/bnb-chain/bsc-deploy): deploy tool for setting up both BNB Beacon Chain, BNB Smart Chain and the cross chain infrastructure between them.
+- [BSC-Deploy](https://github.com/bnb-chain/node-deploy/): deploy tool for setting up both BNB Beacon Chain, BNB Smart Chain and the cross chain infrastructure between them.
 - [BSC-Docker](https://github.com/bnb-chain/bsc-docker): deploy tool for setting up local BSC cluster in container.
 
 ## Contribution


### PR DESCRIPTION
### Description
The lint to bsc-deploy repo is wrong, this PR is going to fix it.

### Rationale
Fix the wrong link of bsc-deploy repo

### Example
No impact to user

### Changes
No notable change
