### PR TITLE
dep: update tendermint to v0.31.14

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Test Build
       run: |
-        GOPROXY=direct go mod download
+        go mod download
         make geth
 
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,5 +23,4 @@ jobs:
 
     - name: Truffle test
       run: |
-        GOPROXY=direct go mod download
         make truffle-test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
           ${{ runner.os }}-go-
     
     - run: |
-        GOPROXY=direct go mod download
+        go mod download
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -6,9 +6,6 @@ on:
     tags:
       - 'pre-*'
 
-env:
-  GOPROXY: direct
-
 jobs:
   build:
     name: Build Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,6 @@ on:
     tags:
       - v*
 
-env:
-  GOPROXY: direct
-
 jobs:
   build:
     name: Build Release

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -47,6 +47,6 @@ jobs:
       env:
         ANDROID_HOME: "" # Skip android test
       run: |
-        GOPROXY=direct go mod download
+        go mod download
         make test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git bash
 # Get dependencies - will also be cached if we won't change go.mod/go.sum
 COPY go.mod /go-ethereum/
 COPY go.sum /go-ethereum/
-ENV GOPROXY=direct
 RUN cd /go-ethereum && go mod download
 
 ADD . /go-ethereum

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git bash
 
 ADD . /bsc
 WORKDIR /bsc
-RUN GOPROXY=direct go mod download && make geth
+RUN make geth
 RUN mv /bsc/build/bin/geth /usr/local/bin/geth
 
 EXPOSE 8545 8547 30303 30303/udp

--- a/go.mod
+++ b/go.mod
@@ -122,4 +122,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/tendermint/tendermint => github.com/bnb-chain/tendermint v0.31.13
+replace github.com/tendermint/tendermint => github.com/bnb-chain/tendermint v0.31.14

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/tendermint v0.31.13 h1:lhFliG2zXqDaMiW9qc8wtUODo0spF7mhgfjO6SoRxRM=
-github.com/bnb-chain/tendermint v0.31.13/go.mod h1:cmt8HHmQUSVaWQ/hoTefRxsh5X3ERaM1zCUIR0DPbFU=
+github.com/bnb-chain/tendermint v0.31.14 h1:PrO3Owceg0iJ9tSXUUC0yst2VmQLkigUZt+EwegyYLg=
+github.com/bnb-chain/tendermint v0.31.14/go.mod h1:cmt8HHmQUSVaWQ/hoTefRxsh5X3ERaM1zCUIR0DPbFU=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=
 github.com/btcsuite/btcd/btcec/v2 v2.3.2/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=


### PR DESCRIPTION
### Description

1. [dep: update tendermint to v0.31.14](https://github.com/bnb-chain/bsc/commit/b3f7f73f086503c2e4f3c475c936a846a04a2406)
2. [ci build: remove GOPROXY=direct](https://github.com/bnb-chain/bsc/commit/d4b433e6a839177e8485874649fb7688d876e2f2)

### Rationale

github.com/bnb-chain/tendermint v0.31.13 has been deprecated because checksums on GOPROXY are directed to the wrong version.

### Example

N/A

### Changes

Notable changes: 
* dep update
* ci
