### PR TITLE
release: prepare for release v1.1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## v1.1.19
+FEATURE
+* [\#1199](https://github.com/bnb-chain/bsc/pull/1199) mointor: implement double sign monitor
+
+IMPROVEMENT
+* [\#1226](https://github.com/bnb-chain/bsc/pull/1226) eth, trie: sync with upstream v1.10.26 to solve snap sync issues
+* [\#1212](https://github.com/bnb-chain/bsc/pull/1212) metrics: add miner info into metrics server
+* [\#1240](https://github.com/bnb-chain/bsc/pull/1240) Add NewBatchWithSize API for db and use this API for BloomIndexer.Commit()
+* [\#1254](https://github.com/bnb-chain/bsc/pull/1254) ci: update unmaintained tools to use maintained tools
+* [\#1256](https://github.com/bnb-chain/bsc/pull/1256) ci: disable CGO_ENABLED when building binary
+* [\#1274](https://github.com/bnb-chain/bsc/pull/1274) dep: bump the version of several important library
+* [\#1294](https://github.com/bnb-chain/bsc/pull/1294) parlia : add a check for the length of extraData.
+* [\#1298](https://github.com/bnb-chain/bsc/pull/1298) dep: update tendermint to v0.31.14
+
+Document
+* [\#1233](https://github.com/bnb-chain/bsc/pull/1233) doc: update readme
+* [\#1245](https://github.com/bnb-chain/bsc/pull/1245) comments: add comments to clarify flags and byte codes
+* [\#1266](https://github.com/bnb-chain/bsc/pull/1266) docs: update the readme to latest
+* [\#1267](https://github.com/bnb-chain/bsc/pull/1267) docs: minor fix about the readme
+* [\#1287](https://github.com/bnb-chain/bsc/pull/1287) docs: minor fix on geth links
+
+BUGFIX
+* [\#1233](https://github.com/bnb-chain/bsc/pull/1233) doc: update readme
+* [\#1253](https://github.com/bnb-chain/bsc/pull/1253) fix comments: prune ancient compatibility, add prune ancient comments
+* [\#1301](https://github.com/bnb-chain/bsc/pull/1301) fix: p2p sync with lagging peer
+* [\#1302](https://github.com/bnb-chain/bsc/pull/1302) fix: eth fetcher re-queue issue
+
 ## v1.1.18
 IMPROVEMENT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ ENV HOME=${BSC_HOME}
 ENV DATA_DIR=/data
 
 ENV PACKAGES ca-certificates~=20220614-r0 jq~=1.6 \
-  bash~=5.1.16-r2 bind-tools~=9.16.33 tini~=0.19.0 \
-  grep~=3.7 curl=~7.83.1-r3 sed~=4.8-r0
+  bash~=5.1.16-r2 bind-tools~=9.16.36 tini~=0.19.0 \
+  grep~=3.7 curl~=7.83.1 sed~=4.8-r0
 
 RUN apk add --no-cache $PACKAGES \
   && rm -rf /var/cache/apk/* \

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 18 // Patch version component of the current release
+	VersionPatch = 19 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description

Release v1.1.19 is a maintenance release, it includes several bug fixes and improvements.
We upgrade the insecure packages in #1274, and fix the sync issue in #1301.
It is recommended to upgrade to the `v1.1.19` for security, and stability.

### Rationale

## v1.1.19
FEATURE
* [\#1199](https://github.com/bnb-chain/bsc/pull/1199) mointor: implement double sign monitor

IMPROVEMENT
* [\#1226](https://github.com/bnb-chain/bsc/pull/1226) eth, trie: sync with upstream v1.10.26 to solve snap sync issues
* [\#1212](https://github.com/bnb-chain/bsc/pull/1212) metrics: add miner info into metrics server
* [\#1240](https://github.com/bnb-chain/bsc/pull/1240) Add NewBatchWithSize API for db and use this API for BloomIndexer.Commit()
* [\#1254](https://github.com/bnb-chain/bsc/pull/1254) ci: update unmaintained tools to use maintained tools
* [\#1256](https://github.com/bnb-chain/bsc/pull/1256) ci: disable CGO_ENABLED when building binary
* [\#1274](https://github.com/bnb-chain/bsc/pull/1274) dep: bump the version of several important library
* [\#1294](https://github.com/bnb-chain/bsc/pull/1294) parlia : add a check for the length of extraData.
* [\#1298](https://github.com/bnb-chain/bsc/pull/1298) dep: update tendermint to v0.31.14

Document
* [\#1233](https://github.com/bnb-chain/bsc/pull/1233) doc: update readme
* [\#1245](https://github.com/bnb-chain/bsc/pull/1245) comments: add comments to clarify flags and byte codes
* [\#1266](https://github.com/bnb-chain/bsc/pull/1266) docs: update the readme to latest
* [\#1267](https://github.com/bnb-chain/bsc/pull/1267) docs: minor fix about the readme
* [\#1287](https://github.com/bnb-chain/bsc/pull/1287) docs: minor fix on geth links

BUGFIX
* [\#1233](https://github.com/bnb-chain/bsc/pull/1233) doc: update readme
* [\#1253](https://github.com/bnb-chain/bsc/pull/1253) fix comments: prune ancient compatibility, add prune ancient comments
* [\#1301](https://github.com/bnb-chain/bsc/pull/1301) fix: p2p sync with lagging peer
* [\#1302](https://github.com/bnb-chain/bsc/pull/1302) fix: eth fetcher re-queue issue

### Example

No API or Command changes.

### Changes

N/A
