### PR TITLE
fix: Docker build failed because of invalid `bind-tools` version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV HOME=${BSC_HOME}
 ENV DATA_DIR=/data
 
 ENV PACKAGES ca-certificates~=20220614-r0 jq~=1.6 \
-  bash~=5.1.16-r2 bind-tools~=9.16.36 tini~=0.19.0 \
+  bash~=5.1.16-r2 bind-tools~=9.16.37 tini~=0.19.0 \
   grep~=3.7 curl~=7.83.1 sed~=4.8-r0
 
 RUN apk add --no-cache $PACKAGES \


### PR DESCRIPTION
### Description

The Docker image build failed due to the `bind-tools` version.

### Rationale

N/A

### Example

<img width="661" alt="image" src="https://user-images.githubusercontent.com/25412254/218382661-bcafedd4-1a33-44a6-b259-5b7034401776.png">

### Changes

Notable changes: 
* Dockerfile
