### PR TITLE
p2p/discover: implement ENR node filtering

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -35,19 +35,21 @@ import (
 
 func main() {
 	var (
-		listenAddr  = flag.String("addr", ":30301", "listen address")
-		genKey      = flag.String("genkey", "", "generate a node key")
-		writeAddr   = flag.Bool("writeaddress", false, "write out the node's public key and quit")
-		nodeKeyFile = flag.String("nodekey", "", "private key filename")
-		nodeKeyHex  = flag.String("nodekeyhex", "", "private key as hex (for testing)")
-		natdesc     = flag.String("nat", "none", "port mapping mechanism (any|none|upnp|pmp|extip:<IP>)")
-		netrestrict = flag.String("netrestrict", "", "restrict network communication to the given IP networks (CIDR masks)")
-		runv5       = flag.Bool("v5", false, "run a v5 topic discovery bootnode")
-		verbosity   = flag.Int("verbosity", int(log.LvlInfo), "log verbosity (0-5)")
-		vmodule     = flag.String("vmodule", "", "log verbosity pattern")
+		listenAddr    = flag.String("addr", ":30301", "listen address")
+		genKey        = flag.String("genkey", "", "generate a node key")
+		writeAddr     = flag.Bool("writeaddress", false, "write out the node's public key and quit")
+		nodeKeyFile   = flag.String("nodekey", "", "private key filename")
+		nodeKeyHex    = flag.String("nodekeyhex", "", "private key as hex (for testing)")
+		natdesc       = flag.String("nat", "none", "port mapping mechanism (any|none|upnp|pmp|extip:<IP>)")
+		netrestrict   = flag.String("netrestrict", "", "restrict network communication to the given IP networks (CIDR masks)")
+		runv5         = flag.Bool("v5", false, "run a v5 topic discovery bootnode")
+		verbosity     = flag.Int("verbosity", int(log.LvlInfo), "log verbosity (0-5)")
+		vmodule       = flag.String("vmodule", "", "log verbosity pattern")
+		networkFilter = flag.String("network", "", "<bsc/chapel/rialto/yolo> filters nodes by eth ENR entry")
 
-		nodeKey *ecdsa.PrivateKey
-		err     error
+		nodeKey        *ecdsa.PrivateKey
+		filterFunction discover.NodeFilter
+		err            error
 	)
 	flag.Parse()
 
@@ -83,6 +85,12 @@ func main() {
 	case *nodeKeyHex != "":
 		if nodeKey, err = crypto.HexToECDSA(*nodeKeyHex); err != nil {
 			utils.Fatalf("-nodekeyhex: %v", err)
+		}
+	}
+
+	if *networkFilter != "" {
+		if filterFunction, err = discover.ParseEthFilter(*networkFilter); err != nil {
+			utils.Fatalf("-network: %v", err)
 		}
 	}
 
@@ -123,8 +131,9 @@ func main() {
 	db, _ := enode.OpenDB("")
 	ln := enode.NewLocalNode(db, nodeKey)
 	cfg := discover.Config{
-		PrivateKey:  nodeKey,
-		NetRestrict: restrictList,
+		PrivateKey:     nodeKey,
+		NetRestrict:    restrictList,
+		FilterFunction: filterFunction,
 	}
 	if *runv5 {
 		if _, err := discover.ListenV5(conn, ln, cfg); err != nil {

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -45,10 +45,10 @@ func main() {
 		runv5         = flag.Bool("v5", false, "run a v5 topic discovery bootnode")
 		verbosity     = flag.Int("verbosity", int(log.LvlInfo), "log verbosity (0-5)")
 		vmodule       = flag.String("vmodule", "", "log verbosity pattern")
-		networkFilter = flag.String("network", "", "<bsc/chapel/rialto/yolo> filters nodes by eth ENR entry")
+		networkFilter = flag.String("network", "", "<bsc/chapel/rialto> filters nodes by eth ENR entry")
 
 		nodeKey        *ecdsa.PrivateKey
-		filterFunction discover.NodeFilter
+		filterFunction discover.NodeFilterFunc
 		err            error
 	)
 	flag.Parse()

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -633,6 +633,7 @@ func (s *Ethereum) Protocols() []p2p.Protocol {
 // Start implements node.Lifecycle, starting all internal goroutines needed by the
 // Ethereum protocol implementation.
 func (s *Ethereum) Start() error {
+	eth.StartENRFilter(s.blockchain, s.p2pServer)
 	eth.StartENRUpdater(s.blockchain, s.p2pServer.LocalNode())
 
 	// Start the bloom bits servicing goroutines

--- a/eth/protocols/eth/discovery.go
+++ b/eth/protocols/eth/discovery.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/forkid"
+	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -55,6 +56,11 @@ func StartENRUpdater(chain *core.BlockChain, ln *enode.LocalNode) {
 			}
 		}
 	}()
+}
+
+func StartENRFilter(chain *core.BlockChain, p2p *p2p.Server) {
+	forkFilter := forkid.NewFilter(chain)
+	p2p.SetFilter(forkFilter)
 }
 
 // currentENREntry constructs an `eth` ENR entry based on the current state of the chain.

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -18,13 +18,17 @@ package discover
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 	"net"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // UDPConn is a network connection on which discovery can operate.
@@ -35,18 +39,49 @@ type UDPConn interface {
 	LocalAddr() net.Addr
 }
 
+type NodeFilter func(*enr.Record) bool
+
+func ParseEthFilter(chain string) (NodeFilter, error) {
+	var filter forkid.Filter
+	switch chain {
+	case "bsc":
+		filter = forkid.NewStaticFilter(params.BSCChainConfig, params.BSCGenesisHash)
+	case "chapel":
+		filter = forkid.NewStaticFilter(params.ChapelChainConfig, params.ChapelGenesisHash)
+	case "rialto":
+		filter = forkid.NewStaticFilter(params.RialtoChainConfig, params.RialtoGenesisHash)
+	case "yolo":
+		filter = forkid.NewStaticFilter(params.YoloV3ChainConfig, params.YoloV3GenesisHash)
+	default:
+		return nil, fmt.Errorf("unknown network %q", chain)
+	}
+
+	f := func(r *enr.Record) bool {
+		var eth struct {
+			ForkID forkid.ID
+			Tail   []rlp.RawValue `rlp:"tail"`
+		}
+		if r.Load(enr.WithEntry("eth", &eth)) != nil {
+			return false
+		}
+		return filter(eth.ForkID) == nil
+	}
+	return f, nil
+}
+
 // Config holds settings for the discovery listener.
 type Config struct {
 	// These settings are required and configure the UDP listener:
 	PrivateKey *ecdsa.PrivateKey
 
 	// These settings are optional:
-	NetRestrict  *netutil.Netlist   // list of allowed IP networks
-	Bootnodes    []*enode.Node      // list of bootstrap nodes
-	Unhandled    chan<- ReadPacket  // unhandled packets are sent on this channel
-	Log          log.Logger         // if set, log messages go here
-	ValidSchemes enr.IdentityScheme // allowed identity schemes
-	Clock        mclock.Clock
+	NetRestrict    *netutil.Netlist   // list of allowed IP networks
+	Bootnodes      []*enode.Node      // list of bootstrap nodes
+	Unhandled      chan<- ReadPacket  // unhandled packets are sent on this channel
+	Log            log.Logger         // if set, log messages go here
+	ValidSchemes   enr.IdentityScheme // allowed identity schemes
+	Clock          mclock.Clock
+	FilterFunction NodeFilter // function for filtering ENR entries
 }
 
 func (cfg Config) withDefaults() Config {

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -39,9 +39,9 @@ type UDPConn interface {
 	LocalAddr() net.Addr
 }
 
-type NodeFilter func(*enr.Record) bool
+type NodeFilterFunc func(*enr.Record) bool
 
-func ParseEthFilter(chain string) (NodeFilter, error) {
+func ParseEthFilter(chain string) (NodeFilterFunc, error) {
 	var filter forkid.Filter
 	switch chain {
 	case "bsc":
@@ -50,8 +50,6 @@ func ParseEthFilter(chain string) (NodeFilter, error) {
 		filter = forkid.NewStaticFilter(params.ChapelChainConfig, params.ChapelGenesisHash)
 	case "rialto":
 		filter = forkid.NewStaticFilter(params.RialtoChainConfig, params.RialtoGenesisHash)
-	case "yolo":
-		filter = forkid.NewStaticFilter(params.YoloV3ChainConfig, params.YoloV3GenesisHash)
 	default:
 		return nil, fmt.Errorf("unknown network %q", chain)
 	}
@@ -81,7 +79,7 @@ type Config struct {
 	Log            log.Logger         // if set, log messages go here
 	ValidSchemes   enr.IdentityScheme // allowed identity schemes
 	Clock          mclock.Clock
-	FilterFunction NodeFilter // function for filtering ENR entries
+	FilterFunction NodeFilterFunc // function for filtering ENR entries
 }
 
 func (cfg Config) withDefaults() Config {

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -80,6 +80,8 @@ type Table struct {
 	closeReq   chan struct{}
 	closed     chan struct{}
 
+	enrFilter NodeFilter
+
 	nodeAddedHook func(*node) // for testing
 }
 
@@ -100,7 +102,7 @@ type bucket struct {
 	ips          netutil.DistinctNetSet
 }
 
-func newTable(t transport, db *enode.DB, bootnodes []*enode.Node, log log.Logger) (*Table, error) {
+func newTable(t transport, db *enode.DB, bootnodes []*enode.Node, log log.Logger, filter NodeFilter) (*Table, error) {
 	tab := &Table{
 		net:        t,
 		db:         db,
@@ -111,6 +113,7 @@ func newTable(t transport, db *enode.DB, bootnodes []*enode.Node, log log.Logger
 		rand:       mrand.New(mrand.NewSource(0)),
 		ips:        netutil.DistinctNetSet{Subnet: tableSubnet, Limit: tableIPLimit},
 		log:        log,
+		enrFilter:  filter,
 	}
 	if err := tab.setFallbackNodes(bootnodes); err != nil {
 		return nil, err
@@ -339,10 +342,16 @@ func (tab *Table) doRevalidate(done chan<- struct{}) {
 
 	// Also fetch record if the node replied and returned a higher sequence number.
 	if last.Seq() < remoteSeq {
-		n, err := tab.net.RequestENR(unwrapNode(last))
-		if err != nil {
-			tab.log.Debug("ENR request failed", "id", last.ID(), "addr", last.addr(), "err", err)
+		n, enrErr := tab.net.RequestENR(unwrapNode(last))
+		if enrErr != nil {
+			tab.log.Debug("ENR request failed", "id", last.ID(), "addr", last.addr(), "err", enrErr)
 		} else {
+			if tab.enrFilter != nil {
+				if !tab.enrFilter(n.Record()) {
+					tab.log.Trace("ENR record filter out", "id", last.ID(), "addr", last.addr())
+					err = fmt.Errorf("filtered node")
+				}
+			}
 			last = &node{Node: *n, addedAt: last.addedAt, livenessChecks: last.livenessChecks}
 		}
 	}
@@ -473,7 +482,17 @@ func (tab *Table) bucketAtDistance(d int) *bucket {
 //
 // The caller must not hold tab.mutex.
 func (tab *Table) addSeenNode(n *node) {
+	gopool.Submit(func() {
+		tab.addSeenNodeSync(n)
+	})
+}
+
+func (tab *Table) addSeenNodeSync(n *node) {
 	if n.ID() == tab.self().ID() {
+		return
+	}
+
+	if tab.filterNode(n) {
 		return
 	}
 
@@ -502,6 +521,22 @@ func (tab *Table) addSeenNode(n *node) {
 	}
 }
 
+func (tab *Table) filterNode(n *node) bool {
+	if tab.enrFilter != nil {
+		node, err := tab.net.RequestENR(unwrapNode(n))
+		if err != nil {
+			tab.log.Debug("ENR request failed", "id", n.ID(), "addr", n.addr(), "err", err)
+			return false
+		} else {
+			if !tab.enrFilter(node.Record()) {
+				tab.log.Trace("ENR record filter out", "id", n.ID(), "addr", n.addr())
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // addVerifiedNode adds a node whose existence has been verified recently to the front of a
 // bucket. If the node is already in the bucket, it is moved to the front. If the bucket
 // has no space, the node is added to the replacements list.
@@ -511,14 +546,23 @@ func (tab *Table) addSeenNode(n *node) {
 // ping repeatedly.
 //
 // The caller must not hold tab.mutex.
+
 func (tab *Table) addVerifiedNode(n *node) {
+	gopool.Submit(func() {
+		tab.addVerifiedNodeSync(n)
+	})
+}
+
+func (tab *Table) addVerifiedNodeSync(n *node) {
 	if !tab.isInitDone() {
 		return
 	}
 	if n.ID() == tab.self().ID() {
 		return
 	}
-
+	if tab.filterNode(n) {
+		return
+	}
 	tab.mutex.Lock()
 	defer tab.mutex.Unlock()
 	b := tab.bucket(n.ID())

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -27,10 +27,13 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 func TestTable_pingReplace(t *testing.T) {
@@ -65,7 +68,7 @@ func testPingReplace(t *testing.T, newNodeIsResponding, lastInBucketIsResponding
 	// its bucket if it is unresponsive. Revalidate again to ensure that
 	transport.dead[last.ID()] = !lastInBucketIsResponding
 	transport.dead[pingSender.ID()] = !newNodeIsResponding
-	tab.addSeenNode(pingSender)
+	tab.addSeenNodeSync(pingSender)
 	tab.doRevalidate(make(chan struct{}, 1))
 	tab.doRevalidate(make(chan struct{}, 1))
 
@@ -148,7 +151,7 @@ func TestTable_IPLimit(t *testing.T) {
 
 	for i := 0; i < tableIPLimit+1; i++ {
 		n := nodeAtDistance(tab.self().ID(), i, net.IP{172, 0, 1, byte(i)})
-		tab.addSeenNode(n)
+		tab.addSeenNodeSync(n)
 	}
 	if tab.len() > tableIPLimit {
 		t.Errorf("too many nodes in table")
@@ -314,8 +317,8 @@ func TestTable_addVerifiedNode(t *testing.T) {
 	// Insert two nodes.
 	n1 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})
 	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
-	tab.addSeenNode(n1)
-	tab.addSeenNode(n2)
+	tab.addSeenNodeSync(n1)
+	tab.addSeenNodeSync(n2)
 
 	// Verify bucket content:
 	bcontent := []*node{n1, n2}
@@ -327,7 +330,7 @@ func TestTable_addVerifiedNode(t *testing.T) {
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
 	newn2 := wrapNode(enode.SignNull(newrec, n2.ID()))
-	tab.addVerifiedNode(newn2)
+	tab.addVerifiedNodeSync(newn2)
 
 	// Check that bucket is updated correctly.
 	newBcontent := []*node{newn2, n1}
@@ -346,8 +349,8 @@ func TestTable_addSeenNode(t *testing.T) {
 	// Insert two nodes.
 	n1 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})
 	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
-	tab.addSeenNode(n1)
-	tab.addSeenNode(n2)
+	tab.addSeenNodeSync(n1)
+	tab.addSeenNodeSync(n2)
 
 	// Verify bucket content:
 	bcontent := []*node{n1, n2}
@@ -359,7 +362,7 @@ func TestTable_addSeenNode(t *testing.T) {
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
 	newn2 := wrapNode(enode.SignNull(newrec, n2.ID()))
-	tab.addSeenNode(newn2)
+	tab.addSeenNodeSync(newn2)
 
 	// Check that bucket content is unchanged.
 	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
@@ -382,7 +385,7 @@ func TestTable_revalidateSyncRecord(t *testing.T) {
 	r.Set(enr.IP(net.IP{127, 0, 0, 1}))
 	id := enode.ID{1}
 	n1 := wrapNode(enode.SignNull(&r, id))
-	tab.addSeenNode(n1)
+	tab.addSeenNodeSync(n1)
 
 	// Update the node record.
 	r.Set(enr.WithEntry("foo", "bar"))
@@ -393,6 +396,38 @@ func TestTable_revalidateSyncRecord(t *testing.T) {
 	intable := tab.getNode(id)
 	if !reflect.DeepEqual(intable, n2) {
 		t.Fatalf("table contains old record with seq %d, want seq %d", intable.Seq(), n2.Seq())
+	}
+}
+
+// This test checks that ENR filtering is working properly
+func TestTable_filterNode(t *testing.T) {
+	// Create ENR filter
+	type eth struct {
+		ForkID forkid.ID
+		Tail   []rlp.RawValue `rlp:"tail"`
+	}
+
+	enrFilter, _ := ParseEthFilter("bsc")
+
+	// Check test ENR record
+	var r1 enr.Record
+	r1.Set(enr.WithEntry("foo", "bar"))
+	if enrFilter(&r1) {
+		t.Fatalf("filterNode doesn't work correctly for entry")
+	}
+
+	// Check wrong genesis ENR record
+	var r2 enr.Record
+	r2.Set(enr.WithEntry("eth", eth{ForkID: forkid.NewID(params.BSCChainConfig, params.ChapelGenesisHash, uint64(0))}))
+	if enrFilter(&r2) {
+		t.Fatalf("filterNode doesn't work correctly for wrong genesis entry")
+	}
+
+	// Check correct genesis ENR record
+	var r3 enr.Record
+	r3.Set(enr.WithEntry("eth", eth{ForkID: forkid.NewID(params.BSCChainConfig, params.BSCGenesisHash, uint64(0))}))
+	if !enrFilter(&r3) {
+		t.Fatalf("filterNode doesn't work correctly for correct genesis entry")
 	}
 }
 

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -415,6 +415,7 @@ func TestTable_filterNode(t *testing.T) {
 	if enrFilter(&r1) {
 		t.Fatalf("filterNode doesn't work correctly for entry")
 	}
+	t.Logf("Check test ENR record - passed")
 
 	// Check wrong genesis ENR record
 	var r2 enr.Record
@@ -422,6 +423,7 @@ func TestTable_filterNode(t *testing.T) {
 	if enrFilter(&r2) {
 		t.Fatalf("filterNode doesn't work correctly for wrong genesis entry")
 	}
+	t.Logf("Check wrong genesis ENR record - passed")
 
 	// Check correct genesis ENR record
 	var r3 enr.Record
@@ -429,6 +431,7 @@ func TestTable_filterNode(t *testing.T) {
 	if !enrFilter(&r3) {
 		t.Fatalf("filterNode doesn't work correctly for correct genesis entry")
 	}
+	t.Logf("Check correct genesis ENR record - passed")
 }
 
 // gen wraps quick.Value so it's easier to use.

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -43,7 +43,7 @@ func init() {
 
 func newTestTable(t transport) (*Table, *enode.DB) {
 	db, _ := enode.OpenDB("")
-	tab, _ := newTable(t, db, nil, log.Root())
+	tab, _ := newTable(t, db, nil, log.Root(), nil)
 	go tab.loop()
 	return tab, db
 }
@@ -110,7 +110,7 @@ func fillBucket(tab *Table, n *node) (last *node) {
 // if the bucket is not full. The caller must not hold tab.mutex.
 func fillTable(tab *Table, nodes []*node) {
 	for _, n := range nodes {
-		tab.addSeenNode(n)
+		tab.addSeenNodeSync(n)
 	}
 }
 

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -42,7 +42,7 @@ var (
 	errExpired          = errors.New("expired")
 	errUnsolicitedReply = errors.New("unsolicited reply")
 	errUnknownNode      = errors.New("unknown node")
-	errTimeout          = errors.New("RPC timeout")
+	errTimeout          = errors.New("udp timeout")
 	errClockWarp        = errors.New("reply deadline too far in the future")
 	errClosed           = errors.New("socket closed")
 	errLowPort          = errors.New("low port")
@@ -143,7 +143,7 @@ func ListenV4(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
 		log:             cfg.Log,
 	}
 
-	tab, err := newTable(t, ln.Database(), cfg.Bootnodes, t.log)
+	tab, err := newTable(t, ln.Database(), cfg.Bootnodes, t.log, cfg.FilterFunction)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -164,7 +164,7 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 		closeCtx:       closeCtx,
 		cancelCloseCtx: cancelCloseCtx,
 	}
-	tab, err := newTable(t, t.db, cfg.Bootnodes, cfg.Log)
+	tab, err := newTable(t, t.db, cfg.Bootnodes, cfg.Log, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -164,7 +164,7 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 		closeCtx:       closeCtx,
 		cancelCloseCtx: cancelCloseCtx,
 	}
-	tab, err := newTable(t, t.db, cfg.Bootnodes, cfg.Log, nil)
+	tab, err := newTable(t, t.db, cfg.Bootnodes, cfg.Log, cfg.FilterFunction)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -145,7 +145,7 @@ func TestUDPv5_unknownPacket(t *testing.T) {
 
 	// Make node known.
 	n := test.getNode(test.remotekey, test.remoteaddr).Node()
-	test.table.addSeenNode(wrapNode(n))
+	test.table.addSeenNodeSync(wrapNode(n))
 
 	test.packetIn(&v5wire.Unknown{Nonce: nonce})
 	test.waitPacketOut(func(p *v5wire.Whoareyou, addr *net.UDPAddr, _ v5wire.Nonce) {


### PR DESCRIPTION
### Description

This PR implements [BEP194](https://github.com/bnb-chain/BEPs/pull/194)

### Rationale

This change should improve peer discovery time by filtering out peers from different networks e.g. ETH

### Changes

Notable changes: 
* adding peer do the table is now async as it also requires to get ENR record from the node
* this could also help to filter out nodes, that are not running latest HF
