### PR TITLE
cmd/utils/flags.go: --diffsync flag is deprecate.

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1703,7 +1703,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.EnableTrustProtocol = ctx.GlobalIsSet(EnableTrustProtocolFlag.Name)
 	}
 	if ctx.GlobalIsSet(DiffSyncFlag.Name) {
-		cfg.DiffSync = ctx.GlobalBool(DiffSyncFlag.Name)
+		log.Warn("The --diffsync flag is deprecated and will be removed in the future!")
 	}
 	if ctx.GlobalIsSet(PipeCommitFlag.Name) {
 		cfg.PipeCommit = ctx.GlobalBool(PipeCommitFlag.Name)


### PR DESCRIPTION
### Description

deprecate diffsync flag

### Rationale

When the time for the handshake is around 10s, when sending a message to the diffwait channel at the same time, the waitDiffExtension enters the timeout logic, which will cause a deadlock.

### Example

no example
### Changes

Notable changes: 
* flag.go:deprecated --diffsync flag and add a warning about it
