### PR TITLE
core/state: no need to prune block if the same 

### DIFF
--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -378,8 +378,11 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 
 	// If the items in freezer is less than the block amount that we want to reserve, it is not enough, should stop.
 	if itemsOfAncient < p.BlockAmountReserved {
-		log.Error("the number of old blocks is not enough to reserve,", "ancient items", itemsOfAncient, "the amount specified", p.BlockAmountReserved)
+		log.Error("the number of old blocks is not enough to reserve", "ancient items", itemsOfAncient, "the amount specified", p.BlockAmountReserved)
 		return errors.New("the number of old blocks is not enough to reserve")
+	} else if itemsOfAncient == p.BlockAmountReserved {
+		log.Error("the number of old blocks is the same to be reserved", "ancient items", itemsOfAncient, "the amount specified", p.BlockAmountReserved)
+		return errors.New("the number of old blocks is the same to be reserved")
 	}
 
 	var oldOffSet uint64

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -378,11 +378,8 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 
 	// If the items in freezer is less than the block amount that we want to reserve, it is not enough, should stop.
 	if itemsOfAncient < p.BlockAmountReserved {
-		log.Error("the number of old blocks is not enough to reserve", "ancient items", itemsOfAncient, "the amount specified", p.BlockAmountReserved)
+		log.Error("the number of old blocks is not enough to reserve,", "ancient items", itemsOfAncient, "the amount specified", p.BlockAmountReserved)
 		return errors.New("the number of old blocks is not enough to reserve")
-	} else if itemsOfAncient == p.BlockAmountReserved {
-		log.Error("the number of old blocks is the same to be reserved", "ancient items", itemsOfAncient, "the amount specified", p.BlockAmountReserved)
-		return errors.New("the number of old blocks is the same to be reserved")
 	}
 
 	var oldOffSet uint64


### PR DESCRIPTION
### Description

Don't need to run `prune-block` if specified reserve blocks are the same to items in ancientdb

