### PR TITLE
sec: add proof ops check and key checker

### DIFF
--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2109,7 +2109,7 @@ func TestGolangBindings(t *testing.T) {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
 	}
 
-	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/tendermint/tendermint@v0.0.0", "-replace", "github.com/tendermint/tendermint=github.com/bnb-chain/tendermint@v0.31.12") // Repo root
+	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/tendermint/tendermint@v0.0.0", "-replace", "github.com/tendermint/tendermint=github.com/bnb-chain/tendermint@v0.31.15") // Repo root
 	replacer.Dir = pkg
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace tendermint dependency to bnb-chain source: %v\n%s", err, out)

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2114,7 +2114,7 @@ func TestGolangBindings(t *testing.T) {
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace tendermint dependency to bnb-chain source: %v\n%s", err, out)
 	}
-	tidier := exec.Command(gocmd, "mod", "tidy", "-compat=1.17")
+	tidier := exec.Command(gocmd, "mod", "tidy", "-compat=1.19")
 	tidier.Dir = pkg
 	if out, err := tidier.CombinedOutput(); err != nil {
 		t.Fatalf("failed to tidy Go module file: %v\n%s", err, out)

--- a/core/vm/contracts_lightclient.go
+++ b/core/vm/contracts_lightclient.go
@@ -171,7 +171,7 @@ func (c *iavlMerkleProofValidateBohr) Run(input []byte) (result []byte, err erro
 		multiStoreOpVerifier,
 		forbiddenSimpleValueOpVerifier,
 	}
-	c.basicIavlMerkleProofValidate.keyChecker = keyChecker
+	c.basicIavlMerkleProofValidate.keyVerifier = keyVerifier
 	c.basicIavlMerkleProofValidate.opsVerifier = proofOpsVerifier
 	return c.basicIavlMerkleProofValidate.Run(input)
 }
@@ -183,7 +183,7 @@ func successfulMerkleResult() []byte {
 }
 
 type basicIavlMerkleProofValidate struct {
-	keyChecker   lightclient.KeyVerifier
+	keyVerifier  lightclient.KeyVerifier
 	opsVerifier  merkle.ProofOpsVerifier
 	verifiers    []merkle.ProofOpVerifier
 	proofRuntime *merkle.ProofRuntime
@@ -216,7 +216,7 @@ func (c *basicIavlMerkleProofValidate) Run(input []byte) (result []byte, err err
 	}
 	kvmp.SetVerifiers(c.verifiers)
 	kvmp.SetOpsVerifier(c.opsVerifier)
-	kvmp.SetKeyVerifier(c.keyChecker)
+	kvmp.SetKeyVerifier(c.keyVerifier)
 
 	valid := kvmp.Validate()
 	if !valid {
@@ -313,7 +313,7 @@ func proofOpsVerifier(poz merkle.ProofOperators) error {
 	return cmn.NewError("invalid proof type")
 }
 
-func keyChecker(key string) bool {
+func keyVerifier(key string) bool {
 	// https://github.com/bnb-chain/tendermint/blob/72375a6f3d4a72831cc65e73363db89a0073db38/crypto/merkle/proof_key_path.go#L88
 	// since the upper function is ambiguous, `x:00` can be decoded to both kind of key type
 	// we check the key here to make sure the key will not start from `x:`

--- a/core/vm/contracts_lightclient.go
+++ b/core/vm/contracts_lightclient.go
@@ -317,7 +317,7 @@ func keyVerifier(key string) error {
 	// https://github.com/bnb-chain/tendermint/blob/72375a6f3d4a72831cc65e73363db89a0073db38/crypto/merkle/proof_key_path.go#L88
 	// since the upper function is ambiguous, `x:00` can be decoded to both kind of key type
 	// we check the key here to make sure the key will not start from `x:`
-	if !strings.HasPrefix(url.PathEscape(key), "x:") {
+	if strings.HasPrefix(url.PathEscape(key), "x:") {
 		return cmn.NewError("key should not start with x:")
 	}
 	return nil

--- a/core/vm/contracts_lightclient.go
+++ b/core/vm/contracts_lightclient.go
@@ -313,9 +313,12 @@ func proofOpsVerifier(poz merkle.ProofOperators) error {
 	return cmn.NewError("invalid proof type")
 }
 
-func keyVerifier(key string) bool {
+func keyVerifier(key string) error {
 	// https://github.com/bnb-chain/tendermint/blob/72375a6f3d4a72831cc65e73363db89a0073db38/crypto/merkle/proof_key_path.go#L88
 	// since the upper function is ambiguous, `x:00` can be decoded to both kind of key type
 	// we check the key here to make sure the key will not start from `x:`
-	return !strings.HasPrefix(url.PathEscape(key), "x:")
+	if !strings.HasPrefix(url.PathEscape(key), "x:") {
+		return cmn.NewError("key should not start with x:")
+	}
+	return nil
 }

--- a/core/vm/contracts_lightclient.go
+++ b/core/vm/contracts_lightclient.go
@@ -183,7 +183,7 @@ func successfulMerkleResult() []byte {
 }
 
 type basicIavlMerkleProofValidate struct {
-	keyChecker   lightclient.KeyChecker
+	keyChecker   lightclient.KeyVerifier
 	opsVerifier  merkle.ProofOpsVerifier
 	verifiers    []merkle.ProofOpVerifier
 	proofRuntime *merkle.ProofRuntime
@@ -216,7 +216,7 @@ func (c *basicIavlMerkleProofValidate) Run(input []byte) (result []byte, err err
 	}
 	kvmp.SetVerifiers(c.verifiers)
 	kvmp.SetOpsVerifier(c.opsVerifier)
-	kvmp.SetKeyChecker(c.keyChecker)
+	kvmp.SetKeyVerifier(c.keyChecker)
 
 	valid := kvmp.Validate()
 	if !valid {
@@ -317,8 +317,5 @@ func keyChecker(key string) bool {
 	// https://github.com/bnb-chain/tendermint/blob/72375a6f3d4a72831cc65e73363db89a0073db38/crypto/merkle/proof_key_path.go#L88
 	// since the upper function is ambiguous, `x:00` can be decoded to both kind of key type
 	// we check the key here to make sure the key will not start from `x:`
-	if strings.HasPrefix(url.PathEscape(key), "x:") {
-		return false
-	}
-	return true
+	return !strings.HasPrefix(url.PathEscape(key), "x:")
 }

--- a/core/vm/contracts_lightclient_test.go
+++ b/core/vm/contracts_lightclient_test.go
@@ -293,21 +293,21 @@ func TestProofOpsVerifier(t *testing.T) {
 
 func TestKeyVerifier(t *testing.T) {
 	tests := []struct {
-		key    string
-		result bool
+		key string
+		err error
 	}{
 		{
 			"x:sdfdfdsd",
-			false,
+			cmn.NewError("key should not start with x:"),
 		},
 		{
 			"sdfxdfxs",
-			true,
+			nil,
 		},
 	}
 
 	for _, testCase := range tests {
 		err := keyVerifier(testCase.key)
-		assert.Equal(t, err, testCase.result)
+		assert.Equal(t, err, testCase.err)
 	}
 }

--- a/core/vm/contracts_lightclient_test.go
+++ b/core/vm/contracts_lightclient_test.go
@@ -291,7 +291,7 @@ func TestProofOpsVerifier(t *testing.T) {
 	}
 }
 
-func TestKeyChecker(t *testing.T) {
+func TestKeyVerifier(t *testing.T) {
 	tests := []struct {
 		key    string
 		result bool
@@ -307,7 +307,7 @@ func TestKeyChecker(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		err := keyChecker(testCase.key)
+		err := keyVerifier(testCase.key)
 		assert.Equal(t, err, testCase.result)
 	}
 }

--- a/core/vm/contracts_lightclient_test.go
+++ b/core/vm/contracts_lightclient_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/iavl"
+	"github.com/tendermint/tendermint/crypto/merkle"
+	cmn "github.com/tendermint/tendermint/libs/common"
 
 	"github.com/stretchr/testify/require"
 
@@ -232,4 +235,79 @@ func TestMultiStore(t *testing.T) {
 
 	err = multiStoreOpVerifier(badProof)
 	assert.Error(t, err, "duplicated store")
+}
+
+func TestProofOpsVerifier(t *testing.T) {
+	tests := []struct {
+		ops merkle.ProofOperators
+		err error
+	}{
+		{
+			merkle.ProofOperators{
+				iavl.IAVLValueOp{},
+			},
+			cmn.NewError("proof ops should be 2"),
+		},
+		{
+			merkle.ProofOperators{
+				lightclient.MultiStoreProofOp{},
+				lightclient.MultiStoreProofOp{},
+			},
+			cmn.NewError("invalid proof op"),
+		},
+		{
+			merkle.ProofOperators{
+				iavl.IAVLValueOp{},
+				lightclient.MultiStoreProofOp{},
+			},
+			nil,
+		},
+		{
+			merkle.ProofOperators{
+				lightclient.CommitmentOp{Type: lightclient.ProofOpIAVLCommitment},
+				lightclient.CommitmentOp{Type: lightclient.ProofOpSimpleMerkleCommitment},
+			},
+			nil,
+		},
+		{
+			merkle.ProofOperators{
+				lightclient.CommitmentOp{Type: lightclient.ProofOpSimpleMerkleCommitment},
+				lightclient.CommitmentOp{Type: lightclient.ProofOpSimpleMerkleCommitment},
+			},
+			cmn.NewError("invalid proof op"),
+		},
+		{
+			merkle.ProofOperators{
+				lightclient.MultiStoreProofOp{},
+				iavl.IAVLValueOp{},
+			},
+			cmn.NewError("invalid proof type"),
+		},
+	}
+
+	for _, testCase := range tests {
+		err := proofOpsVerifier(testCase.ops)
+		assert.Equal(t, err, testCase.err)
+	}
+}
+
+func TestKeyChecker(t *testing.T) {
+	tests := []struct {
+		key    string
+		result bool
+	}{
+		{
+			"x:sdfdfdsd",
+			false,
+		},
+		{
+			"sdfxdfxs",
+			true,
+		},
+	}
+
+	for _, testCase := range tests {
+		err := keyChecker(testCase.key)
+		assert.Equal(t, err, testCase.result)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1
 	github.com/bnb-chain/ics23 v0.1.0
-	github.com/btcsuite/btcd v0.20.1-beta // indirect
 	github.com/cespare/cp v0.1.0
 	github.com/cloudflare/cloudflare-go v0.14.0
 	github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/panjf2000/ants/v2 v2.4.5
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/tsdb v0.7.1
 	github.com/rjeczalik/notify v0.9.1
 	github.com/rs/cors v1.7.0
@@ -124,4 +124,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/tendermint/tendermint => github.com/bnb-chain/tendermint v0.31.14
+replace github.com/tendermint/tendermint => github.com/bnb-chain/tendermint v0.31.15

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/bnb-chain/ics23 v0.1.0 h1:DvjGOts2FBfbxB48384CYD1LbcrfjThFz8kowY/7KxU=
 github.com/bnb-chain/ics23 v0.1.0/go.mod h1:cU6lTGolbbLFsGCgceNB2AzplH1xecLp6+KXvxM32nI=
-github.com/bnb-chain/tendermint v0.31.14 h1:PrO3Owceg0iJ9tSXUUC0yst2VmQLkigUZt+EwegyYLg=
-github.com/bnb-chain/tendermint v0.31.14/go.mod h1:cmt8HHmQUSVaWQ/hoTefRxsh5X3ERaM1zCUIR0DPbFU=
+github.com/bnb-chain/tendermint v0.31.15 h1:Xyn/Hifb/7X4E1zSuMdnZdMSoM2Fx6cZuKCNnqIxbNU=
+github.com/bnb-chain/tendermint v0.31.15/go.mod h1:cmt8HHmQUSVaWQ/hoTefRxsh5X3ERaM1zCUIR0DPbFU=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=


### PR DESCRIPTION
### Description

This pr will add more strict checks for the proofs of lightclient:

+ make sure that the length of proof operations is equal to 2
+ make sure that the proofs are strictly in the desired order
+ check the key format

### Changes

Notable changes: 
* add proof ops check and key checker
