### PR TITLE
rename: change the next upgrade name to Planck

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -328,10 +328,10 @@ func (p *Parlia) verifyHeader(chain consensus.ChainHeaderReader, header *types.H
 	}
 	number := header.Number.Uint64()
 
-	// According to BEP188, after Bohr fork, an in-turn validator is allowed to broadcast
+	// According to BEP188, after Planck fork, an in-turn validator is allowed to broadcast
 	// a mined block earlier but not earlier than its parent's timestamp when the block is ready .
 	if header.Time > uint64(time.Now().Unix()) {
-		if !chain.Config().IsBohr(header.Number) || header.Difficulty.Cmp(diffInTurn) != 0 {
+		if !chain.Config().IsPlanck(header.Number) || header.Difficulty.Cmp(diffInTurn) != 0 {
 			return consensus.ErrFutureBlock
 		}
 		var parent *types.Header
@@ -883,7 +883,7 @@ func (p *Parlia) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 	}
 
 	// BEP-188 allows an in-turn validator to broadcast the mined block earlier
-	// but not earlier than its parent's timestamp after Bohr fork.
+	// but not earlier than its parent's timestamp after Planck fork.
 	// At the same time, small block which means gas used rate is less than
 	// gasUsedRateDemarcation does not broadcast early to avoid an upcoming fat block.
 	delay := time.Duration(0)
@@ -891,7 +891,7 @@ func (p *Parlia) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 	if header.GasLimit != 0 {
 		gasUsedRate = header.GasUsed * 100 / header.GasLimit
 	}
-	if p.chainConfig.IsBohr(header.Number) && header.Difficulty.Cmp(diffInTurn) == 0 && gasUsedRate >= gasUsedRateDemarcation {
+	if p.chainConfig.IsPlanck(header.Number) && header.Difficulty.Cmp(diffInTurn) == 0 && gasUsedRate >= gasUsedRateDemarcation {
 		parent := chain.GetHeader(header.ParentHash, number-1)
 		if parent == nil || parent.Number.Uint64() != number-1 || parent.Hash() != header.ParentHash {
 			return consensus.ErrUnknownAncestor
@@ -1323,7 +1323,7 @@ func (p *Parlia) backOffTime(snap *Snapshot, header *types.Header, val common.Ad
 	} else {
 		delay := initialBackOffTime
 		validators := snap.validators()
-		if p.chainConfig.IsBohr(header.Number) {
+		if p.chainConfig.IsPlanck(header.Number) {
 			// reverse the key/value of snap.Recents to get recentsMap
 			recentsMap := make(map[common.Address]uint64, len(snap.Recents))
 			for seen, recent := range snap.Recents {

--- a/core/systemcontracts/upgrade.go
+++ b/core/systemcontracts/upgrade.go
@@ -50,7 +50,7 @@ var (
 
 	moranUpgrade = make(map[string]*Upgrade)
 
-	bohrUpgrade = make(map[string]*Upgrade)
+	planckUpgrade = make(map[string]*Upgrade)
 )
 
 func init() {
@@ -483,9 +483,9 @@ func init() {
 		},
 	}
 
-	// TODO: update the commit url of bohr upgrade
-	bohrUpgrade[mainNet] = &Upgrade{
-		UpgradeName: "bohr",
+	// TODO: update the commit url of planck upgrade
+	planckUpgrade[mainNet] = &Upgrade{
+		UpgradeName: "planck",
 		Configs: []*UpgradeConfig{
 			{
 				ContractAddr: common.HexToAddress(SlashContract),
@@ -505,8 +505,8 @@ func init() {
 		},
 	}
 
-	bohrUpgrade[chapelNet] = &Upgrade{
-		UpgradeName: "bohr",
+	planckUpgrade[chapelNet] = &Upgrade{
+		UpgradeName: "planck",
 		Configs: []*UpgradeConfig{
 			{
 				ContractAddr: common.HexToAddress(SlashContract),
@@ -531,8 +531,8 @@ func init() {
 		},
 	}
 
-	bohrUpgrade[rialtoNet] = &Upgrade{
-		UpgradeName: "bohr",
+	planckUpgrade[rialtoNet] = &Upgrade{
+		UpgradeName: "planck",
 		Configs: []*UpgradeConfig{
 			{
 				ContractAddr: common.HexToAddress(SlashContract),
@@ -600,8 +600,8 @@ func UpgradeBuildInSystemContract(config *params.ChainConfig, blockNumber *big.I
 		applySystemContractUpgrade(moranUpgrade[network], blockNumber, statedb, logger)
 	}
 
-	if config.IsOnBohr(blockNumber) {
-		applySystemContractUpgrade(bohrUpgrade[network], blockNumber, statedb, logger)
+	if config.IsOnPlanck(blockNumber) {
+		applySystemContractUpgrade(planckUpgrade[network], blockNumber, statedb, logger)
 	}
 
 	/*

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -155,7 +155,7 @@ var PrecompiledContractsBLS = map[common.Address]PrecompiledContract{
 }
 
 var (
-	PrecompiledAddressesPlanck     []common.Address
+	PrecompiledAddressesPlanck    []common.Address
 	PrecompiledAddressesMoran     []common.Address
 	PrecompiledAddressesNano      []common.Address
 	PrecompiledAddressesBerlin    []common.Address

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -111,7 +111,7 @@ var PrecompiledContractsMoran = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{101}): &iavlMerkleProofValidateMoran{},
 }
 
-var PrecompiledContractsBohr = map[common.Address]PrecompiledContract{
+var PrecompiledContractsPlanck = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{1}): &ecrecover{},
 	common.BytesToAddress([]byte{2}): &sha256hash{},
 	common.BytesToAddress([]byte{3}): &ripemd160hash{},
@@ -123,7 +123,7 @@ var PrecompiledContractsBohr = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2F{},
 
 	common.BytesToAddress([]byte{100}): &tmHeaderValidate{},
-	common.BytesToAddress([]byte{101}): &iavlMerkleProofValidateBohr{},
+	common.BytesToAddress([]byte{101}): &iavlMerkleProofValidatePlanck{},
 }
 
 // PrecompiledContractsBerlin contains the default set of pre-compiled Ethereum
@@ -155,7 +155,7 @@ var PrecompiledContractsBLS = map[common.Address]PrecompiledContract{
 }
 
 var (
-	PrecompiledAddressesBohr      []common.Address
+	PrecompiledAddressesPlanck     []common.Address
 	PrecompiledAddressesMoran     []common.Address
 	PrecompiledAddressesNano      []common.Address
 	PrecompiledAddressesBerlin    []common.Address
@@ -183,16 +183,16 @@ func init() {
 	for k := range PrecompiledContractsMoran {
 		PrecompiledAddressesMoran = append(PrecompiledAddressesMoran, k)
 	}
-	for k := range PrecompiledContractsBohr {
-		PrecompiledAddressesBohr = append(PrecompiledAddressesBohr, k)
+	for k := range PrecompiledContractsPlanck {
+		PrecompiledAddressesPlanck = append(PrecompiledAddressesPlanck, k)
 	}
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
-	case rules.IsBohr:
-		return PrecompiledAddressesBohr
+	case rules.IsPlanck:
+		return PrecompiledAddressesPlanck
 	case rules.IsMoran:
 		return PrecompiledAddressesMoran
 	case rules.IsNano:

--- a/core/vm/contracts_lightclient.go
+++ b/core/vm/contracts_lightclient.go
@@ -155,15 +155,15 @@ func (c *iavlMerkleProofValidateMoran) Run(input []byte) (result []byte, err err
 	return c.basicIavlMerkleProofValidate.Run(input)
 }
 
-type iavlMerkleProofValidateBohr struct {
+type iavlMerkleProofValidatePlanck struct {
 	basicIavlMerkleProofValidate
 }
 
-func (c *iavlMerkleProofValidateBohr) RequiredGas(_ []byte) uint64 {
+func (c *iavlMerkleProofValidatePlanck) RequiredGas(_ []byte) uint64 {
 	return params.IAVLMerkleProofValidateGas
 }
 
-func (c *iavlMerkleProofValidateBohr) Run(input []byte) (result []byte, err error) {
+func (c *iavlMerkleProofValidatePlanck) Run(input []byte) (result []byte, err error) {
 	c.basicIavlMerkleProofValidate.proofRuntime = lightclient.Ics23CompatibleProofRuntime()
 	c.basicIavlMerkleProofValidate.verifiers = []merkle.ProofOpVerifier{
 		forbiddenAbsenceOpVerifier,

--- a/core/vm/contracts_lightclient_test.go
+++ b/core/vm/contracts_lightclient_test.go
@@ -146,7 +146,7 @@ func TestIcs23Proof(t *testing.T) {
 
 	input := append(totalLengthPrefix, merkleProofInput...)
 
-	validator := iavlMerkleProofValidateBohr{}
+	validator := iavlMerkleProofValidatePlanck{}
 	success, err := validator.Run(input)
 	require.NoError(t, err)
 	expectedResult := make([]byte, 32)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -52,8 +52,8 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
-	case evm.chainRules.IsBohr:
-		precompiles = PrecompiledContractsBohr
+	case evm.chainRules.IsPlanck:
+		precompiles = PrecompiledContractsPlanck
 	case evm.chainRules.IsMoran:
 		precompiles = PrecompiledContractsMoran
 	case evm.chainRules.IsNano:

--- a/params/config.go
+++ b/params/config.go
@@ -114,7 +114,7 @@ var (
 		NanoBlock:           big.NewInt(21962149),
 		MoranBlock:          big.NewInt(22107423),
 		GibbsBlock:          big.NewInt(23846001),
-		BohrBlock:           nil, // todo: TBD
+		PlanckBlock:         nil, // todo: TBD
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -141,7 +141,7 @@ var (
 		GibbsBlock:          big.NewInt(22800220),
 		NanoBlock:           big.NewInt(23482428),
 		MoranBlock:          big.NewInt(23603940),
-		BohrBlock:           nil, // todo: TBD
+		PlanckBlock:         nil, // todo: TBD
 		Parlia: &ParliaConfig{
 			Period: 3,
 			Epoch:  200,
@@ -167,7 +167,7 @@ var (
 		GibbsBlock:          big.NewInt(400),
 		NanoBlock:           nil,
 		MoranBlock:          nil,
-		BohrBlock:           nil,
+		PlanckBlock:         nil,
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -285,7 +285,7 @@ type ChainConfig struct {
 	GibbsBlock      *big.Int `json:"gibbsBlock,omitempty" toml:",omitempty"`      // gibbsBlock switch block (nil = no fork, 0 = already activated)
 	NanoBlock       *big.Int `json:"nanoBlock,omitempty" toml:",omitempty"`       // nanoBlock switch block (nil = no fork, 0 = already activated)
 	MoranBlock      *big.Int `json:"moranBlock,omitempty" toml:",omitempty"`      // moranBlock switch block (nil = no fork, 0 = already activated)
-	BohrBlock       *big.Int `json:"bohrBlock,omitempty" toml:",omitempty"`       // bohrBlock switch block (nil = no fork, 0 = already activated)
+	PlanckBlock     *big.Int `json:"planckBlock,omitempty" toml:",omitempty"`     // planckBlock switch block (nil = no fork, 0 = already activated)
 
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty" toml:",omitempty"`
@@ -336,7 +336,7 @@ func (c *ChainConfig) String() string {
 	default:
 		engine = "unknown"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Bohr: %v, Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Planck: %v, Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -363,7 +363,7 @@ func (c *ChainConfig) String() string {
 		c.GibbsBlock,
 		c.NanoBlock,
 		c.MoranBlock,
-		c.BohrBlock,
+		c.PlanckBlock,
 		engine,
 	)
 }
@@ -519,12 +519,12 @@ func (c *ChainConfig) IsOnMoran(num *big.Int) bool {
 	return configNumEqual(c.MoranBlock, num)
 }
 
-func (c *ChainConfig) IsBohr(num *big.Int) bool {
-	return isForked(c.BohrBlock, num)
+func (c *ChainConfig) IsPlanck(num *big.Int) bool {
+	return isForked(c.PlanckBlock, num)
 }
 
-func (c *ChainConfig) IsOnBohr(num *big.Int) bool {
-	return configNumEqual(c.BohrBlock, num)
+func (c *ChainConfig) IsOnPlanck(num *big.Int) bool {
+	return configNumEqual(c.PlanckBlock, num)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported
@@ -655,8 +655,8 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.MoranBlock, newcfg.MoranBlock, head) {
 		return newCompatError("moran fork block", c.MoranBlock, newcfg.MoranBlock)
 	}
-	if isForkIncompatible(c.BohrBlock, newcfg.BohrBlock, head) {
-		return newCompatError("bohr fork block", c.BohrBlock, newcfg.BohrBlock)
+	if isForkIncompatible(c.PlanckBlock, newcfg.PlanckBlock, head) {
+		return newCompatError("planck fork block", c.PlanckBlock, newcfg.PlanckBlock)
 	}
 	return nil
 }
@@ -729,7 +729,7 @@ type Rules struct {
 	IsMerge                                                 bool
 	IsNano                                                  bool
 	IsMoran                                                 bool
-	IsBohr                                                  bool
+	IsPlanck                                                bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -753,6 +753,6 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool) Rules {
 		IsMerge:          isMerge,
 		IsNano:           c.IsNano(num),
 		IsMoran:          c.IsMoran(num),
-		IsBohr:           c.IsBohr(num),
+		IsPlanck:         c.IsPlanck(num),
 	}
 }


### PR DESCRIPTION
### Description
The following BSC upgrades will be named by BLS(Boneh-Lynn-Shacham)
Bohr is too similar to Bonel,  rename Bohr to Planck, to avoid confusion.

