### PR TITLE
consensus: refactor snapshot.recents calculation

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -590,12 +590,10 @@ func (p *Parlia) verifySeal(chain consensus.ChainHeaderReader, header *types.Hea
 		return errUnauthorizedValidator
 	}
 
-	for seen, recent := range snap.Recents {
+	for _, recent := range snap.Recents {
 		if recent == signer {
 			// Signer is among recents, only fail if the current block doesn't shift it out
-			if limit := uint64(len(snap.Validators)/2 + 1); seen > number-limit {
-				return errRecentlySigned
-			}
+			return errRecentlySigned
 		}
 	}
 
@@ -872,13 +870,11 @@ func (p *Parlia) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 	}
 
 	// If we're amongst the recent signers, wait for the next block
-	for seen, recent := range snap.Recents {
+	for _, recent := range snap.Recents {
 		if recent == val {
 			// Signer is among recents, only wait if the current block doesn't shift it out
-			if limit := uint64(len(snap.Validators)/2 + 1); number < limit || seen > number-limit {
-				log.Info("Signed recently, must wait for others")
-				return nil
-			}
+			log.Info("Signed recently, must wait for others")
+			return nil
 		}
 	}
 
@@ -992,13 +988,10 @@ func (p *Parlia) SignRecently(chain consensus.ChainReader, parent *types.Block) 
 	}
 
 	// If we're amongst the recent signers, wait for the next block
-	number := parent.NumberU64() + 1
-	for seen, recent := range snap.Recents {
+	for _, recent := range snap.Recents {
 		if recent == p.val {
 			// Signer is among recents, only wait if the current block doesn't shift it out
-			if limit := uint64(len(snap.Validators)/2 + 1); number < limit || seen > number-limit {
-				return true, nil
-			}
+			return true, nil
 		}
 	}
 	return false, nil

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -167,7 +167,7 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 	for _, header := range headers {
 		number := header.Number.Uint64()
 		// Delete the oldest validator from the recent list to allow it signing again
-		if limit := uint64(len(snap.Validators)/2 + 1); number >= limit {
+		if limit := uint64(len(snap.Validators) / 2); number >= limit {
 			delete(snap.Recents, number-limit)
 		}
 		if limit := uint64(len(snap.Validators)); number >= limit {
@@ -204,8 +204,8 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 			for _, val := range newValArr {
 				newVals[val] = struct{}{}
 			}
-			oldLimit := len(snap.Validators)/2 + 1
-			newLimit := len(newVals)/2 + 1
+			oldLimit := len(snap.Validators) / 2
+			newLimit := len(newVals) / 2
 			if newLimit < oldLimit {
 				for i := 0; i < oldLimit-newLimit; i++ {
 					delete(snap.Recents, number-uint64(newLimit)-uint64(i))


### PR DESCRIPTION
### Description

current `snapsot.Recents` includes `len(validators)/2+1` validators of recent blocks till current block height, but when check  `recentsigned`, parlia actually only check the recent `len(validators)/2` validators.

### Rationale

just keep recent `len(validators)/2` validators in the `snapshot.Recents`, and get rid of unnecessary check for `recentSigned`.

### Example

N/A

### Changes

Notable changes: 
* `consensus/parlia/snapshot.go: apply` method of updating `snapshot.Recent`