### PR TITLE
docker: rm fail when package-lock.json not exists

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,10 +12,12 @@ ENTRYPOINT [ "/usr/local/bin/geth" ]
 
 FROM ethereum/solc:0.6.4-alpine as bsc-genesis
 
-RUN apk add --d --no-cache ca-certificates npm nodejs bash alpine-sdk
+RUN apk add --no-cache ca-certificates npm nodejs bash alpine-sdk
 
 RUN git clone https://github.com/binance-chain/bsc-genesis-contract.git /root/genesis \
-    && rm /root/genesis/package-lock.json && cd /root/genesis && npm install
+    && cd /root/genesis \
+    && (ls package-lock.json && rm package-lock.json && npm install) \
+    || npm install
 
 COPY docker/init_holders.template /root/genesis/init_holders.template
 


### PR DESCRIPTION
### Description

file `package-lock.json` not exists
`-d` not support
### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 