### PR TITLE
release: prepare for v1.1.20 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # Changelog
+## v1.1.20
+FEATURE
+* [\#1322](https://github.com/bnb-chain/bsc/pull/1322) cmd/utils/flags.go: --diffsync flag is deprecate
+* [\#1261](https://github.com/bnb-chain/bsc/pull/1261) tracer: port call tracer `withLog` to bsc
+
+IMPROVEMENT
+* [\#1337](https://github.com/bnb-chain/bsc/pull/1337) clean: Remove support for Ethereum testnet
+* [\#1347](https://github.com/bnb-chain/bsc/pull/1347) upgrade: update the fork height of planck upgrade on testnet
+* [\#1343](https://github.com/bnb-chain/bsc/pull/1343) upgrade: update system contracts' code of planck upgrade
+* [\#1328](https://github.com/bnb-chain/bsc/pull/1328) upgrade: update system contracts' code of testnet
+* [\#1162](https://github.com/bnb-chain/bsc/pull/1162) consensus: fix slash bug when validator set changing
+* [\#1344](https://github.com/bnb-chain/bsc/pull/1344) consensus: fix delete the 1st validator from snapshot.recents list
+* [\#1269](https://github.com/bnb-chain/bsc/pull/1269) parlia: miner changes for BEP-188 of Early Broadcast
+* [\#1268](https://github.com/bnb-chain/bsc/pull/1268) parlia: consensus changes according to BEP of Early Broadcast
+* [\#1149](https://github.com/bnb-chain/bsc/pull/1149) feats: add ics23 proof support for cross chain packages
+* [\#1333](https://github.com/bnb-chain/bsc/pull/1333) sec: add proof ops check and key checker
+
+BUGFIX
+* [\#1348](https://github.com/bnb-chain/bsc/pull/1348) (HEAD, bnb-chain/develop) core/txpool: implement additional DoS defenses
 
 ## v1.1.19
 FEATURE

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 19 // Patch version component of the current release
+	VersionPatch = 20 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
v1.1.20 is a hard-fork release for BSC Chapel testnet.

The Chapel testnet is expected to have a scheduled hardfork upgrade named `Planck` at block height 28,196,022. The current block generation speed forecasts this to occur around 20th Mar 2023 at 01:30 AM (UTC). 
The `Planck` hardfork includes 3 BEPs to enhance network stability and security:
[BEP-171: Security Enhancement for Cross-Chain Module](https://github.com/bnb-chain/BEPs/blob/master/BEP171.md)
[BEP-172: Network Stability Enhancement On Slash Occur](https://github.com/bnb-chain/BEPs/blob/master/BEP172.md)
[BEP-188: Early Broadcast Mature Block For In-Turn Validators](https://github.com/bnb-chain/BEPs/blob/master/BEP188.md)


The validators and full node operators on Chapel testnet should switch their software version to [v1.1.20](https://github.com/bnb-chain/bsc/releases/tag/v1.1.20) before 20th Mar.


### Rationale
FEATURE
* [\#1322](https://github.com/bnb-chain/bsc/pull/1322) cmd/utils/flags.go: --diffsync flag is deprecate
* [\#1261](https://github.com/bnb-chain/bsc/pull/1261) tracer: port call tracer `withLog` to bsc

IMPROVEMENT
* [\#1337](https://github.com/bnb-chain/bsc/pull/1337) clean: Remove support for Ethereum testnet
* [\#1347](https://github.com/bnb-chain/bsc/pull/1347) upgrade: update the fork height of planck upgrade on testnet
* [\#1343](https://github.com/bnb-chain/bsc/pull/1343) upgrade: update system contracts' code of planck upgrade
* [\#1328](https://github.com/bnb-chain/bsc/pull/1328) upgrade: update system contracts' code of testnet
* [\#1162](https://github.com/bnb-chain/bsc/pull/1162) consensus: fix slash bug when validator set changing
* [\#1344](https://github.com/bnb-chain/bsc/pull/1344) consensus: fix delete the 1st validator from snapshot.recents list
* [\#1269](https://github.com/bnb-chain/bsc/pull/1269) parlia: miner changes for BEP-188 of Early Broadcast
* [\#1268](https://github.com/bnb-chain/bsc/pull/1268) parlia: consensus changes according to BEP of Early Broadcast
* [\#1149](https://github.com/bnb-chain/bsc/pull/1149) feats: add ics23 proof support for cross chain packages
* [\#1333](https://github.com/bnb-chain/bsc/pull/1333) sec: add proof ops check and key checker

BUGFIX
* [\#1348](https://github.com/bnb-chain/bsc/pull/1348) core/txpool: implement additional DoS defenses


### Example
None


### Changes
The validators and full node operators on Chapel testnet should switch their software version to [v1.1.20](https://github.com/bnb-chain/bsc/releases/tag/v1.1.20) before 20th Mar 2023.