### PR TITLE
upgrade: remove BEP-188 from planck hardfork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ IMPROVEMENT
 * [\#1328](https://github.com/bnb-chain/bsc/pull/1328) upgrade: update system contracts' code of testnet
 * [\#1162](https://github.com/bnb-chain/bsc/pull/1162) consensus: fix slash bug when validator set changing
 * [\#1344](https://github.com/bnb-chain/bsc/pull/1344) consensus: fix delete the 1st validator from snapshot.recents list
-* [\#1269](https://github.com/bnb-chain/bsc/pull/1269) parlia: miner changes for BEP-188 of Early Broadcast
-* [\#1268](https://github.com/bnb-chain/bsc/pull/1268) parlia: consensus changes according to BEP of Early Broadcast
 * [\#1149](https://github.com/bnb-chain/bsc/pull/1149) feats: add ics23 proof support for cross chain packages
 * [\#1333](https://github.com/bnb-chain/bsc/pull/1333) sec: add proof ops check and key checker
 

--- a/consensus/errors.go
+++ b/consensus/errors.go
@@ -31,10 +31,6 @@ var (
 	// to the current node.
 	ErrFutureBlock = errors.New("block in the future")
 
-	// ErrFutureParentBlock is returned when a block's parent's timestamp is in the future
-	// according to the current node.
-	ErrFutureParentBlock = errors.New("parent block in the future")
-
 	// ErrInvalidNumber is returned if a block's number doesn't equal its parent's
 	// plus one.
 	ErrInvalidNumber = errors.New("invalid block number")

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -327,26 +327,9 @@ func (p *Parlia) verifyHeader(chain consensus.ChainHeaderReader, header *types.H
 	}
 	number := header.Number.Uint64()
 
-	// According to BEP188, after Planck fork, an in-turn validator is allowed to broadcast
-	// a mined block earlier but not earlier than its parent's timestamp when the block is ready .
+	// Don't waste time checking blocks from the future
 	if header.Time > uint64(time.Now().Unix()) {
-		if !chain.Config().IsPlanck(header.Number) || header.Difficulty.Cmp(diffInTurn) != 0 {
-			return consensus.ErrFutureBlock
-		}
-		var parent *types.Header
-		if len(parents) > 0 {
-			parent = parents[len(parents)-1]
-		} else {
-			parent = chain.GetHeader(header.ParentHash, number-1)
-		}
-
-		if parent == nil || parent.Number.Uint64() != number-1 || parent.Hash() != header.ParentHash {
-			return consensus.ErrUnknownAncestor
-		}
-
-		if parent.Time > uint64(time.Now().Unix()) {
-			return consensus.ErrFutureParentBlock
-		}
+		return consensus.ErrFutureBlock
 	}
 	// Check that the extra-data contains the vanity, validators and signature.
 	if len(header.Extra) < extraVanity {

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -60,7 +60,6 @@ const (
 
 	systemRewardPercent = 4 // it means 1/2^4 = 1/16 percentage of gas fee incoming will be distributed to system
 
-	gasUsedRateDemarcation = 75 // Demarcation point of low and high gas used rate
 )
 
 var (
@@ -882,26 +881,8 @@ func (p *Parlia) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 		}
 	}
 
-	// BEP-188 allows an in-turn validator to broadcast the mined block earlier
-	// but not earlier than its parent's timestamp after Planck fork.
-	// At the same time, small block which means gas used rate is less than
-	// gasUsedRateDemarcation does not broadcast early to avoid an upcoming fat block.
-	delay := time.Duration(0)
-	gasUsedRate := uint64(0)
-	if header.GasLimit != 0 {
-		gasUsedRate = header.GasUsed * 100 / header.GasLimit
-	}
-	if p.chainConfig.IsPlanck(header.Number) && header.Difficulty.Cmp(diffInTurn) == 0 && gasUsedRate >= gasUsedRateDemarcation {
-		parent := chain.GetHeader(header.ParentHash, number-1)
-		if parent == nil || parent.Number.Uint64() != number-1 || parent.Hash() != header.ParentHash {
-			return consensus.ErrUnknownAncestor
-		}
-		if parent.Time > uint64(time.Now().Unix()) {
-			delay = time.Until(time.Unix(int64(parent.Time), 0))
-		}
-	} else {
-		delay = p.delayForRamanujanFork(snap, header)
-	}
+	// Sweet, the protocol permits us to sign the block, wait for our time
+	delay := p.delayForRamanujanFork(snap, header)
 
 	log.Info("Sealing block with", "number", number, "delay", delay, "headerDifficulty", header.Difficulty, "val", val.Hex())
 


### PR DESCRIPTION
### Description
There is many reorg detected when running performance stress test, which is caused by BEP-188.
So revert the code of BEP-188.


### Rationale
NA

### Example
NA

### Changes
NA
