### PR TITLE
fix: crash on nil access when TxPool shutdown

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1126,7 +1126,12 @@ LOOP:
 		// subscribe before fillTransactions
 		txsCh := make(chan core.NewTxsEvent, txChanSize)
 		sub := w.eth.TxPool().SubscribeNewTxsEvent(txsCh)
-		defer sub.Unsubscribe()
+		// if TxPool has been stopped, `sub` would be nil, it could happen on shutdown.
+		if sub == nil {
+			log.Info("commitWork SubscribeNewTxsEvent return nil")
+		} else {
+			defer sub.Unsubscribe()
+		}
 
 		// Fill pending transactions from the txpool
 		fillStart := time.Now()
@@ -1196,7 +1201,9 @@ LOOP:
 		}
 		// if sub's channel if full, it will block other NewTxsEvent subscribers,
 		// so unsubscribe ASAP and Unsubscribe() is re-enterable, safe to call several time.
-		sub.Unsubscribe()
+		if sub != nil {
+			sub.Unsubscribe()
+		}
 	}
 	// get the most profitable work
 	bestWork := workList[0]


### PR DESCRIPTION
### Description
It could happen on node shutdown.
The crash callstack:
<img width="1326" alt="image" src="https://user-images.githubusercontent.com/92799281/225201312-7a752def-1104-4f8b-bdb6-a7593972e226.png">

### Rationale
NA

### Example
NA

### Changes
NA
