### PR TITLE
.travis: use go 1.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jobs:
   allow_failures:
     - stage: build
       os: osx
-      go: 1.17.x
+      go: 1.19.x
       env:
         - azure-osx
         - azure-ios
@@ -16,7 +16,7 @@ jobs:
     - stage: lint
       os: linux
       dist: bionic
-      go: 1.17.x
+      go: 1.19.x
       env:
         - lint
       git:
@@ -31,7 +31,7 @@ jobs:
       os: linux
       arch: amd64
       dist: bionic
-      go: 1.17.x
+      go: 1.19.x
       env:
         - docker
       services:
@@ -48,7 +48,7 @@ jobs:
       os: linux
       arch: arm64
       dist: bionic
-      go: 1.17.x
+      go: 1.19.x
       env:
         - docker
       services:
@@ -65,7 +65,7 @@ jobs:
       if: type = push
       os: linux
       dist: bionic
-      go: 1.17.x
+      go: 1.19.x
       env:
         - ubuntu-ppa
         - GO111MODULE=on
@@ -90,7 +90,7 @@ jobs:
       os: linux
       dist: bionic
       sudo: required
-      go: 1.17.x
+      go: 1.19.x
       env:
         - azure-linux
         - GO111MODULE=on
@@ -162,7 +162,7 @@ jobs:
     - stage: build
       if: type = push
       os: osx
-      go: 1.17.x
+      go: 1.19.x
       env:
         - azure-osx
         - azure-ios
@@ -194,7 +194,7 @@ jobs:
       os: linux
       arch: amd64
       dist: bionic
-      go: 1.17.x
+      go: 1.19.x
       env:
         - GO111MODULE=on
       script:
@@ -205,7 +205,7 @@ jobs:
       os: linux
       arch: arm64
       dist: bionic
-      go: 1.17.x
+      go: 1.19.x
       env:
         - GO111MODULE=on
       script:
@@ -225,7 +225,7 @@ jobs:
       if: type = cron
       os: linux
       dist: bionic
-      go: 1.17.x
+      go: 1.19.x
       env:
         - azure-purge
         - GO111MODULE=on
@@ -239,7 +239,7 @@ jobs:
       if: type = cron
       os: linux
       dist: bionic
-      go: 1.17.x
+      go: 1.19.x
       env:
         - GO111MODULE=on
       script:


### PR DESCRIPTION
### Description

Use go 1.19 in travis.

### Rationale

The go version in go.mod should be the same in travis.

