### PR TITLE
bugfix: failed to freeze genesis block with prunedfreezer

### DIFF
--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -300,5 +300,5 @@ func (f *prunedfreezer) AncientRange(kind string, start, count, maxBytes uint64)
 }
 
 func (f *prunedfreezer) ModifyAncients(func(ethdb.AncientWriteOp) error) (int64, error) {
-	return 0, errNotSupported
+	return 0, nil
 }


### PR DESCRIPTION
### Description

I'm running bsc syncing from the genesis block, and failed to sync with errors below:

```
 Error writing genesis to ancients        err="this operation is not supported"
```

So let's skip the error return