### PR TITLE
fix: Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ FROM ethereum/solc:0.6.4-alpine as bsc-genesis
 RUN apk add --d --no-cache ca-certificates npm nodejs bash alpine-sdk
 
 RUN git clone https://github.com/binance-chain/bsc-genesis-contract.git /root/genesis \
-    && rm /root/genesis/package-lock.json && cd /root/genesis && npm install
+    && cd /root/genesis && npm install
 
 COPY docker/init_holders.template /root/genesis/init_holders.template
 


### PR DESCRIPTION
### Description

Removing the `package-lock.json` file is a very bad idea

### Rationale

As dependencies versions are not guaranteed each time, which will cause installations to be very flaky and fail.
