### PR TITLE
tracer: enable withLog for TraceCall

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1301,17 +1301,14 @@ func (p *Parlia) backOffTime(snap *Snapshot, header *types.Header, val common.Ad
 				recentsMap[recent] = seen
 			}
 
-			// if the validator has recently signed, it is unexpected, stop here.
-			if seen, ok := recentsMap[val]; ok {
-				log.Error("unreachable code, validator signed recently",
-					"block", header.Number, "address", val,
-					"seen", seen, "len(snap.Recents)", len(snap.Recents))
+			// The backOffTime does not matter when a validator has signed recently.
+			if _, ok := recentsMap[val]; ok {
 				return 0
 			}
 
 			inTurnAddr := validators[(snap.Number+1)%uint64(len(validators))]
 			if _, ok := recentsMap[inTurnAddr]; ok {
-				log.Info("in turn validator has recently signed, skip initialBackOffTime",
+				log.Debug("in turn validator has recently signed, skip initialBackOffTime",
 					"inTurnAddr", inTurnAddr)
 				delay = 0
 			}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -882,12 +882,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 
 	var traceConfig *TraceConfig
 	if config != nil {
-		traceConfig = &TraceConfig{
-			Config:  config.Config,
-			Tracer:  config.Tracer,
-			Timeout: config.Timeout,
-			Reexec:  config.Reexec,
-		}
+		traceConfig = &config.TraceConfig
 	}
 	return api.traceTx(ctx, msg, new(Context), vmctx, statedb, traceConfig)
 }


### PR DESCRIPTION
### Description

support withLog when TraceCall

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
