### PR TITLE
miner: add fallthrough for switch cases

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1142,7 +1142,9 @@ LOOP:
 			log.Debug("commitWork abort", "err", err)
 			return
 		case errors.Is(err, errBlockInterruptedByRecommit):
+			fallthrough
 		case errors.Is(err, errBlockInterruptedByTimeout):
+			fallthrough
 		case errors.Is(err, errBlockInterruptedByOutOfGas):
 			// break the loop to get the best work
 			log.Debug("commitWork finish", "reason", err)


### PR DESCRIPTION
### Description

cases should be `fallthrough` to use the next statments

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
