### PR TITLE
fix: parlia.snapshot() run into trouble after removedb

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -454,8 +454,10 @@ func (p *Parlia) snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 			}
 		}
 
-		// If we're at the genesis, snapshot the initial state.
-		if number == 0 {
+		// If we're at the genesis, snapshot the initial state. Alternatively if we have
+		// piled up more headers than allowed to be reorged (chain reinit from a freezer),
+		// consider the checkpoint trusted and snapshot it.
+		if number == 0 || (number%p.config.Epoch == 0 && (len(headers) > params.FullImmutabilityThreshold)) {
 			checkpoint := chain.GetHeaderByNumber(number)
 			if checkpoint != nil {
 				// get checkpoint data


### PR DESCRIPTION
### Description
Fix the issue reported in: https://github.com/bnb-chain/bsc/issues/1345 (Bootstrapping Parlia gobbles up RAM and doesn't show progress)

There is a bug in [parlia.go.snapshot()](https://github.com/bnb-chain/bsc/blob/master/consensus/parlia/parlia.go#L434).
It would traverse the blocks in ancient db until the genesis is reached to get the snapshot, which could be huge if the ancient db already contain a huge number of block(e.g. block 26 million).

Actually there is a soft finality height, which is 90000, it can be used as snapshot trust limit. We can use it to rebuild the snapshot.

### Rationale
NA

### Example
NA

### Changes
NA