### PR TITLE
consnesus/parlia: abort sealing when block in the same height has upd…

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -891,7 +891,7 @@ func (p *Parlia) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 				log.Info("Received block process finished, abort block seal")
 				return
 			case <-time.After(time.Duration(processBackOffTime) * time.Second):
-				if number := header.Number.Uint64(); chain.CurrentHeader().Number.Uint64() >= number && chain.GetHeaderByNumber(number-1).Hash() == (header.ParentHash) {
+				if chain.CurrentHeader().Number.Uint64() >= header.Number.Uint64() {
 					log.Info("Process backoff time exhausted, and current header has updated to abort this seal")
 					return
 				}

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -891,7 +891,7 @@ func (p *Parlia) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 				log.Info("Received block process finished, abort block seal")
 				return
 			case <-time.After(time.Duration(processBackOffTime) * time.Second):
-				if chain.CurrentHeader().Number.Uint64() == header.Number.Uint64() {
+				if number := header.Number.Uint64(); chain.CurrentHeader().Number.Uint64() >= number && chain.GetHeaderByNumber(number-1).Hash() == (header.ParentHash) {
 					log.Info("Process backoff time exhausted, and current header has updated to abort this seal")
 					return
 				}

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -891,6 +891,10 @@ func (p *Parlia) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 				log.Info("Received block process finished, abort block seal")
 				return
 			case <-time.After(time.Duration(processBackOffTime) * time.Second):
+				if chain.CurrentHeader().Number.Uint64() == header.Number.Uint64() {
+					log.Info("Process backoff time exhausted, and current header has updated to abort this seal")
+					return
+				}
 				log.Info("Process backoff time exhausted, start to seal block")
 			}
 		}


### PR DESCRIPTION
### Description

 abort sealing when block in the same height has updated the canonical head while this is the `offturn` validator

### Rationale
<img width="1658" alt="log_validators" src="https://user-images.githubusercontent.com/26671219/226990411-b9183a51-1dee-420c-b9c4-7c193f4d9747.png">
log_validator_upper:

- receive B_71317(...682) at 00:56:55,  and its timestamp should before 00:56:54 according to the log from the lower part of the picture (backofftime<=2, timestamp<=prev+5)
- mining B_71317(...e95), commit at 00:56:55 and elapsed time 5.194s => backofftime>=6, and the timestamp of 71316 is 00:56:54, so the backofftime of B_71317 is 3 (timestamp=prev+6)
- from line:4474, shows that at 00:56:55 B_71317(...682) has been imported and the miner.worker had received the new head event, but the B_71317(...e95) was in the sealing stage, so it couldn't be interrupt, and finally sealed and post the offturn block B_71317(...e95) which would be the ultimate canonical block after some reorgs.

log_validator_blow:
- B_71317(...682) received as canonical head at 00:56:54, and received B_71317(...e95, mining stage shown from upper log) as sidechain at 00:56:56

---

BSC have changed the logical of `backoffTime` calculation, this modification make the `backoffTime` more reasonable and expected, but it reduces the interval between `offturn` block's timestamp, this shouldn't be called as `bug`, but could increase the chance of `reorganization` especially when the network not stability or big traffic happens compared to the previous version since it made bigger average interval among `offturn` blocks' timestamp.

![reorgs](https://user-images.githubusercontent.com/26671219/227612198-08f30ddc-9a10-4a27-91c7-a3b4c9efcb62.png)

### Example

N/A

### Changes

Notable changes: 
* 