### PR TITLE
miner: no need to broadcast sidechain header mined by this validator

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -674,7 +674,7 @@ func (w *worker) resultLoop() {
 				if err != nil {
 					log.Error("Failed writing block to chain", "err", err, "status", status)
 				} else {
-					log.Info("Writen block as SideChain and avoid broadcasting", "status", status)
+					log.Info("Written block as SideChain and avoid broadcasting", "status", status)
 				}
 				continue
 			}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -671,7 +671,11 @@ func (w *worker) resultLoop() {
 			start := time.Now()
 			status, err := w.chain.WriteBlockAndSetHead(block, receipts, logs, task.state, true)
 			if status != core.CanonStatTy {
-				log.Error("Failed writing block to chain", "err", err, "status", status)
+				if err != nil {
+					log.Error("Failed writing block to chain", "err", err, "status", status)
+				} else {
+					log.Info("Writen block as SideChain and avoid broadcasting", "status", status)
+				}
 				continue
 			}
 			writeBlockTimer.UpdateSince(start)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -666,20 +666,19 @@ func (w *worker) resultLoop() {
 				w.recentMinedBlocks.Add(block.NumberU64(), []common.Hash{block.ParentHash()})
 			}
 
-			// Broadcast the block and announce chain insertion event
-			w.mux.Post(core.NewMinedBlockEvent{Block: block})
-
 			// Commit block and state to database.
 			task.state.SetExpectedStateRoot(block.Root())
 			start := time.Now()
-			_, err := w.chain.WriteBlockAndSetHead(block, receipts, logs, task.state, true)
-			if err != nil {
-				log.Error("Failed writing block to chain", "err", err)
+			status, err := w.chain.WriteBlockAndSetHead(block, receipts, logs, task.state, true)
+			if status != core.CanonStatTy {
+				log.Error("Failed writing block to chain", "err", err, "status", status)
 				continue
 			}
 			writeBlockTimer.UpdateSince(start)
 			log.Info("Successfully sealed new block", "number", block.Number(), "sealhash", sealhash, "hash", hash,
 				"elapsed", common.PrettyDuration(time.Since(task.createdAt)))
+			// Broadcast the block and announce chain insertion event
+			w.mux.Post(core.NewMinedBlockEvent{Block: block})
 
 			// Insert the block into the set of pending ones to resultLoop for confirmations
 			w.unconfirmed.Insert(block.NumberU64(), block.Hash())


### PR DESCRIPTION
### Description

if the mined block inserted as `sidechain` by the commiter, then shouldn't broadcast it.
details ref: #1382 

test with stress test (tps=800, duration=600s):
- before: reorg_execution=13
- with pr#1382+pr#1383: reorg_executio=0
![reorgs](https://user-images.githubusercontent.com/26671219/227612896-9aa50fe4-0cb0-46d0-988e-dc5ced46232d.png)

### Rationale

Reduce `offturn/sidechain` blocks traffic, reduce the probability of reorgs under big transactions traffic.
This could reduce the `offturn/sidechain` network traffic, and 
- since`parlia` is order based, it's unnecessary for validator to broadcast the block mined by itself and considered as `sidechain`.
- under big traffic or bad network condition, the `sidechain` blocks would cause more chaos(reorgs) since validators decided to reorg the head of canonical chain by 50% probability when the ttd were equal.

### Example

N/A

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
