### PR TITLE
ci: Fix truffle test

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ FROM ethereum/solc:0.6.4-alpine as bsc-genesis
 RUN apk add --d --no-cache ca-certificates npm nodejs bash alpine-sdk
 
 RUN git clone https://github.com/binance-chain/bsc-genesis-contract.git /root/genesis \
-    && rm /root/genesis/package-lock.json && cd /root/genesis && npm install
+    && cd /root/genesis && npm install
 
 COPY docker/init_holders.template /root/genesis/init_holders.template
 


### PR DESCRIPTION
### Description

fix truffle test

### Rationale

web3 package not found when exec generate-genesis.js
using package-lock.json works


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
