### PR TITLE
release: draft release v1.1.21

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1301,17 +1301,14 @@ func (p *Parlia) backOffTime(snap *Snapshot, header *types.Header, val common.Ad
 				recentsMap[recent] = seen
 			}
 
-			// if the validator has recently signed, it is unexpected, stop here.
-			if seen, ok := recentsMap[val]; ok {
-				log.Error("unreachable code, validator signed recently",
-					"block", header.Number, "address", val,
-					"seen", seen, "len(snap.Recents)", len(snap.Recents))
+			// The backOffTime does not matter when a validator has signed recently.
+			if _, ok := recentsMap[val]; ok {
 				return 0
 			}
 
 			inTurnAddr := validators[(snap.Number+1)%uint64(len(validators))]
 			if _, ok := recentsMap[inTurnAddr]; ok {
-				log.Info("in turn validator has recently signed, skip initialBackOffTime",
+				log.Debug("in turn validator has recently signed, skip initialBackOffTime",
 					"inTurnAddr", inTurnAddr)
 				delay = 0
 			}

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -49,10 +49,12 @@ func (h *nonceHeap) Push(x interface{}) {
 
 func (h *nonceHeap) Pop() interface{} {
 	old := *h
-	n := len(old)
-	x := old[n-1]
-	*h = old[0 : n-1]
-	return x
+	if n := len(old); n > 0 {
+		x := old[n-1]
+		*h = old[0 : n-1]
+		return x
+	}
+	return nil
 }
 
 // txSortedMap is a nonce->transaction hash map with a heap based index to allow

--- a/core/vm/contracts_lightclient.go
+++ b/core/vm/contracts_lightclient.go
@@ -28,6 +28,11 @@ const (
 // 32 bytes               |                 |                   |
 func decodeTendermintHeaderValidationInput(input []byte) (*lightclient.ConsensusState, *lightclient.Header, error) {
 	csLen := binary.BigEndian.Uint64(input[consensusStateLengthBytesLength-uint64TypeLength : consensusStateLengthBytesLength])
+
+	if consensusStateLengthBytesLength+csLen < consensusStateLengthBytesLength {
+		return nil, nil, fmt.Errorf("integer overflow, csLen: %d", csLen)
+	}
+
 	if uint64(len(input)) <= consensusStateLengthBytesLength+csLen {
 		return nil, nil, fmt.Errorf("expected payload size %d, actual size: %d", consensusStateLengthBytesLength+csLen, len(input))
 	}

--- a/core/vm/lightclient/types.go
+++ b/core/vm/lightclient/types.go
@@ -270,8 +270,9 @@ func DecodeKeyValueMerkleProof(input []byte) (*KeyValueMerkleProof, error) {
 	inputLength := uint64(len(input))
 	pos := uint64(0)
 
-	if inputLength <= storeNameLengthBytesLength+keyLengthBytesLength+valueLengthBytesLength+appHashLength {
-		return nil, fmt.Errorf("input length should be no less than %d", storeNameLengthBytesLength+keyLengthBytesLength+valueLengthBytesLength+appHashLength)
+	fixedSize := storeNameLengthBytesLength + keyLengthBytesLength + valueLengthBytesLength + appHashLength
+	if inputLength <= fixedSize {
+		return nil, fmt.Errorf("input length should be no less than %d", fixedSize)
 	}
 	storeName := string(bytes.Trim(input[pos:pos+storeNameLengthBytesLength], "\x00"))
 	pos += storeNameLengthBytesLength
@@ -279,7 +280,8 @@ func DecodeKeyValueMerkleProof(input []byte) (*KeyValueMerkleProof, error) {
 	keyLength := binary.BigEndian.Uint64(input[pos+keyLengthBytesLength-8 : pos+keyLengthBytesLength])
 	pos += keyLengthBytesLength
 
-	if inputLength <= storeNameLengthBytesLength+keyLengthBytesLength+keyLength+valueLengthBytesLength {
+	fixedSize = storeNameLengthBytesLength + keyLengthBytesLength + valueLengthBytesLength
+	if inputLength <= fixedSize+keyLength || fixedSize+keyLength < fixedSize {
 		return nil, fmt.Errorf("invalid input, keyLength %d is too long", keyLength)
 	}
 	key := input[pos : pos+keyLength]
@@ -288,7 +290,10 @@ func DecodeKeyValueMerkleProof(input []byte) (*KeyValueMerkleProof, error) {
 	valueLength := binary.BigEndian.Uint64(input[pos+valueLengthBytesLength-8 : pos+valueLengthBytesLength])
 	pos += valueLengthBytesLength
 
-	if inputLength <= storeNameLengthBytesLength+keyLengthBytesLength+keyLength+valueLengthBytesLength+valueLength+appHashLength {
+	fixedSize = storeNameLengthBytesLength + keyLengthBytesLength + valueLengthBytesLength + appHashLength
+	if inputLength <= fixedSize+keyLength+valueLength ||
+		fixedSize+keyLength < fixedSize ||
+		fixedSize+keyLength+valueLength < valueLength {
 		return nil, fmt.Errorf("invalid input, valueLength %d is too long", valueLength)
 	}
 	value := input[pos : pos+valueLength]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ FROM ethereum/solc:0.6.4-alpine as bsc-genesis
 RUN apk add --d --no-cache ca-certificates npm nodejs bash alpine-sdk
 
 RUN git clone https://github.com/binance-chain/bsc-genesis-contract.git /root/genesis \
-    && rm /root/genesis/package-lock.json && cd /root/genesis && npm install
+    && cd /root/genesis && npm install
 
 COPY docker/init_holders.template /root/genesis/init_holders.template
 

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -882,12 +882,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 
 	var traceConfig *TraceConfig
 	if config != nil {
-		traceConfig = &TraceConfig{
-			Config:  config.Config,
-			Tracer:  config.Tracer,
-			Timeout: config.Timeout,
-			Reexec:  config.Reexec,
-		}
+		traceConfig = &config.TraceConfig
 	}
 	return api.traceTx(ctx, msg, new(Context), vmctx, statedb, traceConfig)
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1142,7 +1142,9 @@ LOOP:
 			log.Debug("commitWork abort", "err", err)
 			return
 		case errors.Is(err, errBlockInterruptedByRecommit):
+			fallthrough
 		case errors.Is(err, errBlockInterruptedByTimeout):
+			fallthrough
 		case errors.Is(err, errBlockInterruptedByOutOfGas):
 			// break the loop to get the best work
 			log.Debug("commitWork finish", "reason", err)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1126,7 +1126,12 @@ LOOP:
 		// subscribe before fillTransactions
 		txsCh := make(chan core.NewTxsEvent, txChanSize)
 		sub := w.eth.TxPool().SubscribeNewTxsEvent(txsCh)
-		defer sub.Unsubscribe()
+		// if TxPool has been stopped, `sub` would be nil, it could happen on shutdown.
+		if sub == nil {
+			log.Info("commitWork SubscribeNewTxsEvent return nil")
+		} else {
+			defer sub.Unsubscribe()
+		}
 
 		// Fill pending transactions from the txpool
 		fillStart := time.Now()
@@ -1196,7 +1201,9 @@ LOOP:
 		}
 		// if sub's channel if full, it will block other NewTxsEvent subscribers,
 		// so unsubscribe ASAP and Unsubscribe() is re-enterable, safe to call several time.
-		sub.Unsubscribe()
+		if sub != nil {
+			sub.Unsubscribe()
+		}
 	}
 	// get the most profitable work
 	bestWork := workList[0]

--- a/params/config.go
+++ b/params/config.go
@@ -114,7 +114,7 @@ var (
 		NanoBlock:           big.NewInt(21962149),
 		MoranBlock:          big.NewInt(22107423),
 		GibbsBlock:          big.NewInt(23846001),
-		PlanckBlock:         nil,
+		PlanckBlock:         big.NewInt(27281024),
 
 		Parlia: &ParliaConfig{
 			Period: 3,


### PR DESCRIPTION
### Description
v1.1.21 is a hard-fork release for BSC mainnet.

The mainnet  is expected to have a scheduled hardfork upgrade named `Planck` at block height 27,281,024. The current block generation speed forecasts this to occur around 12th April 2023 at 05:30 AM (UTC). 
The `Planck` hardfork includes 2 BEPs to enhance network stability and security:
[BEP-171: Security Enhancement for Cross-Chain Module](https://github.com/bnb-chain/BEPs/blob/master/BEP171.md)
[BEP-172: Network Stability Enhancement On Slash Occur](https://github.com/bnb-chain/BEPs/blob/master/BEP172.md)

The validators and full node operators on mainnet should switch their software version to [v1.1.21](https://github.com/bnb-chain/bsc/releases/tag/v1.1.21) before 12th April 2023.


### Rationale
FEATURE
* [\#1322](https://github.com/bnb-chain/bsc/pull/1322) cmd/utils/flags.go: --diffsync flag is deprecate
* [\#1261](https://github.com/bnb-chain/bsc/pull/1261) tracer: port call tracer `withLog` to bsc

IMPROVEMENT
* [\#1337](https://github.com/bnb-chain/bsc/pull/1337) clean: Remove support for Ethereum testnet
* [\#1347](https://github.com/bnb-chain/bsc/pull/1389) upgrade: update the fork height of planck upgrade on mainnet
* [\#1343](https://github.com/bnb-chain/bsc/pull/1343) upgrade: update system contracts' code of planck upgrade
* [\#1328](https://github.com/bnb-chain/bsc/pull/1328) upgrade: update system contracts' code of testnet
* [\#1162](https://github.com/bnb-chain/bsc/pull/1162) consensus: fix slash bug when validator set changing
* [\#1344](https://github.com/bnb-chain/bsc/pull/1344) consensus: fix delete the 1st validator from snapshot.recents list
* [\#1149](https://github.com/bnb-chain/bsc/pull/1149) feats: add ics23 proof support for cross chain packages
* [\#1333](https://github.com/bnb-chain/bsc/pull/1333) sec: add proof ops check and key checker

BUGFIX
* [\#1348](https://github.com/bnb-chain/bsc/pull/1348) core/txpool: implement additional DoS defenses


### Example
None


### Changes
The validators and full node operators on mainnet should switch their software version to [v1.1.21](https://github.com/bnb-chain/bsc/releases/tag/v1.1.21) before 12th April 2023.