### PR TITLE
Implement BEP-212 : Reduction of Refunds

### DIFF
--- a/core/blockchain_eip_3529_test.go
+++ b/core/blockchain_eip_3529_test.go
@@ -1,0 +1,169 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// Boneh Instruction Set
+func bonehConfig() *params.ChainConfig {
+	config := *params.TestChainConfig
+	config.LondonBlock = nil
+	config.BonehBlock = big.NewInt(0)
+	return &config
+}
+
+// Berlin Instruction Set
+func preEIP3529Config() *params.ChainConfig {
+	config := *params.TestChainConfig
+	config.LondonBlock = nil
+	config.BonehBlock = nil
+	return &config
+}
+
+func TestSelfDestructGasPreEIP3529(t *testing.T) {
+	bytecode := []byte{
+		byte(vm.PC),
+		byte(vm.SELFDESTRUCT),
+	}
+
+	// Expected gas is (intrinsic +  pc + cold load (due to legacy tx)  + selfdestruct cost ) / 2
+	// The refund of 24000 gas (i.e. params.SelfdestructRefundGas) is not applied since refunds pre-EIP3529 are
+	// capped to half of the transaction's gas.
+	expectedGasUsed := (params.TxGas + vm.GasQuickStep + params.ColdAccountAccessCostEIP2929 + params.SelfdestructGasEIP150) / 2
+	testGasUsage(t, preEIP3529Config(), ethash.NewFaker(), bytecode, nil, 60_000, expectedGasUsed)
+}
+
+func TestSstoreGasPreEIP3529(t *testing.T) {
+	bytecode := []byte{
+		byte(vm.PUSH1), 0x3, // value
+		byte(vm.PUSH1), 0x3, // location
+		byte(vm.SSTORE), // Set slot[3] = 3
+	}
+	// 	// Expected gas is intrinsic +  2*pushGas + cold load (due to legacy tx) +  SstoreGas
+	expectedGasUsed := params.TxGas + 2*vm.GasFastestStep + params.ColdSloadCostEIP2929 + params.SstoreSetGasEIP2200
+	testGasUsage(t, preEIP3529Config(), ethash.NewFaker(), bytecode, nil, 60_000, expectedGasUsed)
+}
+
+func TestSelfDestructGasPostEIP3529(t *testing.T) {
+	bytecode := []byte{
+		byte(vm.PC),
+		byte(vm.SELFDESTRUCT),
+	}
+	// Expected gas is intrinsic +  pc + cold load (due to legacy tx) + SelfDestructGas
+	expectedGasUsed := params.TxGas + vm.GasQuickStep + params.ColdAccountAccessCostEIP2929 + params.SelfdestructGasEIP150
+	testGasUsage(t, bonehConfig(), ethash.NewFaker(), bytecode, nil, 60_000, expectedGasUsed)
+}
+
+func TestSstoreGasPostEIP3529(t *testing.T) {
+	bytecode := []byte{
+		byte(vm.PUSH1), 0x3, // value
+		byte(vm.PUSH1), 0x3, // location
+		byte(vm.SSTORE), // Set slot[3] = 3
+	}
+	// Expected gas is intrinsic +  2*pushGas + cold load (due to legacy tx) +  SstoreGas
+	expectedGasUsed := params.TxGas + 2*vm.GasFastestStep + params.ColdSloadCostEIP2929 + params.SstoreSetGasEIP2200
+	testGasUsage(t, bonehConfig(), ethash.NewFaker(), bytecode, nil, 60_000, expectedGasUsed)
+}
+
+func TestSstoreModifyGasPostEIP3529(t *testing.T) {
+	bytecode := []byte{
+		byte(vm.PUSH1), 0x3, // value
+		byte(vm.PUSH1), 0x1, // location
+		byte(vm.SSTORE), // Set slot[1] = 3
+	}
+	// initalize contract storage
+	initialStorage := make(map[common.Hash]common.Hash)
+	// Populate two slots
+	initialStorage[common.HexToHash("01")] = common.HexToHash("01")
+	initialStorage[common.HexToHash("02")] = common.HexToHash("02")
+	// Expected gas is intrinsic +  2*pushGas + cold load (due to legacy tx) + SstoreReset (a->b such that a,b!=0)
+	expectedGasUsed := params.TxGas + 2*vm.GasFastestStep + params.ColdSloadCostEIP2929 + (params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929)
+	testGasUsage(t, bonehConfig(), ethash.NewFaker(), bytecode, initialStorage, 60_000, expectedGasUsed)
+}
+
+func TestSstoreClearGasPostEIP3529(t *testing.T) {
+	bytecode := []byte{
+		byte(vm.PUSH1), 0x0, // value
+		byte(vm.PUSH1), 0x1, // location
+		byte(vm.SSTORE), // Set slot[1] = 0
+	}
+	// initalize contract storage
+	initialStorage := make(map[common.Hash]common.Hash)
+	// Populate two slots
+	initialStorage[common.HexToHash("01")] = common.HexToHash("01")
+	initialStorage[common.HexToHash("02")] = common.HexToHash("02")
+
+	// Expected gas is intrinsic +  2*pushGas + cold load (due to legacy tx) + SstoreReset (a->b such that a,b!=0) - sstoreClearGasRefund
+	expectedGasUsage := params.TxGas + 2*vm.GasFastestStep + params.ColdSloadCostEIP2929 + (params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929) - params.SstoreClearsScheduleRefundEIP3529
+	testGasUsage(t, bonehConfig(), ethash.NewFaker(), bytecode, initialStorage, 60_000, expectedGasUsage)
+}
+
+// Test the gas used by running a transaction sent to a smart contract with given bytecode and storage.
+func testGasUsage(t *testing.T, config *params.ChainConfig, engine consensus.Engine, bytecode []byte, initialStorage map[common.Hash]common.Hash, initialGas, expectedGasUsed uint64) {
+	var (
+		aa = common.HexToAddress("0x000000000000000000000000000000000000aaaa")
+
+		// Generate a canonical chain to act as the main dataset
+		db = rawdb.NewMemoryDatabase()
+
+		// A sender who makes transactions, has some funds
+		key, _        = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address       = crypto.PubkeyToAddress(key.PublicKey)
+		balanceBefore = big.NewInt(1000000000000000)
+		gspec         = &Genesis{
+			Config: config,
+			Alloc: GenesisAlloc{
+				address: {Balance: balanceBefore},
+				aa: {
+					Code:    bytecode,
+					Storage: initialStorage,
+					Nonce:   0,
+					Balance: big.NewInt(0),
+				},
+			},
+		}
+		genesis = gspec.MustCommit(db)
+	)
+
+	blocks, _ := GenerateChain(gspec.Config, genesis, engine, db, 1, func(i int, b *BlockGen) {
+		b.SetCoinbase(common.Address{1})
+
+		// One transaction to 0xAAAA
+		signer := types.LatestSigner(gspec.Config)
+		tx, _ := types.SignNewTx(key, signer, &types.LegacyTx{
+			Nonce:    0,
+			To:       &aa,
+			Gas:      initialGas,
+			GasPrice: newGwei(5),
+		})
+		b.AddTx(tx)
+	})
+
+	// Import the canonical chain
+	diskdb := rawdb.NewMemoryDatabase()
+	gspec.MustCommit(diskdb)
+
+	chain, err := NewBlockChain(diskdb, nil, gspec.Config, engine, vm.Config{}, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	if n, err := chain.InsertChain(blocks); err != nil {
+		t.Fatalf("block %d: failed to insert into chain: %v", n, err)
+	}
+
+	block := chain.GetBlockByNumber(1)
+
+	if block.GasUsed() != expectedGasUsed {
+		t.Fatalf("incorrect amount of gas spent: expected %d, got %d", expectedGasUsed, block.GasUsed())
+	}
+}

--- a/core/blockchain_eip_3529_test.go
+++ b/core/blockchain_eip_3529_test.go
@@ -81,7 +81,7 @@ func TestSstoreModifyGasPostEIP3529(t *testing.T) {
 		byte(vm.PUSH1), 0x1, // location
 		byte(vm.SSTORE), // Set slot[1] = 3
 	}
-	// initalize contract storage
+	// initialize contract storage
 	initialStorage := make(map[common.Hash]common.Hash)
 	// Populate two slots
 	initialStorage[common.HexToHash("01")] = common.HexToHash("01")
@@ -97,7 +97,7 @@ func TestSstoreClearGasPostEIP3529(t *testing.T) {
 		byte(vm.PUSH1), 0x1, // location
 		byte(vm.SSTORE), // Set slot[1] = 0
 	}
-	// initalize contract storage
+	// initialize contract storage
 	initialStorage := make(map[common.Hash]common.Hash)
 	// Populate two slots
 	initialStorage[common.HexToHash("01")] = common.HexToHash("01")

--- a/core/blockchain_eip_3529_test.go
+++ b/core/blockchain_eip_3529_test.go
@@ -86,7 +86,7 @@ func TestSstoreModifyGasPostEIP3529(t *testing.T) {
 	// Populate two slots
 	initialStorage[common.HexToHash("01")] = common.HexToHash("01")
 	initialStorage[common.HexToHash("02")] = common.HexToHash("02")
-	// Expected gas is intrinsic +  2*pushGas + cold load (due to legacy tx) + SstoreReset (a->b such that a,b!=0)
+	// Expected gas is intrinsic +  2*pushGas + cold load (due to legacy tx) + SstoreReset (a->b such that a!=0)
 	expectedGasUsed := params.TxGas + 2*vm.GasFastestStep + params.ColdSloadCostEIP2929 + (params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929)
 	testGasUsage(t, bonehConfig(), ethash.NewFaker(), bytecode, initialStorage, 60_000, expectedGasUsed)
 }
@@ -103,7 +103,7 @@ func TestSstoreClearGasPostEIP3529(t *testing.T) {
 	initialStorage[common.HexToHash("01")] = common.HexToHash("01")
 	initialStorage[common.HexToHash("02")] = common.HexToHash("02")
 
-	// Expected gas is intrinsic +  2*pushGas + cold load (due to legacy tx) + SstoreReset (a->b such that a,b!=0) - sstoreClearGasRefund
+	// Expected gas is intrinsic +  2*pushGas + cold load (due to legacy tx) + SstoreReset (a->b such that a!=0) - sstoreClearGasRefund
 	expectedGasUsage := params.TxGas + 2*vm.GasFastestStep + params.ColdSloadCostEIP2929 + (params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929) - params.SstoreClearsScheduleRefundEIP3529
 	testGasUsage(t, bonehConfig(), ethash.NewFaker(), bytecode, initialStorage, 60_000, expectedGasUsage)
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -345,7 +345,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		ret, st.gas, vmerr = st.evm.Call(sender, st.to(), st.data, st.gas, st.value)
 	}
 
-	if !rules.IsLondon {
+	// combined if-else for Ethereum and BSC determining the amount of gas refund
+	if !rules.IsLondon && !rules.IsBoneh {
 		// Before EIP-3529: refunds were capped to gasUsed / 2
 		st.refundGas(params.RefundQuotient)
 	} else {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -77,6 +77,8 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	// If jump table was not initialised we set the default one.
 	if cfg.JumpTable == nil {
 		switch {
+		case evm.chainRules.IsBoneh:
+			cfg.JumpTable = &bonehInstructionSet
 		case evm.chainRules.IsMerge:
 			cfg.JumpTable = &mergeInstructionSet
 		case evm.chainRules.IsLondon:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -55,6 +55,7 @@ var (
 	berlinInstructionSet           = newBerlinInstructionSet()
 	londonInstructionSet           = newLondonInstructionSet()
 	mergeInstructionSet            = newMergeInstructionSet()
+	bonehInstructionSet            = newBonehInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -86,6 +87,13 @@ func newMergeInstructionSet() JumpTable {
 		minStack:    minStack(0, 1),
 		maxStack:    maxStack(0, 1),
 	}
+	return validate(instructionSet)
+}
+
+// newBonehInstructionSet returns the instruction set with EIP-3529 enabled
+func newBonehInstructionSet() JumpTable {
+	instructionSet := newBerlinInstructionSet()
+	enable3529(&instructionSet)
 	return validate(instructionSet)
 }
 

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -197,7 +197,7 @@ var (
 	gasStaticCallEIP2929   = makeCallVariantGasCallEIP2929(gasStaticCall)
 	gasCallCodeEIP2929     = makeCallVariantGasCallEIP2929(gasCallCode)
 	gasSelfdestructEIP2929 = makeSelfdestructGasFn(true)
-	// gasSelfdestructEIP3529 implements the changes in EIP-2539 (no refunds)
+	// gasSelfdestructEIP3529 implements the changes in EIP-3529 (no refunds)
 	gasSelfdestructEIP3529 = makeSelfdestructGasFn(false)
 
 	// gasSStoreEIP2929 implements gas cost for SSTORE according to EIP-2929
@@ -214,12 +214,12 @@ var (
 	// see gasSStoreEIP2200(...) in core/vm/gas_table.go for more info about how EIP 2200 is specified
 	gasSStoreEIP2929 = makeGasSStoreFunc(params.SstoreClearsScheduleRefundEIP2200)
 
-	// gasSStoreEIP2539 implements gas cost for SSTORE according to EIP-2539
+	// gasSStoreEIP3529 implements gas cost for SSTORE according to EIP-3529
 	// Replace `SSTORE_CLEARS_SCHEDULE` with `SSTORE_RESET_GAS + ACCESS_LIST_STORAGE_KEY_COST` (4,800)
 	gasSStoreEIP3529 = makeGasSStoreFunc(params.SstoreClearsScheduleRefundEIP3529)
 )
 
-// makeSelfdestructGasFn can create the selfdestruct dynamic gas function for EIP-2929 and EIP-2539
+// makeSelfdestructGasFn can create the selfdestruct dynamic gas function for EIP-2929 and EIP-3529
 func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
 	gasFunc := func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 		var (

--- a/params/config.go
+++ b/params/config.go
@@ -180,16 +180,16 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), new(EthashConfig), nil, nil}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), new(EthashConfig), nil, nil}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, big.NewInt(0), nil, nil, nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, big.NewInt(0), nil, nil, nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, new(EthashConfig), nil, nil}
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(EthashConfig), nil, nil}
 	TestRules       = TestChainConfig.Rules(new(big.Int), false)
 )
 
@@ -286,7 +286,7 @@ type ChainConfig struct {
 	NanoBlock       *big.Int `json:"nanoBlock,omitempty" toml:",omitempty"`       // nanoBlock switch block (nil = no fork, 0 = already activated)
 	MoranBlock      *big.Int `json:"moranBlock,omitempty" toml:",omitempty"`      // moranBlock switch block (nil = no fork, 0 = already activated)
 	PlanckBlock     *big.Int `json:"planckBlock,omitempty" toml:",omitempty"`     // planckBlock switch block (nil = no fork, 0 = already activated)
-
+	BonehBlock      *big.Int `json:"bonehBlock,omitempty" toml:",omitempty"`      // bonehBlock switch block  (nil = no fork, 0 = already activated)
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty" toml:",omitempty"`
 	Clique *CliqueConfig `json:"clique,omitempty" toml:",omitempty"`
@@ -336,7 +336,7 @@ func (c *ChainConfig) String() string {
 	default:
 		engine = "unknown"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Planck: %v, Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Planck: %v, Boneh: %v, Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -364,6 +364,7 @@ func (c *ChainConfig) String() string {
 		c.NanoBlock,
 		c.MoranBlock,
 		c.PlanckBlock,
+		c.BonehBlock,
 		engine,
 	)
 }
@@ -527,6 +528,14 @@ func (c *ChainConfig) IsOnPlanck(num *big.Int) bool {
 	return configNumEqual(c.PlanckBlock, num)
 }
 
+func (c *ChainConfig) IsBoneh(num *big.Int) bool {
+	return isForked(c.BonehBlock, num)
+}
+
+func (c *ChainConfig) isOnBoneh(num *big.Int) bool {
+	return configNumEqual(c.BonehBlock, num)
+}
+
 // CheckCompatible checks whether scheduled fork transitions have been imported
 // with a mismatching chain configuration.
 func (c *ChainConfig) CheckCompatible(newcfg *ChainConfig, height uint64) *ConfigCompatError {
@@ -658,6 +667,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.PlanckBlock, newcfg.PlanckBlock, head) {
 		return newCompatError("planck fork block", c.PlanckBlock, newcfg.PlanckBlock)
 	}
+	if isForkIncompatible(c.BonehBlock, newcfg.BonehBlock, head) {
+		return newCompatError("boneh fork block", c.BonehBlock, newcfg.BonehBlock)
+	}
 	return nil
 }
 
@@ -730,6 +742,7 @@ type Rules struct {
 	IsNano                                                  bool
 	IsMoran                                                 bool
 	IsPlanck                                                bool
+	IsBoneh                                                 bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -754,5 +767,6 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool) Rules {
 		IsNano:           c.IsNano(num),
 		IsMoran:          c.IsMoran(num),
 		IsPlanck:         c.IsPlanck(num),
+		IsBoneh:          c.IsBoneh(num),
 	}
 }


### PR DESCRIPTION
### Description

This PR implements  [BEP-212](https://github.com/bnb-chain/BEPs/pull/212) . This is done  by enabling [EIP-3529](https://github.com/ethereum/EIPs/pull/3529)  for BSC on the next hard fork block.

Concretely this BEP:
-  Removes gas refund for `SELFDESTRUCT`.
-  Caps the refund for `SSTORE` to 1/5th of the gas used in the transaction.
-  Lowers the `SstoreClearsScheduleRefund` from 15,000 to 4,800 .

### Rationale
Currently the code implementing EIP-3592 is present in the repository, but is not enabled. 

Moreover, no tests were added in the pull request implementing it in go-ethereum : https://github.com/ethereum/go-ethereum/pull/22733 . Those tests were added in the ethereum git submodules which BSC does not use. For this reason new tests for EIP-3529 are added in this PR.

Since EIP-3529 is built upon EIP-2929, this PR also enables EIP-2929. For this a new VM instructionset is defined with both EIPs enabled.


### Changes

Notable changes: 
* `params/config.go` : config changes to include hard fork block.
* `vm/jump_table.go`  : defining a new instructionset with EIP3529 and EIP2929 enabled.
* `core/blockchain_eip3529_test.go` : tests for the gas refunds when EIP3529 is enabled or disabled.
