### PR TITLE
#1387 Added SubscribeFullPendingTransactions method from go-etherium

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -923,6 +923,14 @@ func (fb *filterBackend) ServiceFilter(ctx context.Context, ms *bloombits.Matche
 	panic("not supported")
 }
 
+func (fb *filterBackend) ChainConfig() *params.ChainConfig {
+	panic("not supported")
+}
+
+func (fb *filterBackend) CurrentHeader() *types.Header {
+	panic("not supported")
+}
+
 func nullSubscription() event.Subscription {
 	return event.NewSubscription(func(quit <-chan struct{}) error {
 		<-quit

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/gopool"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -39,6 +40,8 @@ type filter struct {
 	typ      Type
 	deadline *time.Timer // filter is inactiv when deadline triggers
 	hashes   []common.Hash
+	fullTx   bool
+	txs      []*types.Transaction
 	crit     FilterCriteria
 	logs     []*types.Log
 	s        *Subscription // associated subscription in event system
@@ -106,22 +109,22 @@ func (api *PublicFilterAPI) timeoutLoop(timeout time.Duration) {
 // `eth_getFilterChanges` polling method that is also used for log filters.
 //
 // https://eth.wiki/json-rpc/API#eth_newpendingtransactionfilter
-func (api *PublicFilterAPI) NewPendingTransactionFilter() rpc.ID {
+func (api *PublicFilterAPI) NewPendingTransactionFilter(fullTx *bool) rpc.ID {
 	var (
-		pendingTxs   = make(chan []common.Hash)
+		pendingTxs   = make(chan []*types.Transaction)
 		pendingTxSub = api.events.SubscribePendingTxs(pendingTxs)
 	)
 	api.filtersMu.Lock()
-	api.filters[pendingTxSub.ID] = &filter{typ: PendingTransactionsSubscription, deadline: time.NewTimer(api.timeout), hashes: make([]common.Hash, 0), s: pendingTxSub}
+	api.filters[pendingTxSub.ID] = &filter{typ: PendingTransactionsSubscription, fullTx: fullTx != nil && *fullTx, deadline: time.NewTimer(api.timeout), txs: make([]*types.Transaction, 0), s: pendingTxSub}
 	api.filtersMu.Unlock()
 
 	gopool.Submit(func() {
 		for {
 			select {
-			case ph := <-pendingTxs:
+			case pTx := <-pendingTxs:
 				api.filtersMu.Lock()
 				if f, found := api.filters[pendingTxSub.ID]; found {
-					f.hashes = append(f.hashes, ph...)
+					f.txs = append(f.txs, pTx...)
 				}
 				api.filtersMu.Unlock()
 			case <-pendingTxSub.Err():
@@ -136,9 +139,10 @@ func (api *PublicFilterAPI) NewPendingTransactionFilter() rpc.ID {
 	return pendingTxSub.ID
 }
 
-// NewPendingTransactions creates a subscription that is triggered each time a transaction
-// enters the transaction pool and was signed from one of the transactions this nodes manages.
-func (api *PublicFilterAPI) NewPendingTransactions(ctx context.Context) (*rpc.Subscription, error) {
+// NewPendingTransactions creates a subscription that is triggered each time a
+// transaction enters the transaction pool. If fullTx is true the full tx is
+// sent to the client, otherwise the hash is sent.
+func (api *PublicFilterAPI) NewPendingTransactions(ctx context.Context, fullTx *bool) (*rpc.Subscription, error) {
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
@@ -146,17 +150,26 @@ func (api *PublicFilterAPI) NewPendingTransactions(ctx context.Context) (*rpc.Su
 
 	rpcSub := notifier.CreateSubscription()
 
+	isFullTX := fullTx != nil && *fullTx
+
 	gopool.Submit(func() {
-		txHashes := make(chan []common.Hash, 128)
-		pendingTxSub := api.events.SubscribePendingTxs(txHashes)
+		txs := make(chan []*types.Transaction, 128)
+		pendingTxSub := api.events.SubscribePendingTxs(txs)
+		chainConfig := api.backend.ChainConfig()
 
 		for {
 			select {
-			case hashes := <-txHashes:
+			case txs := <-txs:
 				// To keep the original behaviour, send a single tx hash in one notification.
 				// TODO(rjl493456442) Send a batch of tx hashes in one notification
-				for _, h := range hashes {
-					notifier.Notify(rpcSub.ID, h)
+				latest := api.backend.CurrentHeader()
+				for _, tx := range txs {
+					if isFullTX {
+						rpcTx := ethapi.NewRPCPendingTransaction(tx, latest, chainConfig)
+						notifier.Notify(rpcSub.ID, rpcTx)
+					} else {
+						notifier.Notify(rpcSub.ID, tx.Hash())
+					}
 				}
 			case <-rpcSub.Err():
 				pendingTxSub.Unsubscribe()
@@ -551,10 +564,14 @@ func (api *PublicFilterAPI) GetFilterChanges(id rpc.ID) (interface{}, error) {
 		f.deadline.Reset(api.timeout)
 
 		switch f.typ {
-		case PendingTransactionsSubscription, BlocksSubscription, VotesSubscription:
+		case BlocksSubscription, VotesSubscription:
 			hashes := f.hashes
 			f.hashes = nil
 			return returnHashes(hashes), nil
+		case PendingTransactionsSubscription:
+			txs := f.txs
+			f.txs = nil
+			return txs, nil
 		case LogsSubscription, MinedAndPendingLogsSubscription:
 			logs := f.logs
 			f.logs = nil

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -40,6 +41,8 @@ type Backend interface {
 	GetLogs(ctx context.Context, blockHash common.Hash) ([][]*types.Log, error)
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 
+	CurrentHeader() *types.Header
+	ChainConfig() *params.ChainConfig
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
 	SubscribeFinalizedHeaderEvent(ch chan<- core.FinalizedHeaderEvent) event.Subscription

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -175,6 +175,11 @@ func (ec *Client) GetNodeInfo(ctx context.Context) (*p2p.NodeInfo, error) {
 	return &result, err
 }
 
+// SubscribeFullPendingTransactions subscribes to new pending transactions.
+func (ec *Client) SubscribeFullPendingTransactions(ctx context.Context, ch chan<- *types.Transaction) (*rpc.ClientSubscription, error) {
+	return ec.c.EthSubscribe(ctx, ch, "newPendingTransactions", true)
+}
+
 // SubscribePendingTransactions subscribes to new pending transactions.
 func (ec *Client) SubscribePendingTransactions(ctx context.Context, ch chan<- common.Hash) (*rpc.ClientSubscription, error) {
 	return ec.c.EthSubscribe(ctx, ch, "newPendingTransactions")

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -123,8 +123,11 @@ func TestGethClient(t *testing.T) {
 			"TestSetHead",
 			func(t *testing.T) { testSetHead(t, client) },
 		}, {
-			"TestSubscribePendingTxs",
+			"TestSubscribePendingTxHashes",
 			func(t *testing.T) { testSubscribePendingTransactions(t, client) },
+		}, {
+			"TestSubscribePendingTxs",
+			func(t *testing.T) { testSubscribeFullPendingTransactions(t, client) },
 		}, {
 			"TestCallContract",
 			func(t *testing.T) { testCallContract(t, client) },
@@ -295,6 +298,40 @@ func testSubscribePendingTransactions(t *testing.T, client *rpc.Client) {
 	hash := <-ch
 	if hash != signedTx.Hash() {
 		t.Fatalf("Invalid tx hash received, got %v, want %v", hash, signedTx.Hash())
+	}
+}
+
+func testSubscribeFullPendingTransactions(t *testing.T, client *rpc.Client) {
+	ec := New(client)
+	ethcl := ethclient.NewClient(client)
+	// Subscribe to Transactions
+	ch := make(chan *types.Transaction)
+	ec.SubscribeFullPendingTransactions(context.Background(), ch)
+	// Send a transaction
+	chainID, err := ethcl.ChainID(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create transaction
+	tx := types.NewTransaction(1, common.Address{1}, big.NewInt(1), 22000, big.NewInt(1), nil)
+	signer := types.LatestSignerForChainID(chainID)
+	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), testKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signedTx, err := tx.WithSignature(signer, signature)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Send transaction
+	err = ethcl.SendTransaction(context.Background(), signedTx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the transaction was send over the channel
+	tx = <-ch
+	if tx.Hash() != signedTx.Hash() {
+		t.Fatalf("Invalid tx hash received, got %v, want %v", tx.Hash(), signedTx.Hash())
 	}
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1550,6 +1550,11 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	return result
 }
 
+// NewRPCPendingTransaction returns a pending transaction that will serialize to the RPC representation
+func NewRPCPendingTransaction(tx *types.Transaction, current *types.Header, config *params.ChainConfig) *RPCTransaction {
+	return newRPCPendingTransaction(tx, current, config)
+}
+
 // newRPCPendingTransaction returns a pending transaction that will serialize to the RPC representation
 func newRPCPendingTransaction(tx *types.Transaction, current *types.Header, config *params.ChainConfig) *RPCTransaction {
 	var baseFee *big.Int


### PR DESCRIPTION
### Rationale
The main point of this changes to return full transaction info by `eth_subcribe` **newPendingTransactions** call instead of just hash of transaction.

### Example
#### Old way works as usual
Request:
```json
{ "id": 1, "method": "eth_subscribe", "params": ["newPendingTransactions"] }
```
Responses:
```json
{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0xf0106ed7d96d764d75cfacab6fb4c323","result":"0x395d396d98f95734e8d535bd9c5d6bc8de977972cc51f462a5b01ae2c3b11d92"}}
{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0xf0106ed7d96d764d75cfacab6fb4c323","result":"0xaeeebcca4010dafbdc287d549722d6466f46c4dabfa828e977a9cfa18c194542"}}
{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0xf0106ed7d96d764d75cfacab6fb4c323","result":"0x64791f5dd9939614a2666ed8345ce7c957f3d18f1185ae08068fb4056ed7df52"}}
```
#### New way to receive full transaction info 
With new method
Request
```json
{ "id": 1, "method": "eth_subscribe", "params": ["newPendingTransactions", true] }
```
Response:
```json
{
    "jsonrpc": "2.0",
    "method": "eth_subscription",
    "params": {
        "subscription": "0x8642ababc46df6c1e685b6906f0aea1b",
        "result": {
            "blockHash": null,
            "blockNumber": null,
            "from": "0x455212ba0821e2d1015f995100901e5950ee95cc",
            "gas": "0x3aa67",
            "gasPrice": "0x12a05f200",
            "hash": "0xc5321110741c45f21ec8d67103ad3f41eda1fec3268581a6e45d4c74e31d9787",
            "input": "0x5c11d795000000000000000000000000000000000000000000000000000089a5fc91740000000000000000000000000000000000000000000000000a4b820393f83248b000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000455212ba0821e2d1015f995100901e5950ee95cc0000000000000000000000000000000000000000000000000000000064290d0c00000000000000000000000000000000000000000000000000000000000000030000000000000000000000005fafa84e61fd335d39471647d15f47324d25203e000000000000000000000000bb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c000000000000000000000000e9e7cea3dedca5984780bafc599bd69add087d56",
            "nonce": "0x12a",
            "to": "0x10ed43c718714eb63d5aa57b78b54704e256024e",
            "transactionIndex": null,
            "value": "0x0",
            "type": "0x0",
            "v": "0x93",
            "r": "0xa2d365969f3a3940f10891ffc9758b5bc3678bbd3e4be0835a0a2a09c69752a1",
            "s": "0x2643dd71a31db6db43315386d67c8f96d0bee5bd249be5f9fb49a4ca6159ba58"
        }
    }
}
```

From the the code it will looks like:
```golang
package main

import (
	"context"
	"fmt"
	"time"

	"github.com/ethereum/go-ethereum/core/types"
	"github.com/ethereum/go-ethereum/ethclient/gethclient"
	ethrpc "github.com/ethereum/go-ethereum/rpc"
)

const nodeURL = "ws://your_path_to_node_ws"

func main() {
	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
	defer cancel()

	wsETHrpcClient, err := ethrpc.Dial(nodeURL)
	if err != nil {
		panic(err)
	}
	defer wsETHrpcClient.Close()

	wsGethClient := gethclient.New(wsETHrpcClient)

	txChan := make(chan *types.Transaction, 100)
	subs, err := wsGethClient.SubscribeFullPendingTransactions(ctx, txChan)
	if err != nil {
		panic(err)
	}
	defer subs.Unsubscribe()
	defer close(txChan)

	for {
		select {
		case <-ctx.Done():
			return
		case e := <-subs.Err():
			panic(e)
		case tx := <-txChan:
			message, err := tx.AsMessage(types.NewEIP155Signer(tx.ChainId()), nil)
			if err != nil {
				continue
			}
			fmt.Println("New pending tx")
			fmt.Println("From: ", message.From())
			fmt.Println("To: ", message.To())
			// etc
		}
	}
}
```
We will call `SubscribeFullPendingTransactions` method and will receive `*types.Transaction` type instead of `common.Hash`

The old way to receive only hashes also works as expected
```
txChan := make(chan common.Hash, 100)
subs, err := wsGethClient.SubscribePendingTransactions(ctx, txChan)
if err != nil {
	panic(err)
}
defer subs.Unsubscribe()
defer close(txChan)
```
