### PR TITLE
release: prepare for release v1.1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## v1.1.21
+FEATURE
+* [\#1389](https://github.com/bnb-chain/bsc/pull/1389) upgrade: update the fork height of planck upgrade on mainnet
+
+BUGFIX
+* [\#1354](https://github.com/bnb-chain/bsc/pull/1354) fix: add some boundary check for security
+* [\#1373](https://github.com/bnb-chain/bsc/pull/1373) tracer: enable withLog for TraceCall
+* [\#1377](https://github.com/bnb-chain/bsc/pull/1377) miner: add fallthrough for switch cases
+
 ## v1.1.20
 FEATURE
 * [\#1322](https://github.com/bnb-chain/bsc/pull/1322) cmd/utils/flags.go: --diffsync flag is deprecate
@@ -15,7 +24,7 @@ IMPROVEMENT
 * [\#1333](https://github.com/bnb-chain/bsc/pull/1333) sec: add proof ops check and key checker
 
 BUGFIX
-* [\#1348](https://github.com/bnb-chain/bsc/pull/1348) (HEAD, bnb-chain/develop) core/txpool: implement additional DoS defenses
+* [\#1348](https://github.com/bnb-chain/bsc/pull/1348) core/txpool: implement additional DoS defenses
 
 ## v1.1.19
 FEATURE

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 20 // Patch version component of the current release
+	VersionPatch = 21 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
v1.1.21 is a hard-fork release for BSC mainnet.

The mainnet  is expected to have a scheduled hardfork upgrade named `Planck` at block height 27,281,024. The current block generation speed forecasts this to occur around 12th April 2023 at 05:30 AM (UTC). 
The `Planck` hardfork includes 2 BEPs to enhance network stability and security:
[BEP-171: Security Enhancement for Cross-Chain Module](https://github.com/bnb-chain/BEPs/blob/master/BEP171.md)
[BEP-172: Network Stability Enhancement On Slash Occur](https://github.com/bnb-chain/BEPs/blob/master/BEP172.md)

The validators and full node operators on mainnet should switch their software version to [v1.1.21](https://github.com/bnb-chain/bsc/releases/tag/v1.1.21) before 12th April 2023.

### Rationale
FEATURE
* [\#1389](https://github.com/bnb-chain/bsc/pull/1389) upgrade: update the fork height of planck upgrade on mainnet

BUGFIX
* [\#1354](https://github.com/bnb-chain/bsc/pull/1354) fix: add some boundary check for security
* [\#1373](https://github.com/bnb-chain/bsc/pull/1373) tracer: enable withLog for TraceCall
* [\#1377](https://github.com/bnb-chain/bsc/pull/1377) miner: add fallthrough for switch cases

### Example
None


### Changes
The validators and full node operators on mainnet should switch their software version to [v1.1.21](https://github.com/bnb-chain/bsc/releases/tag/v1.1.21) before 12th April 2023.