### PR TITLE
log: support custom time format configuration

### DIFF
--- a/log/format.go
+++ b/log/format.go
@@ -14,9 +14,12 @@ import (
 	"unicode/utf8"
 )
 
+var (
+	timeFormat     = "2006-01-02T15:04:05-0700"
+	termTimeFormat = "01-02|15:04:05.000"
+)
+
 const (
-	timeFormat        = "2006-01-02T15:04:05-0700"
-	termTimeFormat    = "01-02|15:04:05.000"
 	floatFormat       = 'f'
 	termMsgJust       = 40
 	termCtxMaxPadding = 40
@@ -481,4 +484,12 @@ func escapeString(s string) string {
 		return s
 	}
 	return strconv.Quote(s)
+}
+
+func SetTermTimeFormat(format string) {
+	termTimeFormat = format
+}
+
+func SetTimeFormat(format string) {
+	timeFormat = format
 }

--- a/node/config.go
+++ b/node/config.go
@@ -502,8 +502,13 @@ func (c *Config) warnOnce(w *bool, format string, args ...interface{}) {
 }
 
 type LogConfig struct {
-	FileRoot     string
-	FilePath     string
-	MaxBytesSize uint
-	Level        string
+	FileRoot     *string
+	FilePath     *string
+	MaxBytesSize *uint
+	Level        *string
+
+	// TermTimeFormat is the time format used for console logging.
+	TermTimeFormat *string
+	// TimeFormat is the time format used for file logging.
+	TimeFormat *string
 }

--- a/node/node.go
+++ b/node/node.go
@@ -86,13 +86,25 @@ func New(conf *Config) (*Node, error) {
 		conf.DataDir = absdatadir
 	}
 	if conf.LogConfig != nil {
-		logFilePath := ""
-		if conf.LogConfig.FileRoot == "" {
-			logFilePath = path.Join(conf.DataDir, conf.LogConfig.FilePath)
-		} else {
-			logFilePath = path.Join(conf.LogConfig.FileRoot, conf.LogConfig.FilePath)
+		if conf.LogConfig.TermTimeFormat != nil && *conf.LogConfig.TermTimeFormat != "" {
+			log.SetTermTimeFormat(*conf.LogConfig.TermTimeFormat)
 		}
-		log.Root().SetHandler(log.NewFileLvlHandler(logFilePath, conf.LogConfig.MaxBytesSize, conf.LogConfig.Level))
+
+		if conf.LogConfig.TimeFormat != nil && *conf.LogConfig.TimeFormat != "" {
+			log.SetTimeFormat(*conf.LogConfig.TimeFormat)
+		}
+
+		if conf.LogConfig.FileRoot != nil && conf.LogConfig.FilePath != nil &&
+			conf.LogConfig.MaxBytesSize != nil && conf.LogConfig.Level != nil {
+			// log to file
+			logFilePath := ""
+			if *conf.LogConfig.FileRoot == "" {
+				logFilePath = path.Join(conf.DataDir, *conf.LogConfig.FilePath)
+			} else {
+				logFilePath = path.Join(*conf.LogConfig.FileRoot, *conf.LogConfig.FilePath)
+			}
+			log.Root().SetHandler(log.NewFileLvlHandler(logFilePath, *conf.LogConfig.MaxBytesSize, *conf.LogConfig.Level))
+		}
 	}
 	if conf.Logger == nil {
 		conf.Logger = log.New()


### PR DESCRIPTION
### Description

Support custom time format configuration for `console log` and `file log`

### Rationale

Add `TermTimeFormat` and `TimeFormat` files in config.toml to support custom configuration
<img width="422" alt="image" src="https://user-images.githubusercontent.com/25412254/228829580-cc630252-7d84-4db1-82b3-a824ef6d0011.png">

`TermTimeFormat` is the time format used for console logging.
`TimeFormat` is the time format used for file logging.

### Example

1. Console log
<img width="384" alt="image" src="https://user-images.githubusercontent.com/25412254/228830143-fee1b7e4-266c-4829-a625-b5b35cb30616.png">
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/25412254/228830179-5ccf0837-761d-4878-afa9-f5d874a6868b.png">

2. File log
<img width="382" alt="image" src="https://user-images.githubusercontent.com/25412254/228830287-0ea753d0-e46f-4a1d-af4e-188cce2a0a44.png">
<img width="964" alt="image" src="https://user-images.githubusercontent.com/25412254/228830338-5a335b76-95f5-4131-8e6e-f35265d3da69.png">


### Changes

Notable changes: 
* logger
