### PR TITLE
Fix init network without  setting TimeFormat

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -502,13 +502,13 @@ func (c *Config) warnOnce(w *bool, format string, args ...interface{}) {
 }
 
 type LogConfig struct {
-	FileRoot     *string
-	FilePath     *string
-	MaxBytesSize *uint
-	Level        *string
+	FileRoot     *string `toml:",omitempty"`
+	FilePath     *string `toml:",omitempty"`
+	MaxBytesSize *uint   `toml:",omitempty"`
+	Level        *string `toml:",omitempty"`
 
 	// TermTimeFormat is the time format used for console logging.
-	TermTimeFormat *string
+	TermTimeFormat *string `toml:",omitempty"`
 	// TimeFormat is the time format used for file logging.
-	TimeFormat *string
+	TimeFormat *string `toml:",omitempty"`
 }


### PR DESCRIPTION
### Description

fields of Node.LogConfig is pointer,
when a field is not set, generate config.toml will fail for marshaling nil

### Rationale

<img width="281" alt="image" src="https://user-images.githubusercontent.com/122502194/229513451-0381a38c-5e07-4b25-924f-224c8bf86f41.png">
<img width="1275" alt="image" src="https://user-images.githubusercontent.com/122502194/229513541-2eecf6ae-5545-4969-90ac-e3e7fd606436.png">
<img width="351" alt="image" src="https://user-images.githubusercontent.com/122502194/229513580-ebee0f21-3d4f-4aba-8897-30741b39c726.png">

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
