### PR TITLE
Fix invalid merkle root problem

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1173,7 +1173,10 @@ func (s *StateDB) StateIntermediateRoot() common.Hash {
 	// the remainder without, but pre-byzantium even the initial prefetcher is
 	// useless, so no sleep lost.
 	prefetcher := s.prefetcher
-	defer s.StopPrefetcher()
+	defer func() {
+		s.StopPrefetcher()
+		s.prefetcher = nil
+	}()
 
 	// Now we're about to start to write changes to the trie. The trie is so far
 	// _untouched_. We can check with the prefetcher, if it can give us a trie
@@ -1371,7 +1374,10 @@ func (s *StateDB) Commit(failPostCommitFunc func(), postCommitFuncs ...func() er
 	}
 	// Finalize any pending changes and merge everything into the tries
 	if s.lightProcessed {
-		defer s.StopPrefetcher()
+		defer func() {
+			s.StopPrefetcher()
+			s.prefetcher = nil
+		}()
 		root, diff, err := s.LightCommit()
 		if err != nil {
 			return root, diff, err
@@ -1580,7 +1586,10 @@ func (s *StateDB) Commit(failPostCommitFunc func(), postCommitFuncs ...func() er
 	if s.pipeCommit {
 		go commmitTrie()
 	} else {
-		defer s.StopPrefetcher()
+		defer func() {
+			s.StopPrefetcher()
+			s.prefetcher = nil
+		}()
 		commitFuncs = append(commitFuncs, commmitTrie)
 	}
 	commitRes := make(chan error, len(commitFuncs))


### PR DESCRIPTION
### Description

Currently there are a lot of commits where unit tests are failing with the following message:
```
panic: invalid merkle root (remote: 6a81c3ca010e075173c8bad9046c54780c9cbcb03a123cf9f825a66b1b2239d3 local: 1cf81787533773d481f028d96a73e3bbc645630a18b7cb9a32f13cb4faca22fc) [recovered]
	panic: invalid merkle root (remote: 6a81c3ca010e075173c8bad9046c54780c9cbcb03a123cf9f825a66b1b2239d3 local: 1cf81787533773d481f028d96a73e3bbc645630a18b7cb9a32f13cb4faca22fc)
```

<img width="1406" alt="image" src="https://user-images.githubusercontent.com/124279774/230036229-a5a9340a-9761-4ab1-a5e4-769286bc7fe2.png">


As you can see above this does not happen every time.  Also, it is not due to any breaking change in the code. For example in the commit linked below only comments where changed, and 2 unit tests failed with the `invalid merkle root` message.

https://github.com/bnb-chain/bsc/actions/runs/4564587330/jobs/8054550629

This means that there is nondeterministic behavior in the code.

#### Analysis of the issue
After some analysis, I concluded that the problem is due to a concurrency issue in `statedb.go`.  The StateDB uses a trie prefetcher that runs concurrently with the code in StateDB.  Every few thousand blocks after the trie is updated, the prefetcher will overwrite it with the previous value. This leads to the merkle root not being up to date thus causing the error.


### Rationale
Making sure that prefetcher is closed and set to nil at the end of  StateDB functions ensures that the new value will not be overwritten by an old value.


### Changes

Notable changes: 
*  `statedb.go`