### PR TITLE
docker: upgrade alpine version & fix apks version error;

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ADD . /go-ethereum
 RUN cd /go-ethereum && go run build/ci.go install ./cmd/geth
 
 # Pull Geth into a second stage deploy alpine container
-FROM alpine:3.16.0
+FROM alpine:3.17
 
 ARG BSC_USER=bsc
 ARG BSC_USER_UID=1000
@@ -26,9 +26,9 @@ ENV BSC_HOME=/bsc
 ENV HOME=${BSC_HOME}
 ENV DATA_DIR=/data
 
-ENV PACKAGES ca-certificates~=20220614-r0 jq~=1.6 \
-  bash~=5.1.16-r2 bind-tools~=9.16.37 tini~=0.19.0 \
-  grep~=3.7 curl~=7.83.1 sed~=4.8-r0
+ENV PACKAGES ca-certificates jq \
+  bash bind-tools tini \
+  grep curl sed
 
 RUN apk add --no-cache $PACKAGES \
   && rm -rf /var/cache/apk/* \


### PR DESCRIPTION
### Description
docker: upgrade alpine version & fix apks version error;

`bind-tools` version break frequently, may use the latest default.
<img width="1298" alt="image" src="https://user-images.githubusercontent.com/12880651/230849425-78342a9b-cb19-4326-b906-75632988c898.png">

### Changes

Notable changes: 
* upgrade docker alpine version;
* fix apks version error;
