### PR TITLE
fix: improvements after testing fast finality

### DIFF
--- a/cmd/geth/blsaccountcmd.go
+++ b/cmd/geth/blsaccountcmd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/crypto/bls"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/io/prompt"
+	"github.com/prysmaticlabs/prysm/v3/proto/eth/service"
 	"github.com/prysmaticlabs/prysm/v3/validator/accounts"
 	"github.com/prysmaticlabs/prysm/v3/validator/accounts/iface"
 	"github.com/prysmaticlabs/prysm/v3/validator/accounts/petnames"
@@ -381,7 +382,7 @@ func blsAccountImport(ctx *cli.Context) error {
 
 	password := utils.GetPassPhrase("Enter the password for your imported account.", false)
 	fmt.Println("Importing BLS account, this may take a while...")
-	_, err = accounts.ImportAccounts(context.Background(), &accounts.ImportAccountsConfig{
+	statuses, err := accounts.ImportAccounts(context.Background(), &accounts.ImportAccountsConfig{
 		Importer:        k,
 		Keystores:       []*keymanager.Keystore{keystore},
 		AccountPassword: password,
@@ -389,7 +390,12 @@ func blsAccountImport(ctx *cli.Context) error {
 	if err != nil {
 		utils.Fatalf("Import BLS account failed: %v.", err)
 	}
-	fmt.Println("Successfully import BLS account.")
+	// len(statuses)==len(Keystores) when err==nil
+	if statuses[0].Status == service.ImportedKeystoreStatus_ERROR {
+		fmt.Printf("Could not import keystore: %v.", statuses[0].Message)
+	} else {
+		fmt.Println("Successfully import BLS account.")
+	}
 	return nil
 }
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -169,6 +169,7 @@ var (
 		utils.BlockAmountReserved,
 		utils.CheckSnapshotWithMPT,
 		utils.EnableDoubleSignMonitorFlag,
+		utils.VotingEnabledFlag,
 		utils.BLSPasswordFileFlag,
 		utils.BLSWalletDirFlag,
 		utils.VoteJournalDirFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -199,6 +199,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.MinerRecommitIntervalFlag,
 			utils.MinerDelayLeftoverFlag,
 			utils.MinerNoVerfiyFlag,
+			utils.VotingEnabledFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -897,6 +897,11 @@ var (
 		Usage: "Enable double sign monitor to check whether any validator signs multiple blocks",
 	}
 
+	VotingEnabledFlag = cli.BoolFlag{
+		Name:  "vote",
+		Usage: "Enable voting",
+	}
+
 	BLSPasswordFileFlag = cli.StringFlag{
 		Name:  "blspassword",
 		Usage: "File path for the BLS password, which contains the password to unlock BLS wallet for managing votes in fast_finality feature",
@@ -1531,6 +1536,9 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	}
 	if ctx.GlobalIsSet(LegacyMinerGasTargetFlag.Name) {
 		log.Warn("The generic --miner.gastarget flag is deprecated and will be removed in the future!")
+	}
+	if ctx.GlobalBool(VotingEnabledFlag.Name) {
+		cfg.VoteEnable = true
 	}
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -249,11 +249,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	eth.txPool = core.NewTxPool(config.TxPool, chainConfig, eth.blockchain)
 
-	conf := stack.Config()
-	blsPasswordPath := stack.ResolvePath(conf.BLSPasswordFile)
-	blsWalletPath := stack.ResolvePath(conf.BLSWalletDir)
-	voteJournalPath := stack.ResolvePath(conf.VoteJournalDir)
-
 	// Create voteManager instance
 	if posa, ok := eth.engine.(consensus.PoSA); ok {
 		// Create votePool instance
@@ -266,11 +261,17 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		}
 		log.Info("Create votePool successfully")
 
-		if _, err := vote.NewVoteManager(eth.EventMux(), chainConfig, eth.blockchain, votePool, voteJournalPath, blsPasswordPath, blsWalletPath, posa); err != nil {
-			log.Error("Failed to Initialize voteManager", "err", err)
-			return nil, err
+		if config.Miner.VoteEnable {
+			conf := stack.Config()
+			blsPasswordPath := stack.ResolvePath(conf.BLSPasswordFile)
+			blsWalletPath := stack.ResolvePath(conf.BLSWalletDir)
+			voteJournalPath := stack.ResolvePath(conf.VoteJournalDir)
+			if _, err := vote.NewVoteManager(eth.EventMux(), chainConfig, eth.blockchain, votePool, voteJournalPath, blsPasswordPath, blsWalletPath, posa); err != nil {
+				log.Error("Failed to Initialize voteManager", "err", err)
+				return nil, err
+			}
+			log.Info("Create voteManager successfully")
 		}
-		log.Info("Create voteManager successfully")
 	}
 
 	// Permit the downloader to use the trie cache allowance during fast sync

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -54,6 +54,7 @@ type Config struct {
 	GasPrice      *big.Int       // Minimum gas price for mining a transaction
 	Recommit      time.Duration  // The time interval for miner to re-create mining work.
 	Noverify      bool           // Disable remote mining solution verification(only useful in ethash).
+	VoteEnable    bool           // whether enable voting
 }
 
 // Miner creates blocks and searches for proof-of-work values.


### PR DESCRIPTION
### Description

1. fix: handle error when fail to import bls account
2. fix: only validator need bls wallet

### Rationale
1. when account password mismatch or key file is bad
    report error instead of success
2. add flag to enable voting
    geth with '--vote' or configure in config.toml both supported
<img width="232" alt="image" src="https://user-images.githubusercontent.com/122502194/232028493-cd8df6c1-c4ea-4486-abf0-72e4b5f233f8.png">

   


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
