### PR TITLE
[fix] Dockerfile: relax package versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ ENV HOME=${BSC_HOME}
 ENV DATA_DIR=/data
 
 ENV PACKAGES ca-certificates~=20220614-r0 jq~=1.6 \
-  bash~=5.1.16-r2 bind-tools~=9.16.37 tini~=0.19.0 \
-  grep~=3.7 curl~=7.83.1 sed~=4.8-r0
+  bash~=5.1 bind-tools~=9.16 tini~=0.19 \
+  grep~=3.7 curl~=7.83 sed~=4.8
 
 RUN apk add --no-cache $PACKAGES \
   && rm -rf /var/cache/apk/* \


### PR DESCRIPTION
### Description

Relax package versions pins,  fixes #1438 probably

### Rationale

Docker build fails due to mainstream alpine updates
```
#6 0.977 ERROR: unable to select packages:
#6 0.992   bind-tools-9.16.39-r0:
#6 0.992     breaks: world[bind-tools~9.16.37]
```
### Changes

Notable changes: 
* Dockerfile: relax package versions pins

