### PR TITLE
cmd/faucet: clear reqs list when reorg to lower nonce

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -667,6 +667,9 @@ func (f *faucet) refresh(head *types.Header) error {
 	f.lock.Lock()
 	f.head, f.balance = head, balance
 	f.price, f.nonce = price, nonce
+	if len(f.reqs) > 0 && f.reqs[0].Tx.Nonce() > f.nonce {
+		f.reqs = f.reqs[:0]
+	}
 	for len(f.reqs) > 0 && f.reqs[0].Tx.Nonce() < f.nonce {
 		f.reqs = f.reqs[1:]
 	}


### PR DESCRIPTION
### Description

Faucet service would have chance to block when reorg happend.

### Rationale

- imported block with contract_nonce: 10
- reqs: `txs` with nonce: 10, 11
- reorg block with nonce: 7
- reqs: `txs` list grows to: 10, 11, 9(=7+`len{10,11}`)
- reorg block with nonce: 10
- reqs: `txs` list grows to: 10, 11, 9, 13(=10+`len{10,11,9}`)
- GAP: nonce=12
### Example

N/A

### Changes

Notable changes: 
* clear `reqs` list when `updated nonce` became lower
