### PR TITLE
fix: panic on using WaitGroup after it is freed.

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1584,18 +1584,20 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 					}
 				}
 				// Garbage collect anything below our required write retention
+				wg2 := sync.WaitGroup{}
 				for !bc.triegc.Empty() {
 					root, number := bc.triegc.Pop()
 					if uint64(-number) > chosen {
 						bc.triegc.Push(root, number)
 						break
 					}
-					wg.Add(1)
+					wg2.Add(1)
 					go func() {
 						triedb.Dereference(root.(common.Hash))
-						wg.Done()
+						wg2.Done()
 					}()
 				}
+				wg2.Wait()
 			}
 		}
 		return nil


### PR DESCRIPTION
### Description
https://github.com/bnb-chain/bsc/pull/1379 try to fix the random UT fail of TestLargeReorgTrieGC, while it introduced another bug.
It could cause panic crash, since `wg` could be used after it is freed, since there is an asynchronous risk.
For detail of the panic, you may refer: https://github.com/bnb-chain/bsc/issues/1456

### Rationale
To fix the UT fail, we only need to make sure `triedb.Dereference(root.(common.Hash))` can be done in `tryCommitTrieDB()`, so we can just add another `WaitGroup` in `tryCommitTrieDB()` for synchronization.

### Example
NA

### Changes
NA
