### PR TITLE
release: prepare for release v1.1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v1.1.23
+BUGFIX
+* [\#1464](https://github.com/bnb-chain/bsc/pull/1464) fix: panic on using WaitGroup after it is freed
+
 ## v1.1.22
 FEATURE
 * [\#1361](https://github.com/bnb-chain/bsc/pull/1361) cmd/faucet: merge ipfaucet2 branch to develop

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 22 // Patch version component of the current release
+	VersionPatch = 23 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description

Release v1.1.23 is a hot fix release, v1.1.22 has a critical bug, the client could crash due to improperly use of a local variable. 
For detail, just refer the following PR.

### Rationale
## 1.1.23
BUGFIX
* [\#1464](https://github.com/bnb-chain/bsc/pull/1464) fix: panic on using WaitGroup after it is freed

### Example
No API or Command changes.

### Changes

N/A
