### PR TITLE
fix: solve potential deadlock for bsc p2p protocol handshake

### DIFF
--- a/eth/handler_bsc.go
+++ b/eth/handler_bsc.go
@@ -17,21 +17,6 @@ func (h *bscHandler) Chain() *core.BlockChain { return h.chain }
 
 // RunPeer is invoked when a peer joins on the `bsc` protocol.
 func (h *bscHandler) RunPeer(peer *bsc.Peer, hand bsc.Handler) error {
-	if err := peer.Handshake(); err != nil {
-		// ensure that waitBscExtension receives the exit signal normally
-		// otherwise, can't graceful shutdown
-		ps := h.peers
-		id := peer.ID()
-
-		// Ensure nobody can double connect
-		ps.lock.Lock()
-		if wait, ok := ps.bscWait[id]; ok {
-			delete(ps.bscWait, id)
-			wait <- peer
-		}
-		ps.lock.Unlock()
-		return err
-	}
 	return (*handler)(h).runBscExtension(peer, hand)
 }
 

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -458,7 +458,12 @@ func (ps *peerSet) registerPeer(peer *eth.Peer, ext *snap.Peer, diffExt *diff.Pe
 		eth.trustExt = &trustPeer{trustExt}
 	}
 	if bscExt != nil {
-		eth.bscExt = &bscPeer{bscExt}
+		if err := bscExt.Handshake(); err == nil {
+			eth.bscExt = &bscPeer{bscExt}
+		} else {
+			peer.Log().Debug("bsc protocol handshake failed", "err", err)
+			return err
+		}
 	}
 	ps.peers[id] = eth
 	return nil

--- a/eth/protocols/bsc/handshake.go
+++ b/eth/protocols/bsc/handshake.go
@@ -42,6 +42,7 @@ func (p *Peer) Handshake() error {
 			return p2p.DiscReadTimeout
 		}
 	}
+	p.handshaked <- struct{}{}
 	return nil
 }
 

--- a/eth/protocols/bsc/peer.go
+++ b/eth/protocols/bsc/peer.go
@@ -34,6 +34,8 @@ type Peer struct {
 	version   uint              // Protocol version negotiated
 	logger    log.Logger        // Contextual logger with the peer id injected
 	term      chan struct{}     // Termination channel to stop the broadcasters
+
+	handshaked chan struct{} // channel to start handleMessage after handshake
 }
 
 // NewPeer create a wrapper for a network connection and negotiated protocol
@@ -49,6 +51,7 @@ func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter) *Peer {
 		version:       version,
 		logger:        log.New("peer", id[:8]),
 		term:          make(chan struct{}),
+		handshaked:    make(chan struct{}, 1), //asynchronous for handshake only once
 	}
 	go peer.broadcastVotes()
 	return peer


### PR DESCRIPTION
### Description

fix potential deadlock by bsc p2p protocol handshake

### Rationale

**Process description:**
1. runEthPeer wait bsc extension in waitBscExtension
    timeout is 10 seconds
2. bscHandler.RunPeer, then do handshake protocol, has a smaller timeout
3. timeout (10 seconds) is reached,
     but ps.lock is got by other go routines, such as bscHandler.RunPeer and registerBscExtension
     they are blocked in such code now
            `wait <- peer`
    then deadlock happens
    
**Root cause :** 
func RunPeer  is designed as not cost much time before.
but when handshake process added in, handshake also has a timeout, 
so ethPeer have to wait more time than before, more close to  timeout (10 seconds),
thus leading to improve chance of potential deadlock greatly.

**Solve out:**
we can move handshake of sub protocol such as bsc and diff
to behind handshake of main protocol

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...