### PR TITLE
fix: a deadlock caused by bsc protocol handeshake timeout

### DIFF
--- a/eth/handler_bsc.go
+++ b/eth/handler_bsc.go
@@ -27,7 +27,7 @@ func (h *bscHandler) RunPeer(peer *bsc.Peer, hand bsc.Handler) error {
 		ps.lock.Lock()
 		if wait, ok := ps.bscWait[id]; ok {
 			delete(ps.bscWait, id)
-			wait <- peer
+			wait <- nil
 		}
 		ps.lock.Unlock()
 		return err


### PR DESCRIPTION
### Description
The bug has been described in: https://github.com/bnb-chain/bsc/issues/1483


### Rationale
The current code of P2P module has the concurrent bug, it will lock a channel operation, which is not suggested.
To fully address the issue, we need to refactor the code, prefer not to carry it out now.
Just use TryLock & Wait to fix the deadlock.

### Example
NA

### Changes
NA
