### PR TITLE
release: prepare for release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 # Changelog
+## v1.2.0
+FEATURE
+* [\#936](https://github.com/bnb-chain/bsc/pull/936) BEP-126: Introduce Fast Finality Mechanism
+* [\#1325](https://github.com/bnb-chain/bsc/pull/1325) genesis: add BEP174 changes to relayer contract
+* [\#1357](https://github.com/bnb-chain/bsc/pull/1357) Integration API for EIP-4337 bundler with an L2 validator/sequencer
+* [\#1463](https://github.com/bnb-chain/bsc/pull/1463) BEP-221: implement cometBFT light block validation
+
+IMPROVEMENT
+* [\#1486](https://github.com/bnb-chain/bsc/pull/1486) feature: remove diff protocol registration
+* [\#1434](https://github.com/bnb-chain/bsc/pull/1434) fix: improvements after testing fast finality
+
+BUGFIX
+* [\#1430](https://github.com/bnb-chain/bsc/pull/1430) docker: upgrade alpine version & remove apks version
+* [\#1458](https://github.com/bnb-chain/bsc/pull/1458) cmd/faucet: clear reqs list when reorg to lower nonce
+* [\#1484](https://github.com/bnb-chain/bsc/pull/1484) fix: a deadlock caused by bsc protocol handeshake timeout
+
 ## v1.1.23
 BUGFIX
 * [\#1464](https://github.com/bnb-chain/bsc/pull/1464) fix: panic on using WaitGroup after it is freed

--- a/params/version.go
+++ b/params/version.go
@@ -22,8 +22,8 @@ import (
 
 const (
 	VersionMajor = 1  // Major version component of the current release
-	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 23 // Patch version component of the current release
+	VersionMinor = 2  // Minor version component of the current release
+	VersionPatch = 0  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
v1.2.0 is a hard-fork release for BSC testnet.
It is a big release, since it includes the big feature: FastFinality.

The Chapel testnet is expected to have a scheduled hardfork upgrade named `Boneh` at block height 29,295,050. The current block generation speed forecasts this to occur around 27th April 2023 at 06:30 AM (UTC). 

The `Boneh` hardfork includes 3 BEPs:
[BEP-126: Introduce Fast Finality Mechanism 6(The 1st Part)](https://github.com/bnb-chain/BEPs/blob/master/BEP126.md)
[BEP-174: Cross Chain Relayer Management 5](https://github.com/bnb-chain/BEPs/blob/master/BEP174.md)
[BEP-221: CometBFT Light Block Validation](https://github.com/bnb-chain/BEPs/pull/221)


The validators and full node operators on Chapel testnet should switch their software version to [v1.2.0](https://github.com/bnb-chain/bsc/releases/tag/v1.2.0) before 27th April 2023.


### Rationale
FEATURE
https://github.com/bnb-chain/bsc/pull/936 BEP-126: Introduce Fast Finality Mechanism
https://github.com/bnb-chain/bsc/pull/1325 genesis: add BEP174 changes to relayer contract
https://github.com/bnb-chain/bsc/pull/1357 Integration API for EIP-4337 bundler with an L2 validator/sequencer  
https://github.com/bnb-chain/bsc/pull/1463 BEP-221: implement cometBFT light block validation

IMPROVEMENT
https://github.com/bnb-chain/bsc/pull/1486 feature: remove diff protocol registration
https://github.com/bnb-chain/bsc/pull/1434 fix: improvements after testing fast finality

BUGFIX
https://github.com/bnb-chain/bsc/pull/1430 docker: upgrade alpine version & remove apks version
https://github.com/bnb-chain/bsc/pull/1458 cmd/faucet: clear reqs list when reorg to lower nonce
https://github.com/bnb-chain/bsc/pull/1484 fix: a deadlock caused by bsc protocol handeshake timeout


### Example
None
