### PR TITLE
fix: no need to call distributeFinalityReward when weights is null

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1016,6 +1016,10 @@ func (p *Parlia) distributeFinalityReward(chain consensus.ChainHeaderReader, sta
 		}
 	}
 
+	if len(accumulatedWeights) == 0 {
+		return nil
+	}
+
 	validators := make([]common.Address, 0, len(accumulatedWeights))
 	weights := make([]*big.Int, 0, len(accumulatedWeights))
 	for val := range accumulatedWeights {


### PR DESCRIPTION
### Description

add a description of your changes here...

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
