### PR TITLE
upgrade: rename hardfork to Luban & Plato

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FEATURE
 * [\#1325](https://github.com/bnb-chain/bsc/pull/1325) genesis: add BEP174 changes to relayer contract
 * [\#1357](https://github.com/bnb-chain/bsc/pull/1357) Integration API for EIP-4337 bundler with an L2 validator/sequencer
 * [\#1463](https://github.com/bnb-chain/bsc/pull/1463) BEP-221: implement cometBFT light block validation
-* [\#1493](https://github.com/bnb-chain/bsc/pull/1493) bep: update the bytecode of boneh fork after the contract release
+* [\#1493](https://github.com/bnb-chain/bsc/pull/1493) bep: update the bytecode of luban fork after the contract release
 
 IMPROVEMENT
 * [\#1486](https://github.com/bnb-chain/bsc/pull/1486) feature: remove diff protocol registration
@@ -91,7 +91,6 @@ BUGFIX
 
 ## v1.1.18
 IMPROVEMENT
-
 * [\#1209](https://github.com/bnb-chain/bsc/pull/1209) metrics: add build info into metrics server
 * [\#1204](https://github.com/bnb-chain/bsc/pull/1204) worker: NewTxsEvent and triePrefetch reuse in mining task
 * [\#1195](https://github.com/bnb-chain/bsc/pull/1195) hardfork: update Gibbs fork height and system contract code

--- a/consensus/parlia/abi.go
+++ b/consensus/parlia/abi.go
@@ -1,6 +1,6 @@
 package parlia
 
-const validatorSetABIBeforeBoneh = `
+const validatorSetABIBeforeLuban = `
 [
     {
       "anonymous": false,

--- a/consensus/parlia/lubanFork.go
+++ b/consensus/parlia/lubanFork.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-func (p *Parlia) getCurrentValidatorsBeforeBoneh(blockHash common.Hash, blockNumber *big.Int) ([]common.Address, error) {
+func (p *Parlia) getCurrentValidatorsBeforeLuban(blockHash common.Hash, blockNumber *big.Int) ([]common.Address, error) {
 	blockNr := rpc.BlockNumberOrHashWithHash(blockHash, false)
 
 	// prepare different method
@@ -25,7 +25,7 @@ func (p *Parlia) getCurrentValidatorsBeforeBoneh(blockHash common.Hash, blockNum
 	ctx, cancel := context.WithCancel(context.Background())
 	// cancel when we are finished consuming integers
 	defer cancel()
-	data, err := p.validatorSetABIBeforeBoneh.Pack(method)
+	data, err := p.validatorSetABIBeforeLuban.Pack(method)
 	if err != nil {
 		log.Error("Unable to pack tx for getValidators", "error", err)
 		return nil, err
@@ -44,6 +44,6 @@ func (p *Parlia) getCurrentValidatorsBeforeBoneh(blockHash common.Hash, blockNum
 	}
 
 	var valSet []common.Address
-	err = p.validatorSetABIBeforeBoneh.UnpackIntoInterface(&valSet, method, result)
+	err = p.validatorSetABIBeforeLuban.UnpackIntoInterface(&valSet, method, result)
 	return valSet, err
 }

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -56,9 +56,9 @@ const (
 	extraSeal        = 65 // Fixed number of extra-data suffix bytes reserved for signer seal
 	nextForkHashSize = 4  // Fixed number of extra-data suffix bytes reserved for nextForkHash.
 
-	validatorBytesLengthBeforeBoneh = common.AddressLength
+	validatorBytesLengthBeforeLuban = common.AddressLength
 	validatorBytesLength            = common.AddressLength + types.BLSPublicKeyLength
-	validatorNumberSize             = 1 // Fixed number of extra prefix bytes reserved for validator number after Boneh
+	validatorNumberSize             = 1 // Fixed number of extra prefix bytes reserved for validator number after Luban
 
 	wiggleTime         = uint64(1) // second, Random delay (per signer) to allow concurrent signers
 	initialBackOffTime = uint64(1) // second
@@ -217,7 +217,7 @@ type Parlia struct {
 
 	ethAPI                     *ethapi.PublicBlockChainAPI
 	VotePool                   consensus.VotePool
-	validatorSetABIBeforeBoneh abi.ABI
+	validatorSetABIBeforeLuban abi.ABI
 	validatorSetABI            abi.ABI
 	slashABI                   abi.ABI
 
@@ -249,7 +249,7 @@ func New(
 	if err != nil {
 		panic(err)
 	}
-	vABIBeforeBoneh, err := abi.JSON(strings.NewReader(validatorSetABIBeforeBoneh))
+	vABIBeforeLuban, err := abi.JSON(strings.NewReader(validatorSetABIBeforeLuban))
 	if err != nil {
 		panic(err)
 	}
@@ -269,7 +269,7 @@ func New(
 		ethAPI:                     ethAPI,
 		recentSnaps:                recentSnaps,
 		signatures:                 signatures,
-		validatorSetABIBeforeBoneh: vABIBeforeBoneh,
+		validatorSetABIBeforeLuban: vABIBeforeLuban,
 		validatorSetABI:            vABI,
 		slashABI:                   sABI,
 		signer:                     types.NewEIP155Signer(chainConfig.ChainID),
@@ -333,16 +333,16 @@ func (p *Parlia) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*typ
 
 // getValidatorBytesFromHeader returns the validators bytes extracted from the header's extra field if exists.
 // The validators bytes would be contained only in the epoch block's header, and its each validator bytes length is fixed.
-// On boneh fork, we introduce vote attestation into the header's extra field, so extra format is different from before.
-// Before boneh fork: |---Extra Vanity---|---Validators Bytes (or Empty)---|---Extra Seal---|
-// After boneh fork:  |---Extra Vanity---|---Validators Number and Validators Bytes (or Empty)---|---Vote Attestation (or Empty)---|---Extra Seal---|
+// On luban fork, we introduce vote attestation into the header's extra field, so extra format is different from before.
+// Before luban fork: |---Extra Vanity---|---Validators Bytes (or Empty)---|---Extra Seal---|
+// After luban fork:  |---Extra Vanity---|---Validators Number and Validators Bytes (or Empty)---|---Vote Attestation (or Empty)---|---Extra Seal---|
 func getValidatorBytesFromHeader(header *types.Header, chainConfig *params.ChainConfig, parliaConfig *params.ParliaConfig) []byte {
 	if len(header.Extra) <= extraVanity+extraSeal {
 		return nil
 	}
 
-	if !chainConfig.IsBoneh(header.Number) {
-		if header.Number.Uint64()%parliaConfig.Epoch == 0 && (len(header.Extra)-extraSeal-extraVanity)%validatorBytesLengthBeforeBoneh != 0 {
+	if !chainConfig.IsLuban(header.Number) {
+		if header.Number.Uint64()%parliaConfig.Epoch == 0 && (len(header.Extra)-extraSeal-extraVanity)%validatorBytesLengthBeforeLuban != 0 {
 			return nil
 		}
 		return header.Extra[extraVanity : len(header.Extra)-extraSeal]
@@ -366,7 +366,7 @@ func getVoteAttestationFromHeader(header *types.Header, chainConfig *params.Chai
 		return nil, nil
 	}
 
-	if !chainConfig.IsBoneh(header.Number) {
+	if !chainConfig.IsLuban(header.Number) {
 		return nil, nil
 	}
 
@@ -596,7 +596,7 @@ func (p *Parlia) verifyCascadingFields(chain consensus.ChainHeaderReader, header
 
 	// Verify vote attestation for fast finality.
 	if err := p.verifyVoteAttestation(chain, header, parents); err != nil {
-		if chain.Config().IsLynn(header.Number) {
+		if chain.Config().IsPlato(header.Number) {
 			return err
 		}
 		log.Warn("Verify vote attestation failed", "error", err, "hash", header.Hash(), "number", header.Number,
@@ -691,9 +691,9 @@ func (p *Parlia) snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 
 	verifiedAttestations := make(map[common.Hash]struct{}, len(headers))
 	for index, header := range headers {
-		// vote attestation should be checked here to decide whether to update attestation of snapshot between [Boneh,Lynn)
-		// because err of verifyVoteAttestation is ignored when importing blocks and headers before Lynn.
-		if p.chainConfig.IsBoneh(header.Number) && !p.chainConfig.IsLynn(header.Number) && p.verifyVoteAttestation(chain, header, headers[:index]) == nil {
+		// vote attestation should be checked here to decide whether to update attestation of snapshot between [Luban,Plato)
+		// because err of verifyVoteAttestation is ignored when importing blocks and headers before Plato.
+		if p.chainConfig.IsLuban(header.Number) && !p.chainConfig.IsPlato(header.Number) && p.verifyVoteAttestation(chain, header, headers[:index]) == nil {
 			verifiedAttestations[header.Hash()] = struct{}{}
 		}
 	}
@@ -792,7 +792,7 @@ func (p *Parlia) prepareValidators(header *types.Header) error {
 	}
 	// sort validator by address
 	sort.Sort(validatorsAscending(newValidators))
-	if !p.chainConfig.IsBoneh(header.Number) {
+	if !p.chainConfig.IsLuban(header.Number) {
 		for _, validator := range newValidators {
 			header.Extra = append(header.Extra, validator.Bytes()...)
 		}
@@ -807,7 +807,7 @@ func (p *Parlia) prepareValidators(header *types.Header) error {
 }
 
 func (p *Parlia) assembleVoteAttestation(chain consensus.ChainHeaderReader, header *types.Header) error {
-	if !p.chainConfig.IsBoneh(header.Number) || header.Number.Uint64() < 2 {
+	if !p.chainConfig.IsLuban(header.Number) || header.Number.Uint64() < 2 {
 		return nil
 	}
 
@@ -942,10 +942,10 @@ func (p *Parlia) verifyValidators(header *types.Header) error {
 	sort.Sort(validatorsAscending(newValidators))
 	var validatorsBytes []byte
 	validatorsNumber := len(newValidators)
-	if !p.chainConfig.IsBoneh(header.Number) {
-		validatorsBytes = make([]byte, validatorsNumber*validatorBytesLengthBeforeBoneh)
+	if !p.chainConfig.IsLuban(header.Number) {
+		validatorsBytes = make([]byte, validatorsNumber*validatorBytesLengthBeforeLuban)
 		for i, validator := range newValidators {
-			copy(validatorsBytes[i*validatorBytesLengthBeforeBoneh:], validator.Bytes())
+			copy(validatorsBytes[i*validatorBytesLengthBeforeLuban:], validator.Bytes())
 		}
 	} else {
 		if uint8(validatorsNumber) != header.Extra[extraVanity] {
@@ -1090,7 +1090,7 @@ func (p *Parlia) Finalize(chain consensus.ChainHeaderReader, header *types.Heade
 		return err
 	}
 
-	if p.chainConfig.IsLynn(header.Number) {
+	if p.chainConfig.IsPlato(header.Number) {
 		if err := p.distributeFinalityReward(chain, state, header, cx, txs, receipts, systemTxs, usedGas, false); err != nil {
 			return err
 		}
@@ -1147,7 +1147,7 @@ func (p *Parlia) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *
 		return nil, nil, err
 	}
 
-	if p.chainConfig.IsLynn(header.Number) {
+	if p.chainConfig.IsPlato(header.Number) {
 		if err := p.distributeFinalityReward(chain, state, header, cx, &txs, &receipts, nil, &header.GasUsed, true); err != nil {
 			return nil, nil, err
 		}
@@ -1479,8 +1479,8 @@ func (p *Parlia) getCurrentValidators(blockHash common.Hash, blockNum *big.Int) 
 	// block
 	blockNr := rpc.BlockNumberOrHashWithHash(blockHash, false)
 
-	if !p.chainConfig.IsBoneh(blockNum) {
-		validators, err := p.getCurrentValidatorsBeforeBoneh(blockHash, blockNum)
+	if !p.chainConfig.IsLuban(blockNum) {
+		validators, err := p.getCurrentValidatorsBeforeLuban(blockHash, blockNum)
 		return validators, nil, err
 	}
 
@@ -1723,7 +1723,7 @@ func (p *Parlia) GetJustifiedNumberAndHash(chain consensus.ChainHeaderReader, he
 	}
 
 	if snap.Attestation == nil {
-		if p.chainConfig.IsBoneh(header.Number) {
+		if p.chainConfig.IsLuban(header.Number) {
 			log.Debug("once one attestation generated, attestation of snap would not be nil forever basically")
 		}
 		return 0, chain.GetHeaderByNumber(0).Hash(), nil
@@ -1739,7 +1739,7 @@ func (p *Parlia) GetFinalizedHeader(chain consensus.ChainHeaderReader, header *t
 	if chain == nil || header == nil {
 		return nil
 	}
-	if !chain.Config().IsLynn(header.Number) {
+	if !chain.Config().IsPlato(header.Number) {
 		return chain.GetHeaderByNumber(0)
 	}
 	if header.Number.Uint64() < backward {

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -74,7 +74,7 @@ func newSnapshot(
 		Validators:       make(map[common.Address]*ValidatorInfo),
 	}
 	for idx, v := range validators {
-		// The boneh fork from the genesis block
+		// The luban fork from the genesis block
 		if len(voteAddrs) == len(validators) {
 			snap.Validators[v] = &ValidatorInfo{
 				VoteAddress: voteAddrs[idx],
@@ -84,7 +84,7 @@ func newSnapshot(
 		}
 	}
 
-	// The boneh fork from the genesis block
+	// The luban fork from the genesis block
 	if len(voteAddrs) == len(validators) {
 		validators := snap.validators()
 		for idx, v := range validators {
@@ -249,7 +249,7 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 			}
 			newVals := make(map[common.Address]*ValidatorInfo, len(newValArr))
 			for idx, val := range newValArr {
-				if !chainConfig.IsBoneh(header.Number) {
+				if !chainConfig.IsLuban(header.Number) {
 					newVals[val] = &ValidatorInfo{}
 				} else {
 					newVals[val] = &ValidatorInfo{
@@ -272,7 +272,7 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 				}
 			}
 			snap.Validators = newVals
-			if chainConfig.IsBoneh(header.Number) {
+			if chainConfig.IsLuban(header.Number) {
 				validators := snap.validators()
 				for idx, val := range validators {
 					snap.Validators[val].Index = idx + 1 // offset by 1
@@ -281,7 +281,7 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 		}
 
 		_, voteAssestationNoErr := verifiedAttestations[header.Hash()]
-		if chainConfig.IsLynn(header.Number) || (chainConfig.IsBoneh(header.Number) && voteAssestationNoErr) {
+		if chainConfig.IsPlato(header.Number) || (chainConfig.IsLuban(header.Number) && voteAssestationNoErr) {
 			snap.updateAttestation(header, chainConfig, s.config)
 		}
 
@@ -355,11 +355,11 @@ func parseValidators(header *types.Header, chainConfig *params.ChainConfig, parl
 		return nil, nil, errors.New("invalid validators bytes")
 	}
 
-	if !chainConfig.IsBoneh(header.Number) {
-		n := len(validatorsBytes) / validatorBytesLengthBeforeBoneh
+	if !chainConfig.IsLuban(header.Number) {
+		n := len(validatorsBytes) / validatorBytesLengthBeforeLuban
 		result := make([]common.Address, n)
 		for i := 0; i < n; i++ {
-			result[i] = common.BytesToAddress(validatorsBytes[i*validatorBytesLengthBeforeBoneh : (i+1)*validatorBytesLengthBeforeBoneh])
+			result[i] = common.BytesToAddress(validatorsBytes[i*validatorBytesLengthBeforeLuban : (i+1)*validatorBytesLengthBeforeLuban])
 		}
 		return result, nil, nil
 	}

--- a/core/forkchoice.go
+++ b/core/forkchoice.go
@@ -122,10 +122,10 @@ func (f *ForkChoice) ReorgNeededWithFastFinality(current *types.Header, header *
 	}
 
 	justifiedNumber, curJustifiedNumber := uint64(0), uint64(0)
-	if f.chain.Config().IsLynn(header.Number) {
+	if f.chain.Config().IsPlato(header.Number) {
 		justifiedNumber = f.chain.GetJustifiedNumber(header)
 	}
-	if f.chain.Config().IsLynn(current.Number) {
+	if f.chain.Config().IsPlato(current.Number) {
 		curJustifiedNumber = f.chain.GetJustifiedNumber(current)
 	}
 	if justifiedNumber == curJustifiedNumber {

--- a/core/systemcontracts/upgrade.go
+++ b/core/systemcontracts/upgrade.go
@@ -52,7 +52,7 @@ var (
 
 	planckUpgrade = make(map[string]*Upgrade)
 
-	bonehUpgrade = make(map[string]*Upgrade)
+	lubanUpgrade = make(map[string]*Upgrade)
 )
 
 func init() {
@@ -553,8 +553,8 @@ func init() {
 		},
 	}
 
-	bonehUpgrade[mainNet] = &Upgrade{
-		UpgradeName: "boneh",
+	lubanUpgrade[mainNet] = &Upgrade{
+		UpgradeName: "luban",
 		Configs: []*UpgradeConfig{
 			{
 				ContractAddr: common.HexToAddress(ValidatorContract),
@@ -584,8 +584,8 @@ func init() {
 		},
 	}
 
-	bonehUpgrade[chapelNet] = &Upgrade{
-		UpgradeName: "boneh",
+	lubanUpgrade[chapelNet] = &Upgrade{
+		UpgradeName: "luban",
 		Configs: []*UpgradeConfig{
 			{
 				ContractAddr: common.HexToAddress(ValidatorContract),
@@ -615,8 +615,8 @@ func init() {
 		},
 	}
 
-	bonehUpgrade[rialtoNet] = &Upgrade{
-		UpgradeName: "boneh",
+	lubanUpgrade[rialtoNet] = &Upgrade{
+		UpgradeName: "luban",
 		Configs: []*UpgradeConfig{
 			{
 				ContractAddr: common.HexToAddress(ValidatorContract),
@@ -697,8 +697,8 @@ func UpgradeBuildInSystemContract(config *params.ChainConfig, blockNumber *big.I
 		applySystemContractUpgrade(planckUpgrade[network], blockNumber, statedb, logger)
 	}
 
-	if config.IsOnBoneh(blockNumber) {
-		applySystemContractUpgrade(bonehUpgrade[network], blockNumber, statedb, logger)
+	if config.IsOnLuban(blockNumber) {
+		applySystemContractUpgrade(lubanUpgrade[network], blockNumber, statedb, logger)
 	}
 
 	/*

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -141,9 +141,9 @@ var PrecompiledContractsBerlin = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2F{},
 }
 
-// PrecompiledContractsBoneh contains the default set of pre-compiled Ethereum
-// contracts used in the Boneh release.
-var PrecompiledContractsBoneh = map[common.Address]PrecompiledContract{
+// PrecompiledContractsLuban contains the default set of pre-compiled Ethereum
+// contracts used in the Luban release.
+var PrecompiledContractsLuban = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{1}): &ecrecover{},
 	common.BytesToAddress([]byte{2}): &sha256hash{},
 	common.BytesToAddress([]byte{3}): &ripemd160hash{},
@@ -175,7 +175,7 @@ var PrecompiledContractsBLS = map[common.Address]PrecompiledContract{
 }
 
 var (
-	PrecompiledAddressesBoneh     []common.Address
+	PrecompiledAddressesLuban     []common.Address
 	PrecompiledAddressesPlanck    []common.Address
 	PrecompiledAddressesMoran     []common.Address
 	PrecompiledAddressesNano      []common.Address
@@ -207,16 +207,16 @@ func init() {
 	for k := range PrecompiledContractsPlanck {
 		PrecompiledAddressesPlanck = append(PrecompiledAddressesPlanck, k)
 	}
-	for k := range PrecompiledContractsBoneh {
-		PrecompiledAddressesBoneh = append(PrecompiledAddressesBoneh, k)
+	for k := range PrecompiledContractsLuban {
+		PrecompiledAddressesLuban = append(PrecompiledAddressesLuban, k)
 	}
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
-	case rules.IsBoneh:
-		return PrecompiledAddressesBoneh
+	case rules.IsLuban:
+		return PrecompiledAddressesLuban
 	case rules.IsPlanck:
 		return PrecompiledAddressesPlanck
 	case rules.IsMoran:

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -52,8 +52,8 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
-	case evm.chainRules.IsBoneh:
-		precompiles = PrecompiledContractsBoneh
+	case evm.chainRules.IsLuban:
+		precompiles = PrecompiledContractsLuban
 	case evm.chainRules.IsPlanck:
 		precompiles = PrecompiledContractsPlanck
 	case evm.chainRules.IsMoran:

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -136,8 +136,8 @@ func newTestBackend(t *testing.T, londonBlock *big.Int, pending bool) *testBacke
 	config.LondonBlock = londonBlock
 	config.ArrowGlacierBlock = londonBlock
 	config.GibbsBlock = nil
-	config.BonehBlock = nil
-	config.LynnBlock = nil
+	config.LubanBlock = nil
+	config.PlatoBlock = nil
 	engine := ethash.NewFaker()
 	db := rawdb.NewMemoryDatabase()
 	genesis, err := gspec.Commit(db)

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -108,8 +108,8 @@ func testForkIDSplit(t *testing.T, protocol uint) {
 			GibbsBlock:          big.NewInt(5),
 			NanoBlock:           big.NewInt(5),
 			MoranBlock:          big.NewInt(5),
-			BonehBlock:          big.NewInt(6),
-			LynnBlock:           big.NewInt(6),
+			LubanBlock:          big.NewInt(6),
+			PlatoBlock:          big.NewInt(6),
 		}
 		dbNoFork  = rawdb.NewMemoryDatabase()
 		dbProFork = rawdb.NewMemoryDatabase()

--- a/params/config.go
+++ b/params/config.go
@@ -192,8 +192,8 @@ var (
 
 		// TODO modify blockNumber, make sure the blockNumber is not an integer multiple of 200 (epoch number)
 		// TODO Caution !!! it should be very careful !!!
-		BonehBlock: nil,
-		LynnBlock:  nil,
+		LubanBlock: nil,
+		PlatoBlock: nil,
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -224,8 +224,8 @@ var (
 
 		// TODO modify blockNumber, make sure the blockNumber is not an integer multiple of 200 (epoch number)
 		// TODO Caution !!! it should be very careful !!!
-		BonehBlock: big.NewInt(29295050),
-		LynnBlock:  nil,
+		LubanBlock: big.NewInt(29295050),
+		PlatoBlock: nil,
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -255,8 +255,8 @@ var (
 		PlanckBlock:         nil,
 
 		// TODO
-		BonehBlock: nil,
-		LynnBlock:  nil,
+		LubanBlock: nil,
+		PlatoBlock: nil,
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -376,8 +376,8 @@ type ChainConfig struct {
 	NanoBlock       *big.Int `json:"nanoBlock,omitempty" toml:",omitempty"`       // nanoBlock switch block (nil = no fork, 0 = already activated)
 	MoranBlock      *big.Int `json:"moranBlock,omitempty" toml:",omitempty"`      // moranBlock switch block (nil = no fork, 0 = already activated)
 	PlanckBlock     *big.Int `json:"planckBlock,omitempty" toml:",omitempty"`     // planckBlock switch block (nil = no fork, 0 = already activated)
-	BonehBlock      *big.Int `json:"bonehBlock,omitempty" toml:",omitempty"`      // bonehBlock switch block (nil = no fork, 0 = already activated)
-	LynnBlock       *big.Int `json:"lynnBlock,omitempty" toml:",omitempty"`       // lynnBlock switch block (nil = no fork, 0 = already activated)
+	LubanBlock      *big.Int `json:"lubanBlock,omitempty" toml:",omitempty"`      // lubanBlock switch block (nil = no fork, 0 = already activated)
+	PlatoBlock      *big.Int `json:"platoBlock,omitempty" toml:",omitempty"`      // platoBlock switch block (nil = no fork, 0 = already activated)
 
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty" toml:",omitempty"`
@@ -429,7 +429,7 @@ func (c *ChainConfig) String() string {
 		engine = "unknown"
 	}
 
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Planck: %v,Boneh: %v, Lynn: %v, Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Planck: %v,Luban: %v, Plato: %v, Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -457,8 +457,8 @@ func (c *ChainConfig) String() string {
 		c.NanoBlock,
 		c.MoranBlock,
 		c.PlanckBlock,
-		c.BonehBlock,
-		c.LynnBlock,
+		c.LubanBlock,
+		c.PlatoBlock,
 		engine,
 	)
 }
@@ -548,24 +548,24 @@ func (c *ChainConfig) IsOnEuler(num *big.Int) bool {
 	return configNumEqual(c.EulerBlock, num)
 }
 
-// IsBoneh returns whether num is either equal to the first fast finality fork block or greater.
-func (c *ChainConfig) IsBoneh(num *big.Int) bool {
-	return isForked(c.BonehBlock, num)
+// IsLuban returns whether num is either equal to the first fast finality fork block or greater.
+func (c *ChainConfig) IsLuban(num *big.Int) bool {
+	return isForked(c.LubanBlock, num)
 }
 
-// IsOnBoneh returns whether num is equal to the first fast finality fork block.
-func (c *ChainConfig) IsOnBoneh(num *big.Int) bool {
-	return configNumEqual(c.BonehBlock, num)
+// IsOnLuban returns whether num is equal to the first fast finality fork block.
+func (c *ChainConfig) IsOnLuban(num *big.Int) bool {
+	return configNumEqual(c.LubanBlock, num)
 }
 
-// IsLynn returns whether num is either equal to the second fast finality fork block or greater.
-func (c *ChainConfig) IsLynn(num *big.Int) bool {
-	return isForked(c.LynnBlock, num)
+// IsPlato returns whether num is either equal to the second fast finality fork block or greater.
+func (c *ChainConfig) IsPlato(num *big.Int) bool {
+	return isForked(c.PlatoBlock, num)
 }
 
-// IsOnLynn returns whether num is equal to the second fast finality fork block.
-func (c *ChainConfig) IsOnLynn(num *big.Int) bool {
-	return configNumEqual(c.LynnBlock, num)
+// IsOnPlato returns whether num is equal to the second fast finality fork block.
+func (c *ChainConfig) IsOnPlato(num *big.Int) bool {
+	return configNumEqual(c.PlatoBlock, num)
 }
 
 // IsMuirGlacier returns whether num is either equal to the Muir Glacier (EIP-2384) fork block or greater.
@@ -674,8 +674,8 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "brunoBlock", block: c.BrunoBlock},
 		{name: "eulerBlock", block: c.EulerBlock},
 		{name: "gibbsBlock", block: c.GibbsBlock},
-		{name: "bonehBlock", block: c.BonehBlock},
-		{name: "lynnBlock", block: c.LynnBlock},
+		{name: "lubanBlock", block: c.LubanBlock},
+		{name: "platoBlock", block: c.PlatoBlock},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -775,11 +775,11 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.PlanckBlock, newcfg.PlanckBlock, head) {
 		return newCompatError("planck fork block", c.PlanckBlock, newcfg.PlanckBlock)
 	}
-	if isForkIncompatible(c.BonehBlock, newcfg.BonehBlock, head) {
-		return newCompatError("boneh fork block", c.BonehBlock, newcfg.BonehBlock)
+	if isForkIncompatible(c.LubanBlock, newcfg.LubanBlock, head) {
+		return newCompatError("luban fork block", c.LubanBlock, newcfg.LubanBlock)
 	}
-	if isForkIncompatible(c.LynnBlock, newcfg.LynnBlock, head) {
-		return newCompatError("lynn fork block", c.LynnBlock, newcfg.LynnBlock)
+	if isForkIncompatible(c.PlatoBlock, newcfg.PlatoBlock, head) {
+		return newCompatError("plato fork block", c.PlatoBlock, newcfg.PlatoBlock)
 	}
 	return nil
 }
@@ -853,7 +853,7 @@ type Rules struct {
 	IsNano                                                  bool
 	IsMoran                                                 bool
 	IsPlanck                                                bool
-	IsBoneh                                                 bool
+	IsLuban                                                 bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -878,6 +878,6 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool) Rules {
 		IsNano:           c.IsNano(num),
 		IsMoran:          c.IsMoran(num),
 		IsPlanck:         c.IsPlanck(num),
-		IsBoneh:          c.IsBoneh(num),
+		IsLuban:          c.IsLuban(num),
 	}
 }


### PR DESCRIPTION
### Description
To follow the naming rule of BNB Chain hard fork, we replace Boneh-Lynn with Luban & Plato.

### Rationale
NA

### Example
NA

### Changes
No impact to users.