### PR TITLE
fix: all votes rejected for span voting caused by reorg

### DIFF
--- a/core/vote/vote_journal.go
+++ b/core/vote/vote_journal.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	maxSizeOfRecentEntry = 512
+	maxSizeOfRecentEntry    = 512
+	maliciousVoteSlashScope = 256
 )
 
 type VoteJournal struct {

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -180,7 +180,11 @@ func (voteManager *VoteManager) UnderRules(header *types.Header) (bool, uint64, 
 	}
 
 	//Rule 2: A validator must not vote within the span of its other votes.
-	for blockNumber := sourceNumber + 1; blockNumber < targetNumber; blockNumber++ {
+	blockNumber := sourceNumber + 1
+	if blockNumber+maxSizeOfRecentEntry < targetNumber {
+		blockNumber = targetNumber - maxSizeOfRecentEntry
+	}
+	for ; blockNumber < targetNumber; blockNumber++ {
 		if voteDataBuffer.Contains(blockNumber) {
 			voteData, ok := voteDataBuffer.Get(blockNumber)
 			if !ok {
@@ -188,7 +192,8 @@ func (voteManager *VoteManager) UnderRules(header *types.Header) (bool, uint64, 
 				continue
 			}
 			if voteData.(*types.VoteData).SourceNumber > sourceNumber {
-				log.Debug("error: cur vote is within the span of other votes")
+				log.Debug(fmt.Sprintf("error: cur vote %d-->%d is within the span of other votes %d-->%d",
+					sourceNumber, targetNumber, voteData.(*types.VoteData).SourceNumber, voteData.(*types.VoteData).TargetNumber))
 				return false, 0, common.Hash{}
 			}
 		}

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -181,8 +181,8 @@ func (voteManager *VoteManager) UnderRules(header *types.Header) (bool, uint64, 
 
 	//Rule 2: A validator must not vote within the span of its other votes.
 	blockNumber := sourceNumber + 1
-	if blockNumber+maxSizeOfRecentEntry < targetNumber {
-		blockNumber = targetNumber - maxSizeOfRecentEntry
+	if blockNumber+maliciousVoteSlashScope < targetNumber {
+		blockNumber = targetNumber - maliciousVoteSlashScope
 	}
 	for ; blockNumber < targetNumber; blockNumber++ {
 		if voteDataBuffer.Contains(blockNumber) {


### PR DESCRIPTION
### Description

![image](https://user-images.githubusercontent.com/122502194/233833709-bb229fb6-1944-40b6-9f62-6d3b1edbeb35.png)
after luban upgrade, voting is enabled, but not use justified number in fork choice;
so it can generate reorg easily as before by shutdown one validator
as in picture:
validator vote for 49578-->49579
then reorg and sourceNumber reset to 49577
all votes after reorg will rejected for span voting

### Rationale
1. there may be great distance between blockNumber and targetNumber
    so iterator from sourceNumber + 1 to targetNumber is dangerous
2. just ignore votes for target before targetNumber - maxSizeOfRecentEntry when checking rules
    
by the way:
this case is just a reason why we require sourceNumber of vote is in a range before block.number
![image](https://user-images.githubusercontent.com/122502194/233834158-5dc12b55-8857-41a5-9c80-8a2003f6d560.png)

set maliciousVoteSlashScope to 256 is safe:
if current block is n
then target block number is n-1
then iterate begin target number is n-1-256
then                    max(begin source number) is n-1-256-1 = n-258
in contracts _begin source number_ is n-255

n-288<n-255, so scan scope in bsc is larger, it's safe to set  maliciousVoteSlashScope to 256


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
