### PR TITLE
fix: simplify update of attestation

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -689,15 +689,7 @@ func (p *Parlia) snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 		headers[i], headers[len(headers)-1-i] = headers[len(headers)-1-i], headers[i]
 	}
 
-	verifiedAttestations := make(map[common.Hash]struct{}, len(headers))
-	for index, header := range headers {
-		// vote attestation should be checked here to decide whether to update attestation of snapshot between [Luban,Plato)
-		// because err of verifyVoteAttestation is ignored when importing blocks and headers before Plato.
-		if p.chainConfig.IsLuban(header.Number) && !p.chainConfig.IsPlato(header.Number) && p.verifyVoteAttestation(chain, header, headers[:index]) == nil {
-			verifiedAttestations[header.Hash()] = struct{}{}
-		}
-	}
-	snap, err := snap.apply(headers, chain, parents, p.chainConfig, verifiedAttestations)
+	snap, err := snap.apply(headers, chain, parents, p.chainConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -28,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	lru "github.com/hashicorp/golang-lru"
 )
@@ -174,9 +176,23 @@ func (s *Snapshot) isMajorityFork(forkHash string) bool {
 }
 
 func (s *Snapshot) updateAttestation(header *types.Header, chainConfig *params.ChainConfig, parliaConfig *params.ParliaConfig) {
+	if !chainConfig.IsLuban(header.Number) {
+		return
+	}
+
 	// The attestation should have been checked in verify header, update directly
 	attestation, _ := getVoteAttestationFromHeader(header, chainConfig, parliaConfig)
 	if attestation == nil {
+		return
+	}
+
+	// Headers with bad attestation are accepted before Plato upgrade,
+	// but Attestation of snapshot is only updated when the target block is direct parent of the header
+	targetNumber := attestation.Data.TargetNumber
+	targetHash := attestation.Data.TargetHash
+	if targetHash != header.ParentHash || targetNumber+1 != header.Number.Uint64() {
+		log.Warn("updateAttestation failed", "error", fmt.Errorf("invalid attestation, target mismatch, expected block: %d, hash: %s; real block: %d, hash: %s",
+			header.Number.Uint64()-1, header.ParentHash, targetNumber, targetHash))
 		return
 	}
 
@@ -189,7 +205,7 @@ func (s *Snapshot) updateAttestation(header *types.Header, chainConfig *params.C
 	}
 }
 
-func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderReader, parents []*types.Header, chainConfig *params.ChainConfig, verifiedAttestations map[common.Hash]struct{}) (*Snapshot, error) {
+func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderReader, parents []*types.Header, chainConfig *params.ChainConfig) (*Snapshot, error) {
 	// Allow passing in no headers for cleaner code
 	if len(headers) == 0 {
 		return s, nil
@@ -280,10 +296,7 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 			}
 		}
 
-		_, voteAssestationNoErr := verifiedAttestations[header.Hash()]
-		if chainConfig.IsPlato(header.Number) || (chainConfig.IsLuban(header.Number) && voteAssestationNoErr) {
-			snap.updateAttestation(header, chainConfig, s.config)
-		}
+		snap.updateAttestation(header, chainConfig, s.config)
 
 		snap.RecentForkHashes[number] = hex.EncodeToString(header.Extra[extraVanity-nextForkHashSize : extraVanity])
 	}

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -193,6 +193,7 @@ func (s *Snapshot) updateAttestation(header *types.Header, chainConfig *params.C
 	if targetHash != header.ParentHash || targetNumber+1 != header.Number.Uint64() {
 		log.Warn("updateAttestation failed", "error", fmt.Errorf("invalid attestation, target mismatch, expected block: %d, hash: %s; real block: %d, hash: %s",
 			header.Number.Uint64()-1, header.ParentHash, targetNumber, targetHash))
+		updateAttestationFailedGauge.Inc(1)
 		return
 	}
 


### PR DESCRIPTION
### Description

![image](https://user-images.githubusercontent.com/122502194/233891003-00b128c1-c0ba-48d1-aab3-58b8dec4a3ac.png)
![image](https://user-images.githubusercontent.com/122502194/233891097-4a5b917a-8e6d-4e73-81f9-ff222714b742.png)
attestation of snapshot went to wrong on two machines in old qa env
and can't be fixed by rewinding blocks
### Rationale
1.PR https://github.com/node-real/bsc/pull/64 is to fix a vote attestation security flaw 
but it leads to much more complexity, because of recursive call, as following 
```
verifyVoteAttestation  block n,   nearest checkpoint and before n is m
		--> GetJustifiedNumberAndHash block n-1
					--> snapshot      block n-1
							get snapshot at m
							--> verifyVoteAttestation m+1,verifyVoteAttestation m+2...verifyVoteAttestation n-1
								...

		--> snapshot
					--> snapshot      block n-2			
							get snapshot at m
							--> verifyVoteAttestation m+1,verifyVoteAttestation m+2...verifyVoteAttestation n-2
								...
```

it's difficult to analyze the reason when problem generated
so need to simplify update of attestation and keep the vote attestation security flaw fixed.
a way is found, just add a simple check before updateAttestation

2. verifyVoteAttestation and updateAttestation are critical to fast finality
so add metrics to follow it, they are both expected to be zero.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
