### PR TITLE
fix: memory leak of receivedVotes

### DIFF
--- a/core/vote/vote_pool.go
+++ b/core/vote/vote_pool.go
@@ -257,6 +257,7 @@ func (pool *VotePool) transfer(blockHash common.Hash) {
 	for _, vote := range voteBox.voteMessages {
 		// Verify if the vote comes from valid validators based on voteAddress (BLSPublicKey).
 		if pool.engine.VerifyVote(pool.chain, vote) != nil {
+			pool.receivedVotes.Remove(vote.Hash())
 			continue
 		}
 


### PR DESCRIPTION
### Description

<img width="660" alt="image" src="https://user-images.githubusercontent.com/122502194/233913316-774cbdd0-d64e-401c-a43a-1449b16885e5.png">
receivedVotes  extend not as expected

### Rationale

when transfer votes from futurevotes to curvotes,
discard invalid votes, but forget to remove it from receivedVotes

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
