### PR TITLE
ci: fix v1.2.0 release job

### DIFF
--- a/.github/generate_change_log.sh
+++ b/.github/generate_change_log.sh
@@ -29,13 +29,13 @@ OUTPUT=$(cat <<-END
 ## Changelog\n
 ${CHANGE_LOG}\n
 ## Assets\n
-|    Assets    | Sha256 Checksum  |\n
-| :-----------: |------------|\n
-| mainnet.zip | ${MAINNET_ZIP_SUM} |\n
-| testnet.zip | ${TESTNET_ZIP_SUM} |\n
-| geth_linux | ${LINUX_BIN_SUM} |\n
-| geth_mac  | ${MAC_BIN_SUM} |\n
-| geth_windows  | ${WINDOWS_BIN_SUM} |\n
+|    Assets    | Sha256 Checksum  |
+| :-----------: |------------|
+| mainnet.zip | ${MAINNET_ZIP_SUM} |
+| testnet.zip | ${TESTNET_ZIP_SUM} |
+| geth_linux | ${LINUX_BIN_SUM} |
+| geth_mac  | ${MAC_BIN_SUM} |
+| geth_windows  | ${WINDOWS_BIN_SUM} |
 | geth_linux_arm64  | ${ARM64_BIN_SUM} |\n
 END
 )

--- a/.github/generate_change_log.sh
+++ b/.github/generate_change_log.sh
@@ -24,9 +24,6 @@ TESTNET_ZIP_SUM="$(checksum ./testnet.zip)"
 LINUX_BIN_SUM="$(checksum ./linux/geth)"
 MAC_BIN_SUM="$(checksum ./macos/geth)"
 WINDOWS_BIN_SUM="$(checksum ./windows/geth.exe)"
-ARM5_BIN_SUM="$(checksum ./arm5/geth-linux-arm-5)"
-ARM6_BIN_SUM="$(checksum ./arm6/geth-linux-arm-6)"
-ARM7_BIN_SUM="$(checksum ./arm7/geth-linux-arm-7)"
 ARM64_BIN_SUM="$(checksum ./arm64/geth-linux-arm64)"
 OUTPUT=$(cat <<-END
 ## Changelog\n
@@ -39,11 +36,8 @@ ${CHANGE_LOG}\n
 | geth_linux | ${LINUX_BIN_SUM} |\n
 | geth_mac  | ${MAC_BIN_SUM} |\n
 | geth_windows  | ${WINDOWS_BIN_SUM} |\n
-| geth_linux_arm-5  | ${ARM5_BIN_SUM} |\n
-| geth_linux_arm-6  | ${ARM6_BIN_SUM} |\n
-| geth_linux_arm-7  | ${ARM7_BIN_SUM} |\n
 | geth_linux_arm64  | ${ARM64_BIN_SUM} |\n
 END
 )
 
-echo -e ${OUTPUT}
+echo -e "${OUTPUT}"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -44,8 +44,17 @@ jobs:
       # ==============================
 
       - name: Build Binary for ${{matrix.os}}
-        env:
-          CGO_ENABLED: "0"
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          go mod download
+          wget https://musl.cc/x86_64-linux-musl-cross.tgz
+          tar -xvf ./x86_64-linux-musl-cross.tgz
+          GIT_COMMIT=$(git rev-parse HEAD)
+          GIT_COMMIT_DATE=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=1 CC=$(pwd)/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc go build -ldflags "-X main.gitCommit=$GIT_COMMIT -X main.gitDate=$GIT_COMMIT_DATE -extldflags=-static" -o ./build/bin/geth -a ./cmd/geth
+      
+      - name: Build Binary for ${{matrix.os}}
+        if: matrix.os != 'ubuntu-latest'
         run: |
           go mod download
           make geth
@@ -58,7 +67,12 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           go mod download
-          make geth-linux-arm
+          wget https://musl.cc/aarch64-linux-musl-cross.tgz
+          tar -xvf ./aarch64-linux-musl-cross.tgz
+          GIT_COMMIT=$(git rev-parse HEAD)
+          GIT_COMMIT_DATE=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=1 CC=$(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc go build -ldflags "-X main.gitCommit=$GIT_COMMIT -X main.gitDate=$GIT_COMMIT_DATE -extldflags=-static" -o ./build/bin/geth-linux-arm64 -a ./cmd/geth
+
       # ==============================
       #       Upload artifacts
       # ==============================

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -84,27 +84,6 @@ jobs:
           name: windows
           path: ./build/bin/geth.exe
 
-      - name: Upload ARM-5 Build
-        uses: actions/upload-artifact@v3
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          name: arm5
-          path: ./build/bin/geth-linux-arm-5
-      
-      - name: Upload ARM-6 Build
-        uses: actions/upload-artifact@v3
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          name: arm6
-          path: ./build/bin/geth-linux-arm-6
-
-      - name: Upload ARM-7 Build
-        uses: actions/upload-artifact@v3
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          name: arm7
-          path: ./build/bin/geth-linux-arm-7
-
       - name: Upload ARM-64 Build
         uses: actions/upload-artifact@v3
         if: matrix.os == 'ubuntu-latest'
@@ -148,24 +127,6 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: arm5
-          path: ./arm5
-      
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: arm6
-          path: ./arm6
-      
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: arm7
-          path: ./arm7
-      
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-        with:
           name: arm64
           path: ./arm64
       
@@ -204,7 +165,4 @@ jobs:
             ./linux/geth_linux
             ./macos/geth_macos
             ./windows/geth_windows.exe
-            ./arm5/geth-linux-arm-5
-            ./arm6/geth-linux-arm-6
-            ./arm7/geth-linux-arm-7
             ./arm64/geth-linux-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,9 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           go mod download
-          make geth-linux-arm
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          make CC=aarch64-linux-gnu-gcc geth-linux-arm
+          
       # ==============================
       #       Upload artifacts
       # ==============================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,6 @@ jobs:
       # ==============================
 
       - name: Build Binary for ${{matrix.os}}
-        env:
-          CGO_ENABLED: "0"
         run: |
           go mod download
           make geth

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,17 @@ jobs:
       # ==============================
 
       - name: Build Binary for ${{matrix.os}}
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          go mod download
+          wget https://musl.cc/x86_64-linux-musl-cross.tgz
+          tar -xvf ./x86_64-linux-musl-cross.tgz
+          GIT_COMMIT=$(git rev-parse HEAD)
+          GIT_COMMIT_DATE=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=1 CC=$(pwd)/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc go build -ldflags "-X main.gitCommit=$GIT_COMMIT -X main.gitDate=$GIT_COMMIT_DATE -extldflags=-static" -o ./build/bin/geth -a ./cmd/geth
+      
+      - name: Build Binary for ${{matrix.os}}
+        if: matrix.os != 'ubuntu-latest'
         run: |
           go mod download
           make geth
@@ -58,7 +69,9 @@ jobs:
           go mod download
           wget https://musl.cc/aarch64-linux-musl-cross.tgz
           tar -xvf ./aarch64-linux-musl-cross.tgz
-          GOOS=linux GOARCH=arm64 CGO_ENABLED=1 CC=$(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc go build -o ./build/bin/geth-linux-arm64 -a -ldflags=-extldflags=-static ./cmd/geth
+          GIT_COMMIT=$(git rev-parse HEAD)
+          GIT_COMMIT_DATE=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=1 CC=$(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc go build -ldflags "-X main.gitCommit=$GIT_COMMIT -X main.gitDate=$GIT_COMMIT_DATE -extldflags=-static" -o ./build/bin/geth-linux-arm64 -a ./cmd/geth
 
       # ==============================
       #       Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,8 @@ jobs:
         run: |
           go mod download
           sudo apt-get install -y gcc-aarch64-linux-gnu
-          make CC=aarch64-linux-gnu-gcc geth-linux-arm
-          
+          make CC=aarch64-linux-gnu-gcc CC_FOR_TARGET=gcc-aarch64-linux-gnu geth-linux-arm
+
       # ==============================
       #       Upload artifacts
       # ==============================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,9 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           go mod download
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          make CC=aarch64-linux-gnu-gcc CC_FOR_TARGET=gcc-aarch64-linux-gnu geth-linux-arm
+          wget https://musl.cc/aarch64-linux-musl-cross.tgz
+          tar -xvf ./aarch64-linux-musl-cross.tgz
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=1 CC=$(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc go build -o ./build/bin/geth-linux-arm64 -a -ldflags=-extldflags=-static ./cmd/geth
 
       # ==============================
       #       Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,27 +82,6 @@ jobs:
           name: windows
           path: ./build/bin/geth.exe
 
-      - name: Upload ARM-5 Build
-        uses: actions/upload-artifact@v3
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          name: arm5
-          path: ./build/bin/geth-linux-arm-5
-      
-      - name: Upload ARM-6 Build
-        uses: actions/upload-artifact@v3
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          name: arm6
-          path: ./build/bin/geth-linux-arm-6
-
-      - name: Upload ARM-7 Build
-        uses: actions/upload-artifact@v3
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          name: arm7
-          path: ./build/bin/geth-linux-arm-7
-
       - name: Upload ARM-64 Build
         uses: actions/upload-artifact@v3
         if: matrix.os == 'ubuntu-latest'
@@ -142,24 +121,6 @@ jobs:
         with:
           name: windows
           path: ./windows
-      
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: arm5
-          path: ./arm5
-      
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: arm6
-          path: ./arm6
-      
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: arm7
-          path: ./arm7
       
       - name: Download Artifacts
         uses: actions/download-artifact@v3
@@ -209,7 +170,4 @@ jobs:
             ./linux/geth_linux
             ./macos/geth_macos
             ./windows/geth_windows.exe
-            ./arm5/geth-linux-arm-5
-            ./arm6/geth-linux-arm-6
-            ./arm7/geth-linux-arm-7
             ./arm64/geth-linux-arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ USER ${BSC_USER_UID}:${BSC_USER_GID}
 # rpc ws graphql
 EXPOSE 8545 8546 8547 30303 30303/udp
 
-# For blst
+# For blst runtime env
 ENV CGO_CFLAGS="-O -D__BLST_PORTABLE__" 
 ENV CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
 ENTRYPOINT ["/sbin/tini", "--", "./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ COPY go.sum /go-ethereum/
 RUN cd /go-ethereum && go mod download
 
 ADD . /go-ethereum
-ENV CGO_CFLAGS="-O -D__BLST_PORTABLE__" 
-ENV CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
 RUN cd /go-ethereum && go run build/ci.go install ./cmd/geth
 
 # Pull Geth into a second stage deploy alpine container
@@ -28,10 +26,9 @@ ENV BSC_HOME=/bsc
 ENV HOME=${BSC_HOME}
 ENV DATA_DIR=/data
 
-ARG VERSION_GCC=11.2.1_git20220219-r2
 ENV PACKAGES ca-certificates jq \
   bash bind-tools tini \
-  grep curl sed gcc==${VERSION_GCC}
+  grep curl sed gcc
 
 RUN apk add --no-cache $PACKAGES \
   && rm -rf /var/cache/apk/* \
@@ -59,4 +56,7 @@ USER ${BSC_USER_UID}:${BSC_USER_GID}
 # rpc ws graphql
 EXPOSE 8545 8546 8547 30303 30303/udp
 
+# For blst
+ENV CGO_CFLAGS="-O -D__BLST_PORTABLE__" 
+ENV CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
 ENTRYPOINT ["/sbin/tini", "--", "./docker-entrypoint.sh"]

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -29,3 +29,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 LABEL commit="$COMMIT" version="$VERSION" buildnum="$BUILDNUM"
+
+# For blst runtime env
+ENV CGO_CFLAGS="-O -D__BLST_PORTABLE__" 
+ENV CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,6 @@ GORUN = env GO111MODULE=on go run
 GIT_COMMIT=$(shell git rev-parse HEAD)
 GIT_COMMIT_DATE=$(shell git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
 
-CC = gcc
-ifdef CC
-	CFLAGS += -cc=$(CC)
-endif
-ifdef CC_FOR_TARGET
-	CFLAGS += -cc_for_target=$(CC_FOR_TARGET)
-endif
-
 geth:
 	$(GORUN) build/ci.go install ./cmd/geth
 	@echo "Done building."
@@ -28,7 +20,7 @@ geth:
 geth-linux-arm: geth-linux-arm64
 
 geth-linux-arm64:  
-	$(GORUN) build/ci.go install -arch=arm64 $(CFLAGS) -o=build/bin/geth-linux-arm64 ./cmd/geth 
+	$(GORUN) build/ci.go install -arch=arm64 -o=build/bin/geth-linux-arm64 ./cmd/geth 
 
 all:
 	$(GORUN) build/ci.go install

--- a/Makefile
+++ b/Makefile
@@ -17,22 +17,19 @@ geth:
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
-ldflags = -X main.gitCommit=$(GIT_COMMIT) \
-          -X main.gitDate=$(GIT_COMMIT_DATE)
-
 geth-linux-arm: geth-linux-arm5 geth-linux-arm6 geth-linux-arm7 geth-linux-arm64
 
 geth-linux-arm5:
-	env GO111MODULE=on GOARCH=arm GOARM=5 GOOS=linux go build -ldflags="$(ldflags)" -o build/bin/geth-linux-arm-5 ./cmd/geth
+	GOARM=5 $(GORUN) build/ci.go install -arch=arm -o=build/bin/geth-linux-arm-5 ./cmd/geth
 
 geth-linux-arm6:
-	env GO111MODULE=on GOARCH=arm GOARM=6 GOOS=linux go build -ldflags="$(ldflags)" -o build/bin/geth-linux-arm-6 ./cmd/geth
+	GOARM=6 $(GORUN) build/ci.go install -arch=arm -o=build/bin/geth-linux-arm-6 ./cmd/geth
 
 geth-linux-arm7:
-	env GO111MODULE=on GOARCH=arm GOARM=7 GOOS=linux go build -ldflags="$(ldflags)" -o build/bin/geth-linux-arm-7 ./cmd/geth
+	GOARM=7 $(GORUN) build/ci.go install -arch=arm -o=build/bin/geth-linux-arm-7 ./cmd/geth
 
 geth-linux-arm64:
-	env GO111MODULE=on GOARCH=arm64 GOOS=linux go build -ldflags="$(ldflags)" -o build/bin/geth-linux-arm64 ./cmd/geth
+	$(GORUN) build/ci.go install -arch=arm64 -o=build/bin/geth-linux-arm64 ./cmd/geth
 
 all:
 	$(GORUN) build/ci.go install

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 .PHONY: geth android ios evm all test truffle-test clean
 .PHONY: docker
-.PHONY: geth-linux-arm geth-linux-arm64 geth-linux-arm5 geth-linux-arm6 geth-linux-arm7
+.PHONY: geth-linux-arm geth-linux-arm64
 
 GOBIN = ./build/bin
 GO ?= latest
@@ -12,15 +12,20 @@ GORUN = env GO111MODULE=on go run
 GIT_COMMIT=$(shell git rev-parse HEAD)
 GIT_COMMIT_DATE=$(shell git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
 
+
 geth:
 	$(GORUN) build/ci.go install ./cmd/geth
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
+CC = gcc
+ifdef CC
+	CFLAGS = -cc=$(CC)
+endif
 geth-linux-arm: geth-linux-arm64
 
-geth-linux-arm64:
-	$(GORUN) build/ci.go install -arch=arm64 -o=build/bin/geth-linux-arm64 ./cmd/geth
+geth-linux-arm64:  
+	$(GORUN) build/ci.go install -arch=arm64 $(CFLAGS) -o=build/bin/geth-linux-arm64 ./cmd/geth 
 
 all:
 	$(GORUN) build/ci.go install

--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,7 @@ geth:
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
-geth-linux-arm: geth-linux-arm5 geth-linux-arm6 geth-linux-arm7 geth-linux-arm64
-
-geth-linux-arm5:
-	GOARM=5 $(GORUN) build/ci.go install -arch=arm -o=build/bin/geth-linux-arm-5 ./cmd/geth
-
-geth-linux-arm6:
-	GOARM=6 $(GORUN) build/ci.go install -arch=arm -o=build/bin/geth-linux-arm-6 ./cmd/geth
-
-geth-linux-arm7:
-	GOARM=7 $(GORUN) build/ci.go install -arch=arm -o=build/bin/geth-linux-arm-7 ./cmd/geth
+geth-linux-arm: geth-linux-arm64
 
 geth-linux-arm64:
 	$(GORUN) build/ci.go install -arch=arm64 -o=build/bin/geth-linux-arm64 ./cmd/geth

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,6 @@ geth:
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
-geth-linux-arm: geth-linux-arm64
-
-geth-linux-arm64:  
-	$(GORUN) build/ci.go install -arch=arm64 -o=build/bin/geth-linux-arm64 ./cmd/geth 
-
 all:
 	$(GORUN) build/ci.go install
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 
 .PHONY: geth android ios evm all test truffle-test clean
 .PHONY: docker
-.PHONY: geth-linux-arm geth-linux-arm64
 
 GOBIN = ./build/bin
 GO ?= latest

--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,19 @@ GORUN = env GO111MODULE=on go run
 GIT_COMMIT=$(shell git rev-parse HEAD)
 GIT_COMMIT_DATE=$(shell git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
 
+CC = gcc
+ifdef CC
+	CFLAGS += -cc=$(CC)
+endif
+ifdef CC_FOR_TARGET
+	CFLAGS += -cc_for_target=$(CC_FOR_TARGET)
+endif
 
 geth:
 	$(GORUN) build/ci.go install ./cmd/geth
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
-CC = gcc
-ifdef CC
-	CFLAGS = -cc=$(CC)
-endif
 geth-linux-arm: geth-linux-arm64
 
 geth-linux-arm64:  

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Download latest chaindata snapshot from [here](https://github.com/bnb-chain/bsc-
 
 #### 4. Start a full node
 ```shell
+## This two environment variables are required for blst library to work after v1.2.0
+export CGO_CFLAGS="-O -D__BLST_PORTABLE__" 
+export CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
+
 ./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0
 
 ## It is recommand to run fullnode with `--tries-verify-mode none` if you want high performance and care little about state consistency

--- a/build/ci.go
+++ b/build/ci.go
@@ -197,15 +197,16 @@ func main() {
 
 func doInstall(cmdline []string) {
 	var (
-		dlgo   = flag.Bool("dlgo", false, "Download Go and build with it")
-		arch   = flag.String("arch", "", "Architecture to cross build for")
-		cc     = flag.String("cc", "", "C compiler to cross build with")
-		output = flag.String("o", "", "Output directory for build artifacts")
+		dlgo        = flag.Bool("dlgo", false, "Download Go and build with it")
+		arch        = flag.String("arch", "", "Architecture to cross build for")
+		cc          = flag.String("cc", "", "C compiler to cross build with")
+		ccForTarget = flag.String("cc_for_target", "", "C compiler to build for the target platform")
+		output      = flag.String("o", "", "Output directory for build artifacts")
 	)
 	flag.CommandLine.Parse(cmdline)
 
 	// Configure the toolchain.
-	tc := build.GoToolchain{GOARCH: *arch, CC: *cc}
+	tc := build.GoToolchain{GOARCH: *arch, CC: *cc, CCForTarget: *ccForTarget}
 	if *dlgo {
 		csdb := build.MustLoadChecksums("build/checksums.txt")
 		tc.Root = build.DownloadGo(csdb, dlgoVersion)

--- a/build/ci.go
+++ b/build/ci.go
@@ -24,19 +24,18 @@ Usage: go run build/ci.go <command> <command flags/arguments>
 
 Available commands are:
 
-   install    [ -arch architecture ] [ -cc compiler ] [ packages... ]                          -- builds packages and executables
-   test       [ -coverage ] [ packages... ]                                                    -- runs the tests
-   lint                                                                                        -- runs certain pre-selected linters
-   archive    [ -arch architecture ] [ -type zip|tar ] [ -signer key-envvar ] [ -signify key-envvar ] [ -upload dest ] -- archives build artifacts
-   importkeys                                                                                  -- imports signing keys from env
-   debsrc     [ -signer key-id ] [ -upload dest ]                                              -- creates a debian source package
-   nsis                                                                                        -- creates a Windows NSIS installer
-   aar        [ -local ] [ -sign key-id ] [-deploy repo] [ -upload dest ]                      -- creates an Android archive
-   xcode      [ -local ] [ -sign key-id ] [-deploy repo] [ -upload dest ]                      -- creates an iOS XCode framework
-   purge      [ -store blobstore ] [ -days threshold ]                                         -- purges old archives from the blobstore
+	install    [ -arch architecture ] [ -cc compiler ] [ packages... ]                          -- builds packages and executables
+	test       [ -coverage ] [ packages... ]                                                    -- runs the tests
+	lint                                                                                        -- runs certain pre-selected linters
+	archive    [ -arch architecture ] [ -type zip|tar ] [ -signer key-envvar ] [ -signify key-envvar ] [ -upload dest ] -- archives build artifacts
+	importkeys                                                                                  -- imports signing keys from env
+	debsrc     [ -signer key-id ] [ -upload dest ]                                              -- creates a debian source package
+	nsis                                                                                        -- creates a Windows NSIS installer
+	aar        [ -local ] [ -sign key-id ] [-deploy repo] [ -upload dest ]                      -- creates an Android archive
+	xcode      [ -local ] [ -sign key-id ] [-deploy repo] [ -upload dest ]                      -- creates an iOS XCode framework
+	purge      [ -store blobstore ] [ -days threshold ]                                         -- purges old archives from the blobstore
 
 For all commands, -n prevents execution of external programs (dry run mode).
-
 */
 package main
 
@@ -198,9 +197,10 @@ func main() {
 
 func doInstall(cmdline []string) {
 	var (
-		dlgo = flag.Bool("dlgo", false, "Download Go and build with it")
-		arch = flag.String("arch", "", "Architecture to cross build for")
-		cc   = flag.String("cc", "", "C compiler to cross build with")
+		dlgo   = flag.Bool("dlgo", false, "Download Go and build with it")
+		arch   = flag.String("arch", "", "Architecture to cross build for")
+		cc     = flag.String("cc", "", "C compiler to cross build with")
+		output = flag.String("o", "", "Output directory for build artifacts")
 	)
 	flag.CommandLine.Parse(cmdline)
 
@@ -213,7 +213,8 @@ func doInstall(cmdline []string) {
 
 	// Configure the build.
 	env := build.Env()
-	gobuild := tc.Go("build", buildFlags(env)...)
+	buildArgs := buildFlags(env)
+	gobuild := tc.Go("build", buildArgs...)
 
 	// arm64 CI builders are memory-constrained and can't handle concurrent builds,
 	// better disable it. This check isn't the best, it should probably
@@ -239,7 +240,11 @@ func doInstall(cmdline []string) {
 	for _, pkg := range packages {
 		args := make([]string, len(gobuild.Args))
 		copy(args, gobuild.Args)
-		args = append(args, "-o", executablePath(path.Base(pkg)))
+		outputPath := executablePath(path.Base(pkg))
+		if output != nil && *output != "" {
+			outputPath = *output
+		}
+		args = append(args, "-o", outputPath)
 		args = append(args, pkg)
 		build.MustRun(&exec.Cmd{Path: gobuild.Path, Args: args, Env: gobuild.Env})
 	}

--- a/build/ci.go
+++ b/build/ci.go
@@ -197,16 +197,15 @@ func main() {
 
 func doInstall(cmdline []string) {
 	var (
-		dlgo        = flag.Bool("dlgo", false, "Download Go and build with it")
-		arch        = flag.String("arch", "", "Architecture to cross build for")
-		cc          = flag.String("cc", "", "C compiler to cross build with")
-		ccForTarget = flag.String("cc_for_target", "", "C compiler to build for the target platform")
-		output      = flag.String("o", "", "Output directory for build artifacts")
+		dlgo   = flag.Bool("dlgo", false, "Download Go and build with it")
+		arch   = flag.String("arch", "", "Architecture to cross build for")
+		cc     = flag.String("cc", "", "C compiler to cross build with")
+		output = flag.String("o", "", "Output directory for build artifacts")
 	)
 	flag.CommandLine.Parse(cmdline)
 
 	// Configure the toolchain.
-	tc := build.GoToolchain{GOARCH: *arch, CC: *cc, CCForTarget: *ccForTarget}
+	tc := build.GoToolchain{GOARCH: *arch, CC: *cc}
 	if *dlgo {
 		csdb := build.MustLoadChecksums("build/checksums.txt")
 		tc.Root = build.DownloadGo(csdb, dlgoVersion)

--- a/internal/build/gotool.go
+++ b/internal/build/gotool.go
@@ -30,9 +30,10 @@ type GoToolchain struct {
 	Root string // GOROOT
 
 	// Cross-compilation variables. These are set when running the go tool.
-	GOARCH string
-	GOOS   string
-	CC     string
+	GOARCH      string
+	GOOS        string
+	CC          string
+	CCForTarget string
 }
 
 // Go creates an invocation of the go command.
@@ -52,6 +53,12 @@ func (g *GoToolchain) Go(command string, args ...string) *exec.Cmd {
 		tool.Env = append(tool.Env, "CC="+g.CC)
 	} else if os.Getenv("CC") != "" {
 		tool.Env = append(tool.Env, "CC="+os.Getenv("CC"))
+	}
+	// Configure C compiler.
+	if g.CCForTarget != "" {
+		tool.Env = append(tool.Env, "CC_FOR_TARGET="+g.CCForTarget)
+	} else if os.Getenv("CCForTarget") != "" {
+		tool.Env = append(tool.Env, "CC_FOR_TARGET="+os.Getenv("CC_FOR_TARGET"))
 	}
 	return tool
 }

--- a/internal/build/gotool.go
+++ b/internal/build/gotool.go
@@ -30,10 +30,9 @@ type GoToolchain struct {
 	Root string // GOROOT
 
 	// Cross-compilation variables. These are set when running the go tool.
-	GOARCH      string
-	GOOS        string
-	CC          string
-	CCForTarget string
+	GOARCH string
+	GOOS   string
+	CC     string
 }
 
 // Go creates an invocation of the go command.
@@ -53,12 +52,6 @@ func (g *GoToolchain) Go(command string, args ...string) *exec.Cmd {
 		tool.Env = append(tool.Env, "CC="+g.CC)
 	} else if os.Getenv("CC") != "" {
 		tool.Env = append(tool.Env, "CC="+os.Getenv("CC"))
-	}
-	// Configure C compiler.
-	if g.CCForTarget != "" {
-		tool.Env = append(tool.Env, "CC_FOR_TARGET="+g.CCForTarget)
-	} else if os.Getenv("CCForTarget") != "" {
-		tool.Env = append(tool.Env, "CC_FOR_TARGET="+os.Getenv("CC_FOR_TARGET"))
 	}
 	return tool
 }


### PR DESCRIPTION
### Description

after `v1.2.0` version, the binary will need `blst` package that needs to execute with `cgo`.

!!! Notice
Please make sure these two env was set before running the node.
```bash
CGO_CFLAGS="-O -D__BLST_PORTABLE__" 
CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
```

### Rationale

N/A

### Example

```
CGO_CFLAGS="-O -D__BLST_PORTABLE__"  CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__" geth --datadir ...
```

### Changes

Notable changes: 
* ci
