### PR TITLE
log: revert a log back to trace level (#1527)

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -435,7 +435,7 @@ func (p *Peer) startProtocols(writeStart <-chan struct{}, writeErr chan<- error)
 				p.log.Trace(fmt.Sprintf("Protocol %s/%d returned", proto.Name, proto.Version))
 				err = errProtocolReturned
 			} else if !errors.Is(err, io.EOF) {
-				p.log.Warn(fmt.Sprintf("Protocol %s/%d failed", proto.Name, proto.Version), "err", err)
+				p.log.Trace(fmt.Sprintf("Protocol %s/%d failed", proto.Name, proto.Version), "err", err)
 			}
 			p.protoErr <- err
 		}()


### PR DESCRIPTION
### Description
The previous PR: https://github.com/bnb-chain/bsc/pull/1484/, raised the log level from trace to warn, try to print more log on P2P error.
But it turns out the warning log will spam over the screen.
Complain received in https://github.com/bnb-chain/bsc/issues/1526

### Rationale
Revert the level to trace.

### Example
NA

### Changes
NA
