### PR TITLE
fix: config for VoteJournalDir and BLSWalletDir

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1403,7 +1403,7 @@ func setVoteJournalDir(ctx *cli.Context, cfg *node.Config) {
 	dataDir := cfg.DataDir
 	if ctx.GlobalIsSet(VoteJournalDirFlag.Name) {
 		cfg.VoteJournalDir = ctx.GlobalString(VoteJournalDirFlag.Name)
-	} else {
+	} else if cfg.VoteJournalDir == "" {
 		cfg.VoteJournalDir = filepath.Join(dataDir, "voteJournal")
 	}
 }
@@ -1412,7 +1412,7 @@ func setBLSWalletDir(ctx *cli.Context, cfg *node.Config) {
 	dataDir := cfg.DataDir
 	if ctx.GlobalIsSet(BLSWalletDirFlag.Name) {
 		cfg.BLSWalletDir = ctx.GlobalString(BLSWalletDirFlag.Name)
-	} else {
+	} else if cfg.BLSWalletDir == "" {
 		cfg.BLSWalletDir = filepath.Join(dataDir, "bls/wallet")
 	}
 }


### PR DESCRIPTION
### Description

refer to https://github.com/bnb-chain/bsc/issues/1536

### Rationale
Set it to default only when BLSWalletDir is empty and there is no flag for it
So is VoteJournalDir.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
