### PR TITLE
fix: remove dynamic metric labels about fast finality

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -75,9 +75,9 @@ var (
 	diffInTurn = big.NewInt(2)            // Block difficulty for in-turn signatures
 	diffNoTurn = big.NewInt(1)            // Block difficulty for out-of-turn signatures
 	// 100 native token
-	maxSystemBalance                 = new(big.Int).Mul(big.NewInt(100), big.NewInt(params.Ether))
-	verifyVoteAttestationFailedGauge = metrics.NewRegisteredGauge("parlia/verifyVoteAttestationFailed", nil)
-	updateAttestationFailedGauge     = metrics.NewRegisteredGauge("parlia/updateAttestationFailed", nil)
+	maxSystemBalance           = new(big.Int).Mul(big.NewInt(100), big.NewInt(params.Ether))
+	verifyVoteAttestationError = metrics.NewRegisteredGauge("parlia/verifyVoteAttestation/error", nil)
+	updateAttestationError     = metrics.NewRegisteredGauge("parlia/updateAttestation/error", nil)
 
 	systemContracts = map[common.Address]bool{
 		common.HexToAddress(systemcontracts.ValidatorContract):          true,
@@ -599,7 +599,7 @@ func (p *Parlia) verifyCascadingFields(chain consensus.ChainHeaderReader, header
 
 	// Verify vote attestation for fast finality.
 	if err := p.verifyVoteAttestation(chain, header, parents); err != nil {
-		verifyVoteAttestationFailedGauge.Inc(1)
+		verifyVoteAttestationError.Inc(1)
 		if chain.Config().IsPlato(header.Number) {
 			return err
 		}

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -75,9 +75,9 @@ var (
 	diffInTurn = big.NewInt(2)            // Block difficulty for in-turn signatures
 	diffNoTurn = big.NewInt(1)            // Block difficulty for out-of-turn signatures
 	// 100 native token
-	maxSystemBalance           = new(big.Int).Mul(big.NewInt(100), big.NewInt(params.Ether))
-	verifyVoteAttestationError = metrics.NewRegisteredGauge("parlia/verifyVoteAttestation/error", nil)
-	updateAttestationError     = metrics.NewRegisteredGauge("parlia/updateAttestation/error", nil)
+	maxSystemBalance                  = new(big.Int).Mul(big.NewInt(100), big.NewInt(params.Ether))
+	verifyVoteAttestationErrorCounter = metrics.NewRegisteredCounter("parlia/verifyVoteAttestation/error", nil)
+	updateAttestationErrorCounter     = metrics.NewRegisteredCounter("parlia/updateAttestation/error", nil)
 
 	systemContracts = map[common.Address]bool{
 		common.HexToAddress(systemcontracts.ValidatorContract):          true,
@@ -599,7 +599,7 @@ func (p *Parlia) verifyCascadingFields(chain consensus.ChainHeaderReader, header
 
 	// Verify vote attestation for fast finality.
 	if err := p.verifyVoteAttestation(chain, header, parents); err != nil {
-		verifyVoteAttestationError.Inc(1)
+		verifyVoteAttestationErrorCounter.Inc(1)
 		if chain.Config().IsPlato(header.Number) {
 			return err
 		}

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -194,7 +194,7 @@ func (s *Snapshot) updateAttestation(header *types.Header, chainConfig *params.C
 	if targetHash != header.ParentHash || targetNumber+1 != header.Number.Uint64() {
 		log.Warn("updateAttestation failed", "error", fmt.Errorf("invalid attestation, target mismatch, expected block: %d, hash: %s; real block: %d, hash: %s",
 			header.Number.Uint64()-1, header.ParentHash, targetNumber, targetHash))
-		updateAttestationError.Inc(1)
+		updateAttestationErrorCounter.Inc(1)
 		return
 	}
 

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -194,7 +194,7 @@ func (s *Snapshot) updateAttestation(header *types.Header, chainConfig *params.C
 	if targetHash != header.ParentHash || targetNumber+1 != header.Number.Uint64() {
 		log.Warn("updateAttestation failed", "error", fmt.Errorf("invalid attestation, target mismatch, expected block: %d, hash: %s; real block: %d, hash: %s",
 			header.Number.Uint64()-1, header.ParentHash, targetNumber, targetHash))
-		updateAttestationFailedGauge.Inc(1)
+		updateAttestationError.Inc(1)
 		return
 	}
 

--- a/core/vote/vote_journal.go
+++ b/core/vote/vote_journal.go
@@ -24,7 +24,7 @@ type VoteJournal struct {
 	voteDataBuffer *lru.Cache
 }
 
-var voteJournalError = metrics.NewRegisteredGauge("voteJournal/local", nil)
+var voteJournalError = metrics.NewRegisteredGauge("voteJournal/error", nil)
 
 func NewVoteJournal(filePath string) (*VoteJournal, error) {
 	walLog, err := wal.Open(filePath, &wal.Options{

--- a/core/vote/vote_journal.go
+++ b/core/vote/vote_journal.go
@@ -24,7 +24,7 @@ type VoteJournal struct {
 	voteDataBuffer *lru.Cache
 }
 
-var voteJournalError = metrics.NewRegisteredGauge("voteJournal/error", nil)
+var voteJournalErrorCounter = metrics.NewRegisteredCounter("voteJournal/error", nil)
 
 func NewVoteJournal(filePath string) (*VoteJournal, error) {
 	walLog, err := wal.Open(filePath, &wal.Options{

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-var votesManagerCount = metrics.NewRegisteredGauge("votesManager/count", nil)
+var votesManagerCounter = metrics.NewRegisteredCounter("votesManager/local", nil)
 
 // VoteManager will handle the vote produced by self.
 type VoteManager struct {
@@ -141,18 +141,18 @@ func (voteManager *VoteManager) loop() {
 
 				if err := voteManager.signer.SignVote(voteMessage); err != nil {
 					log.Error("Failed to sign vote", "err", err, "votedBlockNumber", voteMessage.Data.TargetNumber, "votedBlockHash", voteMessage.Data.TargetHash, "voteMessageHash", voteMessage.Hash())
-					votesSigningError.Inc(1)
+					votesSigningErrorCounter.Inc(1)
 					continue
 				}
 				if err := voteManager.journal.WriteVote(voteMessage); err != nil {
 					log.Error("Failed to write vote into journal", "err", err)
-					voteJournalError.Inc(1)
+					voteJournalErrorCounter.Inc(1)
 					continue
 				}
 
 				log.Debug("vote manager produced vote", "votedBlockNumber", voteMessage.Data.TargetNumber, "votedBlockHash", voteMessage.Data.TargetHash, "voteMessageHash", voteMessage.Hash())
 				voteManager.pool.PutVote(voteMessage)
-				votesManagerCount.Inc(1)
+				votesManagerCounter.Inc(1)
 			}
 		case <-voteManager.chainHeadSub.Err():
 			log.Debug("voteManager subscribed chainHead failed")

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
+var votesManagerCount = metrics.NewRegisteredGauge("votesManager/count", nil)
+
 // VoteManager will handle the vote produced by self.
 type VoteManager struct {
 	mux *event.TypeMux
@@ -138,8 +140,8 @@ func (voteManager *VoteManager) loop() {
 				voteMessage.Data.SourceHash = sourceHash
 
 				if err := voteManager.signer.SignVote(voteMessage); err != nil {
-					log.Error("Failed to sign vote", "err", err)
-					votesSigningErrorMetric(vote.TargetNumber, vote.TargetHash).Inc(1)
+					log.Error("Failed to sign vote", "err", err, "votedBlockNumber", voteMessage.Data.TargetNumber, "votedBlockHash", voteMessage.Data.TargetHash, "voteMessageHash", voteMessage.Hash())
+					votesSigningError.Inc(1)
 					continue
 				}
 				if err := voteManager.journal.WriteVote(voteMessage); err != nil {
@@ -150,7 +152,7 @@ func (voteManager *VoteManager) loop() {
 
 				log.Debug("vote manager produced vote", "votedBlockNumber", voteMessage.Data.TargetNumber, "votedBlockHash", voteMessage.Data.TargetHash, "voteMessageHash", voteMessage.Hash())
 				voteManager.pool.PutVote(voteMessage)
-				votesManagerMetric(vote.TargetNumber, vote.TargetHash).Inc(1)
+				votesManagerCount.Inc(1)
 			}
 		case <-voteManager.chainHeadSub.Err():
 			log.Debug("voteManager subscribed chainHead failed")
@@ -216,9 +218,4 @@ func (voteManager *VoteManager) UnderRules(header *types.Header) (bool, uint64, 
 	// Since the header subscribed to is the canonical chain, so this rule is satisified by default.
 	log.Debug("All three rules check passed")
 	return true, sourceNumber, sourceHash
-}
-
-// Metrics to monitor if voteManager worked in the expetected logic.
-func votesManagerMetric(blockNumber uint64, blockHash common.Hash) metrics.Gauge {
-	return metrics.GetOrRegisterGauge(fmt.Sprintf("voteManager/blockNumber/%d/blockHash/%s", blockNumber, blockHash), nil)
 }

--- a/core/vote/vote_pool.go
+++ b/core/vote/vote_pool.go
@@ -29,8 +29,8 @@ const (
 )
 
 var (
-	localCurVotesGauge    = metrics.NewRegisteredGauge("curVotes/local", nil)
-	localFutureVotesGauge = metrics.NewRegisteredGauge("futureVotes/local", nil)
+	localCurVotesCounter    = metrics.NewRegisteredCounter("curVotes/local", nil)
+	localFutureVotesCounter = metrics.NewRegisteredCounter("futureVotes/local", nil)
 
 	localReceivedVotesGauge = metrics.NewRegisteredGauge("receivedVotes/local", nil)
 
@@ -203,9 +203,9 @@ func (pool *VotePool) putVote(m map[common.Hash]*VoteBox, votesPq *votesPriority
 	log.Debug("VoteHash put into votepool is:", "voteHash", voteHash)
 
 	if isFutureVote {
-		localFutureVotesGauge.Inc(1)
+		localFutureVotesCounter.Inc(1)
 	} else {
-		localCurVotesGauge.Inc(1)
+		localCurVotesCounter.Inc(1)
 	}
 	localReceivedVotesGauge.Update(int64(pool.receivedVotes.Cardinality()))
 }
@@ -278,8 +278,8 @@ func (pool *VotePool) transfer(blockHash common.Hash) {
 
 	delete(futureVotes, blockHash)
 
-	localCurVotesGauge.Inc(int64(len(validVotes)))
-	localFutureVotesGauge.Dec(int64(len(voteBox.voteMessages)))
+	localCurVotesCounter.Inc(int64(len(validVotes)))
+	localFutureVotesCounter.Dec(int64(len(voteBox.voteMessages)))
 }
 
 // Prune old data of duplicationSet, curVotePq and curVotesMap.
@@ -304,7 +304,7 @@ func (pool *VotePool) prune(latestBlockNumber uint64) {
 			// Prune curVotes Map.
 			delete(curVotes, blockHash)
 
-			localCurVotesGauge.Dec(int64(len(voteMessages)))
+			localCurVotesCounter.Dec(int64(len(voteMessages)))
 			localReceivedVotesGauge.Update(int64(pool.receivedVotes.Cardinality()))
 		}
 	}

--- a/core/vote/vote_signer.go
+++ b/core/vote/vote_signer.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/validator/accounts/wallet"
 	"github.com/prysmaticlabs/prysm/v3/validator/keymanager"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
@@ -23,6 +22,8 @@ import (
 const (
 	voteSignerTimeout = time.Second * 5
 )
+
+var votesSigningError = metrics.NewRegisteredGauge("votesSigner/error", nil)
 
 type VoteSigner struct {
 	km     *keymanager.IKeymanager
@@ -102,9 +103,4 @@ func (signer *VoteSigner) SignVote(vote *types.VoteEnvelope) error {
 	copy(vote.VoteAddress[:], blsPubKey.Marshal()[:])
 	copy(vote.Signature[:], signature.Marshal()[:])
 	return nil
-}
-
-// Metrics to indicate if there's any failed signing.
-func votesSigningErrorMetric(blockNumber uint64, blockHash common.Hash) metrics.Gauge {
-	return metrics.GetOrRegisterGauge(fmt.Sprintf("voteSigning/blockNumber/%d/blockHash/%s", blockNumber, blockHash), nil)
 }

--- a/core/vote/vote_signer.go
+++ b/core/vote/vote_signer.go
@@ -23,7 +23,7 @@ const (
 	voteSignerTimeout = time.Second * 5
 )
 
-var votesSigningError = metrics.NewRegisteredGauge("votesSigner/error", nil)
+var votesSigningErrorCounter = metrics.NewRegisteredCounter("votesSigner/error", nil)
 
 type VoteSigner struct {
 	km     *keymanager.IKeymanager


### PR DESCRIPTION
### Description

1. dynamic metrics labels make metrics too large to display
    votesManagerMetric --> votesManagerCount
    votesSigningErrorMetric-->votesSigningError and log.Error
2. unify error metrics about fast finality
   verifyVoteAttestationFailedGauge--> verifyVoteAttestationError
   updateAttestationFailedGauge--> updateAttestationError
   "voteJournal/local"-->"voteJournal/error"
3. NewRegisteredCounter instead of NewRegisteredGauge

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
