### PR TITLE
fix: output an error log when bsc extension fail to handshake

### DIFF
--- a/eth/handler_bsc.go
+++ b/eth/handler_bsc.go
@@ -27,6 +27,7 @@ func (h *bscHandler) RunPeer(peer *bsc.Peer, hand bsc.Handler) error {
 		ps.lock.Lock()
 		if wait, ok := ps.bscWait[id]; ok {
 			delete(ps.bscWait, id)
+			peer.Log().Error("Bsc extension Handshake failed", "err", err)
 			wait <- nil
 		}
 		ps.lock.Unlock()


### PR DESCRIPTION
### Description

for now,
p2p protocol run as normally even when bsc extension failed to handshake.
even if we don't drop p2p connect with nill bsc extension,
an error log should be output, to provide info for  analysing by node runner

### Rationale


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
