### PR TITLE
metrics: add a counter for validator to check work status of voting

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -78,6 +78,7 @@ var (
 	maxSystemBalance                  = new(big.Int).Mul(big.NewInt(100), big.NewInt(params.Ether))
 	verifyVoteAttestationErrorCounter = metrics.NewRegisteredCounter("parlia/verifyVoteAttestation/error", nil)
 	updateAttestationErrorCounter     = metrics.NewRegisteredCounter("parlia/updateAttestation/error", nil)
+	validVotesfromSelfCounter         = metrics.NewRegisteredCounter("parlia/VerifyVote/self", nil)
 
 	systemContracts = map[common.Address]bool{
 		common.HexToAddress(systemcontracts.ValidatorContract):          true,
@@ -1216,8 +1217,11 @@ func (p *Parlia) VerifyVote(chain consensus.ChainHeaderReader, vote *types.VoteE
 
 	validators := snap.Validators
 	voteAddress := vote.VoteAddress
-	for _, validator := range validators {
+	for addr, validator := range validators {
 		if validator.VoteAddress == voteAddress {
+			if addr == p.val {
+				validVotesfromSelfCounter.Inc(1)
+			}
 			return nil
 		}
 	}


### PR DESCRIPTION
### Description

it's from a FQA 'for validators, How To Check If Vote Works?'
here add a counter to check it easily.

### Rationale
1.add log at debug level is not good, it's will force validators to set log level to debug, which will lead to log spam,
  so add a metric is a better way.
2. votesManagerCounter is not  accurate
  because, after validator set up vote key locally, votesManagerCounter will increase,
  even before using bsc-edit-validtor to add vote key
3. when VerifyVote == true, it shows that
  a. vote key is set right locally and vote has passed bls signature verification by func basicVerify
  b. can get vote key from snapshot, so vote key is properly added by using  bsc-edit-validtor
  c. bsc p2p is enabled by default
  so we can add a counter in VerifyVote to detect whether Voting Works right

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
