### PR TITLE
fix: fix snap flaky tests

### DIFF
--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -404,13 +404,15 @@ func ServiceGetStorageRangesQuery(chain *core.BlockChain, req *GetStorageRangesP
 				break
 			}
 		}
-		slots = append(slots, storage)
+		if len(storage) > 0 {
+			slots = append(slots, storage)
+		}
 		it.Release()
 
 		// Generate the Merkle proofs for the first and last storage slot, but
 		// only if the response was capped. If the entire storage trie included
 		// in the response, no need for any proofs.
-		if origin != (common.Hash{}) || abort {
+		if origin != (common.Hash{}) || (abort && len(storage) > 0) {
 			// Request started at a non-zero hash or was capped prematurely, add
 			// the endpoint Merkle proofs
 			accTrie, err := trie.New(req.Root, chain.StateCache().TrieDB())

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -334,13 +334,14 @@ func createStorageRequestResponse(t *testPeer, root common.Hash, accounts []comm
 				break
 			}
 		}
-		hashes = append(hashes, keys)
-		slots = append(slots, vals)
-
+		if len(keys) > 0 {
+			hashes = append(hashes, keys)
+			slots = append(slots, vals)
+		}
 		// Generate the Merkle proofs for the first and last storage slot, but
 		// only if the response was capped. If the entire storage trie included
 		// in the response, no need for any proofs.
-		if originHash != (common.Hash{}) || abort {
+		if originHash != (common.Hash{}) || (abort && len(keys) > 0) {
 			// If we're aborting, we need to prove the first and last item
 			// This terminates the response (and thus the loop)
 			proof := light.NewNodeSet()


### PR DESCRIPTION
### Description
These tests fail randomly, including `TestMultiSyncManyUselessWithLowTimeout`, and `TestMultiSyncManyUnresponsive` in `eth/protocols/snap`.

you could reproduce it by following:

```bash
seq 1 20 | parallel go test -count=10 ./eth/protocols/snap -run "TestMultiSyncManyUselessWithLowTimeout" -failfast
```

Because of append empty slot to results, cause err "Remote side rejected our delivery: more entries available".

### Changes

Notable changes: 
* eth/protocols/snap: fix flaky test, don't include empty snapshot slot slice;
