### PR TITLE
jsre: add new block types

### DIFF
--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -3696,7 +3696,7 @@ var outputBigNumberFormatter = function (number) {
 };
 
 var isPredefinedBlockNumber = function (blockNumber) {
-    return blockNumber === 'latest' || blockNumber === 'pending' || blockNumber === 'earliest';
+    return blockNumber === 'latest' || blockNumber === 'pending' || blockNumber === 'earliest' || blockNumber === 'safe' || blockNumber === 'finalized';
 };
 
 var inputDefaultBlockNumberFormatter = function (blockNumber) {


### PR DESCRIPTION
### Description

As we introduced new RPC block types recently with FF https://github.com/bnb-chain/bsc/blob/develop/rpc/types.go#L63
```
	SafeBlockNumber      = BlockNumber(-4)
	FinalizedBlockNumber = BlockNumber(-3)
```
we need to add support to JS console too

### Rationale

Resolves https://github.com/bnb-chain/bsc/issues/1605

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
