### PR TITLE
upgrade: avoid to modify RialtoGenesisHash and restart when testing in rialtoNet

### DIFF
--- a/core/systemcontracts/upgrade.go
+++ b/core/systemcontracts/upgrade.go
@@ -55,6 +55,8 @@ var (
 	lubanUpgrade = make(map[string]*Upgrade)
 
 	platoUpgrade = make(map[string]*Upgrade)
+
+	latestUpgrade = platoUpgrade
 )
 
 func init() {
@@ -695,6 +697,8 @@ func init() {
 			},
 		},
 	}
+
+	latestUpgrade[defaultNet] = latestUpgrade[rialtoNet]
 }
 
 func UpgradeBuildInSystemContract(config *params.ChainConfig, blockNumber *big.Int, statedb *state.StateDB) {


### PR DESCRIPTION
### Description

we need restart bsc after modifying RialtoGenesisHash if there is a code upgrade in test network for QA

### Rationale

add latestUpgrade and let it point to latest code upgrade

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
