### PR TITLE
release: draft release v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
-## v1.2.2
+## v1.2.4
+FEATURE
+* [\#1636](https://github.com/bnb-chain/bsc/pull/1636) upgrade: block height of Luban on mainnet
+
+## v1.2.3
 FEATURE
 * [\#1574](https://github.com/bnb-chain/bsc/pull/1574) upgrade: update PlatoUpgrade contracts code
 * [\#1594](https://github.com/bnb-chain/bsc/pull/1594) upgrade: block height of Plato on testnet
@@ -18,6 +22,9 @@ BUGFIX
 * [\#1572](https://github.com/bnb-chain/bsc/pull/1572) fix: remove dynamic metric labels about fast finality
 * [\#1575](https://github.com/bnb-chain/bsc/pull/1575) fix: make BLST PORTABLE for release binary
 * [\#1590](https://github.com/bnb-chain/bsc/pull/1590) fix: fix snap flaky tests
+
+## v1.2.2
+It was skipped by a mistake, replaced by v1.2.3
 
 ## v1.2.1
 IMPROVEMENT

--- a/params/config.go
+++ b/params/config.go
@@ -192,7 +192,7 @@ var (
 
 		// TODO modify blockNumber, make sure the blockNumber is not an integer multiple of 200 (epoch number)
 		// TODO Caution !!! it should be very careful !!!
-		LubanBlock: nil,
+		LubanBlock: big.NewInt(29020050),
 		PlatoBlock: nil,
 
 		Parlia: &ParliaConfig{

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 2  // Minor version component of the current release
-	VersionPatch = 2  // Patch version component of the current release
+	VersionPatch = 4  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
v1.2.4 is a hard-fork release for BSC mainnet.

The mainnet is expected to have a scheduled hardfork upgrade named `Luban` at block height 29,020,050. The current block generation speed forecasts this to occur around 12th Jun 2023. 

The `Luban` hardfork includes 3 BEPs:
[BEP-126: Introduce Fast Finality Mechanism 6(The 1st Part)](https://github.com/bnb-chain/BEPs/blob/master/BEP126.md)
[BEP-174: Cross Chain Relayer Management 5](https://github.com/bnb-chain/BEPs/blob/master/BEP174.md)
[BEP-221: CometBFT Light Block Validation](https://github.com/bnb-chain/BEPs/pull/221)

The validators and full node operators on mainnet  should switch their software version to [v1.2.4](https://github.com/bnb-chain/bsc/releases/tag/v1.2.4) before 12th Jun 2023.

### Rationale
FEATURE
https://github.com/bnb-chain/bsc/pull/1636: upgrade: block height of Luban on mainnet

### Example
None
