### PR TITLE
Enable log rotation based on time constraints

### DIFF
--- a/log/async_file_writer_test.go
+++ b/log/async_file_writer_test.go
@@ -1,14 +1,19 @@
 package log
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWriter(t *testing.T) {
-	w := NewAsyncFileWriter("./hello.log", 100)
+	w := NewAsyncFileWriter("./hello.log", 100, nil)
 	w.Start()
 	w.Write([]byte("hello\n"))
 	w.Write([]byte("world\n"))
@@ -16,11 +21,47 @@ func TestWriter(t *testing.T) {
 	files, _ := ioutil.ReadDir("./")
 	for _, f := range files {
 		fn := f.Name()
+		fmt.Println(fn)
 		if strings.HasPrefix(fn, "hello") {
 			t.Log(fn)
 			content, _ := ioutil.ReadFile(fn)
 			t.Log(content)
 			os.Remove(fn)
+		}
+	}
+}
+
+func TestWriterNames(t *testing.T) {
+	interval := 2 * time.Second
+	w := NewAsyncFileWriter("./hello.log", 1000, &interval)
+	w.Start()
+	w.Write([]byte("hello\n"))
+	// time.Sleep(3 * time.Second)
+	w.Write([]byte("cruel\n"))
+	// time.Sleep(3 * time.Second)
+	w.Write([]byte("world\n"))
+	w.Stop()
+	files, _ := ioutil.ReadDir("./")
+	logCounter := 0
+	for _, f := range files {
+		fn := f.Name()
+		if strings.HasPrefix(fn, "hello") {
+			if logCounter == 0 {
+				logCounter++
+				continue
+			}
+
+			t.Log(fn)
+			fmt.Println(logCounter, " ", fn)
+			secs, _ := strconv.Atoi(fn[len(fn)-2:])
+			fmt.Println(secs)
+			if logCounter >= 2 {
+				assert.Equal(t, secs%2, 0, "Must be divisible by 2")
+			}
+			content, _ := ioutil.ReadFile(fn)
+			t.Log(content)
+			os.Remove(fn)
+			logCounter++
 		}
 	}
 }

--- a/log/handler.go
+++ b/log/handler.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/go-stack/stack"
 )
@@ -74,14 +75,14 @@ func FileHandler(path string, fmtr Format) (Handler, error) {
 // RotatingFileHandler returns a handler which writes log records to file chunks
 // at the given path. When a file's size reaches the limit, the handler creates
 // a new file named after the timestamp of the first log record it will contain.
-func RotatingFileHandler(filePath string, limit uint, formatter Format) (Handler, error) {
+func RotatingFileHandler(filePath string, limit uint, formatter Format, duration *time.Duration) (Handler, error) {
 	if _, err := os.Stat(path.Dir(filePath)); os.IsNotExist(err) {
 		err := os.MkdirAll(path.Dir(filePath), 0755)
 		if err != nil {
 			return nil, fmt.Errorf("could not create directory %s, %v", path.Dir(filePath), err)
 		}
 	}
-	fileWriter := NewAsyncFileWriter(filePath, int64(limit))
+	fileWriter := NewAsyncFileWriter(filePath, int64(limit), duration)
 	fileWriter.Start()
 	return StreamHandler(fileWriter, formatter), nil
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -244,11 +244,12 @@ func (c Ctx) toArray() []interface{} {
 	return arr
 }
 
-func NewFileLvlHandler(logPath string, maxBytesSize uint, level string) Handler {
+func NewFileLvlHandler(logPath string, maxBytesSize uint, level string, duration *time.Duration) Handler {
 	rfh, err := RotatingFileHandler(
 		logPath,
 		maxBytesSize,
 		LogfmtFormat(),
+		duration,
 	)
 	if err != nil {
 		panic(err)

--- a/node/config.go
+++ b/node/config.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -525,4 +526,6 @@ type LogConfig struct {
 	TermTimeFormat *string `toml:",omitempty"`
 	// TimeFormat is the time format used for file logging.
 	TimeFormat *string `toml:",omitempty"`
+
+	Duration *time.Duration `toml:",omitempty"`
 }

--- a/node/node.go
+++ b/node/node.go
@@ -103,7 +103,15 @@ func New(conf *Config) (*Node, error) {
 			} else {
 				logFilePath = path.Join(*conf.LogConfig.FileRoot, *conf.LogConfig.FilePath)
 			}
-			log.Root().SetHandler(log.NewFileLvlHandler(logFilePath, *conf.LogConfig.MaxBytesSize, *conf.LogConfig.Level))
+
+			log.Root().SetHandler(
+				log.NewFileLvlHandler(
+					logFilePath,
+					*conf.LogConfig.MaxBytesSize,
+					*conf.LogConfig.Level,
+					conf.LogConfig.Duration,
+				),
+			)
 		}
 	}
 	if conf.Logger == nil {

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -461,6 +461,11 @@ func startExecNodeStack() (*node.Node, error) {
 		return nil, fmt.Errorf("error decoding %s: %v", envNodeConfig, err)
 	}
 
+	// Validate the config
+	if conf.Stack.LogConfig.Duration != nil && conf.Stack.LogConfig.Duration.Seconds() < minSecsLogRotation {
+		return nil, fmt.Errorf("error configuring logging: Minimal rotation interval is %d seconds", minSecsLogRotation)
+	}
+
 	// create enode record
 	nodeTcpConn, _ := net.ResolveTCPAddr("tcp", conf.Stack.P2P.ListenAddr)
 	if nodeTcpConn.IP == nil {
@@ -512,8 +517,9 @@ func startExecNodeStack() (*node.Node, error) {
 }
 
 const (
-	envStatusURL  = "_P2P_STATUS_URL"
-	envNodeConfig = "_P2P_NODE_CONFIG"
+	envStatusURL       = "_P2P_STATUS_URL"
+	envNodeConfig      = "_P2P_NODE_CONFIG"
+	minSecsLogRotation = 5
 )
 
 // nodeStartupJSON is sent to the simulation host after startup.


### PR DESCRIPTION
### Description

Enable log rotation based on time constraints.

### Rationale

Currently, logs are rotated by hour, sometimes it is useful to specify different time interval.
