### PR TITLE
fix: support getFilterChanges after NewFinalizedHeaderFilter

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -551,7 +551,7 @@ func (api *PublicFilterAPI) GetFilterChanges(id rpc.ID) (interface{}, error) {
 		f.deadline.Reset(api.timeout)
 
 		switch f.typ {
-		case PendingTransactionsSubscription, BlocksSubscription, VotesSubscription:
+		case PendingTransactionsSubscription, BlocksSubscription, FinalizedHeadersSubscription, VotesSubscription:
 			hashes := f.hashes
 			f.hashes = nil
 			return returnHashes(hashes), nil


### PR DESCRIPTION
### Description

 support getFilterChanges after NewFinalizedHeaderFilter

### Rationale
1.firstly, create a FinalizedHeaderFilter
curl -X POST "http://localhost:8545" -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"eth_newFinalizedHeaderFilter","params":[],"id":1}' 
2. then, etFilterChanges 
curl -X POST "http://localhost:8545" -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"eth_getFilterChanges","params":["0x7bb75c9bda98cb09c9e5eb912f241929"],"id":1}'
but got `filter not found`

this PR is to fix this.

### Example
<img width="848" alt="image" src="https://github.com/bnb-chain/bsc/assets/122502194/14d70ac7-1082-4df6-a143-ae10303fce89">

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
