### PR TITLE
readme: update the disk requirement to 2.5TB

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ on how you can run your own `geth` instance.
 
 The hardware must meet certain requirements to run a full node on mainnet:
 - VPS running recent versions of Mac OS X, Linux, or Windows.
-- IMPORTANT 2 TB of free disk space, solid-state drive(SSD), gp3, 8k IOPS, 250 MB/S throughput, read latency <1ms. (if node is started with snap sync, it will need NVMe SSD)
+- IMPORTANT 2.5 TB(May 2023) of free disk space, solid-state drive(SSD), gp3, 8k IOPS, 250 MB/S throughput, read latency <1ms. (if node is started with snap sync, it will need NVMe SSD)
 - 16 cores of CPU and 64 GB of memory (RAM)
 - Suggest m5zn.3xlarge instance type on AWS, c2-standard-16 on Google cloud.
 - A broadband Internet connection with upload/download speeds of 5 MB/S


### PR DESCRIPTION

### Description
Tried with this command:
  ./geth --tries-verify-mode none --config ./config.toml --datadir ./node  --cache 8000
Sync to block: 28459251(May 23 2023), it takes ~2.1TB

### Rationale
NA

### Example
NA

### Changes
NA