### PR TITLE
Allow validator node to use bloXroute MEV services

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -144,6 +144,8 @@ var (
 		utils.MinerRecommitIntervalFlag,
 		utils.MinerNoVerfiyFlag,
 		utils.MinerDelayLeftoverFlag,
+		utils.MinerMEVRelaysFlag,
+		utils.MinerMEVProposedBlockUriFlag,
 		utils.NATFlag,
 		utils.NoDiscoverFlag,
 		utils.DiscoveryV5Flag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -198,6 +198,8 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.MinerExtraDataFlag,
 			utils.MinerRecommitIntervalFlag,
 			utils.MinerDelayLeftoverFlag,
+			utils.MinerMEVRelaysFlag,
+			utils.MinerMEVProposedBlockUriFlag,
 			utils.MinerNoVerfiyFlag,
 			utils.VotingEnabledFlag,
 		},

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -408,3 +408,7 @@ func (b *EthAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, *state.StateDB, error) {
 	return b.eth.stateAtTransaction(block, txIndex, reexec)
 }
+
+func (b *EthAPIBackend) ProposedBlock(ctx context.Context, blockNumber *big.Int, prevBlockHash common.Hash, reward *big.Int, gasLimit uint64, gasUsed uint64, txs types.Transactions) error {
+	return b.eth.miner.ProposedBlock(blockNumber, prevBlockHash, reward, gasLimit, gasUsed, txs)
+}

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -85,6 +85,7 @@ type Backend interface {
 	TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
 	TxPoolContentFrom(addr common.Address) (types.Transactions, types.Transactions)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
+	ProposedBlock(ctx context.Context, blockNumber *big.Int, prevBlockHash common.Hash, reward *big.Int, gasLimit uint64, gasUsed uint64, txs types.Transactions) error
 
 	// Filter API
 	BloomStatus() (uint64, uint64)

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -569,6 +569,11 @@ web3._extend({
 			call: 'eth_getLogs',
 			params: 1,
 		}),
+		new.web3._extend.Method({
+			name: 'proposedBlock',
+			call: 'eth_proposedBlock',
+			params: 1
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -345,3 +345,7 @@ func (b *LesApiBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 func (b *LesApiBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, *state.StateDB, error) {
 	return b.eth.stateAtTransaction(ctx, block, txIndex, reexec)
 }
+
+func (b *LesApiBackend) ProposedBlock(ctx context.Context, blockNumber *big.Int, prevBlockHash common.Hash, reward *big.Int, gasLimit uint64, gasUsed uint64, txs types.Transactions) error {
+	return nil
+}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -23,6 +23,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/internal/ethapi"
+	"github.com/ethereum/go-ethereum/rpc"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -55,6 +58,10 @@ type Config struct {
 	Recommit      time.Duration  // The time interval for miner to re-create mining work.
 	Noverify      bool           // Disable remote mining solution verification(only useful in ethash).
 	VoteEnable    bool           // whether enable voting
+
+	MEVRelays                   map[string]*rpc.Client // RPC clients to register validator each epoch
+	ProposedBlockUri            string                 // received eth_proposedBlocks on that uri
+	RegisterValidatorSignedHash []byte                 // signed value of crypto.Keccak256([]byte(ProposedBlockUri))
 }
 
 // Miner creates blocks and searches for proof-of-work values.
@@ -69,6 +76,10 @@ type Miner struct {
 	stopCh   chan struct{}
 
 	wg sync.WaitGroup
+
+	mevRelays              map[string]*rpc.Client
+	proposedBlockUri       string
+	signedProposedBlockUri []byte
 }
 
 func New(eth Backend, config *Config, chainConfig *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, isLocalBlock func(header *types.Header) bool) *Miner {
@@ -80,6 +91,10 @@ func New(eth Backend, config *Config, chainConfig *params.ChainConfig, mux *even
 		startCh: make(chan common.Address),
 		stopCh:  make(chan struct{}),
 		worker:  newWorker(config, chainConfig, engine, eth, mux, isLocalBlock, false),
+
+		mevRelays:              config.MEVRelays,
+		proposedBlockUri:       config.ProposedBlockUri,
+		signedProposedBlockUri: config.RegisterValidatorSignedHash,
 	}
 	miner.wg.Add(1)
 	go miner.update()
@@ -100,9 +115,18 @@ func (miner *Miner) update() {
 		}
 	}()
 
+	chainBlockCh := make(chan core.ChainHeadEvent, chainHeadChanSize)
+
+	chainBlockSub := miner.eth.BlockChain().SubscribeChainBlockEvent(chainBlockCh)
+	defer chainBlockSub.Unsubscribe()
+
 	shouldStart := false
 	canStart := true
 	dlEventCh := events.Chan()
+
+	// miner started at the middle of an epoch, we want to register it
+	miner.registerValidator()
+
 	for {
 		select {
 		case ev := <-dlEventCh:
@@ -142,11 +166,18 @@ func (miner *Miner) update() {
 				miner.worker.start()
 			}
 			shouldStart = true
+
+		case block := <-chainBlockCh:
+			if block.Block.NumberU64()%miner.eth.BlockChain().Config().Parlia.Epoch == 0 {
+				miner.registerValidator()
+			}
 		case <-miner.stopCh:
 			shouldStart = false
 			miner.worker.stop()
 		case <-miner.exitCh:
 			miner.worker.close()
+			return
+		case <-chainBlockSub.Err():
 			return
 		}
 	}
@@ -251,4 +282,50 @@ func (miner *Miner) GetSealingBlock(parent common.Hash, timestamp uint64, coinba
 // to the given channel.
 func (miner *Miner) SubscribePendingLogs(ch chan<- []*types.Log) event.Subscription {
 	return miner.worker.pendingLogsFeed.Subscribe(ch)
+}
+
+// ProposedBlock add the block to the list of works
+func (miner *Miner) ProposedBlock(blockNumber *big.Int, prevBlockHash common.Hash, reward *big.Int, gasLimit uint64, gasUsed uint64, txs types.Transactions) error {
+	log.Info("Received ProposedBlock", "number", blockNumber, "prevHash", prevBlockHash.Hex(), "potential reward", reward, "gasLimit", gasLimit, "gasUsed", gasUsed, "txcount", len(txs))
+
+	if gasLimit > miner.worker.current.header.GasLimit {
+		log.Debug("Skipping the block as gas limit exceeds the current block gas limit", "number", blockNumber.Int64(), "proposedBlockGasLimit", gasLimit, "currentGasLimit", miner.worker.current.header.GasLimit, "chainCurrentBlock", miner.worker.current.header.Number.Int64())
+		return fmt.Errorf("gasLimit exceeds the current block gas limit")
+	}
+
+	if gasUsed > miner.worker.current.header.GasLimit {
+		log.Debug("Skipping the block as gas used exceeds the current block gas limit", "number", blockNumber.Int64(), "proposedBlockGasUsed", gasUsed, "currentGasLimit", miner.worker.current.header.GasLimit, "chainCurrentBlock", miner.worker.current.header.Number.Int64())
+		return fmt.Errorf("gasUsed exceeds the current block gas limit")
+	}
+	miner.worker.proposedCh <- &ProposedBlockArgs{
+		blockNumber:   blockNumber,
+		prevBlockHash: prevBlockHash,
+		blockReward:   reward,
+		gasLimit:      gasLimit,
+		gasUsed:       gasUsed,
+		txs:           txs,
+	}
+	return nil
+}
+
+func (miner *Miner) registerValidator() {
+	log.Info("register validator to MEV relays")
+	registerValidatorArgs := &ethapi.RegisterValidatorArgs{
+		Data:      []byte(miner.proposedBlockUri),
+		Signature: miner.signedProposedBlockUri,
+	}
+	for dest, destClient := range miner.mevRelays {
+		go func(dest string, destinationClient *rpc.Client, registerValidatorArgs *ethapi.RegisterValidatorArgs) {
+			var result any
+
+			if err := destinationClient.Call(
+				&result, "eth_registerValidator", registerValidatorArgs,
+			); err != nil {
+				log.Warn("Failed to register validator to MEV relay ", "dest", dest, "err", err)
+				return
+			}
+
+			log.Debug("register validator to MEV relay", "dest", dest, "result", result)
+		}(dest, destClient, registerValidatorArgs)
+	}
 }


### PR DESCRIPTION
### Description

This PR allows a validator node to utilize bloXroute MEV. The validator node

registers itself to MEV relay upon restart or an epoch change
processes eth_proposedBlock from bloXroute MEV relays

### Rationale

The introduction of mev-boost in Ethereum enabled a win-win situation for Searchers, Block builders and Proposers which allows all three to profit off of potential arbitrage opportunities, and do so not at the expense of other traders and dApps executing transactions on chain.

This PR implements the validator to MEV relay integration

### Example

eth_proposedBlock endpoint receives

```
{
   "id": "1",
   "method": "eth_proposedBlock",
   "params": [{
      "blockNumber": "0xba10d0",
      "prevBlockHash": "0xabc123...555",
      "blockReward": 1230000000000000,
      "gasLimit": 140000000,
      "gasUsed": 70000000,
      "payload": ["ab..ab", "cd..cd"],
   }]
}

```
### Changes

Notable changes: 
* Added couple of startup argument
  * miner.mevrelays - list of uris of MEV relays the validator works with
  *miner.mevproposedblockuri - the callback uri which the MEV relay should send the proposed blocks
* Added web3 endpoint eth_proposedBlock - the MEV relays use this endpoint to send their proposed blocks
* Added a logic in the miner to validate the proposed blocks from the MEV relays and consider them when the validator choose which block it should propose