### PR TITLE
fix: use probabilistic finality instead of naturally finality

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1719,10 +1719,10 @@ func (p *Parlia) GetJustifiedNumberAndHash(chain consensus.ChainHeaderReader, he
 }
 
 // GetFinalizedHeader returns highest finalized block header.
-// It will find vote finalized block within NaturallyFinalizedDist blocks firstly,
-// If the vote finalized block not found, return its naturally finalized block.
+// It will find vote finalized block within ProbabilisticFinalizedDist blocks firstly,
+// If the vote finalized block not found, return its probabilistic finalized block.
 func (p *Parlia) GetFinalizedHeader(chain consensus.ChainHeaderReader, header *types.Header) *types.Header {
-	backward := uint64(types.NaturallyFinalizedDist)
+	backward := uint64(types.ProbabilisticFinalizedDist)
 	if chain == nil || header == nil {
 		return nil
 	}

--- a/core/types/vote.go
+++ b/core/types/vote.go
@@ -13,8 +13,8 @@ const (
 	BLSPublicKeyLength = 48
 	BLSSignatureLength = 96
 
-	MaxAttestationExtraLength = 256
-	NaturallyFinalizedDist    = 21 // The distance to naturally finalized a block
+	MaxAttestationExtraLength  = 256
+	ProbabilisticFinalizedDist = 15 // The distance to probabilistic finalized a block
 )
 
 type BLSPublicKey [BLSPublicKeyLength]byte


### PR DESCRIPTION
### Description

 use probabilistic finality instead of naturally finality

### Rationale
Simplify the concepts, 3 to 2:
before:
    vote finality
    probabilistic finality
    naturally finality
now:
    vote finality
    probabilistic finality

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
