### PR TITLE
fix: remove naturally finality

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1719,18 +1719,12 @@ func (p *Parlia) GetJustifiedNumberAndHash(chain consensus.ChainHeaderReader, he
 }
 
 // GetFinalizedHeader returns highest finalized block header.
-// It will find vote finalized block within NaturallyFinalizedDist blocks firstly,
-// If the vote finalized block not found, return its naturally finalized block.
 func (p *Parlia) GetFinalizedHeader(chain consensus.ChainHeaderReader, header *types.Header) *types.Header {
-	backward := uint64(types.NaturallyFinalizedDist)
 	if chain == nil || header == nil {
 		return nil
 	}
 	if !chain.Config().IsPlato(header.Number) {
 		return chain.GetHeaderByNumber(0)
-	}
-	if header.Number.Uint64() < backward {
-		backward = header.Number.Uint64()
 	}
 
 	snap, err := p.snapshot(chain, header.Number.Uint64(), header.Hash(), nil)
@@ -1740,20 +1734,10 @@ func (p *Parlia) GetFinalizedHeader(chain consensus.ChainHeaderReader, header *t
 		return nil
 	}
 
-	for snap.Attestation != nil && snap.Attestation.SourceNumber >= header.Number.Uint64()-backward {
-		if snap.Attestation.TargetNumber == snap.Attestation.SourceNumber+1 {
-			return chain.GetHeaderByHash(snap.Attestation.SourceHash)
-		}
-
-		snap, err = p.snapshot(chain, snap.Attestation.SourceNumber, snap.Attestation.SourceHash, nil)
-		if err != nil {
-			log.Error("Unexpected error when getting snapshot",
-				"error", err, "blockNumber", snap.Attestation.SourceNumber, "blockHash", snap.Attestation.SourceHash)
-			return nil
-		}
+	if snap.Attestation != nil {
+		return chain.GetHeader(snap.Attestation.SourceHash, snap.Attestation.SourceNumber)
 	}
-
-	return FindAncientHeader(header, backward, chain, nil)
+	return nil
 }
 
 // ===========================     utility function        ==========================

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -46,7 +46,7 @@ type Snapshot struct {
 	Validators       map[common.Address]*ValidatorInfo `json:"validators"`            // Set of authorized validators at this moment
 	Recents          map[uint64]common.Address         `json:"recents"`               // Set of recent validators for spam protections
 	RecentForkHashes map[uint64]string                 `json:"recent_fork_hashes"`    // Set of recent forkHash
-	Attestation      *types.VoteData                   `json:"attestation:omitempty"` // Attestation for fast finality
+	Attestation      *types.VoteData                   `json:"attestation:omitempty"` // Attestation for fast finality, but `Source` used as `Finalized`
 }
 
 type ValidatorInfo struct {
@@ -199,11 +199,11 @@ func (s *Snapshot) updateAttestation(header *types.Header, chainConfig *params.C
 	}
 
 	// Update attestation
-	s.Attestation = &types.VoteData{
-		SourceNumber: attestation.Data.SourceNumber,
-		SourceHash:   attestation.Data.SourceHash,
-		TargetNumber: attestation.Data.TargetNumber,
-		TargetHash:   attestation.Data.TargetHash,
+	if s.Attestation != nil && attestation.Data.SourceNumber+1 != attestation.Data.TargetNumber {
+		s.Attestation.TargetNumber = attestation.Data.TargetNumber
+		s.Attestation.TargetHash = attestation.Data.TargetHash
+	} else {
+		s.Attestation = attestation.Data
 	}
 }
 

--- a/core/types/vote.go
+++ b/core/types/vote.go
@@ -14,7 +14,6 @@ const (
 	BLSSignatureLength = 96
 
 	MaxAttestationExtraLength = 256
-	NaturallyFinalizedDist    = 21 // The distance to naturally finalized a block
 )
 
 type BLSPublicKey [BLSPublicKeyLength]byte


### PR DESCRIPTION
### Description

remove naturally finality

### Rationale
naturally finality is alias of probabilistic finality in the code.
1. The probabilistic finality is only probabilistic. In extreme cases, it may be reverted without penalty, so it is not suitable to acknowledge it through the interface
2. Different application scenarios of probabilistic finality may choose different numbers of blocks. For example, 15 is recommended, while the main station uses 21 for deposits and withdrawals. but only a fixed number can be specified in the code
3. The Ethereum client will also degenerate to a probabilistic finality when the vote fails, but the number of blocks is not specified in the code; Bitcoin has probabilistic finality, and the number of blocks is not specified in the code

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
