### PR TITLE
consensus, core/rawdb, miner: downgrade logs

### DIFF
--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -256,7 +256,7 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 			return nil, err
 		}
 		if _, ok := snap.Validators[validator]; !ok {
-			return nil, errUnauthorizedValidator
+			return nil, errUnauthorizedValidator(validator.String())
 		}
 		for _, recent := range snap.Recents {
 			if recent == validator {

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -348,7 +348,7 @@ func unindexTransactions(db ethdb.Database, from uint64, to uint64, interrupt ch
 	case <-interrupt:
 		log.Debug("Transaction unindexing interrupted", "blocks", blocks, "txs", txs, "tail", to, "elapsed", common.PrettyDuration(time.Since(start)))
 	default:
-		log.Info("Unindexed transactions", "blocks", blocks, "txs", txs, "tail", to, "elapsed", common.PrettyDuration(time.Since(start)))
+		log.Debug("Unindexed transactions", "blocks", blocks, "txs", txs, "tail", to, "elapsed", common.PrettyDuration(time.Since(start)))
 	}
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -419,7 +419,7 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 			if p, ok := w.engine.(*parlia.Parlia); ok {
 				signedRecent, err := p.SignRecently(w.chain, head.Block)
 				if err != nil {
-					log.Info("Not allowed to propose block", "err", err)
+					log.Debug("Not allowed to propose block", "err", err)
 					continue
 				}
 				if signedRecent {


### PR DESCRIPTION
### Description

Some logs are not needed to be shown to an average user, so they can be downgraded from "info" to "debug".

Refer: #1650

### Rationale

It helps to improve the UX.

### Example

The following are the logs of a mock validator:
```
t=2023-05-31T02:21:16+0000 lvl=info msg="The validator is not authorized"       addr=0xB8f7166496996A7da21cF1f1b04d9B3E26a3d077
t=2023-05-31T02:21:17+0000 lvl=info msg="The validator is not authorized"       addr=0xB8f7166496996A7da21cF1f1b04d9B3E26a3d077
t=2023-05-31T02:21:17+0000 lvl=info msg="The validator is not authorized"       addr=0xB8f7166496996A7da21cF1f1b04d9B3E26a3d077
t=2023-05-31T02:21:17+0000 lvl=info msg="Commit new mining work"                number=28,679,795 sealhash=0xdbdd4f52de9f2a433d55defdd2a036effcab25f3439f5a93c69e89f1be134f06 uncles=0 txs=120  gas=9,680,235   elapsed=2.374s
t=2023-05-31T02:21:17+0000 lvl=warn msg="Block sealing failed"                  err="unauthorized validator"
t=2023-05-31T02:21:18+0000 lvl=info msg="Imported new chain segment"            blocks=1  txs=126  mgas=9.972   elapsed=34.832ms    mgasps=286.290  number=28,679,795 hash=0xc4f40a4d88e8125645730fb34bf48e0cd1e483ae5aafe3bf3caa4b6c22d98b88 dirty="964.06 MiB"
t=2023-05-31T02:21:18+0000 lvl=info msg="Not allowed to propose block"          err="unauthorized validator"
```

As shown, there are 3 different error messages but with the same indication that it's due to an unauthorized validator. Therefore, 1 error message is sufficient. 

### Changes
UX improvement, no other changes.