### PR TITLE
fix: voting can only be enabled when mining

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -905,7 +905,7 @@ var (
 
 	VotingEnabledFlag = cli.BoolFlag{
 		Name:  "vote",
-		Usage: "Enable voting",
+		Usage: "Enable voting when mining",
 	}
 
 	EnableMaliciousVoteMonitorFlag = cli.BoolFlag{

--- a/core/vote/vote_pool_test.go
+++ b/core/vote/vote_pool_test.go
@@ -68,6 +68,17 @@ type mockInvalidPOSA struct {
 	consensus.PoSA
 }
 
+// testBackend is a mock implementation of the live Ethereum message handler.
+type testBackend struct {
+	eventMux *event.TypeMux
+}
+
+func newTestBackend() *testBackend {
+	return &testBackend{eventMux: new(event.TypeMux)}
+}
+func (b *testBackend) IsMining() bool           { return true }
+func (b *testBackend) EventMux() *event.TypeMux { return b.eventMux }
+
 func (p *mockPOSA) GetJustifiedNumberAndHash(chain consensus.ChainHeaderReader, header *types.Header) (uint64, common.Hash, error) {
 	parentHeader := chain.GetHeaderByHash(header.ParentHash)
 	if parentHeader == nil {
@@ -167,7 +178,7 @@ func testVotePool(t *testing.T, isValidRules bool) {
 	file.Close()
 	os.Remove(journal)
 
-	voteManager, err := NewVoteManager(mux, params.TestChainConfig, chain, votePool, journal, walletPasswordDir, walletDir, mockEngine)
+	voteManager, err := NewVoteManager(newTestBackend(), params.TestChainConfig, chain, votePool, journal, walletPasswordDir, walletDir, mockEngine)
 	if err != nil {
 		t.Fatalf("failed to create vote managers")
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -249,31 +249,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	eth.txPool = core.NewTxPool(config.TxPool, chainConfig, eth.blockchain)
 
-	// Create voteManager instance
-	if posa, ok := eth.engine.(consensus.PoSA); ok {
-		// Create votePool instance
-		votePool := vote.NewVotePool(chainConfig, eth.blockchain, posa)
-		eth.votePool = votePool
-		if parlia, ok := eth.engine.(*parlia.Parlia); ok {
-			parlia.VotePool = votePool
-		} else {
-			return nil, fmt.Errorf("Engine is not Parlia type")
-		}
-		log.Info("Create votePool successfully")
-
-		if config.Miner.VoteEnable {
-			conf := stack.Config()
-			blsPasswordPath := stack.ResolvePath(conf.BLSPasswordFile)
-			blsWalletPath := stack.ResolvePath(conf.BLSWalletDir)
-			voteJournalPath := stack.ResolvePath(conf.VoteJournalDir)
-			if _, err := vote.NewVoteManager(eth.EventMux(), chainConfig, eth.blockchain, votePool, voteJournalPath, blsPasswordPath, blsWalletPath, posa); err != nil {
-				log.Error("Failed to Initialize voteManager", "err", err)
-				return nil, err
-			}
-			log.Info("Create voteManager successfully")
-		}
-	}
-
 	// Permit the downloader to use the trie cache allowance during fast sync
 	cacheLimit := cacheConfig.TrieCleanLimit + cacheConfig.TrieDirtyLimit + cacheConfig.SnapshotLimit
 	checkpoint := config.Checkpoint
@@ -299,16 +274,39 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}); err != nil {
 		return nil, err
 	}
-	if eth.votePool != nil {
-		eth.handler.votepool = eth.votePool
+
+	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
+	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
+
+	// Create voteManager instance
+	if posa, ok := eth.engine.(consensus.PoSA); ok {
+		// Create votePool instance
+		votePool := vote.NewVotePool(chainConfig, eth.blockchain, posa)
+		eth.votePool = votePool
+		if parlia, ok := eth.engine.(*parlia.Parlia); ok {
+			parlia.VotePool = votePool
+		} else {
+			return nil, fmt.Errorf("Engine is not Parlia type")
+		}
+		log.Info("Create votePool successfully")
+		eth.handler.votepool = votePool
 		if stack.Config().EnableMaliciousVoteMonitor {
 			eth.handler.maliciousVoteMonitor = monitor.NewMaliciousVoteMonitor()
 			log.Info("Create MaliciousVoteMonitor successfully")
 		}
-	}
 
-	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
-	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
+		if config.Miner.VoteEnable {
+			conf := stack.Config()
+			blsPasswordPath := stack.ResolvePath(conf.BLSPasswordFile)
+			blsWalletPath := stack.ResolvePath(conf.BLSWalletDir)
+			voteJournalPath := stack.ResolvePath(conf.VoteJournalDir)
+			if _, err := vote.NewVoteManager(eth, chainConfig, eth.blockchain, votePool, voteJournalPath, blsPasswordPath, blsWalletPath, posa); err != nil {
+				log.Error("Failed to Initialize voteManager", "err", err)
+				return nil, err
+			}
+			log.Info("Create voteManager successfully")
+		}
+	}
 
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -54,7 +54,7 @@ type Config struct {
 	GasPrice      *big.Int       // Minimum gas price for mining a transaction
 	Recommit      time.Duration  // The time interval for miner to re-create mining work.
 	Noverify      bool           // Disable remote mining solution verification(only useful in ethash).
-	VoteEnable    bool           // whether enable voting
+	VoteEnable    bool           // Whether to vote when mining
 }
 
 // Miner creates blocks and searches for proof-of-work values.


### PR DESCRIPTION
### Description

voting can only be enabled when mining

### Rationale

The node operator generally starts two nodes with the same consensus key. After having ff, the node will configure the same vote key.
After startup, use miner.stop() and miner.start() in geth console to switch out block nodes.
If the --vote option is used when both nodes are started, conflicting votes will be cast, which will be judged as malicious voting.

the solution is as following:
neither mining decide voting, nor they are independent
Instead, let mining be a prerequisite of voting

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
