### PR TITLE
fix: check integer overflow when decode cross-chain payload

### DIFF
--- a/core/vm/lightclient/v2/lightclient.go
+++ b/core/vm/lightclient/v2/lightclient.go
@@ -194,6 +194,11 @@ func DecodeLightBlockValidationInput(input []byte) (*ConsensusState, *types.Ligh
 	}
 
 	csLen := binary.BigEndian.Uint64(input[consensusStateLengthBytesLength-uint64TypeLength : consensusStateLengthBytesLength])
+
+	if consensusStateLengthBytesLength+csLen < consensusStateLengthBytesLength {
+		return nil, nil, fmt.Errorf("integer overflow, csLen: %d", csLen)
+	}
+
 	if uint64(len(input)) <= consensusStateLengthBytesLength+csLen {
 		return nil, nil, fmt.Errorf("expected payload size %d, actual size: %d", consensusStateLengthBytesLength+csLen, len(input))
 	}


### PR DESCRIPTION
### Description

This pr will check the integer overflow when decoding the cross-chain payload for light client check.

### Rationale

Check integer overflow.

### Example

N/A

### Changes

Notable changes: 
* check integer overflow when decode cross-chain payload
