### PR TITLE
fix: not double GasLimit of block upon London upgrade

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -173,11 +173,6 @@ func (b *BlockGen) AddUncle(h *types.Header) {
 	h.GasLimit = parent.GasLimit
 	if b.config.IsLondon(h.Number) {
 		h.BaseFee = misc.CalcBaseFee(b.config, parent)
-		h.BaseFee = misc.CalcBaseFee(b.config, parent)
-		if !b.config.IsLondon(parent.Number) {
-			parentGasLimit := parent.GasLimit * params.ElasticityMultiplier
-			h.GasLimit = CalcGasLimit(parentGasLimit, parentGasLimit)
-		}
 	}
 	b.uncles = append(b.uncles, h)
 }
@@ -310,10 +305,6 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.S
 	}
 	if chain.Config().IsLondon(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(chain.Config(), parent.Header())
-		if !chain.Config().IsLondon(parent.Number()) {
-			parentGasLimit := parent.GasLimit() * params.ElasticityMultiplier
-			header.GasLimit = CalcGasLimit(parentGasLimit, parentGasLimit)
-		}
 	}
 	return header
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -968,10 +968,6 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
 	if w.chainConfig.IsLondon(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
-		if !w.chainConfig.IsLondon(parent.Number()) {
-			parentGasLimit := parent.GasLimit() * params.ElasticityMultiplier
-			header.GasLimit = core.CalcGasLimit(parentGasLimit, w.config.GasCeil)
-		}
 	}
 	// Run the consensus preparation with the default or customized consensus engine.
 	if err := w.engine.Prepare(w.chain, header); err != nil {


### PR DESCRIPTION
### Description

chain will be blocked upon london upgrade, failed to verify gaslimit 

### Rationale
gas limit doubled  by following code
`                       parentGasLimit := parent.GasLimit() * params.ElasticityMultiplier
                       header.GasLimit = CalcGasLimit(parentGasLimit, parentGasLimit)
`
failed to verify gas limit in func verifyCascadingFields
`
	if uint64(diff) >= limit || header.GasLimit < params.MinGasLimit {
		return fmt.Errorf("invalid gas limit: have %d, want %d += %d", header.GasLimit, parent.GasLimit, limit)
	}
`

we may 
1. not need to double gaslimit of block upon London upgrade
2. or change logic of verify in func verifyCascadingFields

this PR choose first way to solve out, because base fee of bsc is always 0, 
no concept of `gas target`, so there is no need to double the gaslimit .


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
