### PR TITLE
release: prepare for release v1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v1.2.5
+BUGFIX
+* [\#1675](https://github.com/bnb-chain/bsc/pull/1675) goleveldb: downgrade the version for performance
+
 ## v1.2.4
 FEATURE
 * [\#1636](https://github.com/bnb-chain/bsc/pull/1636) upgrade: block height of Luban on mainnet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,30 @@
 # Changelog
+## v1.2.6
+FEATURE
+* [\#1697](https://github.com/bnb-chain/bsc/pull/1697) upgrade: block height of Hertz(London&Berlin) on testnet
+* [\#1686](https://github.com/bnb-chain/bsc/pull/1686) eip3529tests: refactor tests
+* [\#1676](https://github.com/bnb-chain/bsc/pull/1676) EIP-3529 (BEP-212) Unit tests for Parlia Config
+* [\#1660](https://github.com/bnb-chain/bsc/pull/1660) feat: add a tool for submitting evidence of maliciousvoting
+* [\#1623](https://github.com/bnb-chain/bsc/pull/1623) P2P: try to limit the connection number per IP address
+* [\#1608](https://github.com/bnb-chain/bsc/pull/1608) feature: Enable Berlin EIPs
+* [\#1597](https://github.com/bnb-chain/bsc/pull/1597) feature: add malicious vote monitor
+* [\#1422](https://github.com/bnb-chain/bsc/pull/1422) core: port several London EIPs on BSC
+
+IMPROVEMENT
+* [\#1662](https://github.com/bnb-chain/bsc/pull/1662) consensus, core/rawdb, miner: downgrade logs
+* [\#1654](https://github.com/bnb-chain/bsc/pull/1654) config: use default fork config if not specified in config.toml
+* [\#1642](https://github.com/bnb-chain/bsc/pull/1642) readme: update the disk requirement to 2.5TB
+* [\#1621](https://github.com/bnb-chain/bsc/pull/1621) upgrade: avoid to modify RialtoGenesisHash when testing in rialtoNet
+
+BUGFIX
+* [\#1682](https://github.com/bnb-chain/bsc/pull/1682) fix: set the signer of parlia to the most permissive one
+* [\#1681](https://github.com/bnb-chain/bsc/pull/1681) fix: not double GasLimit of block upon London upgrade
+* [\#1679](https://github.com/bnb-chain/bsc/pull/1679) fix: check integer overflow when decode crosschain payload
+* [\#1671](https://github.com/bnb-chain/bsc/pull/1671) fix: voting can only be enabled when mining
+* [\#1663](https://github.com/bnb-chain/bsc/pull/1663) fix: ungraceful shutdown caused by malicious Vote Monitor
+* [\#1651](https://github.com/bnb-chain/bsc/pull/1651) fix: remove naturally finality
+* [\#1641](https://github.com/bnb-chain/bsc/pull/1641) fix: support getFilterChanges after NewFinalizedHeaderFilter
+
 ## v1.2.5
 BUGFIX
 * [\#1675](https://github.com/bnb-chain/bsc/pull/1675) goleveldb: downgrade the version for performance

--- a/params/config.go
+++ b/params/config.go
@@ -231,9 +231,9 @@ var (
 		LubanBlock: big.NewInt(29295050),
 		PlatoBlock: big.NewInt(29861024),
 		// TODO modify blockNumber, make sure HertzBlock=BerlinBlock=LondonBlock to enable Berlin and London EIPs
-		BerlinBlock: nil,
-		LondonBlock: nil,
-		HertzBlock:  nil,
+		BerlinBlock: big.NewInt(31103030),
+		LondonBlock: big.NewInt(31103030),
+		HertzBlock:  big.NewInt(31103030),
 
 		Parlia: &ParliaConfig{
 			Period: 3,

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 2  // Minor version component of the current release
-	VersionPatch = 5  // Patch version component of the current release
+	VersionPatch = 6  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 2  // Minor version component of the current release
-	VersionPatch = 4  // Patch version component of the current release
+	VersionPatch = 5  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
v1.2.6 is a hard-fork release for BSC testnet.

The testnet is expected to have a scheduled hardfork upgrade named `Hertz(London&Berlin)` at block height 31,103,030. The current block generation speed forecasts this to occur around 29th Jun 2023. 

The `Hertz` hardfork will port some of `London&Berlin` upgrades from Ethereum to BSC for compatiblity. But due to the difference between the 2 networks, there would inevitably has difference in implementation, especially the different in EIP-1559, the BaseFee will be zero on BSC, so this hard fork will not introduce new burn mechanism neither the concept of GasTip. In short words, it only provides the interface, but actually no change to the current BSC Gas mechanism.

Here is the list of `Hertz` upgrade:
- Berlin Upgrades Ported:
a.[BEP-225: Implement EIP-2565 ModExp Gas Cost](https://github.com/bnb-chain/BEPs/pull/225)
b.[BEP-229: Implement EIP-2718 Typed Transaction Envelope](https://github.com/bnb-chain/BEPs/pull/229)
c.[BEP-230: Implement EIP-2929 Gas cost increases for state access opcodes](https://github.com/bnb-chain/BEPs/pull/230)
d.[BEP-231: Implement EIP-2930: Optional access lists](https://github.com/bnb-chain/BEPs/pull/231)

- London Upgrades Ported:
a.[BEP-227: Implement EIP-3198: BASEFEE opcode](https://github.com/bnb-chain/BEPs/pull/227)
b.[BEP-226: Implement EIP-1559 with base fee of 0](https://github.com/bnb-chain/BEPs/pull/226)
c.[BEP-228: Implement EIP-3541: Prevent deploying contracts starting with 0xEF](https://github.com/bnb-chain/BEPs/pull/228)
d.[BEP-212: Implement EIP-3529: Reduction in Refunds](https://github.com/bnb-chain/BEPs/pull/212)

The validators and full node operators on testnet  should switch their software version to [v1.2.6](https://github.com/bnb-chain/bsc/releases/tag/v1.2.6) before 29th Jun 2023.

### Rationale
FEATURE
* [\#1697](https://github.com/bnb-chain/bsc/pull/1697) upgrade: block height of Hertz(London&Berlin) on testnet
* [\#1686](https://github.com/bnb-chain/bsc/pull/1686) eip3529tests: refactor tests
* [\#1676](https://github.com/bnb-chain/bsc/pull/1676) EIP-3529 (BEP-212) Unit tests for Parlia Config
* [\#1660](https://github.com/bnb-chain/bsc/pull/1660) feat: add a tool for submitting evidence of maliciousvoting
* [\#1623](https://github.com/bnb-chain/bsc/pull/1623) P2P: try to limit the connection number per IP address
* [\#1608](https://github.com/bnb-chain/bsc/pull/1608) feature: Enable Berlin EIPs
* [\#1597](https://github.com/bnb-chain/bsc/pull/1597) feature: add malicious vote monitor
* [\#1422](https://github.com/bnb-chain/bsc/pull/1422) core: port several London EIPs on BSC

IMPROVEMENT
* [\#1662](https://github.com/bnb-chain/bsc/pull/1662) consensus, core/rawdb, miner: downgrade logs
* [\#1654](https://github.com/bnb-chain/bsc/pull/1654) config: use default fork config if not specified in config.toml
* [\#1642](https://github.com/bnb-chain/bsc/pull/1642) readme: update the disk requirement to 2.5TB
* [\#1621](https://github.com/bnb-chain/bsc/pull/1621) upgrade: avoid to modify RialtoGenesisHash when testing in rialtoNet

BUGFIX
* [\#1682](https://github.com/bnb-chain/bsc/pull/1682) fix: set the signer of parlia to the most permissive one
* [\#1681](https://github.com/bnb-chain/bsc/pull/1681) fix: not double GasLimit of block upon London upgrade
* [\#1679](https://github.com/bnb-chain/bsc/pull/1679) fix: check integer overflow when decode crosschain payload
* [\#1671](https://github.com/bnb-chain/bsc/pull/1671) fix: voting can only be enabled when mining
* [\#1663](https://github.com/bnb-chain/bsc/pull/1663) fix: ungraceful shutdown caused by malicious Vote Monitor
* [\#1651](https://github.com/bnb-chain/bsc/pull/1651) fix: remove naturally finality
* [\#1641](https://github.com/bnb-chain/bsc/pull/1641) fix: support getFilterChanges after NewFinalizedHeaderFilter


### Example
None
