### PR TITLE
core/statedb: always clear out access list when setting a new one

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1677,6 +1677,9 @@ func (s *StateDB) SnapToDiffLayer() ([]common.Address, []types.DiffAccount, []ty
 //
 // This method should only be called if Berlin/2929+2930 is applicable at the current number.
 func (s *StateDB) PrepareAccessList(sender common.Address, dst *common.Address, precompiles []common.Address, list types.AccessList) {
+	// Clear out any leftover from previous executions
+	s.accessList = newAccessList()
+
 	s.AddAddressToAccessList(sender)
 	if dst != nil {
 		s.AddAddressToAccessList(*dst)


### PR DESCRIPTION
### Description

always clear out access list when setting a new one

### Rationale

porting from 
https://github.com/ethereum/go-ethereum/commit/48605b5f61f7ce63cb3148099047309156c959a9

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
