### PR TITLE
core: use reflection to set default block values

### DIFF
--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -182,3 +182,56 @@ func TestGenesis_Commit(t *testing.T) {
 		t.Errorf("inequal difficulty; stored: %v, genesisBlock: %v", stored, genesisBlock.Difficulty())
 	}
 }
+
+func TestConfigOrDefault(t *testing.T) {
+	defaultGenesis := DefaultGenesisBlock()
+	if defaultGenesis.Config.PlanckBlock != nil {
+		t.Errorf("initial config should have PlanckBlock = nil, but instead PlanckBlock = %v", defaultGenesis.Config.PlanckBlock)
+	}
+	gHash := params.BSCGenesisHash
+	config := defaultGenesis.configOrDefault(gHash)
+
+	if config.ChainID.Cmp(params.MainnetChainConfig.ChainID) != 0 {
+		t.Errorf("ChainID of resulting config should be %v, but is %v instead", params.BSCChainConfig.ChainID, config.ChainID)
+	}
+
+	if config.HomesteadBlock.Cmp(params.MainnetChainConfig.HomesteadBlock) != 0 {
+		t.Errorf("resulting config should have HomesteadBlock = %v, but instead is %v", params.MainnetChainConfig, config.HomesteadBlock)
+	}
+
+	if config.PlanckBlock == nil {
+		t.Errorf("resulting config should have PlanckBlock = %v , but instead is nil", params.BSCChainConfig.PlanckBlock)
+	}
+
+	if config.PlanckBlock.Cmp(params.BSCChainConfig.PlanckBlock) != 0 {
+		t.Errorf("resulting config should have PlanckBlock = %v , but instead is %v", params.BSCChainConfig.PlanckBlock, config.PlanckBlock)
+	}
+}
+
+func TestSetDefaultBlockValues(t *testing.T) {
+	genesis := &Genesis{Config: &params.ChainConfig{ChainID: big.NewInt(66), HomesteadBlock: big.NewInt(11)}}
+	genesis.setDefaultBlockValues(params.BSCChainConfig)
+
+	// Make sure the non-nil block was not modified
+	if genesis.Config.HomesteadBlock.Cmp(big.NewInt(11)) != 0 {
+		t.Errorf("Homestead block should not have been modified. HomesteadBlock = %v", genesis.Config.HomesteadBlock)
+	}
+
+	// Spot check a few blocks
+	if genesis.Config.NielsBlock.Cmp(params.BSCChainConfig.NielsBlock) != 0 {
+		t.Errorf("Niels block not matching: in genesis = %v , in defaultConfig = %v", genesis.Config.NielsBlock, params.BSCChainConfig.NielsBlock)
+	}
+
+	if genesis.Config.NanoBlock.Cmp(params.BSCChainConfig.NanoBlock) != 0 {
+		t.Errorf("Nano block not matching: in genesis = %v , in defaultConfig = %v", genesis.Config.NanoBlock, params.BSCChainConfig.NanoBlock)
+	}
+
+	if genesis.Config.PlanckBlock.Cmp(params.BSCChainConfig.PlanckBlock) != 0 {
+		t.Errorf("Nano block not matching: in genesis = %v , in defaultConfig = %v", genesis.Config.PlanckBlock, params.BSCChainConfig.PlanckBlock)
+	}
+
+	// Lastly make sure non-block fields such as ChainID have not been modified
+	if genesis.Config.ChainID.Cmp(big.NewInt(66)) != 0 {
+		t.Errorf("ChainID should not have been modified. ChainID = %v", genesis.Config.ChainID)
+	}
+}


### PR DESCRIPTION
### Description
Set the deault block values of genesis config  using reflection, to avoid a long sequence of if-statements.

For more context:
https://github.com/bnb-chain/bsc/issues/1625

### Rationale
Maintaining a long sequence of if-statements with hardcoded block names is not scalable as more hard forks are introduced in BSC. Forgetting to update the code when a new hard fork happens would result in a wrong config. 

A more robust way is to use reflection to achieve the same result, without having to worry about keeping the file up-to-date every time there is a hard fork. This way the code is also kept short.


### Changes

Notable changes: 
* `genesis.go` : replace long series of if-statements with a `setDefaultBlockValues` method which uses the `.*Block` regex and reflection to achieve the same result.
* `genesis_test.go`: add tests to ensure that reflection modifies the relevant block values correctly, and leaves other fields untouched.
