### PR TITLE
p2p: fix length calculation for headPeers method

### DIFF
--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -517,6 +517,9 @@ func (ps *peerSet) headPeers(num uint) []*ethPeer {
 
 	list := make([]*ethPeer, 0, num)
 	for _, p := range ps.peers {
+		if len(list) > int(num) {
+			break
+		}
 		list = append(list, p)
 	}
 	return list


### PR DESCRIPTION
### Description

The `headPeers` method is introduced in #570, but in fact the passed `num` does not take effect, and always returns all peers

### Rationale

`ps.peers` will range all peers to the list.

### Example

n/a

### Changes

Notable changes: 
* p2p
