### PR TITLE
metrics: add counter for voting status of whole network

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1249,6 +1249,7 @@ func (p *Parlia) VerifyVote(chain consensus.ChainHeaderReader, vote *types.VoteE
 			if addr == p.val {
 				validVotesfromSelfCounter.Inc(1)
 			}
+			metrics.GetOrRegisterCounter(fmt.Sprintf("parlia/VerifyVote/%s", addr.String()), nil).Inc(1)
 			return nil
 		}
 	}


### PR DESCRIPTION
### Description

add counter for voting status of whole network

### Rationale

need to monitor voting status of whole network
even not get metrics from all validators

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
