### PR TITLE
release: prepare for release v1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## v1.2.7
+FEATURE
+* [\#1645](https://github.com/bnb-chain/bsc/pull/1645) lightclient: fix validator set change
+* [\#1717](https://github.com/bnb-chain/bsc/pull/1717) feat: support creating a bls keystore from a specified private key
+* [\#1720](https://github.com/bnb-chain/bsc/pull/1720) metrics: add counter for voting status of whole network
+
 ## v1.2.6
 FEATURE
 * [\#1697](https://github.com/bnb-chain/bsc/pull/1697) upgrade: block height of Hertz(London&Berlin) on testnet

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 2  // Minor version component of the current release
-	VersionPatch = 6  // Patch version component of the current release
+	VersionPatch = 7  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
v1.2.7 replaces [v1.2.6](https://github.com/bnb-chain/bsc/pull/1697) as the official **hertz** hard-fork release for BSC testnet.
It mainly add a bug fix on the precompiled contract(address: 103):
```
// before hertz
common.BytesToAddress([]byte{103}): &cometBFTLightBlockValidate{},
// after hertz
common.BytesToAddress([]byte{103}): &cometBFTLightBlockValidateHertz{},
```

### Rationale
FEATURE
* [\#1645](https://github.com/bnb-chain/bsc/pull/1645) lightclient: fix validator set change
* [\#1717](https://github.com/bnb-chain/bsc/pull/1717) feat: support creating a bls keystore from a specified private key
* [\#1720](https://github.com/bnb-chain/bsc/pull/1720) metrics: add counter for voting status of whole network


### Example
NA

### Changes
The precompiled contract 103 is introduced by [Luban upgrade](https://forum.bnbchain.org/t/bnb-chain-upgrades-mainnet/936#luban-7), the BEP is mainly for cross chain between BSC&Greenfield, so it is probably will have no impact to current users.
