### PR TITLE
discov: increase bucket size for bootnodes

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -134,6 +134,7 @@ func main() {
 		PrivateKey:     nodeKey,
 		NetRestrict:    restrictList,
 		FilterFunction: filterFunction,
+		IsBootnode:     true,
 	}
 	if *runv5 {
 		if _, err := discover.ListenV5(conn, ln, cfg); err != nil {

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -80,6 +80,7 @@ type Config struct {
 	ValidSchemes   enr.IdentityScheme // allowed identity schemes
 	Clock          mclock.Clock
 	FilterFunction NodeFilterFunc // function for filtering ENR entries
+	IsBootnode     bool           // defines if it's bootnode
 }
 
 func (cfg Config) withDefaults() Config {

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -43,7 +43,7 @@ func init() {
 
 func newTestTable(t transport) (*Table, *enode.DB) {
 	db, _ := enode.OpenDB("")
-	tab, _ := newTable(t, db, nil, log.Root(), nil)
+	tab, _ := newTable(t, db, nil, log.Root(), nil, false)
 	go tab.loop()
 	return tab, db
 }

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -143,7 +143,7 @@ func ListenV4(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
 		log:             cfg.Log,
 	}
 
-	tab, err := newTable(t, ln.Database(), cfg.Bootnodes, t.log, cfg.FilterFunction)
+	tab, err := newTable(t, ln.Database(), cfg.Bootnodes, t.log, cfg.FilterFunction, cfg.IsBootnode)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -164,7 +164,7 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 		closeCtx:       closeCtx,
 		cancelCloseCtx: cancelCloseCtx,
 	}
-	tab, err := newTable(t, t.db, cfg.Bootnodes, cfg.Log, cfg.FilterFunction)
+	tab, err := newTable(t, t.db, cfg.Bootnodes, cfg.Log, cfg.FilterFunction, cfg.IsBootnode)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Increase bucket size for bootnodes
The present discovery protocol employs a Distributed Hash Table (DHT), which is organized into "buckets." Each bucket presently stores 16 entries, and there is a total of 17 buckets. This configuration allows for a capacity of 272 node records per individual node.
```
    bucketSize        = 16 // Kademlia bucket size
    hashBits          = len(common.Hash{}) * 8
    nBuckets          = hashBits / 15       // Number of buckets
```
I propose increasing the `bucketSize` value to 256, which is 16 times its current size. Since the bootnode binary is extremely lightweight, this change should not impact overall performance, and it could substantially enhance the discovery process.
add a description of your changes here...
