### PR TITLE
release: prepare for release v1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## v1.2.8
+FEATURE
+* [\#1626](https://github.com/bnb-chain/bsc/pull/1626) eth/filters, ethclient/gethclient: add fullTx option to pending tx filter
+* [\#1726](https://github.com/bnb-chain/bsc/pull/1726) feat: support password flag when handling bls keys
+
+BUGFIX
+* [\#1734](https://github.com/bnb-chain/bsc/pull/1734) fix: avoid to block the chain when failed to send votes
+
 ## v1.2.7
 FEATURE
 * [\#1645](https://github.com/bnb-chain/bsc/pull/1645) lightclient: fix validator set change

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 2  // Minor version component of the current release
-	VersionPatch = 7  // Patch version component of the current release
+	VersionPatch = 8  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.2.8 is a maintenance release, it mainly fixes a potential deadlock on FastFinality VotePool and provides 2 other features(FastFinality & Web3 API related).

### Rationale
## v1.2.8
FEATURE
* [\#1626](https://github.com/bnb-chain/bsc/pull/1626) eth/filters, ethclient/gethclient: add fullTx option to pending tx filter
* [\#1726](https://github.com/bnb-chain/bsc/pull/1726) feat: support password flag when handling bls keys

BUGFIX
* [\#1734](https://github.com/bnb-chain/bsc/pull/1734) fix: avoid to block the chain when failed to send votes

### Example
- usage of `eth_newPendingTransactionFilter` has been changed, it will return full transaction content, rather then pure hash
- a new flag: `--blsaccountpassword ` is provided to specify the password file to managing votes in fast_finality feature

### Changes
N/A
