### PR TITLE
fix: defend ddos voting attack with other mini fix according to audit

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -67,7 +67,7 @@ const (
 
 	systemRewardPercent = 4 // it means 1/2^4 = 1/16 percentage of gas fee incoming will be distributed to system
 
-	collectAdditionalVotesRewardRatio = float64(1) // ratio of additional reward for collecting more votes than needed
+	collectAdditionalVotesRewardRatio = 100 // ratio of additional reward for collecting more votes than needed, the denominator is 100
 )
 
 var (
@@ -1027,7 +1027,7 @@ func (p *Parlia) distributeFinalityReward(chain consensus.ChainHeaderReader, sta
 		}
 		quorum := cmath.CeilDiv(len(snap.Validators)*2, 3)
 		if validVoteCount > quorum {
-			accumulatedWeights[head.Coinbase] += uint64(float64(validVoteCount-quorum) * collectAdditionalVotesRewardRatio)
+			accumulatedWeights[head.Coinbase] += uint64((validVoteCount - quorum) * collectAdditionalVotesRewardRatio / 100)
 		}
 	}
 
@@ -1788,7 +1788,7 @@ func encodeSigHeader(w io.Writer, header *types.Header, chainId *big.Int) {
 		header.GasLimit,
 		header.GasUsed,
 		header.Time,
-		header.Extra[:len(header.Extra)-65], // this will panic if extra is too short, should check before calling encodeSigHeader
+		header.Extra[:len(header.Extra)-extraSeal], // this will panic if extra is too short, should check before calling encodeSigHeader
 		header.MixDigest,
 		header.Nonce,
 	})

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -944,6 +944,8 @@ func (h *handler) voteBroadcastLoop() {
 	for {
 		select {
 		case event := <-h.voteCh:
+			// The timeliness of votes is very important,
+			// so one vote will be sent instantly without waiting for other votes for batch sending by design.
 			h.BroadcastVote(event.Vote)
 		case <-h.votesSub.Err():
 			return

--- a/eth/protocols/bsc/peer.go
+++ b/eth/protocols/bsc/peer.go
@@ -1,6 +1,8 @@
 package bsc
 
 import (
+	"time"
+
 	mapset "github.com/deckarep/golang-set"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -16,6 +18,15 @@ const (
 
 	// voteBufferSize is the maximum number of batch votes can be hold before sending
 	voteBufferSize = 21 * 2
+
+	// used to avoid of DDOS attack
+	// It's the max number of received votes per second from one peer
+	// 21 validators exist now, so 21 votes will be produced every one block interval
+	// so the limit is 7 = 21/3, here set it to 10 with a buffer.
+	receiveRateLimitPerSecond = 10
+
+	// the time span of one period
+	secondsPerPeriod = float64(10)
 )
 
 // max is a helper function which returns the larger of the two given integers.
@@ -31,6 +42,8 @@ type Peer struct {
 	id            string                     // Unique ID for the peer, cached
 	knownVotes    *knownCache                // Set of vote hashes known to be known by this peer
 	voteBroadcast chan []*types.VoteEnvelope // Channel used to queue votes propagation requests
+	periodBegin   time.Time                  // Begin time of the latest period for votes counting
+	periodCounter uint                       // Votes number in the latest period
 
 	*p2p.Peer                   // The embedded P2P package peer
 	rw        p2p.MsgReadWriter // Input/output streams for bsc
@@ -47,6 +60,8 @@ func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter) *Peer {
 		id:            id,
 		knownVotes:    newKnownCache(maxKnownVotes),
 		voteBroadcast: make(chan []*types.VoteEnvelope, voteBufferSize),
+		periodBegin:   time.Now(),
+		periodCounter: 0,
 		Peer:          p,
 		rw:            rw,
 		version:       version,
@@ -112,6 +127,18 @@ func (p *Peer) AsyncSendVotes(votes []*types.VoteEnvelope) {
 	default:
 		p.Log().Debug("Dropping vote propagation for abnormal peer", "count", len(votes))
 	}
+}
+
+// Step into the next period when secondsPerPeriod seconds passed,
+// Otherwise, check whether the number of received votes extra (secondsPerPeriod * receiveRateLimitPerSecond)
+func (p *Peer) IsOverLimitAfterReceiving() bool {
+	if timeInterval := time.Since(p.periodBegin).Seconds(); timeInterval >= secondsPerPeriod {
+		p.periodBegin = time.Now()
+		p.periodCounter = 0
+		return false
+	}
+	p.periodCounter += 1
+	return p.periodCounter > uint(secondsPerPeriod*receiveRateLimitPerSecond)
 }
 
 // broadcastVotes is a write loop that schedules votes broadcasts


### PR DESCRIPTION
### Description

defend ddos voting attack with other mini fix according to audit

### Rationale

1. change type of collectAdditionalVotesRewardRatio to int from float
2. defend ddos voting attack by limit the arrival rate of votes from other peers
    a. force only one vote sent every time, to avoid ddos attack, which batching a large number of votes
    b. set a max number in every period, when extra it , votes will be dropped

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
