### PR TITLE
discov: do not filter out bootnodes

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -611,7 +611,7 @@ func (srv *Server) setupDiscovery() error {
 			Tail   []rlp.RawValue `rlp:"tail"`
 		}
 		if r.Load(enr.WithEntry("eth", &eth)) != nil {
-			return false
+			return true
 		}
 		return srv.forkFilter(eth.ForkID) == nil
 	}


### PR DESCRIPTION
### Description

Our current ENR filtering will remove nodes, that do not report `eth` field, but that's not correct and we should keep them in  DHT.

### Rationale

With these changes we can connect to the bootnodes just fine

