### PR TITLE
release: prepare for release v1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v1.2.9
+FEATURE
+* [\#1775](https://github.com/bnb-chain/bsc/pull/1775) upgrade: several hardfork block height on mainnet: Plato, Hertz(Berlin, London)
+
 ## v1.2.8
 FEATURE
 * [\#1626](https://github.com/bnb-chain/bsc/pull/1626) eth/filters, ethclient/gethclient: add fullTx option to pending tx filter

--- a/params/config.go
+++ b/params/config.go
@@ -193,11 +193,11 @@ var (
 		// TODO modify blockNumber, make sure the blockNumber is not an integer multiple of 200 (epoch number)
 		// TODO Caution !!! it should be very careful !!!
 		LubanBlock: big.NewInt(29020050),
-		PlatoBlock: nil,
+		PlatoBlock: big.NewInt(30720096),
 		// TODO modify blockNumber, make sure HertzBlock=BerlinBlock=LondonBlock to enable Berlin and London EIPs
-		BerlinBlock: nil,
-		LondonBlock: nil,
-		HertzBlock:  nil,
+		BerlinBlock: big.NewInt(31302048),
+		LondonBlock: big.NewInt(31302048),
+		HertzBlock:  big.NewInt(31302048),
 
 		Parlia: &ParliaConfig{
 			Period: 3,

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 2  // Minor version component of the current release
-	VersionPatch = 8  // Patch version component of the current release
+	VersionPatch = 9  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.2.9 is a hard fork release for BSC mainnet.
It sets up the hard fork height for both Plato and Hertz(Berlin,London).
- Plato: fully enable FastFinality at block height: [30,720,096](https://bscscan.com/block/countdown/30720096), around Aug-10-2023
- Hertz: several customized EIPs of Berlin&London on BSC, at block height: [31,302,048](https://bscscan.com/block/countdown/31302048), around Aug-30-2023

The two hard forks have been running on Testnet for a while and their hard fork height are close, so we decide to put them within a single release to save the upgrade effort.
For the detail changes of the two hard fork, pls refer: https://forum.bnbchain.org/t/bnb-chain-upgrades-mainnet/936

### Rationale
## v1.2.9
FEATURE
* [\#1775](https://github.com/bnb-chain/bsc/pull/1775) upgrade: several hardfork block height on mainnet: Plato, Hertz(Berlin, London)

### Example
NA

### Changes
This PR setup the hard fork height, the enabled BEPS could bring lots of changes to the ecosystem, include:
**After Plato:**
- Block Finality: businesses rely on block finality could use the FastFinality feature after Plato

**After Hertz:**
- New Transaction Types: new types are supported, i.e. "AccessList" & "EIP-1559, but different from Ethereum on BSC"
- Gas Metering: more reasonable gas metering
- new EVM opcode: BaseFee(0x48)
- Reduction in Refunds: SELFDESTRUCT refund will no longer be supported, SSTORE refund will be reduced