### PR TITLE
fix: exclude same votes when doing malicious voting check

### DIFF
--- a/core/monitor/malicious_vote_monitor.go
+++ b/core/monitor/malicious_vote_monitor.go
@@ -58,6 +58,7 @@ func (m *MaliciousVoteMonitor) ConflictDetect(newVote *types.VoteEnvelope, pendi
 	if !(blockNumber+maliciousVoteSlashScope > pendingBlockNumber) {
 		blockNumber = pendingBlockNumber - maliciousVoteSlashScope + 1
 	}
+	newVoteHash := newVote.Data.Hash()
 	for ; blockNumber <= pendingBlockNumber+upperLimitOfVoteBlockNumber; blockNumber++ {
 		if voteDataBuffer.Contains(blockNumber) {
 			voteEnvelope, ok := voteDataBuffer.Get(blockNumber)
@@ -66,7 +67,7 @@ func (m *MaliciousVoteMonitor) ConflictDetect(newVote *types.VoteEnvelope, pendi
 				continue
 			}
 			maliciousVote := false
-			if blockNumber == targetNumber {
+			if blockNumber == targetNumber && voteEnvelope.(*types.VoteEnvelope).Data.Hash() != newVoteHash {
 				violateRule1Counter.Inc(1)
 				maliciousVote = true
 			} else if (blockNumber < targetNumber && voteEnvelope.(*types.VoteEnvelope).Data.SourceNumber > sourceNumber) ||

--- a/core/monitor/malicious_vote_monitor_test.go
+++ b/core/monitor/malicious_vote_monitor_test.go
@@ -22,9 +22,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: uint64(0),
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - maliciousVoteSlashScope - 1,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(1)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes(("01"))),
 			},
 		}
 		assert.Equal(t, false, maliciousVoteMonitor.ConflictDetect(vote1, pendingBlockNumber))
@@ -34,9 +34,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: uint64(0),
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - maliciousVoteSlashScope - 1,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(2)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes("02")),
 			},
 		}
 		assert.Equal(t, false, maliciousVoteMonitor.ConflictDetect(vote2, pendingBlockNumber))
@@ -54,9 +54,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: uint64(0),
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - maliciousVoteSlashScope - 1,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(1)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes("01")),
 			},
 		}
 		assert.Equal(t, false, maliciousVoteMonitor.ConflictDetect(vote1, pendingBlockNumber))
@@ -65,9 +65,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: uint64(0),
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - maliciousVoteSlashScope - 1,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(2)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes("02")),
 			},
 		}
 		assert.Equal(t, false, maliciousVoteMonitor.ConflictDetect(vote2, pendingBlockNumber))
@@ -85,9 +85,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: uint64(0),
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - 1,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(1)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes("01")),
 			},
 		}
 		assert.Equal(t, false, maliciousVoteMonitor.ConflictDetect(vote1, pendingBlockNumber))
@@ -96,9 +96,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: uint64(0),
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - 1,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(2)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes("02")),
 			},
 		}
 		assert.Equal(t, true, maliciousVoteMonitor.ConflictDetect(vote2, pendingBlockNumber))
@@ -116,9 +116,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: pendingBlockNumber - 4,
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - 1,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(1)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes("01")),
 			},
 		}
 		assert.Equal(t, false, maliciousVoteMonitor.ConflictDetect(vote1, pendingBlockNumber))
@@ -127,9 +127,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: pendingBlockNumber - 2,
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - 3,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(2)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes("02")),
 			},
 		}
 		assert.Equal(t, true, maliciousVoteMonitor.ConflictDetect(vote2, pendingBlockNumber))
@@ -147,9 +147,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: pendingBlockNumber - 2,
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - 3,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(1)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes("01")),
 			},
 		}
 		assert.Equal(t, false, maliciousVoteMonitor.ConflictDetect(vote1, pendingBlockNumber))
@@ -158,9 +158,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: pendingBlockNumber - 4,
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - 1,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(2)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes("02")),
 			},
 		}
 		assert.Equal(t, true, maliciousVoteMonitor.ConflictDetect(vote2, pendingBlockNumber))
@@ -178,9 +178,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: pendingBlockNumber - 4,
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - 3,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(1)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes("01")),
 			},
 		}
 		assert.Equal(t, false, maliciousVoteMonitor.ConflictDetect(vote1, pendingBlockNumber))
@@ -189,9 +189,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: pendingBlockNumber - 3,
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - 2,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(2)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes("02")),
 			},
 		}
 		assert.Equal(t, false, maliciousVoteMonitor.ConflictDetect(vote2, pendingBlockNumber))
@@ -200,9 +200,9 @@ func TestMaliciousVoteMonitor(t *testing.T) {
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
 				SourceNumber: pendingBlockNumber - 2,
-				SourceHash:   common.BytesToHash(common.Hex2Bytes(string(rune(0)))),
+				SourceHash:   common.BytesToHash(common.Hex2Bytes("00")),
 				TargetNumber: pendingBlockNumber - 1,
-				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(2)))),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes("02")),
 			},
 		}
 		assert.Equal(t, false, maliciousVoteMonitor.ConflictDetect(vote3, pendingBlockNumber))


### PR DESCRIPTION
### Description

fix: exclude same votes when doing malicious voting check

### Rationale

even we have used `receivedVotes` to mark votes received,
in a corner cases, a vote has been pruned, then a reorg to older block happened
so the pruned votes can be received again, this will lead to alert malicious vote in a wrong way

so add more check in monitor.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
