### PR TITLE
rpc: add GetFinalizedHeader/Block to simplify using the fast finality feature

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1758,10 +1758,12 @@ func (p *Parlia) GetFinalizedHeader(chain consensus.ChainHeaderReader, header *t
 		return nil
 	}
 
-	if snap.Attestation != nil {
-		return chain.GetHeader(snap.Attestation.SourceHash, snap.Attestation.SourceNumber)
+	// snap.Attestation is nil after plato upgrade, only can happen in local testnet
+	if snap.Attestation == nil {
+		return chain.GetHeaderByNumber(0) // keep consistent with GetJustifiedNumberAndHash
 	}
-	return nil
+
+	return chain.GetHeader(snap.Attestation.SourceHash, snap.Attestation.SourceNumber)
 }
 
 // ===========================     utility function        ==========================


### PR DESCRIPTION
### Description

add GetFinalizedHeader/Block to simplify using the fast finality feature

### Rationale

the fast finality feature  may not work stable in early time or in some extreme scenes, 
then the chain will decade back to probabilistic finality.
we need more simple APIs to handle block finality easily regardless of the status of fast finality mechanism.
here comes in this PR
```
//  eth_getFinalizedHeader returns the requested finalized block header.
//   - probabilisticFinalized should be in range [2,21],
//     then the block header with number `max(fastFinalized, latest-probabilisticFinalized)` is returned
eth_getFinalizedHeader(probabilisticFinalized int64)

//  eth_getFinalizedBlock returns the requested finalized block.
//   - probabilisticFinalized should be in range [2,21],
//     then the block with number `max(fastFinalized, latest-probabilisticFinalized)` is returned
//   - When fullTx is true all transactions in the block are returned, otherwise
//     only the transaction hash is returned.
eth_getFinalizedBlock(probabilisticFinalized int64 ,fullTx bool)
```
### Example
you can use it as following:
```
curl -X POST "http://localhost:8545/" -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"eth_getFinalizedHeader","params":[11],"id":1}'

curl -X POST "http://localhost:8545/" -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"eth_getFinalizedBlock","params":[14, true],"id":1}'
```
### Changes

Notable changes: 
* add each change in a bullet point here
* ...
