### PR TITLE
finality: add more check to ensure reuslt of assembleVoteAttestation

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -882,6 +882,11 @@ func (p *Parlia) assembleVoteAttestation(chain consensus.ChainHeaderReader, head
 			attestation.VoteAddressSet |= 1 << (valInfo.Index - 1) //Index is offset by 1
 		}
 	}
+	validatorsBitSet := bitset.From([]uint64{uint64(attestation.VoteAddressSet)})
+	if validatorsBitSet.Count() < uint(len(signatures)) {
+		log.Warn(fmt.Sprintf("assembleVoteAttestation, check VoteAddress Set failed, expected:%d, real:%d", len(signatures), validatorsBitSet.Count()))
+		return fmt.Errorf("invalid attestation, check VoteAddress Set failed")
+	}
 
 	// Append attestation to header extra field.
 	buf := new(bytes.Buffer)
@@ -1758,7 +1763,6 @@ func (p *Parlia) GetFinalizedHeader(chain consensus.ChainHeaderReader, header *t
 		return nil
 	}
 
-	// snap.Attestation is nil after plato upgrade, only can happen in local testnet
 	if snap.Attestation == nil {
 		return chain.GetHeaderByNumber(0) // keep consistent with GetJustifiedNumberAndHash
 	}


### PR DESCRIPTION
### Description

finality: add more check to ensure reuslt of assembleVoteAttestation

### Rationale

drop attestation when two same votes included or vote with invalid validator included

by the way, these two senses have been excluded by func basicVerify and verifyVote, 
but assembleVoteAttestation should depend them less

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
