### PR TITLE
vote: disable votepool when bsc protocol not enabled

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -827,7 +827,7 @@ func (p *Parlia) assembleVoteAttestation(chain consensus.ChainHeaderReader, head
 	}
 
 	if p.VotePool == nil {
-		return errors.New("vote pool is nil")
+		return nil
 	}
 
 	// Fetch direct parent's votes

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -279,7 +279,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
 	// Create voteManager instance
-	if posa, ok := eth.engine.(consensus.PoSA); ok {
+	if posa, ok := eth.engine.(consensus.PoSA); ok && !config.DisableBscProtocol {
 		// Create votePool instance
 		votePool := vote.NewVotePool(chainConfig, eth.blockchain, posa)
 		eth.votePool = votePool


### PR DESCRIPTION
### Description

disable votepool when bsc protocol not enabled

### Rationale

we need a emergency handler when chain stopped after plato upgrade,

set flag `disablebscprotocol` will disable vote propagation, so most parts of fast finality have been disabled,

but votpool will still be constructed.

In this PR, we disable votepool when bsc protocol not enabled, so we can use flag `disablebscprotocol` to remove 

fast finality much more clean


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
