### PR TITLE
CVE-2023-39533, CVE-2020-8565, CVE-2023-3978

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -151,7 +151,7 @@ require (
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-cidranger v1.1.0 // indirect
 	github.com/libp2p/go-flow-metrics v0.1.0 // indirect
-	github.com/libp2p/go-libp2p v0.26.2 // indirect
+	github.com/libp2p/go-libp2p v0.27.8 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.2.0 // indirect
 	github.com/libp2p/go-libp2p-pubsub v0.9.3 // indirect
 	github.com/libp2p/go-mplex v0.7.0 // indirect
@@ -247,7 +247,7 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771 // indirect
 	golang.org/x/mod v0.8.0 // indirect
-	golang.org/x/net v0.7.0 // indirect
+	golang.org/x/net v0.13.0 // indirect
 	golang.org/x/oauth2 v0.3.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	google.golang.org/api v0.34.0 // indirect
@@ -260,7 +260,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.18.3 // indirect
-	k8s.io/client-go v0.18.3 // indirect
+	k8s.io/client-go v0.20.0-alpha.2 // indirect
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/klog/v2 v2.80.0 // indirect
 	k8s.io/utils v0.0.0-20200520001619-278ece378a50 // indirect


### PR DESCRIPTION
fix CVE-2023-39533, CVE-2020-8565, CVE-2023-3978

### Description

fix CVE-2023-39533, CVE-2020-8565, CVE-2023-3978

### Rationale

there should be no CVE in bsc ....

### Example

add an example CLI or API response...

### Changes

Notable changes: 
*golang.org/x/net
*github.com/libp2p/go-libp2p
*k8s.io/client-go
