### PR TITLE
release: prepare for release v1.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Changelog
+## v1.2.11
+FEATURE
+* [\#1797](https://github.com/bnb-chain/bsc/pull/1797) client: add FinalizedHeader/Block to use the fast finality
+* [\#1805](https://github.com/bnb-chain/bsc/pull/1805) vote: remove DisableBscProtocol and add flag to skip votes assmebling
+
+BUGFIX
+* [\#1829](https://github.com/bnb-chain/bsc/pull/1829) fix: lagging nodes failed to sync
+
 ## v1.2.10
 FEATURE
 * [\#1780](https://github.com/bnb-chain/bsc/pull/1780) log: reduce logs when receiving too much votes from a peer
 * [\#1788](https://github.com/bnb-chain/bsc/pull/1788) metrics: add txpool config into metrics server
 * [\#1789](https://github.com/bnb-chain/bsc/pull/1789) rpc: add GetFinalizedHeader/Block to simplify using the fast finality feature
 * [\#1791](https://github.com/bnb-chain/bsc/pull/1791) finality: add more check to ensure result of assembleVoteAttestation
+* [\#1795](https://github.com/bnb-chain/bsc/pull/1795) tool: add a tool extradump to parse extra data after luban
 
 BUGFIX
 * [\#1773](https://github.com/bnb-chain/bsc/pull/1773) discov: do not filter out bootnodes

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 2  // Minor version component of the current release
-	VersionPatch = 10 // Patch version component of the current release
+	VersionPatch = 11 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.2.11 is another maintenance release for BSC mainnet and testnet.
It mainly fixed a sync bug, for peers that are lagging behind too much blocks(>90,000), it may not be able to sync.

And it also provides a new option to disable attestation: `--disablevoteattestation` on some special cases and the option `--disablebscprotocol` was abandoned.

### Change Log
FEATURE
* [\#1797](https://github.com/bnb-chain/bsc/pull/1797) client: add FinalizedHeader/Block to use the fast finality
* [\#1805](https://github.com/bnb-chain/bsc/pull/1805) vote: remove DisableBscProtocol and add flag to skip votes assmebling

BUGFIX
* [\#1829](https://github.com/bnb-chain/bsc/pull/1829) fix: lagging nodes failed to sync

### Example
NA

### Compatibility
NA