### PR TITLE
Update init-network command

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -318,16 +318,18 @@ func initNetwork(ctx *cli.Context) error {
 		utils.Fatalf("init.dir is required")
 	}
 	size := ctx.Int(utils.InitNetworkSize.Name)
+	if size <= 0 {
+		utils.Fatalf("size should be greater than 0")
+	}
 	port := ctx.Int(utils.InitNetworkPort.Name)
+	if port <= 0 {
+		utils.Fatalf("port should be greater than 0")
+	}
 	ipStr := ctx.String(utils.InitNetworkIps.Name)
 	cfgFile := ctx.String(configFileFlag.Name)
 
 	if len(cfgFile) == 0 {
 		utils.Fatalf("config file is required")
-	}
-
-	if size <= 0 {
-		utils.Fatalf("size should be greater than 0")
 	}
 
 	ips, err := parseIps(ipStr, size)

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path"
@@ -237,6 +238,79 @@ func initGenesis(ctx *cli.Context) error {
 	return nil
 }
 
+func parseIps(ipStr string, size int) ([]string, error) {
+	var ips []string
+	if len(ipStr) != 0 {
+		ips = strings.Split(ipStr, ",")
+		if len(ips) != size {
+			return nil, errors.New("mismatch of size and length of ips")
+		}
+		for i := 0; i < size; i++ {
+			_, err := net.ResolveIPAddr("", ips[i])
+			if err != nil {
+				return nil, errors.New("invalid format of ip")
+			}
+		}
+	} else {
+		ips = make([]string, size)
+		for i := 0; i < size; i++ {
+			ips[i] = "127.0.0.1"
+		}
+	}
+	return ips, nil
+}
+
+func createPorts(ipStr string, port int, size int) []int {
+	ports := make([]int, size)
+	if len(ipStr) == 0 { // localhost , so different ports
+		for i := 0; i < size; i++ {
+			ports[i] = port + i
+		}
+	} else { // different machines, keep same port
+		for i := 0; i < size; i++ {
+			ports[i] = port
+		}
+	}
+	return ports
+}
+
+// Create config for node i in the cluster
+func createNodeConfig(baseConfig gethConfig, enodes []*enode.Node, ip string, port int, size int, i int) gethConfig {
+	baseConfig.Node.HTTPHost = ip
+	baseConfig.Node.P2P.ListenAddr = fmt.Sprintf(":%d", port+i)
+	baseConfig.Node.P2P.BootstrapNodes = make([]*enode.Node, size-1)
+	// Set the P2P connections between this node and the other nodes
+	for j := 0; j < i; j++ {
+		baseConfig.Node.P2P.BootstrapNodes[j] = enodes[j]
+	}
+	for j := i + 1; j < size; j++ {
+		baseConfig.Node.P2P.BootstrapNodes[j-1] = enodes[j]
+	}
+	return baseConfig
+}
+
+// Create configs for nodes in the cluster
+func createNodeConfigs(baseConfig gethConfig, initDir string, ips []string, ports []int, size int) ([]gethConfig, error) {
+	// Create the nodes
+	enodes := make([]*enode.Node, size)
+	for i := 0; i < size; i++ {
+		stack, err := node.New(&baseConfig.Node)
+		if err != nil {
+			return nil, err
+		}
+		stack.Config().DataDir = path.Join(initDir, fmt.Sprintf("node%d", i))
+		pk := stack.Config().NodeKey()
+		enodes[i] = enode.NewV4(&pk.PublicKey, net.ParseIP(ips[i]), ports[i], ports[i])
+	}
+
+	// Create the configs
+	configs := make([]gethConfig, size)
+	for i := 0; i < size; i++ {
+		configs[i] = createNodeConfig(baseConfig, enodes, ips[i], ports[i], size, i)
+	}
+	return configs, nil
+}
+
 // initNetwork will bootstrap and initialize a new genesis block, and nodekey, config files for network nodes
 func initNetwork(ctx *cli.Context) error {
 	initDir := ctx.String(utils.InitNetworkDir.Name)
@@ -251,42 +325,33 @@ func initNetwork(ctx *cli.Context) error {
 	if len(cfgFile) == 0 {
 		utils.Fatalf("config file is required")
 	}
-	var ips []string
-	if len(ipStr) != 0 {
-		ips = strings.Split(ipStr, ",")
-		if len(ips) != size {
-			utils.Fatalf("mismatch of size and length of ips")
-		}
-		for i := 0; i < size; i++ {
-			_, err := net.ResolveIPAddr("", ips[i])
-			if err != nil {
-				utils.Fatalf("invalid format of ip")
-				return err
-			}
-		}
-	} else {
-		ips = make([]string, size)
-		for i := 0; i < size; i++ {
-			ips[i] = "127.0.0.1"
-		}
+
+	if size <= 0 {
+		utils.Fatalf("size should be greater than 0")
 	}
+
+	ips, err := parseIps(ipStr, size)
+	if err != nil {
+		utils.Fatalf("Failed to pase ips string: %v", err)
+	}
+
+	ports := createPorts(ipStr, port, size)
 
 	// Make sure we have a valid genesis JSON
 	genesisPath := ctx.Args().First()
 	if len(genesisPath) == 0 {
 		utils.Fatalf("Must supply path to genesis JSON file")
 	}
-	file, err := os.Open(genesisPath)
+	inGenesisFile, err := os.Open(genesisPath)
 	if err != nil {
 		utils.Fatalf("Failed to read genesis file: %v", err)
 	}
-	defer file.Close()
+	defer inGenesisFile.Close()
 
 	genesis := new(core.Genesis)
-	if err := json.NewDecoder(file).Decode(genesis); err != nil {
+	if err := json.NewDecoder(inGenesisFile).Decode(genesis); err != nil {
 		utils.Fatalf("invalid genesis file: %v", err)
 	}
-	enodes := make([]*enode.Node, size)
 
 	// load config
 	var config gethConfig
@@ -294,37 +359,38 @@ func initNetwork(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	config.Eth.Genesis = genesis
 
-	for i := 0; i < size; i++ {
-		stack, err := node.New(&config.Node)
-		if err != nil {
-			return err
-		}
-		stack.Config().DataDir = path.Join(initDir, fmt.Sprintf("node%d", i))
-		pk := stack.Config().NodeKey()
-		enodes[i] = enode.NewV4(&pk.PublicKey, net.ParseIP(ips[i]), port, port)
+	configs, err := createNodeConfigs(config, initDir, ips, ports, size)
+	if err != nil {
+		utils.Fatalf("Failed to create node configs: %v", err)
 	}
 
 	for i := 0; i < size; i++ {
-		config.Node.HTTPHost = ips[i]
-		config.Node.P2P.StaticNodes = make([]*enode.Node, size-1)
-		for j := 0; j < i; j++ {
-			config.Node.P2P.StaticNodes[j] = enodes[j]
-		}
-		for j := i + 1; j < size; j++ {
-			config.Node.P2P.StaticNodes[j-1] = enodes[j]
-		}
-		out, err := tomlSettings.Marshal(config)
+		// Write config.toml
+		configBytes, err := tomlSettings.Marshal(configs[i])
 		if err != nil {
 			return err
 		}
-		dump, err := os.OpenFile(path.Join(initDir, fmt.Sprintf("node%d", i), "config.toml"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		configFile, err := os.OpenFile(path.Join(initDir, fmt.Sprintf("node%d", i), "config.toml"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return err
 		}
-		defer dump.Close()
-		dump.Write(out)
+		defer configFile.Close()
+		configFile.Write(configBytes)
+
+		// Write the input genesis.json to the node's directory
+		outGenesisFile, err := os.OpenFile(path.Join(initDir, fmt.Sprintf("node%d", i), "genesis.json"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		_, err = inGenesisFile.Seek(0, io.SeekStart)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(outGenesisFile, inGenesisFile)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
### Description
This PR modifies the behavior of the `init-network` command so that:

- it no longer writes the genesis config to the `config.toml` of the nodes, but writes it to `genesis.json` instead.
- nodes on the same host use different ports, while nodes in different hosts use the same port.
-  split the long function into smaller functions.
- Uses bootstrap nodes instead of static nodes to setup the p2p connections among nodes.

### Rationale
The `init-network` command is used by the [node-deploy](https://github.com/bnb-chain/node-deploy/) repository to generate the configs for a local cluster of BSC nodes. The command receives a size for the network and `config.toml` and `genesis.json` and produces a folder structure where the subfolders are the configurations for the individual nodes in the network.

The problems with the current implementation that are addressed in this PR are the following:
- The command parses the input `config.toml` and `genesis.json` files, and combines them into a `config.toml` file written in each node's directory . The problem is that some hard fork blocks in the genesis config might be nil, and if the genesis config is written to the `config.toml`, these blocks will be serialized into `<nil>`, which will lead to parsing errors when the nodes in the cluster are started. The `node-deploy` repo deals with this by modifying each generated `config.toml` file to delete lines with nil blocks. However, a better solution would be to not include the genesis config in `config.toml` as it was never intended to be included there, and instead write the `genesis.json` to the node's directories.
- Currently all nodes use the same port to listen for p2p connections, however this doesn't work when the nodes are all running on the same host. `node-deploy` deals with this by manually editing the port numbers in the generated `config.toml` files, but a better solution would be to have custom logic so that when the host is localhost the nodes are listening on different ports, while if the nodes are running on different hosts the same port may be used.


### Example

`bin/geth init-network --init.dir ./.local/bsc/clusterNetwork --init.size=3  --config ./config.toml ./genesis/genesis.json`

### Changes

Notable changes: 
* `cmd/geth/chaincmd.go`
