### PR TITLE
release: prepare for release v1.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+## v1.2.12
+FEATURE
+* [\#1852](https://github.com/bnb-chain/bsc/pull/1852) discov: add hardcoded bootnodes
+
+BUGFIX
+* [\#1844](https://github.com/bnb-chain/bsc/pull/1844) crypto: Update BLST to v0.3.11
+* [\#1854](https://github.com/bnb-chain/bsc/pull/1854) fetcher: no import blocks before or equal to the finalized height
+* [\#1855](https://github.com/bnb-chain/bsc/pull/1855) eth/tracers: trace system tx should add intrinsicGas
+
+IMPROVEMENT
+* [\#1839](https://github.com/bnb-chain/bsc/pull/1839) Update init-network command
+* [\#1858](https://github.com/bnb-chain/bsc/pull/1858) vote: check consensus key match vote key before voting
+
 ## v1.2.11
 FEATURE
 * [\#1797](https://github.com/bnb-chain/bsc/pull/1797) client: add FinalizedHeader/Block to use the fast finality

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 2  // Minor version component of the current release
-	VersionPatch = 11 // Patch version component of the current release
+	VersionPatch = 12 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.2.12 is a maintenance release for BSC mainnet and testnet.
It mainly support BootNodes on BSC mainnet, it would be easier for user to sync with the BSC network.
And it also fixed three bugs to make the node more reliable, not critical bugs, pls check the change list for detail.

### Change Log
FEATURE
* [\#1852](https://github.com/bnb-chain/bsc/pull/1852) discov: add hardcoded bootnodes

BUGFIX
* [\#1844](https://github.com/bnb-chain/bsc/pull/1844) crypto: Update BLST to v0.3.11
* [\#1854](https://github.com/bnb-chain/bsc/pull/1854) fetcher: no import blocks before or equal to the finalized height
* [\#1855](https://github.com/bnb-chain/bsc/pull/1855) eth/tracers: trace system tx should add intrinsicGas

IMPROVEMENT
* [\#1839](https://github.com/bnb-chain/bsc/pull/1839) Update init-network command
* [\#1858](https://github.com/bnb-chain/bsc/pull/1858) vote: check consensus key match vote key before voting

### Example
NA

### Compatibility
No Impact to users.