### PR TITLE
core/state: handle account destruction after updating account state

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -336,7 +336,6 @@ func (s *stateObject) updateTrie() (Trie, error) {
 		}
 		var v []byte
 		if value != (common.Hash{}) {
-			// Encoding []byte cannot fail, ok to ignore the error.
 			value := value
 			v = common.TrimLeftZeroes(value[:])
 		}
@@ -392,7 +391,7 @@ func (s *stateObject) updateTrie() (Trie, error) {
 
 			// Track the original value of slot only if it's mutated first time
 			prev := s.originStorage[key]
-			s.originStorage[key] = common.BytesToHash(value)
+			s.originStorage[key] = common.BytesToHash(value) // fill back left zeroes by BytesToHash
 			if _, ok := origin[khash]; !ok {
 				if prev == (common.Hash{}) {
 					origin[khash] = nil // nil if it was not present previously
@@ -422,7 +421,7 @@ func (s *stateObject) updateRoot() {
 	// If node runs in no trie mode, set root to empty.
 	defer func() {
 		if s.db.db.NoTries() {
-			s.data.Root = common.Hash{}
+			s.data.Root = types.EmptyRootHash
 		}
 	}()
 


### PR DESCRIPTION
### Description

handle account destruction after updating account state

### Rationale

#### Bugfix:
1. `handleDestruction` depend on `accounts` and this map will be updated when `updateStateObject`,
so move `handleDestruction` after `updateStateObject`, otherwise will **pathdb** will behavior unexpectedly.
2. check err returned by `commmitTrie`
3. revert logic of New statedb to support new a statedb when OpenTrie failed(for example, no trie data)

#### Improve performance
1.  avoid copy accounts and storages twice in `copyInternal`
2. avoid both update accounts in `AccountsIntermediateRoot` and `StateIntermediateRoot`
3. make two funcs in `commitFuncs` run in parallel

#### Others:
 use `types.EmptyRootHash` instead of `common.Hash{}` to express empty root hash of account

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
