### PR TITLE
discov: add status log for bootnode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -245,7 +245,6 @@ require (
 	github.com/schollz/progressbar/v3 v3.3.4 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
-	github.com/supranational/blst v0.3.11 // indirect
 	github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e // indirect
 	github.com/tidwall/gjson v1.10.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -411,6 +411,7 @@ func (t *UDPv4) loop() {
 	var (
 		plist        = list.New()
 		timeout      = time.NewTimer(0)
+		statusTicker = time.NewTicker(60 * time.Second)
 		nextTimeout  *replyMatcher // head of plist when timeout was last reset
 		contTimeouts = 0           // number of continuous timeouts to do NTP checks
 		ntpWarnTime  = time.Unix(0, 0)
@@ -438,6 +439,10 @@ func (t *UDPv4) loop() {
 		}
 		nextTimeout = nil
 		timeout.Stop()
+	}
+
+	logStatistic := func() {
+		t.log.Info("Current status", "table_size", t.tab.len(), "pending_size", plist.Len(), "db_size", t.db.Size())
 	}
 
 	for {
@@ -495,6 +500,9 @@ func (t *UDPv4) loop() {
 				}
 				contTimeouts = 0
 			}
+
+		case <-statusTicker.C:
+			logStatistic()
 		}
 	}
 }

--- a/p2p/enode/nodedb.go
+++ b/p2p/enode/nodedb.go
@@ -504,3 +504,9 @@ func (db *DB) Close() {
 	close(db.quit)
 	db.lvl.Close()
 }
+
+func (db *DB) Size() int64 {
+	var stats leveldb.DBStats
+	db.lvl.Stats(&stats)
+	return stats.LevelSizes.Sum()
+}


### PR DESCRIPTION
### Description

As adding metrics is kind of complex thing for bootnode. Adding simple log will be enough. 

```
INFO [09-18|16:42:21.369] Current status                           table_size=889 pending_size=0 db_size=630,543
```

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
