### PR TITLE
Revert "core/rawdb: open meta file in read only mode (#26009)"

### DIFF
--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -145,12 +145,20 @@ func newTable(path string, name string, readMeter metrics.Meter, writeMeter metr
 		meta  *os.File
 	)
 	if readonly {
-		// Will fail if table index file or meta file is not existent
+		// Will fail if table doesn't exist
 		index, err = openFreezerFileForReadOnly(filepath.Join(path, idxName))
 		if err != nil {
 			return nil, err
 		}
-		meta, err = openFreezerFileForReadOnly(filepath.Join(path, fmt.Sprintf("%s.meta", name)))
+		// TODO(rjl493456442) change it to read-only mode. Open the metadata file
+		// in rw mode. It's a temporary solution for now and should be changed
+		// whenever the tail deletion is actually used. The reason for this hack is
+		// the additional meta file for each freezer table is added in order to support
+		// tail deletion, but for most legacy nodes this file is missing. This check
+		// will suddenly break lots of database relevant commands. So the metadata file
+		// is always opened for mutation and nothing else will be written except
+		// the initialization.
+		meta, err = openFreezerFileForAppend(filepath.Join(path, fmt.Sprintf("%s.meta", name)))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION

### Description

This reverts commit [b9ba6f6e4d86d0ee86c63e8f4552e233fe0450aa](https://github.com/ethereum/go-ethereum/pull/26009).

### Rationale

dir `chaindata` generated by old version of geth(before big merge)  doesn't contain *meta files which are used to `tail deletion`.
so for back-compatible, still open meta file in append mode even readonly flagged.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
