### PR TITLE
parlia: reject header with `WithdrawalsHash` before shanghai fork

### DIFF
--- a/cmd/evm/t8n_test.go
+++ b/cmd/evm/t8n_test.go
@@ -262,7 +262,7 @@ func TestT8n(t *testing.T) {
 			output: t8nOutput{alloc: true, result: true},
 			expOut: "exp.json",
 		},
-		// TODO: Cancun not ready
+		// TODO(Nathan): Cancun not ready
 		/*
 			{ // Cancun tests
 				base: "./testdata/28",

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	ipcAPIs  = "admin:1.0 debug:1.0 eth:1.0 miner:1.0 net:1.0 rpc:1.0 txpool:1.0 web3:1.0"
+	ipcAPIs  = "admin:1.0 debug:1.0 eth:1.0 miner:1.0 net:1.0 parlia:1.0 rpc:1.0 txpool:1.0 web3:1.0"
 	httpAPIs = "eth:1.0 net:1.0 rpc:1.0 web3:1.0"
 )
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -539,15 +539,16 @@ var (
 		Category: flags.MinerCategory,
 	}
 	MinerDelayLeftoverFlag = &cli.DurationFlag{
-		Name:  "miner.delayleftover",
-		Usage: "Time reserved to finalize a block",
-		Value: ethconfig.Defaults.Miner.DelayLeftOver,
+		Name:     "miner.delayleftover",
+		Usage:    "Time reserved to finalize a block",
+		Value:    ethconfig.Defaults.Miner.DelayLeftOver,
+		Category: flags.MinerCategory,
 	}
 	MinerNewPayloadTimeout = &cli.DurationFlag{
-		Name:     "miner.newpayload-timeout",
-		Usage:    "Specify the maximum time allowance for creating a new payload",
-		Value:    ethconfig.Defaults.Miner.NewPayloadTimeout,
-		Category: flags.MinerCategory,
+		Name:  "miner.newpayload-timeout",
+		Usage: "Specify the maximum time allowance for creating a new payload",
+		Value: ethconfig.Defaults.Miner.NewPayloadTimeout,
+		// Category: flags.MinerCategory,
 	}
 
 	// Account settings

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -290,6 +290,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}
+	log.Info("Initialised chain configuration", "config", chainConfig)
 	// Description of chainConfig is empty now
 	/*
 		log.Info("")

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -24,7 +24,6 @@ import (
 	"math/big"
 	"runtime"
 	"sort"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -291,13 +290,16 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}
-	log.Info("")
-	log.Info(strings.Repeat("-", 153))
-	for _, line := range strings.Split(chainConfig.Description(), "\n") {
-		log.Info(line)
-	}
-	log.Info(strings.Repeat("-", 153))
-	log.Info("")
+	// Description of chainConfig is empty now
+	/*
+		log.Info("")
+		log.Info(strings.Repeat("-", 153))
+		for _, line := range strings.Split(chainConfig.Description(), "\n") {
+			log.Info(line)
+		}
+		log.Info(strings.Repeat("-", 153))
+		log.Info("")
+	*/
 
 	bc := &BlockChain{
 		chainConfig:        chainConfig,

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -66,8 +66,8 @@ type Genesis struct {
 	GasUsed       uint64      `json:"gasUsed"`
 	ParentHash    common.Hash `json:"parentHash"`
 	BaseFee       *big.Int    `json:"baseFeePerGas"`                             // EIP-1559
-	ExcessBlobGas *uint64     `json:"excessBlobGas,omitempty" toml:",omitempty"` // EIP-4844, TODO: remove tag `omitempty` after cancun fork
-	BlobGasUsed   *uint64     `json:"blobGasUsed,omitempty" toml:",omitempty"`   // EIP-4844, TODO: remove tag `omitempty` after cancun fork
+	ExcessBlobGas *uint64     `json:"excessBlobGas,omitempty" toml:",omitempty"` // EIP-4844, TODO(Nathan): remove tag `omitempty` after cancun fork
+	BlobGasUsed   *uint64     `json:"blobGasUsed,omitempty" toml:",omitempty"`   // EIP-4844, TODO(Nathan): remove tag `omitempty` after cancun fork
 }
 
 func ReadGenesis(db ethdb.Database) (*Genesis, error) {

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -366,9 +366,7 @@ func (dl *diskLayer) generateRange(ctx *generatorContext, trieId *trie.ID, prefi
 			return false, nil, err
 		}
 		if nodes != nil {
-			// TODO(Nathan): why block is zero?
-			block := uint64(0)
-			tdb.Update(root, types.EmptyRootHash, block, trienode.NewWithNodeSet(nodes), nil)
+			tdb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 			tdb.Commit(root, false)
 		}
 		resolver = func(owner common.Hash, path []byte, hash common.Hash) []byte {

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 var votesManagerCounter = metrics.NewRegisteredCounter("votesManager/local", nil)
@@ -28,8 +27,7 @@ type Backend interface {
 type VoteManager struct {
 	eth Backend
 
-	chain       *core.BlockChain
-	chainconfig *params.ChainConfig
+	chain *core.BlockChain
 
 	chainHeadCh  chan core.ChainHeadEvent
 	chainHeadSub event.Subscription
@@ -45,12 +43,10 @@ type VoteManager struct {
 	engine consensus.PoSA
 }
 
-func NewVoteManager(eth Backend, chainconfig *params.ChainConfig, chain *core.BlockChain, pool *VotePool, journalPath, blsPasswordPath, blsWalletPath string, engine consensus.PoSA) (*VoteManager, error) {
+func NewVoteManager(eth Backend, chain *core.BlockChain, pool *VotePool, journalPath, blsPasswordPath, blsWalletPath string, engine consensus.PoSA) (*VoteManager, error) {
 	voteManager := &VoteManager{
-		eth: eth,
-
+		eth:         eth,
 		chain:       chain,
-		chainconfig: chainconfig,
 		chainHeadCh: make(chan core.ChainHeadEvent, chainHeadChanSize),
 		syncVoteCh:  make(chan core.NewVoteEvent, voteBufferForPut),
 		pool:        pool,

--- a/core/vote/vote_pool.go
+++ b/core/vote/vote_pool.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 const (
@@ -44,9 +43,8 @@ type VoteBox struct {
 }
 
 type VotePool struct {
-	chain       *core.BlockChain
-	chainconfig *params.ChainConfig
-	mu          sync.RWMutex
+	chain *core.BlockChain
+	mu    sync.RWMutex
 
 	votesFeed event.Feed
 	scope     event.SubscriptionScope
@@ -69,10 +67,9 @@ type VotePool struct {
 
 type votesPriorityQueue []*types.VoteData
 
-func NewVotePool(chainconfig *params.ChainConfig, chain *core.BlockChain, engine consensus.PoSA) *VotePool {
+func NewVotePool(chain *core.BlockChain, engine consensus.PoSA) *VotePool {
 	votePool := &VotePool{
 		chain:         chain,
-		chainconfig:   chainconfig,
 		receivedVotes: mapset.NewSet[common.Hash](),
 		curVotes:      make(map[common.Hash]*VoteBox),
 		futureVotes:   make(map[common.Hash]*VoteBox),

--- a/core/vote/vote_pool_test.go
+++ b/core/vote/vote_pool_test.go
@@ -160,7 +160,7 @@ func testVotePool(t *testing.T, isValidRules bool) {
 	}
 
 	// Create vote pool
-	votePool := NewVotePool(params.TestChainConfig, chain, mockEngine)
+	votePool := NewVotePool(chain, mockEngine)
 
 	// Create vote manager
 	// Create a temporary file for the votes journal
@@ -175,7 +175,7 @@ func testVotePool(t *testing.T, isValidRules bool) {
 	file.Close()
 	os.Remove(journal)
 
-	voteManager, err := NewVoteManager(newTestBackend(), params.TestChainConfig, chain, votePool, journal, walletPasswordDir, walletDir, mockEngine)
+	voteManager, err := NewVoteManager(newTestBackend(), chain, votePool, journal, walletPasswordDir, walletDir, mockEngine)
 	if err != nil {
 		t.Fatalf("failed to create vote managers")
 	}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -330,9 +330,9 @@ func (d *Downloader) UnregisterPeer(id string) error {
 	return nil
 }
 
-// Synchronise tries to sync up our local blockchain with a remote peer, both
+// LegacySync tries to sync up our local blockchain with a remote peer, both
 // adding various sanity checks and wrapping it with various log entries.
-func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, ttd *big.Int, mode SyncMode) error {
+func (d *Downloader) LegacySync(id string, head common.Hash, td *big.Int, ttd *big.Int, mode SyncMode) error {
 	err := d.synchronise(id, head, td, ttd, mode, false, nil)
 
 	switch err {

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -1034,7 +1034,7 @@ func testBlockHeaderAttackerDropping(t *testing.T, protocol uint) {
 		// Simulate a synchronisation and check the required result
 		tester.downloader.synchroniseMock = func(string, common.Hash) error { return tt.result }
 
-		tester.downloader.Synchronise(id, tester.chain.Genesis().Hash(), big.NewInt(1000), nil, FullSync)
+		tester.downloader.LegacySync(id, tester.chain.Genesis().Hash(), big.NewInt(1000), nil, FullSync)
 		if _, ok := tester.peers[id]; !ok != tt.drop {
 			t.Errorf("test %d: peer drop mismatch for %v: have %v, want %v", i, tt.result, !ok, tt.drop)
 		}

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -797,6 +797,7 @@ func TestOptionMaxPeersPerIP(t *testing.T) {
 		defer sink.Close()
 
 		wg.Add(1)
+		time.Sleep(time.Duration((tryNum-1)*200) * time.Millisecond)
 		go func(num int) {
 			err := handler.handler.runEthPeer(sink, func(peer *eth.Peer) error {
 				wg.Done()

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -242,7 +242,7 @@ func (h *handler) doSync(op *chainSyncOp) error {
 		}
 	}
 	// Run the sync cycle, and disable snap sync if we're past the pivot block
-	err := h.downloader.Synchronise(op.peer.ID(), op.head, op.td, h.chain.Config().TerminalTotalDifficulty, op.mode)
+	err := h.downloader.LegacySync(op.peer.ID(), op.head, op.td, h.chain.Config().TerminalTotalDifficulty, op.mode)
 	if err != nil {
 		return err
 	}

--- a/les/client.go
+++ b/les/client.go
@@ -19,7 +19,6 @@ package les
 
 import (
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -107,13 +106,16 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Info("")
-	log.Info(strings.Repeat("-", 153))
-	for _, line := range strings.Split(chainConfig.Description(), "\n") {
-		log.Info(line)
-	}
-	log.Info(strings.Repeat("-", 153))
-	log.Info("")
+	// Description of chainConfig is empty now
+	/*
+		log.Info("")
+		log.Info(strings.Repeat("-", 153))
+		for _, line := range strings.Split(chainConfig.Description(), "\n") {
+			log.Info(line)
+		}
+		log.Info(strings.Repeat("-", 153))
+		log.Info("")
+	*/
 
 	peers := newServerPeerSet()
 	merger := consensus.NewMerger(chainDb)

--- a/les/client.go
+++ b/les/client.go
@@ -106,6 +106,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	if err != nil {
 		return nil, err
 	}
+	log.Info("Initialised chain configuration for les.client", "config", chainConfig)
 	// Description of chainConfig is empty now
 	/*
 		log.Info("")

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -259,7 +259,7 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 	// Sanitize the timeout config for creating payload.
 	newpayloadTimeout := worker.config.NewPayloadTimeout
 	if newpayloadTimeout == 0 {
-		log.Warn("Sanitizing new payload timeout to default", "provided", newpayloadTimeout, "updated", DefaultConfig.NewPayloadTimeout)
+		// log.Warn("Sanitizing new payload timeout to default", "provided", newpayloadTimeout, "updated", DefaultConfig.NewPayloadTimeout)
 		newpayloadTimeout = DefaultConfig.NewPayloadTimeout
 	}
 	if newpayloadTimeout < time.Millisecond*100 {

--- a/trie/triedb/pathdb/database.go
+++ b/trie/triedb/pathdb/database.go
@@ -140,7 +140,7 @@ func New(diskdb ethdb.Database, config *Config) *Database {
 	// mechanism also ensures that at most one **non-readOnly** database
 	// is opened at the same time to prevent accidental mutation.
 	if ancient, err := diskdb.AncientDatadir(); err == nil && ancient != "" && !db.readOnly {
-		offset := uint64(0) //TODO(Nathan)
+		offset := uint64(0) //TODO(Nathan): just for passing compilation
 		freezer, err := rawdb.NewStateHistoryFreezer(ancient, false, offset)
 		if err != nil {
 			log.Crit("Failed to open state history freezer", "err", err)


### PR DESCRIPTION
### Description

consensus/parlia: reject header with WithdrawalsHash before shanghai fork

### Rationale

WithdrawalsHash is not need by bsc, ensure it to be nil

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add owner of some TODO
* show flag `miner.delayleftover` in help doc and shadow flag `miner.newpayload-timeout`,
   disable warn log about `newpayloadTimeout`, because it's useless for bsc
* change way of dumping chainConfig
* delete useless param `chainconfig` for VotePool and VoteManager
* fix TestOptionMaxPeersPerIP failure of goroutine order

keep consistent with go-ethereum, miss them when big merge:
* use `LoadChainConfig` to replace `SetupGenesisBlockWithOverride`, the later func has been called in `NewBlockChain`
* rename `Synchronise` to `LegacySync`
