### PR TITLE
core/bloombits: fix deadlock when matcher session hits an error

### DIFF
--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -633,13 +633,16 @@ func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan 
 			request <- &Retrieval{Bit: bit, Sections: sections, Context: s.ctx}
 
 			result := <-request
+
+			// Deliver a result before s.Close() to avoid a deadlock
+			s.deliverSections(result.Bit, result.Sections, result.Bitsets)
+
 			if result.Error != nil {
 				s.errLock.Lock()
 				s.err = result.Error
 				s.errLock.Unlock()
 				s.Close()
 			}
-			s.deliverSections(result.Bit, result.Sections, result.Bitsets)
 		}
 	}
 }


### PR DESCRIPTION
### Description

Calling `eth_getLogs` for pruned blocks causes deadlock.  The exact same issue was reported as #1125 but it was never fixed.

This patch has been merged in the upstream and will be included in the next version v1.13.2.  More technical details are described in https://github.com/ethereum/go-ethereum/pull/28184.

### Rationale

Every node runners running pruned nodes encounter this deadlock.  If a request causes deadlock, the request fail with timeout.  To make matters worse, piled-up deadlock goroutines keep consuming system resource and the process will eventually be killed. due to OOM.

With this patch, the request immediately returns a jsonrpc error.

### Example

Sending a single `eth_getLogs` for a single pruned block is enough to reproduce deadlock.

### Changes

Notable changes: 
* Porting https://github.com/ethereum/go-ethereum/commit/c2cfe35f121cb88650b4d90c958bcc4214d0ce7f from go-ethereum to bsc