### PR TITLE
fix: skip a patch that could fork the chain

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -409,7 +409,7 @@ func (c *dataCopy) RequiredGas(input []byte) uint64 {
 }
 
 func (c *dataCopy) Run(in []byte) ([]byte, error) {
-	return common.CopyBytes(in), nil
+	return in, nil
 }
 
 // bigModExp implements a native big integer exponential modular operation.


### PR DESCRIPTION
### Description
There was a known EVM bug of Geth, refer:
https://github.com/ethereum/go-ethereum/security/advisories/GHSA-69v6-xc2j-r2jf
https://gist.github.com/karalabe/e1891c8a99fdc16c4e60d9713c35401f
https://github.com/ethereum/go-ethereum/pull/25183
BSC has not applied the fix yet, and tend to fix it with a hard fork release.

### Rationale
Just leave it there,could to be fixed in the future.


### Example
NA

### Changes
NA