### PR TITLE
cmd/geth: fix error when writing state history after covert from hbss to pbss

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -207,7 +207,12 @@ var (
 		Usage:    "Exits after block synchronisation completes",
 		Category: flags.EthCategory,
 	}
-
+	// hbss2pbss command options
+	ForceFlag = &cli.BoolFlag{
+		Name:  "force",
+		Usage: "Force convert hbss trie node to pbss trie node. Ingore any metadata",
+		Value: false,
+	}
 	// Dump command options.
 	IterativeOutputFlag = &cli.BoolFlag{
 		Name:  "iterative",

--- a/core/rawdb/accessors_state.go
+++ b/core/rawdb/accessors_state.go
@@ -256,11 +256,31 @@ func ReadStateHistory(db ethdb.AncientReaderOp, id uint64) ([]byte, []byte, []by
 // history starts from one(zero for initial state).
 func WriteStateHistory(db ethdb.AncientWriter, id uint64, meta []byte, accountIndex []byte, storageIndex []byte, accounts []byte, storages []byte) {
 	db.ModifyAncients(func(op ethdb.AncientWriteOp) error {
-		op.AppendRaw(stateHistoryMeta, id-1, meta)
-		op.AppendRaw(stateHistoryAccountIndex, id-1, accountIndex)
-		op.AppendRaw(stateHistoryStorageIndex, id-1, storageIndex)
-		op.AppendRaw(stateHistoryAccountData, id-1, accounts)
-		op.AppendRaw(stateHistoryStorageData, id-1, storages)
+		err := op.AppendRaw(stateHistoryMeta, id-1, meta)
+		if err != nil {
+			log.Error("WriteStateHistory failed", "err", err)
+			return err
+		}
+		err = op.AppendRaw(stateHistoryAccountIndex, id-1, accountIndex)
+		if err != nil {
+			log.Error("WriteStateHistory failed", "err", err)
+			return err
+		}
+		err = op.AppendRaw(stateHistoryStorageIndex, id-1, storageIndex)
+		if err != nil {
+			log.Error("WriteStateHistory failed", "err", err)
+			return err
+		}
+		err = op.AppendRaw(stateHistoryAccountData, id-1, accounts)
+		if err != nil {
+			log.Error("WriteStateHistory failed", "err", err)
+			return err
+		}
+		err = op.AppendRaw(stateHistoryStorageData, id-1, storages)
+		if err != nil {
+			log.Error("WriteStateHistory failed", "err", err)
+			return err
+		}
 		return nil
 	})
 }

--- a/core/rawdb/ancient_utils.go
+++ b/core/rawdb/ancient_utils.go
@@ -18,9 +18,12 @@ package rawdb
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 )
 
 type tableSize struct {
@@ -142,5 +145,25 @@ func InspectFreezerTable(ancient string, freezerName string, tableName string, s
 		return err
 	}
 	table.dumpIndexStdout(start, end)
+	return nil
+}
+
+func ResetStateFreezerTableOffset(ancient string, virtualTail uint64) error {
+	path, tables := filepath.Join(ancient, stateFreezerName), stateFreezerNoSnappy
+
+	for name, disableSnappy := range tables {
+		log.Info("Handle table", "name", name, "disableSnappy", disableSnappy)
+		table, err := newTable(path, name, metrics.NilMeter{}, metrics.NilMeter{}, metrics.NilGauge{}, freezerTableSize, disableSnappy, false)
+		if err != nil {
+			log.Error("New table failed", "error", err)
+			return err
+		}
+		// Reset the metadata of the freezer table
+		err = table.ResetItemsOffset(virtualTail)
+		if err != nil {
+			log.Error("Reset items offset of the table", "name", name, "error", err)
+			return err
+		}
+	}
 	return nil
 }

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -593,13 +593,13 @@ func PruneHashTrieNodeInDataBase(db ethdb.Database) error {
 			db.Delete(key)
 			total_num++
 			if total_num%100000 == 0 {
-				log.Info("Pruning ", "Complete progress: ", total_num, "hash-base trie nodes")
+				log.Info("Pruning hash-base state trie nodes", "Complete progress: ", total_num)
 			}
 		default:
 			continue
 		}
 	}
-	log.Info("Pruning ", "Complete progress", total_num, "hash-base trie nodes")
+	log.Info("Pruning hash-base state trie nodes", "Complete progress", total_num)
 	return nil
 }
 

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -949,3 +949,33 @@ func (t *freezerTable) dumpIndex(w io.Writer, start, stop int64) {
 	}
 	fmt.Fprintf(w, "|--------------------------|\n")
 }
+
+func (t *freezerTable) ResetItemsOffset(virtualTail uint64) error {
+	stat, err := t.index.Stat()
+	if err != nil {
+		return err
+	}
+
+	if stat.Size() == 0 {
+		return fmt.Errorf("Stat size is zero when ResetVirtualTail.")
+	}
+
+	var firstIndex indexEntry
+
+	buffer := make([]byte, indexEntrySize)
+
+	t.index.ReadAt(buffer, 0)
+	firstIndex.unmarshalBinary(buffer)
+
+	firstIndex.offset = uint32(virtualTail)
+	t.index.WriteAt(firstIndex.append(nil), 0)
+
+	var firstIndex2 indexEntry
+	buffer2 := make([]byte, indexEntrySize)
+	t.index.ReadAt(buffer2, 0)
+	firstIndex2.unmarshalBinary(buffer2)
+
+	log.Info("Reset Index", "filenum", t.index.Name(), "offset", firstIndex2.offset)
+
+	return nil
+}

--- a/trie/hbss2pbss.go
+++ b/trie/hbss2pbss.go
@@ -83,7 +83,7 @@ func (h2p *Hbss2Pbss) Run() {
 	h2p.ConcurrentTraversal(h2p.trie, h2p.root, []byte{})
 	h2p.wg.Wait()
 
-	log.Info("Total complete: %v, go routines Num: %v, h2p concurrentQueue: %v\n", h2p.totalNum, runtime.NumGoroutine(), len(h2p.concurrentQueue))
+	log.Info("Total", "complete", h2p.totalNum, "go routines Num", runtime.NumGoroutine, "h2p concurrentQueue", len(h2p.concurrentQueue))
 
 	rawdb.WritePersistentStateID(h2p.db.diskdb, h2p.blocknum)
 	rawdb.WriteStateID(h2p.db.diskdb, h2p.stateRootHash, h2p.blocknum)


### PR DESCRIPTION
### Description

When trieNode is converted from hbss to pbss format, the historical state data also needs to be modified accordingly, otherwise the following error will occur:

```
t=2023-10-07T11:11:19+0800 lvl=eror msg="WriteStateHistory failed" err="the append operation is out-order: have 443956 want 0"
```


### Rationale

This PR modifies the meta of the freezer table to avoid the above error, and enables continued writing of historical state after block chasing.


### Example

```
./geth db hbss-to-pbss --datadir ./node 5000
```

### Changes

Notable changes: 
* Refactor the hbss2pbss tools
* Add state ancient repair function
