### PR TITLE
metrics: fix missing miner-info, build-info and node-info

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -191,7 +191,7 @@ func (r *StandardRegistry) Unregister(name string) {
 
 func (r *StandardRegistry) loadOrRegister(name string, i interface{}) (interface{}, bool, bool) {
 	switch i.(type) {
-	case Counter, CounterFloat64, Gauge, GaugeFloat64, Healthcheck, Histogram, Meter, Timer, ResettingTimer:
+	case Counter, CounterFloat64, Gauge, GaugeFloat64, Healthcheck, Histogram, Meter, Timer, ResettingTimer, Label:
 	default:
 		return nil, false, false
 	}


### PR DESCRIPTION
### Description

metrics: fix missing miner-info, build-info and node-info

### Rationale

resupport type Label in metrics, so miner-info, build-info and node-info can be shown

### Example

![image](https://github.com/bnb-chain/bsc/assets/7995985/4f79af55-a2d8-42b5-a9e5-efc22d09443f)
![image](https://github.com/bnb-chain/bsc/assets/7995985/3ff2326c-724f-4f44-861e-7b245a6d23d8)

![image](https://github.com/bnb-chain/bsc/assets/122502194/34ebec22-3d73-4cab-bf9a-7e617c5a60db)

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
