### PR TITLE
core/state: skip deleting storages for EmptyTrie

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1350,6 +1350,10 @@ func (s *StateDB) deleteStorage(addr common.Address, addrHash common.Hash, root 
 	if err != nil {
 		return false, nil, nil, fmt.Errorf("failed to open storage trie, err: %w", err)
 	}
+	// skip deleting storages for EmptyTrie
+	if _, ok := tr.(*trie.EmptyTrie); ok {
+		return false, nil, nil, nil
+	}
 	it, err := tr.NodeIterator(nil)
 	if err != nil {
 		return false, nil, nil, fmt.Errorf("failed to open storage iterator, err: %w", err)


### PR DESCRIPTION
### Description

core/state: skip deleting storages for EmptyTrie

### Rationale

trie is EmptyTrie for fast node,
iterate it will cause panic

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
