### PR TITLE
core/txpool: ignore nil sub when subpool have been shut down

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -321,7 +321,10 @@ func (p *TxPool) Pending(enforceTips bool) map[common.Address][]*LazyTransaction
 func (p *TxPool) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
 	subs := make([]event.Subscription, len(p.subpools))
 	for i, subpool := range p.subpools {
-		subs[i] = subpool.SubscribeTransactions(ch)
+		sub := subpool.SubscribeTransactions(ch)
+		if sub != nil { // sub will be nil when subpool have been shut down
+			subs[i] = sub
+		}
 	}
 	return p.subs.Track(event.JoinSubscriptions(subs...))
 }
@@ -331,7 +334,10 @@ func (p *TxPool) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscrip
 func (p *TxPool) SubscribeReannoTxsEvent(ch chan<- core.ReannoTxsEvent) event.Subscription {
 	subs := make([]event.Subscription, len(p.subpools))
 	for i, subpool := range p.subpools {
-		subs[i] = subpool.SubscribeReannoTxsEvent(ch)
+		sub := subpool.SubscribeReannoTxsEvent(ch)
+		if sub != nil { // sub will be nil when subpool have been shut down
+			subs[i] = sub
+		}
 	}
 	return p.subs.Track(event.JoinSubscriptions(subs...))
 }


### PR DESCRIPTION
### Description

core/txpool: ignore nil sub when subpool have been shut down

### Rationale

keep continue subscribing result of txs, 
when stop geth, report error as following

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1003ea414]

goroutine 25748 [running]:
github.com/ethereum/go-ethereum/event.JoinSubscriptions.func1.2({0x0?, 0x0?})
	github.com/ethereum/go-ethereum/event/multisub.go:34 +0x34
created by github.com/ethereum/go-ethereum/event.JoinSubscriptions.func1
	github.com/ethereum/go-ethereum/event/multisub.go:32 +0x8c
```

It's caused by nil subscription when subpool has been shut down.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
