### PR TITLE
consensus/parlia: fix nextForkHash in Extra filed of block header

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -950,7 +950,7 @@ func (p *Parlia) Prepare(chain consensus.ChainHeaderReader, header *types.Header
 	}
 
 	header.Extra = header.Extra[:extraVanity-nextForkHashSize]
-	nextForkHash := forkid.NewID(p.chainConfig, p.genesisHash, number, header.Time).Hash
+	nextForkHash := forkid.NextForkHash(p.chainConfig, p.genesisHash, number, header.Time)
 	header.Extra = append(header.Extra, nextForkHash[:]...)
 
 	if err := p.prepareValidators(header); err != nil {
@@ -1084,7 +1084,7 @@ func (p *Parlia) Finalize(chain consensus.ChainHeaderReader, header *types.Heade
 	if err != nil {
 		return err
 	}
-	nextForkHash := forkid.NewID(p.chainConfig, p.genesisHash, number, header.Time).Hash
+	nextForkHash := forkid.NextForkHash(p.chainConfig, p.genesisHash, number, header.Time)
 	if !snap.isMajorityFork(hex.EncodeToString(nextForkHash[:])) {
 		log.Debug("there is a possible fork, and your client is not the majority. Please check...", "nextForkHash", hex.EncodeToString(nextForkHash[:]))
 	}


### PR DESCRIPTION
### Description

consensus/parlia: fix nextForkHash in Extra filed of block header

### Rationale

when sync from old client with debug level log, msg reported
```
t=2023-10-17T07:36:46+0000 lvl=dbug msg="Inserted new block"                     number=208,366    hash=0x6323bffbbfec7c4fbb7762313f5ee9c6d550469f3a83d5ae84170847d702930b uncles=0 txs=0   gas=0         elapsed="213.385µs" root=0xd323557cb3d7f3de97d3726f5ba0e8d84ddd1792d0bab7fe78ff6310c7cdb2ee
t=2023-10-17T07:36:46+0000 lvl=dbug msg="there is a possible fork, and your client is not the majority. Please check..." nextForkHash=3f2e9ae4
```
the reason is that after big merge, use `NewID` to replace of func `NextForkHash`
this patch revert this modification

PS:
the `nextForkHash` logic first added [here](https://github.com/bnb-chain/bsc/pull/53/files#diff-77f77794b42f4fd84db10f281103146d1f12e9b50a404254bc87565e3e423872) 
and refactor [here](https://github.com/bnb-chain/bsc/commit/dbc70ee1e2ce6ed192a0b8815e66ada99fa5dd42) 

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
