### PR TITLE
release: prepare for release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## v1.3.1
+FEATURE
+* [\#1881](https://github.com/bnb-chain/bsc/pull/1881) feat: active pbss
+* [\#1882](https://github.com/bnb-chain/bsc/pull/1881) cmd/geth: add hbss to pbss convert tool
+* [\#1916](https://github.com/bnb-chain/bsc/pull/1916) feat: cherry-pick pbss patch commits from eth repo in v1.13.2
+
+BUGFIX
+* [\#1923](https://github.com/bnb-chain/bsc/pull/1923) consensus/parlia: fix nextForkHash in Extra filed of block header
+
 ## v1.3.0
 #### RPC
 * [internal/ethapi: add debug_getRawReceipts RPC method (#24773)](https://github.com/bnb-chain/bsc/pull/1840/commits/ae7d834bc752a2d94fef9d354ee78fcb9425f3d1)

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 3  // Minor version component of the current release
-	VersionPatch = 0  // Patch version component of the current release
+	VersionPatch = 1  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.3.1 is a maintenance release to support PBSS on BSC.
PBSS stands for: Path-Based-Storage-Scheme, which is used to optimize the MPT trie tree access, to improve its efficiency and also brings the inline state prune. You could refer this post on how it works: [Geth Path-Based Storage Model and Newly Inline State Prune](https://nodereal.io/blog/en/geth-path-based-storage-model-and-newly-inline-state-prune/)

Currently, PBSS is disabled by default, use this new flag to enable it: `--state.scheme path`
**Important**
Before use PBSS, you need to make sure your MPT storage in levelDB are already in PBSS format. There are 2 options to get the PBSS storage:
- 1.Full sync from genesis with the flag: `--state.scheme path`.  // Not recommend, could take 3 months to catch up the latest block.
- 2.Use the converting tool, refer: https://github.com/bnb-chain/bsc/pull/1882.  // Recommend, could take ~3 days to complete the MPT convert from HashBased to PBSS.

### Change Log
FEATURE
* [\#1881](https://github.com/bnb-chain/bsc/pull/1881) feat: active pbss
* [\#1882](https://github.com/bnb-chain/bsc/pull/1881) cmd/geth: add hbss to pbss convert tool
* [\#1916](https://github.com/bnb-chain/bsc/pull/1916) feat: cherry-pick pbss patch commits from eth repo in v1.13.2

BUGFIX
* [\#1923](https://github.com/bnb-chain/bsc/pull/1923) consensus/parlia: fix nextForkHash in Extra filed of block header

### Example
NA

### Compatibility
PBSS will have a new MPT storage scheme, although it is still based the Key/Value database, like LevelDB. HashBased storage could not use PBSS and vice versa.