### PR TITLE
performance: commitTire concurrently during Commit

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1808,6 +1808,7 @@ func (s *StateDB) Commit(block uint64, failPostCommitFunc func(), postCommitFunc
 		go commmitTrie()
 	} else {
 		defer s.StopPrefetcher()
+		commitFuncs = append(commitFuncs, commmitTrie)
 	}
 	commitRes := make(chan error, len(commitFuncs))
 	for _, f := range commitFuncs {
@@ -1822,10 +1823,6 @@ func (s *StateDB) Commit(block uint64, failPostCommitFunc func(), postCommitFunc
 		if r != nil {
 			return common.Hash{}, nil, r
 		}
-	}
-	// commitFuncs[1] and commmitTrie concurrent map `storages` iteration and map write
-	if err := commmitTrie(); err != nil {
-		return common.Hash{}, nil, err
 	}
 
 	root := s.stateRoot


### PR DESCRIPTION
### Description
In `StateDB::Commit()`, run `commmitTrie()` concurrently to improve the performance.
Previous commitTrie was changed to be run serially for `--pipecommit`, but actually, it is ok to run it concurrently.

### Rationale
It was broken after v1.3.0 due to a object concurrent access safety, to reenable it

### Implementation
the safety was about: `StateDB.storages`
```
type StateDB struct {
  ...
  storages       map[common.Hash]map[common.Hash][]byte 
  ...
}
```
it is used to store the modified KV pair for each address on updateTrie which is called during block validation phase, the key is with Keccak hashed.


