### PR TITLE
Fix receipts

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1983,10 +1983,7 @@ func (s *TransactionAPI) GetTransactionReceiptsByBlockNumber(ctx context.Context
 	txReceipts := make([]map[string]interface{}, 0, len(txs))
 	for idx, receipt := range receipts {
 		tx := txs[idx]
-		var signer types.Signer = types.FrontierSigner{}
-		if tx.Protected() {
-			signer = types.NewEIP155Signer(tx.ChainId())
-		}
+		signer := types.MakeSigner(s.b.ChainConfig(), block.Number(), block.Time())
 		from, _ := types.Sender(signer, tx)
 
 		fields := map[string]interface{}{
@@ -2001,6 +1998,8 @@ func (s *TransactionAPI) GetTransactionReceiptsByBlockNumber(ctx context.Context
 			"contractAddress":   nil,
 			"logs":              receipt.Logs,
 			"logsBloom":         receipt.Bloom,
+			"type":              hexutil.Uint(tx.Type()),
+			"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
 		}
 
 		// Assign receipt status or post state.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2038,7 +2038,7 @@ func (s *TransactionAPI) GetTransactionDataAndReceipt(ctx context.Context, hash 
 	receipt := receipts[index]
 
 	// Derive the sender.
-	header, err := s.b.HeaderByHash(ctx, hash)
+	header, err := s.b.HeaderByHash(ctx, blockHash)
 	if err != nil {
 		return nil, err
 	}
@@ -2076,6 +2076,8 @@ func (s *TransactionAPI) GetTransactionDataAndReceipt(ctx context.Context, hash 
 		"contractAddress":   nil,
 		"logs":              receipt.Logs,
 		"logsBloom":         receipt.Bloom,
+		"type":              hexutil.Uint(tx.Type()),
+		"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
 	}
 
 	// Assign receipt status or post state.


### PR DESCRIPTION
### Description
Fix: eth_getTransactionDataAndReceipt
Fix: eth_getTransactionReceiptsByBlockNumber

### Rationale

tell us why we need these changes...

### Example
eth_getTransactionReceiptsByBlockNumber API return wrong data
![image](https://github.com/bnb-chain/bsc/assets/45141191/57a74d2f-ca48-4cb1-826d-d6bcac50502b)


### Changes

Notable changes: 
* internal/ethapi/api.
