### PR TITLE
performance: keep trie prefetch during validation phase

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -149,17 +149,17 @@ func (s *stateObject) touch() {
 func (s *stateObject) getTrie() (Trie, error) {
 	if s.trie == nil {
 		// Try fetching from prefetcher first
-		if s.data.Root != types.EmptyRootHash && s.db.prefetcher != nil {
-			// When the miner is creating the pending state, there is no prefetcher
-			s.trie = s.db.prefetcher.trie(s.addrHash, s.data.Root)
+		// if s.data.Root != types.EmptyRootHash && s.db.prefetcher != nil {
+		// When the miner is creating the pending state, there is no prefetcher
+		//	s.trie = s.db.prefetcher.trie(s.addrHash, s.data.Root)
+		// }
+		// if s.trie == nil {
+		tr, err := s.db.db.OpenStorageTrie(s.db.originalRoot, s.address, s.data.Root)
+		if err != nil {
+			return nil, err
 		}
-		if s.trie == nil {
-			tr, err := s.db.db.OpenStorageTrie(s.db.originalRoot, s.address, s.data.Root)
-			if err != nil {
-				return nil, err
-			}
-			s.trie = tr
-		}
+		s.trie = tr
+		// }
 	}
 	return s.trie, nil
 }


### PR DESCRIPTION
### Description
Recently, we saw some nodes spent lots of time on block validation phase, could even longer than 6 seconds, which leads to slash of some validators. We found out it is caused by some giant transactions, like XenCrypto. Take this transaction for example: https://bscscan.com/tx/0x5d948f50b9f1245fc4c9feaff71e02c607468d9540c33606253fa89998e9b7d8, which consumed ~40M gas in a single transaction. 
It is quite unfriendly to the current trie prefetch logic, which is terminated right after entering validation phase, since `getTrie()` will stop the trie prefetch.
This PR tries to keep trie prefetch until validation phase is completed, which will call `StopPrefetcher()` at the end of `StateIntermediateRoot()`.

### Test Result:
For these long time validation phase, the validation time could be reduced by more than 80%, which is a huge improve.
```
//= latest develop branch: import the trouble  block take ~12s
t=2023-10-30T17:11:19+0000 lvl=info msg="Imported new chain segment"            number=33,060,898 hash=0x59e91888d0b6a5aef78e961ef5eb7545eed3aad3409cc26a38625639f4225c89 miner=0xb218C5D6aF1F979aC42BC68d98A5A0D796C6aB01 blocks=1          txs=115           mgas=24.430  elapsed=11.968s      mgasps=2.041   dirty="86.95 MiB"

// develop with this patch: import the same  block take ~2.1s
t=2023-10-30T17:11:09+0000 lvl=info msg="Imported new chain segment"            number=33,060,898 hash=0x59e91888d0b6a5aef78e961ef5eb7545eed3aad3409cc26a38625639f4225c89 miner=0xb218C5D6aF1F979aC42BC68d98A5A0D796C6aB01 blocks=1          txs=115           mgas=24.430  elapsed=2.137s       mgasps=11.431  dirty="278.60 MiB"

```
Metrics of the test:
<img width="1324" alt="image" src="https://github.com/bnb-chain/bsc/assets/92799281/396c7182-de84-452f-ac7b-84a529b48834">


### Rationale
NA

### Example
NA

### Changes
NA