### PR TITLE
draft release v1.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## v1.2.13
+IMPROVEMENT
+* [\#1954](https://github.com/bnb-chain/bsc/pull/1954) performance: keep trie prefetch during validation phase
+
+BUGFIX
+* [\#1950](https://github.com/bnb-chain/bsc/pull/1950) fix: 2 APIs of get receipt related(#1950)
+
 ## v1.2.12
 FEATURE
 * [\#1852](https://github.com/bnb-chain/bsc/pull/1852) discov: add hardcoded bootnodes

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -165,20 +165,20 @@ func (s *StateObject) getTrie(db Database) Trie {
 	if s.trie == nil {
 		// Try fetching from prefetcher first
 		// We don't prefetch empty tries
-		prefetcher := s.db.prefetcher
-		if s.data.Root != emptyRoot && prefetcher != nil {
-			// When the miner is creating the pending state, there is no
-			// prefetcher
-			s.trie = prefetcher.trie(s.data.Root)
+		// prefetcher := s.db.prefetcher
+		// if s.data.Root != emptyRoot && prefetcher != nil {
+		// When the miner is creating the pending state, there is no
+		// prefetcher
+		// s.trie = prefetcher.trie(s.data.Root)
+		// }
+		// if s.trie == nil {
+		var err error
+		s.trie, err = db.OpenStorageTrie(s.addrHash, s.data.Root)
+		if err != nil {
+			s.trie, _ = db.OpenStorageTrie(s.addrHash, common.Hash{})
+			s.setError(fmt.Errorf("can't create storage trie: %v", err))
 		}
-		if s.trie == nil {
-			var err error
-			s.trie, err = db.OpenStorageTrie(s.addrHash, s.data.Root)
-			if err != nil {
-				s.trie, _ = db.OpenStorageTrie(s.addrHash, common.Hash{})
-				s.setError(fmt.Errorf("can't create storage trie: %v", err))
-			}
-		}
+		// }
 	}
 	return s.trie
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1914,10 +1914,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceiptsByBlockNumber(ctx conte
 	txReceipts := make([]map[string]interface{}, 0, len(txs))
 	for idx, receipt := range receipts {
 		tx := txs[idx]
-		var signer types.Signer = types.FrontierSigner{}
-		if tx.Protected() {
-			signer = types.NewEIP155Signer(tx.ChainId())
-		}
+		signer := types.MakeSigner(s.b.ChainConfig(), block.Number())
 		from, _ := types.Sender(signer, tx)
 
 		fields := map[string]interface{}{
@@ -1932,6 +1929,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceiptsByBlockNumber(ctx conte
 			"contractAddress":   nil,
 			"logs":              receipt.Logs,
 			"logsBloom":         receipt.Bloom,
+			"type":              hexutil.Uint(tx.Type()),
 		}
 
 		// Assign receipt status or post state.
@@ -2005,6 +2003,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionDataAndReceipt(ctx context.Cont
 		"contractAddress":   nil,
 		"logs":              receipt.Logs,
 		"logsBloom":         receipt.Bloom,
+		"type":              hexutil.Uint(tx.Type()),
 	}
 
 	// Assign receipt status or post state.

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 2  // Minor version component of the current release
-	VersionPatch = 12 // Patch version component of the current release
+	VersionPatch = 13 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.2.13 is a maintenance release, which only contains 2 PRs, one for performance enhancement, the other one fixes 2 RPC APIs.


### Change Log
IMPROVEMENT
* [\#1954](https://github.com/bnb-chain/bsc/pull/1954) performance: keep trie prefetch during validation phase

BUGFIX
* [\#1950](https://github.com/bnb-chain/bsc/pull/1950) fix: 2 APIs of get receipt related(#1950)


### Example
NA

### Compatibility
NA