### PR TITLE
consensus/parlia: hardfork block can be epoch block

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -828,6 +828,13 @@ func (p *Parlia) prepareValidators(header *types.Header) error {
 		}
 	} else {
 		header.Extra = append(header.Extra, byte(len(newValidators)))
+		if p.chainConfig.IsOnLuban(header.Number) {
+			voteAddressMap = make(map[common.Address]*types.BLSPublicKey, len(newValidators))
+			var zeroBlsKey types.BLSPublicKey
+			for _, validator := range newValidators {
+				voteAddressMap[validator] = &zeroBlsKey
+			}
+		}
 		for _, validator := range newValidators {
 			header.Extra = append(header.Extra, validator.Bytes()...)
 			header.Extra = append(header.Extra, voteAddressMap[validator].Bytes()...)
@@ -989,6 +996,13 @@ func (p *Parlia) verifyValidators(header *types.Header) error {
 			return errMismatchingEpochValidators
 		}
 		validatorsBytes = make([]byte, validatorsNumber*validatorBytesLength)
+		if p.chainConfig.IsOnLuban(header.Number) {
+			voteAddressMap = make(map[common.Address]*types.BLSPublicKey, len(newValidators))
+			var zeroBlsKey types.BLSPublicKey
+			for _, validator := range newValidators {
+				voteAddressMap[validator] = &zeroBlsKey
+			}
+		}
 		for i, validator := range newValidators {
 			copy(validatorsBytes[i*validatorBytesLength:], validator.Bytes())
 			copy(validatorsBytes[i*validatorBytesLength+common.AddressLength:], voteAddressMap[validator].Bytes())

--- a/params/config.go
+++ b/params/config.go
@@ -159,15 +159,11 @@ var (
 		MoranBlock:          big.NewInt(22107423),
 		GibbsBlock:          big.NewInt(23846001),
 		PlanckBlock:         big.NewInt(27281024),
-
-		// TODO modify blockNumber, make sure the blockNumber is not an integer multiple of 200 (epoch number)
-		// TODO Caution !!! it should be very careful !!!
-		LubanBlock: big.NewInt(29020050),
-		PlatoBlock: big.NewInt(30720096),
-		// TODO modify blockNumber, make sure HertzBlock=BerlinBlock=LondonBlock to enable Berlin and London EIPs
-		BerlinBlock: big.NewInt(31302048),
-		LondonBlock: big.NewInt(31302048),
-		HertzBlock:  big.NewInt(31302048),
+		LubanBlock:          big.NewInt(29020050),
+		PlatoBlock:          big.NewInt(30720096),
+		BerlinBlock:         big.NewInt(31302048),
+		LondonBlock:         big.NewInt(31302048),
+		HertzBlock:          big.NewInt(31302048),
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -195,15 +191,11 @@ var (
 		NanoBlock:           big.NewInt(23482428),
 		MoranBlock:          big.NewInt(23603940),
 		PlanckBlock:         big.NewInt(28196022),
-
-		// TODO modify blockNumber, make sure the blockNumber is not an integer multiple of 200 (epoch number)
-		// TODO Caution !!! it should be very careful !!!
-		LubanBlock: big.NewInt(29295050),
-		PlatoBlock: big.NewInt(29861024),
-		// TODO modify blockNumber, make sure HertzBlock=BerlinBlock=LondonBlock to enable Berlin and London EIPs
-		BerlinBlock: big.NewInt(31103030),
-		LondonBlock: big.NewInt(31103030),
-		HertzBlock:  big.NewInt(31103030),
+		LubanBlock:          big.NewInt(29295050),
+		PlatoBlock:          big.NewInt(29861024),
+		BerlinBlock:         big.NewInt(31103030),
+		LondonBlock:         big.NewInt(31103030),
+		HertzBlock:          big.NewInt(31103030),
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -231,12 +223,10 @@ var (
 		NanoBlock:           nil,
 		MoranBlock:          nil,
 		PlanckBlock:         nil,
-
-		// TODO
-		LubanBlock:  nil,
-		PlatoBlock:  nil,
-		BerlinBlock: nil,
-		HertzBlock:  nil,
+		LubanBlock:          nil,
+		PlatoBlock:          nil,
+		BerlinBlock:         nil,
+		HertzBlock:          nil,
 
 		Parlia: &ParliaConfig{
 			Period: 3,


### PR DESCRIPTION
### Description

consensus/parlia: hardfork block can be epoch block

### Rationale

shanghai hardfork will be enabled based on block time instead of block number

but hardfork block can't be epoch block when enable luban
this patch find the reason , fix it and remove the warning in comments

so no fear of shanghai hardfork time run into epoch block

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
