### PR TITLE
core: enable Shanghai EIPs

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -49,6 +49,7 @@ jobs:
         CGO_CFLAGS_ALLOW: "-O -D__BLST_PORTABLE__"
         ANDROID_HOME: "" # Skip android test
       run: |
+        git submodule update --init --depth 1 --recursive
         go mod download
         make test
 

--- a/consensus/misc/eip1559/eip1559_test.go
+++ b/consensus/misc/eip1559/eip1559_test.go
@@ -51,6 +51,11 @@ func copyConfig(original *params.ChainConfig) *params.ChainConfig {
 
 func config() *params.ChainConfig {
 	config := copyConfig(params.TestChainConfig)
+	config.Ethash = nil
+	config.Parlia = &params.ParliaConfig{
+		Period: 3,
+		Epoch:  200,
+	}
 	config.LondonBlock = big.NewInt(5)
 	return config
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -534,7 +534,7 @@ func (g *Genesis) ToBlock() *types.Block {
 	var withdrawals []*types.Withdrawal
 	if conf := g.Config; conf != nil {
 		num := big.NewInt(int64(g.Number))
-		if conf.IsShanghai(num, g.Timestamp) {
+		if conf.Parlia == nil && conf.IsShanghai(num, g.Timestamp) {
 			head.WithdrawalsHash = &types.EmptyWithdrawalsHash
 			withdrawals = make([]*types.Withdrawal, 0)
 		}

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -90,7 +90,7 @@ func newCancunInstructionSet() JumpTable {
 }
 
 func newShanghaiInstructionSet() JumpTable {
-	instructionSet := newMergeInstructionSet()
+	instructionSet := newLondonInstructionSet()
 	enable3855(&instructionSet) // PUSH0 instruction
 	enable3860(&instructionSet) // Limit and meter initcode
 

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -118,42 +118,40 @@ func TestFilters(t *testing.T) {
 		contract  = common.Address{0xfe}
 		contract2 = common.Address{0xff}
 		abiStr    = `[{"inputs":[],"name":"log0","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"t1","type":"uint256"}],"name":"log1","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"t1","type":"uint256"},{"internalType":"uint256","name":"t2","type":"uint256"}],"name":"log2","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"t1","type":"uint256"},{"internalType":"uint256","name":"t2","type":"uint256"},{"internalType":"uint256","name":"t3","type":"uint256"}],"name":"log3","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"t1","type":"uint256"},{"internalType":"uint256","name":"t2","type":"uint256"},{"internalType":"uint256","name":"t3","type":"uint256"},{"internalType":"uint256","name":"t4","type":"uint256"}],"name":"log4","outputs":[],"stateMutability":"nonpayable","type":"function"}]`
-		// BaseFee in BSC is 0 now, use 1Gwei instead for test here to avoid 0 gasPrice
-		gasPrice1Gwei = big.NewInt(params.GWei)
 		/*
 			// SPDX-License-Identifier: GPL-3.0
 			pragma solidity >=0.7.0 <0.9.0;
 
 			contract Logger {
-			    function log0() external {
-			        assembly {
-			            log0(0, 0)
-			        }
-			    }
+				function log0() external {
+					assembly {
+						log0(0, 0)
+					}
+				}
 
-			    function log1(uint t1) external {
-			        assembly {
-			            log1(0, 0, t1)
-			        }
-			    }
+				function log1(uint t1) external {
+					assembly {
+						log1(0, 0, t1)
+					}
+				}
 
-			    function log2(uint t1, uint t2) external {
-			        assembly {
-			            log2(0, 0, t1, t2)
-			        }
-			    }
+				function log2(uint t1, uint t2) external {
+					assembly {
+						log2(0, 0, t1, t2)
+					}
+				}
 
-			    function log3(uint t1, uint t2, uint t3) external {
-			        assembly {
-			            log3(0, 0, t1, t2, t3)
-			        }
-			    }
+				function log3(uint t1, uint t2, uint t3) external {
+					assembly {
+						log3(0, 0, t1, t2, t3)
+					}
+				}
 
-			    function log4(uint t1, uint t2, uint t3, uint t4) external {
-			        assembly {
-			            log4(0, 0, t1, t2, t3, t4)
-			        }
-			    }
+				function log4(uint t1, uint t2, uint t3, uint t4) external {
+					assembly {
+						log4(0, 0, t1, t2, t3, t4)
+					}
+				}
 			}
 		*/
 		bytecode = common.FromHex("608060405234801561001057600080fd5b50600436106100575760003560e01c80630aa731851461005c5780632a4c08961461006657806378b9a1f314610082578063c670f8641461009e578063c683d6a3146100ba575b600080fd5b6100646100d6565b005b610080600480360381019061007b9190610143565b6100dc565b005b61009c60048036038101906100979190610196565b6100e8565b005b6100b860048036038101906100b391906101d6565b6100f2565b005b6100d460048036038101906100cf9190610203565b6100fa565b005b600080a0565b808284600080a3505050565b8082600080a25050565b80600080a150565b80828486600080a450505050565b600080fd5b6000819050919050565b6101208161010d565b811461012b57600080fd5b50565b60008135905061013d81610117565b92915050565b60008060006060848603121561015c5761015b610108565b5b600061016a8682870161012e565b935050602061017b8682870161012e565b925050604061018c8682870161012e565b9150509250925092565b600080604083850312156101ad576101ac610108565b5b60006101bb8582860161012e565b92505060206101cc8582860161012e565b9150509250929050565b6000602082840312156101ec576101eb610108565b5b60006101fa8482850161012e565b91505092915050565b6000806000806080858703121561021d5761021c610108565b5b600061022b8782880161012e565b945050602061023c8782880161012e565b935050604061024d8782880161012e565b925050606061025e8782880161012e565b9150509295919450925056fea264697066735822122073a4b156f487e59970dc1ef449cc0d51467268f676033a17188edafcee861f9864736f6c63430008110033")
@@ -171,9 +169,7 @@ func TestFilters(t *testing.T) {
 				contract:  {Balance: big.NewInt(0), Code: bytecode},
 				contract2: {Balance: big.NewInt(0), Code: bytecode},
 			},
-			// Ethereum's InitialBaseFee is 1000000000, while BSC is 0, here is to fix CI
-			// BaseFee: big.NewInt(params.InitialBaseFee),
-			BaseFee: gasPrice1Gwei,
+			BaseFee: big.NewInt(params.InitialBaseFeeForEthMainnet),
 		}
 	)
 
@@ -197,7 +193,7 @@ func TestFilters(t *testing.T) {
 			}
 			tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
 				Nonce:    0,
-				GasPrice: gasPrice1Gwei,
+				GasPrice: gen.BaseFee(),
 				Gas:      30000,
 				To:       &contract,
 				Data:     data,
@@ -205,7 +201,7 @@ func TestFilters(t *testing.T) {
 			gen.AddTx(tx)
 			tx2, _ := types.SignTx(types.NewTx(&types.LegacyTx{
 				Nonce:    1,
-				GasPrice: gasPrice1Gwei,
+				GasPrice: gen.BaseFee(),
 				Gas:      30000,
 				To:       &contract2,
 				Data:     data,
@@ -218,7 +214,7 @@ func TestFilters(t *testing.T) {
 			}
 			tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
 				Nonce:    2,
-				GasPrice: gasPrice1Gwei,
+				GasPrice: gen.BaseFee(),
 				Gas:      30000,
 				To:       &contract,
 				Data:     data,
@@ -231,7 +227,7 @@ func TestFilters(t *testing.T) {
 			}
 			tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
 				Nonce:    3,
-				GasPrice: gasPrice1Gwei,
+				GasPrice: gen.BaseFee(),
 				Gas:      30000,
 				To:       &contract2,
 				Data:     data,
@@ -244,7 +240,7 @@ func TestFilters(t *testing.T) {
 			}
 			tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
 				Nonce:    4,
-				GasPrice: gasPrice1Gwei,
+				GasPrice: gen.BaseFee(),
 				Gas:      30000,
 				To:       &contract,
 				Data:     data,
@@ -290,61 +286,74 @@ func TestFilters(t *testing.T) {
 	}{
 		{
 			f:    sys.NewBlockFilter(chain[2].Hash(), []common.Address{contract}, nil),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332","0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x3","transactionHash":"0x0dc0e230687c0b67421b862b6ac7af9d21c157fd5f41d35266bf148f21c754b4","transactionIndex":"0x0","blockHash":"0x552c4d4884746b710049d85c8d6e3c420ff021ff65244672fcdcd82154c9292b","logIndex":"0x0","removed":false}]`,
-		}, {
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332","0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x3","transactionHash":"0xdefe471992a07a02acdfbe33edaae22fbb86d7d3cec3f1b8e4e77702fb3acc1d","transactionIndex":"0x0","blockHash":"0x7a7556792ca7d37882882e2b001fe14833eaf81c2c7f865c9c771ec37a024f6b","logIndex":"0x0","removed":false}]`,
+		},
+		{
 			f:    sys.NewRangeFilter(0, int64(rpc.LatestBlockNumber), []common.Address{contract}, [][]common.Hash{{hash1, hash2, hash3, hash4}}, false),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x2","transactionHash":"0x251cd3065f17245a0a6d528d74ae8bd6f008813e19319d14154bfda99b2e742d","transactionIndex":"0x0","blockHash":"0x41f1a563f54d6ce4330db1ad87c51b8ac3b68b9379e35b51e8c5e9b030b1f1b1","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332","0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x3","transactionHash":"0x0dc0e230687c0b67421b862b6ac7af9d21c157fd5f41d35266bf148f21c754b4","transactionIndex":"0x0","blockHash":"0x552c4d4884746b710049d85c8d6e3c420ff021ff65244672fcdcd82154c9292b","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x71bbc18e2797e26e27fef2e9dd6a65e1eff6421735e9568ea805fc4a57f20482","transactionIndex":"0x0","blockHash":"0x7f0be2e908e7a6b2bcbab9dc574a9050338ed6c6db592bd97be21d4f1a69518a","logIndex":"0x0","removed":false}]`,
-		}, {
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x2","transactionHash":"0xa8028c655b6423204c8edfbc339f57b042d6bec2b6a61145d76b7c08b4cccd42","transactionIndex":"0x0","blockHash":"0x24417bb49ce44cfad65da68f33b510bf2a129c0d89ccf06acb6958b8585ccf34","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332","0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x3","transactionHash":"0xdefe471992a07a02acdfbe33edaae22fbb86d7d3cec3f1b8e4e77702fb3acc1d","transactionIndex":"0x0","blockHash":"0x7a7556792ca7d37882882e2b001fe14833eaf81c2c7f865c9c771ec37a024f6b","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x9a87842100a638dfa5da8842b4beda691d2fd77b0c84b57f24ecfa9fb208f747","transactionIndex":"0x0","blockHash":"0xb360bad5265261c075ece02d3bf0e39498a6a76310482cdfd90588748e6c5ee0","logIndex":"0x0","removed":false}]`,
+		},
+		{
 			f: sys.NewRangeFilter(900, 999, []common.Address{contract}, [][]common.Hash{{hash3}}, false),
-		}, {
+		},
+		{
 			f:    sys.NewRangeFilter(990, int64(rpc.LatestBlockNumber), []common.Address{contract2}, [][]common.Hash{{hash3}}, false),
-			want: `[{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0xcaea5cabe64d59ac0c74ca2eed41b1ef36dc996415ca085396d0f5acb0094935","transactionIndex":"0x0","blockHash":"0xf926a72aac711b12c385bdb7e935c49c3b77b4a857e4c924d9bfcf940694f3c1","logIndex":"0x0","removed":false}]`,
-		}, {
+			want: `[{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0x53e3675800c6908424b61b35a44e51ca4c73ca603e58a65b32c67968b4f42200","transactionIndex":"0x0","blockHash":"0x2e4620a2b426b0612ec6cad9603f466723edaed87f98c9137405dd4f7a2409ff","logIndex":"0x0","removed":false}]`,
+		},
+		{
 			f:    sys.NewRangeFilter(1, 10, []common.Address{contract}, [][]common.Hash{{hash2}, {hash1}}, false),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332","0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x3","transactionHash":"0x0dc0e230687c0b67421b862b6ac7af9d21c157fd5f41d35266bf148f21c754b4","transactionIndex":"0x0","blockHash":"0x552c4d4884746b710049d85c8d6e3c420ff021ff65244672fcdcd82154c9292b","logIndex":"0x0","removed":false}]`,
-		}, {
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332","0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x3","transactionHash":"0xdefe471992a07a02acdfbe33edaae22fbb86d7d3cec3f1b8e4e77702fb3acc1d","transactionIndex":"0x0","blockHash":"0x7a7556792ca7d37882882e2b001fe14833eaf81c2c7f865c9c771ec37a024f6b","logIndex":"0x0","removed":false}]`,
+		},
+		{
 			f:    sys.NewRangeFilter(1, 10, nil, [][]common.Hash{{hash1, hash2}}, false),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x2","transactionHash":"0x251cd3065f17245a0a6d528d74ae8bd6f008813e19319d14154bfda99b2e742d","transactionIndex":"0x0","blockHash":"0x41f1a563f54d6ce4330db1ad87c51b8ac3b68b9379e35b51e8c5e9b030b1f1b1","logIndex":"0x0","removed":false},{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x2","transactionHash":"0x7afd31c9d543a1056ca2d35ce106408f1cb925546fc3a97f337122ca5a9e515e","transactionIndex":"0x1","blockHash":"0x41f1a563f54d6ce4330db1ad87c51b8ac3b68b9379e35b51e8c5e9b030b1f1b1","logIndex":"0x1","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332","0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x3","transactionHash":"0x0dc0e230687c0b67421b862b6ac7af9d21c157fd5f41d35266bf148f21c754b4","transactionIndex":"0x0","blockHash":"0x552c4d4884746b710049d85c8d6e3c420ff021ff65244672fcdcd82154c9292b","logIndex":"0x0","removed":false}]`,
-		}, {
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x2","transactionHash":"0xa8028c655b6423204c8edfbc339f57b042d6bec2b6a61145d76b7c08b4cccd42","transactionIndex":"0x0","blockHash":"0x24417bb49ce44cfad65da68f33b510bf2a129c0d89ccf06acb6958b8585ccf34","logIndex":"0x0","removed":false},{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x2","transactionHash":"0xdba3e2ea9a7d690b722d70ee605fd67ba4c00d1d3aecd5cf187a7b92ad8eb3df","transactionIndex":"0x1","blockHash":"0x24417bb49ce44cfad65da68f33b510bf2a129c0d89ccf06acb6958b8585ccf34","logIndex":"0x1","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332","0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x3","transactionHash":"0xdefe471992a07a02acdfbe33edaae22fbb86d7d3cec3f1b8e4e77702fb3acc1d","transactionIndex":"0x0","blockHash":"0x7a7556792ca7d37882882e2b001fe14833eaf81c2c7f865c9c771ec37a024f6b","logIndex":"0x0","removed":false}]`,
+		},
+		{
 			f: sys.NewRangeFilter(0, int64(rpc.LatestBlockNumber), nil, [][]common.Hash{{common.BytesToHash([]byte("fail"))}}, false),
-		}, {
+		},
+		{
 			f: sys.NewRangeFilter(0, int64(rpc.LatestBlockNumber), []common.Address{common.BytesToAddress([]byte("failmenow"))}, nil, false),
-		}, {
+		},
+		{
 			f: sys.NewRangeFilter(0, int64(rpc.LatestBlockNumber), nil, [][]common.Hash{{common.BytesToHash([]byte("fail"))}, {hash1}}, false),
-		}, {
+		},
+		{
 			f:    sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.LatestBlockNumber), nil, nil, false),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x71bbc18e2797e26e27fef2e9dd6a65e1eff6421735e9568ea805fc4a57f20482","transactionIndex":"0x0","blockHash":"0x7f0be2e908e7a6b2bcbab9dc574a9050338ed6c6db592bd97be21d4f1a69518a","logIndex":"0x0","removed":false}]`,
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x9a87842100a638dfa5da8842b4beda691d2fd77b0c84b57f24ecfa9fb208f747","transactionIndex":"0x0","blockHash":"0xb360bad5265261c075ece02d3bf0e39498a6a76310482cdfd90588748e6c5ee0","logIndex":"0x0","removed":false}]`,
 		},
 		/*
-			// BSC's finalize logic is different from Ethereum, it is achieved from snapshot, no SetFinalized
-			// So skip finality related cases
 			{
 				f:    sys.NewRangeFilter(int64(rpc.FinalizedBlockNumber), int64(rpc.LatestBlockNumber), nil, nil, false),
-				want: `[{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0xcaea5cabe64d59ac0c74ca2eed41b1ef36dc996415ca085396d0f5acb0094935","transactionIndex":"0x0","blockHash":"0xf926a72aac711b12c385bdb7e935c49c3b77b4a857e4c924d9bfcf940694f3c1","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x71bbc18e2797e26e27fef2e9dd6a65e1eff6421735e9568ea805fc4a57f20482","transactionIndex":"0x0","blockHash":"0x7f0be2e908e7a6b2bcbab9dc574a9050338ed6c6db592bd97be21d4f1a69518a","logIndex":"0x0","removed":false}]`,
+				want: `[{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0x53e3675800c6908424b61b35a44e51ca4c73ca603e58a65b32c67968b4f42200","transactionIndex":"0x0","blockHash":"0x2e4620a2b426b0612ec6cad9603f466723edaed87f98c9137405dd4f7a2409ff","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x9a87842100a638dfa5da8842b4beda691d2fd77b0c84b57f24ecfa9fb208f747","transactionIndex":"0x0","blockHash":"0xb360bad5265261c075ece02d3bf0e39498a6a76310482cdfd90588748e6c5ee0","logIndex":"0x0","removed":false}]`,
 			},
 			{
 				f:    sys.NewRangeFilter(int64(rpc.FinalizedBlockNumber), int64(rpc.FinalizedBlockNumber), nil, nil, false),
-				want: `[{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0xcaea5cabe64d59ac0c74ca2eed41b1ef36dc996415ca085396d0f5acb0094935","transactionIndex":"0x0","blockHash":"0xf926a72aac711b12c385bdb7e935c49c3b77b4a857e4c924d9bfcf940694f3c1","logIndex":"0x0","removed":false}]`,
-			}, {
-				f: sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.FinalizedBlockNumber), nil, nil, false),
-			}, {
-				f:   sys.NewRangeFilter(int64(rpc.SafeBlockNumber), int64(rpc.LatestBlockNumber), nil, nil, false),
+				want: `[{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0x53e3675800c6908424b61b35a44e51ca4c73ca603e58a65b32c67968b4f42200","transactionIndex":"0x0","blockHash":"0x2e4620a2b426b0612ec6cad9603f466723edaed87f98c9137405dd4f7a2409ff","logIndex":"0x0","removed":false}]`,
+			},
+			{
+				f: sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.FinalizedBlockNumber), nil, nil),
+			},
+			{
+				f:   sys.NewRangeFilter(int64(rpc.SafeBlockNumber), int64(rpc.LatestBlockNumber), nil, nil),
 				err: "safe header not found",
-			}, {
-				f:   sys.NewRangeFilter(int64(rpc.SafeBlockNumber), int64(rpc.SafeBlockNumber), nil, nil, false),
+			},
+			{
+				f:   sys.NewRangeFilter(int64(rpc.SafeBlockNumber), int64(rpc.SafeBlockNumber), nil, nil),
 				err: "safe header not found",
-			}, {
-				f:   sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.SafeBlockNumber), nil, nil, false),
+			},
+			{
+				f:   sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.SafeBlockNumber), nil, nil),
 				err: "safe header not found",
 			},
 		*/
 		{
 			f:    sys.NewRangeFilter(int64(rpc.PendingBlockNumber), int64(rpc.PendingBlockNumber), nil, nil, false),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696335"],"data":"0x","blockNumber":"0x3e9","transactionHash":"0xb2bb61fcb8a26dae28e833ba97e2e87cfb8d3dcdfe77f9375b8a5a2e62a890e9","transactionIndex":"0x0","blockHash":"0x53a4ca36e4e3108ce28f140f80327c4851a5eb5717abd8324d3bb6fc07fdc328","logIndex":"0x0","removed":false}]`,
-		}, {
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696335"],"data":"0x","blockNumber":"0x3e9","transactionHash":"0x4110587c1b8d86edc85dce929a34127f1cb8809515a9f177c91c866de3eb0638","transactionIndex":"0x0","blockHash":"0xc7245899e5817f16fa99cf5ad2d9c1e4b98443a565a673ec9c764640443ef037","logIndex":"0x0","removed":false}]`,
+		},
+		{
 			f:    sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.PendingBlockNumber), nil, nil, false),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x71bbc18e2797e26e27fef2e9dd6a65e1eff6421735e9568ea805fc4a57f20482","transactionIndex":"0x0","blockHash":"0x7f0be2e908e7a6b2bcbab9dc574a9050338ed6c6db592bd97be21d4f1a69518a","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696335"],"data":"0x","blockNumber":"0x3e9","transactionHash":"0xb2bb61fcb8a26dae28e833ba97e2e87cfb8d3dcdfe77f9375b8a5a2e62a890e9","transactionIndex":"0x0","blockHash":"0x53a4ca36e4e3108ce28f140f80327c4851a5eb5717abd8324d3bb6fc07fdc328","logIndex":"0x0","removed":false}]`,
-		}, {
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x9a87842100a638dfa5da8842b4beda691d2fd77b0c84b57f24ecfa9fb208f747","transactionIndex":"0x0","blockHash":"0xb360bad5265261c075ece02d3bf0e39498a6a76310482cdfd90588748e6c5ee0","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696335"],"data":"0x","blockNumber":"0x3e9","transactionHash":"0x4110587c1b8d86edc85dce929a34127f1cb8809515a9f177c91c866de3eb0638","transactionIndex":"0x0","blockHash":"0xc7245899e5817f16fa99cf5ad2d9c1e4b98443a565a673ec9c764640443ef037","logIndex":"0x0","removed":false}]`,
+		},
+		{
 			f:   sys.NewRangeFilter(int64(rpc.PendingBlockNumber), int64(rpc.LatestBlockNumber), nil, nil, false),
 			err: "invalid block range",
 		},

--- a/params/config.go
+++ b/params/config.go
@@ -540,7 +540,12 @@ func (c *ChainConfig) String() string {
 		engine = "unknown"
 	}
 
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Planck: %v,Luban: %v, Plato: %v, Hertz: %v, Engine: %v}",
+	var ShanghaiTime *big.Int
+	if c.ShanghaiTime != nil {
+		ShanghaiTime = big.NewInt(0).SetUint64(*c.ShanghaiTime)
+	}
+
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Planck: %v,Luban: %v, Plato: %v, Hertz: %v, ShanghaiTime: %d, Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -571,6 +576,7 @@ func (c *ChainConfig) String() string {
 		c.LubanBlock,
 		c.PlatoBlock,
 		c.HertzBlock,
+		ShanghaiTime,
 		engine,
 	)
 }

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -30,7 +30,7 @@ func TestBlockchain(t *testing.T) {
 	// For speedier CI-runs, the line below can be uncommented, so those are skipped.
 	// For now, in hardfork-times (Berlin), we run the tests both as StateTests and
 	// as blockchain tests, since the latter also covers things like receipt root
-	bt.skipLoad(`^GeneralStateTests/`)
+	// bt.skipLoad(`^GeneralStateTests/`)
 
 	// Skip random failures due to selfish mining test
 	bt.skipLoad(`.*bcForgedTest/bcForkUncle\.json`)
@@ -48,6 +48,9 @@ func TestBlockchain(t *testing.T) {
 	// test takes a lot for time and goes easily OOM because of sha3 calculation on a huge range,
 	// using 4.6 TGas
 	bt.skipLoad(`.*randomStatetest94.json.*`)
+
+	bt.runonly(`^GeneralStateTests/Shanghai`)
+	bt.runonly(`^Pyspecs/shanghai/eip3.*`)
 
 	bt.walk(t, blockTestDir, func(t *testing.T, name string, test *BlockTest) {
 		if err := bt.checkFailure(t, test.Run(false, rawdb.HashScheme, nil)); err != nil {

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -93,7 +93,7 @@ type testMatcher struct {
 	failpat        []testFailure
 	skiploadpat    []*regexp.Regexp
 	slowpat        []*regexp.Regexp
-	runonlylistpat *regexp.Regexp
+	runonlylistpat []*regexp.Regexp
 }
 
 type testConfig struct {
@@ -127,7 +127,7 @@ func (tm *testMatcher) fails(pattern string, reason string) {
 }
 
 func (tm *testMatcher) runonly(pattern string) {
-	tm.runonlylistpat = regexp.MustCompile(pattern)
+	tm.runonlylistpat = append(tm.runonlylistpat, regexp.MustCompile(pattern))
 }
 
 // config defines chain config for tests matching the pattern.
@@ -220,7 +220,14 @@ func (tm *testMatcher) runTestFile(t *testing.T, path, name string, runTest inte
 		t.Skip(r)
 	}
 	if tm.runonlylistpat != nil {
-		if !tm.runonlylistpat.MatchString(name) {
+		match := false
+		for _, pat := range tm.runonlylistpat {
+			if pat.MatchString(name) {
+				match = true
+				break
+			}
+		}
+		if !match {
 			t.Skip("Skipped by runonly")
 		}
 	}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -68,6 +68,8 @@ func TestState(t *testing.T) {
 	st.fails(`stEIP4844-blobtransactions/opcodeBlobhashOutOfRange.json`, "test has incorrect state root")
 	st.fails(`stEIP4844-blobtransactions/opcodeBlobhBounds.json`, "test has incorrect state root")
 
+	st.runonly(`^Shanghai`)
+
 	// For Istanbul, older tests were moved into LegacyTests
 	for _, dir := range []string{
 		filepath.Join(baseDir, "EIPTests", "StateTests"),

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -300,7 +300,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	// And _now_ get the state root
 	root := statedb.IntermediateRoot(config.IsEIP158(block.Number()))
 	statedb.SetExpectedStateRoot(root)
-	root, _, err = statedb.Commit(block.NumberU64(), nil)
+	root, _, _ = statedb.Commit(block.NumberU64(), nil)
 	return triedb, snaps, statedb, root, err
 }
 

--- a/trie/triedb/pathdb/database.go
+++ b/trie/triedb/pathdb/database.go
@@ -172,7 +172,7 @@ func New(diskdb ethdb.Database, config *Config) *Database {
 	// mechanism also ensures that at most one **non-readOnly** database
 	// is opened at the same time to prevent accidental mutation.
 	if ancient, err := diskdb.AncientDatadir(); err == nil && ancient != "" && !db.readOnly {
-		offset := uint64(0) //TODO(Nathan): just for passing compilation
+		offset := uint64(0) // differ from in block data, only metadata is used in state data
 		freezer, err := rawdb.NewStateFreezer(ancient, false, offset)
 		if err != nil {
 			log.Crit("Failed to open state history freezer", "err", err)


### PR DESCRIPTION
### Description

core: enable Shanghai EIPs

### Rationale

more compatible with ethereum/evm, 6 points need to check
1. [BEP-216: Implement EIP 3855 PUSH0 instruction](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP216.md#bep-216-implement-eip-3855-push0-instruction)
2. [BEP-217: Implement EIP3860 Limit and meter initcode](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP217.md#bep-217-implement-eip3860-limit-and-meter-initcode)
3. [BEP-311: Implement EIP-3651 Warm COINBASE](https://github.com/bnb-chain/BEPs/pull/311)
4. [BEP-312: Announce EIP-6049 Deprecate SELFDESTRUCT](https://github.com/bnb-chain/BEPs/pull/312)
5. disable [EIP-4895](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4895.md) after code upstream
6. use time based hardfork

### Example
1. to disable EIP-4895, need confirm 3 points:
   a. Parlia.FinalizeAndAssemble ignore `Withdrawals`
   b. Parlia.verifyHeader ensure header.WithdrawalsHash == nil
   c. ValidateBody ensure block.Withdrawals()==nil
2. test BEP-216, BEP-217 and BEP-310
  reuse handreds of test cases in https://github.com/ethereum/tests
```
cd bsc
git submodule update --init --depth 1 --recursive
cd tests
go test -run TestBlockchain -v
go test -run TestState -v
```
3. because [consensus/parlia: hardfork block can be epoch block](https://github.com/bnb-chain/bsc/pull/1964), so Shanghai can use time based hardfork

PS:  BEP-312 just used as a way to announce, no code need to change
### Changes

Notable changes: 
* add each change in a bullet point here
* ...
