### PR TITLE
fix: v1.3.1-beta cannot start with `--pruneancient=true`

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2355,7 +2355,7 @@ func tryMakeReadOnlyDatabase(ctx *cli.Context, stack *node.Node) ethdb.Database 
 	// If datadir doesn't exist we need to open db in write-mode
 	// so database engine can create files.
 	readonly := true
-	if !common.FileExist(stack.ResolvePath("chaindata")) {
+	if !common.FileExist(stack.ResolvePath("chaindata")) || ctx.Bool(PruneAncientDataFlag.Name) {
 		readonly = false
 	}
 	return MakeChainDatabase(ctx, stack, readonly, false)


### PR DESCRIPTION
### Description
Fix the node unable to start issue if `--pruneancient=true` by creating a non-read-only database. 

Refer to #1984 and #1982.

### Rationale
When initializing a readonly database, it will attempt to open a freezer file for read only (refer to code [here](https://github.com/bnb-chain/bsc/blob/v1.3.1-beta/core/rawdb/freezer_table.go#L147-L164)). Since ancient files are pruned and no longer exist, the read file operation will fail and return error. 

### Example
Refer to #1984 and #1982.

### Changes
Create a non-read-only database if `--pruneancient=true`.
