### PR TITLE
cmd/utils: exit process if txlookuplimit flag is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,15 @@ geth --datadir <datadir> --state.scheme path init ./genesis.json
 ```
 #### 4. Start a full node
 ```shell
-./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0
+./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --history.transactions 0
 
 ## It is recommand to run fullnode with `--tries-verify-mode none` if you want high performance and care little about state consistency
 ## It will run with Hash-Base Storage Scheme by default
-./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0 --tries-verify-mode none
+./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --history.transactions 0 --tries-verify-mode none
 
 ## It runs fullnode with Path-Base Storage Scheme. 
 ## It will enable inline state prune, keeping the latest 90000 blocks' history state by default.
-./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0 --tries-verify-mode none --state.scheme path
+./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --history.transactions 0 --tries-verify-mode none --state.scheme path
 ```
 
 #### 5. Monitor node status

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1948,14 +1948,12 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// Parse transaction history flag, if user is still using legacy config
 	// file with 'TxLookupLimit' configured, copy the value to 'TransactionHistory'.
 	if cfg.TransactionHistory == ethconfig.Defaults.TransactionHistory && cfg.TxLookupLimit != ethconfig.Defaults.TxLookupLimit {
-		log.Warn("The config option 'TxLookupLimit' is deprecated and will be removed, please use 'TransactionHistory'")
-		cfg.TransactionHistory = cfg.TxLookupLimit
+		log.Crit("The config option 'TxLookupLimit' is deprecated and may cause unexpected performance degradation issues, please use 'TransactionHistory' instead")
 	}
 	if ctx.IsSet(TransactionHistoryFlag.Name) {
 		cfg.TransactionHistory = ctx.Uint64(TransactionHistoryFlag.Name)
 	} else if ctx.IsSet(TxLookupLimitFlag.Name) {
-		log.Warn("The flag --txlookuplimit is deprecated and will be removed, please use --history.transactions")
-		cfg.TransactionHistory = ctx.Uint64(TransactionHistoryFlag.Name)
+		log.Crit("The flag --txlookuplimit is deprecated and may cause unexpected performance degradation issues. Please use --history.transactions instead")
 	}
 	if ctx.IsSet(PathDBSyncFlag.Name) {
 		cfg.PathSyncFlush = true

--- a/log/root.go
+++ b/log/root.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"os"
+	"time"
 )
 
 var (
@@ -105,6 +106,7 @@ func Error(msg string, ctx ...interface{}) {
 //	log.Crit("msg", "key1", val1, "key2", val2)
 func Crit(msg string, ctx ...interface{}) {
 	root.write(msg, LvlCrit, ctx, skipLevel)
+	time.Sleep(3 * time.Second)
 	os.Exit(1)
 }
 

--- a/tests/truffle/scripts/bsc-rpc.sh
+++ b/tests/truffle/scripts/bsc-rpc.sh
@@ -12,5 +12,5 @@ done
 
 geth --config ${DATA_DIR}/config.toml --datadir ${DATA_DIR} --netrestrict ${CLUSTER_CIDR} \
     --verbosity ${VERBOSE} --nousb \
-    --rpc.allow-unprotected-txs --txlookuplimit 15768000 \
+    --rpc.allow-unprotected-txs --history.transactions 15768000 \
     -unlock ${unlock_sequences} --password /dev/null

--- a/tests/truffle/scripts/bsc-validator.sh
+++ b/tests/truffle/scripts/bsc-validator.sh
@@ -15,4 +15,4 @@ geth --config ${DATA_DIR}/config.toml --datadir ${DATA_DIR} --netrestrict ${CLUS
     --bootnodes enode://${BOOTSTRAP_PUB_KEY}@${BOOTSTRAP_IP}:${BOOTSTRAP_TCP_PORT} \
     --mine -unlock ${VALIDATOR_ADDR} --miner.etherbase ${VALIDATOR_ADDR} --password /dev/null \
     --light.serve 50 \
-    --rpc.allow-unprotected-txs --txlookuplimit 15768000
+    --rpc.allow-unprotected-txs --history.transactions 15768000


### PR DESCRIPTION
### Description
Crash node and exit process if `--txlookuplimit` flag is set instead of `history.transactions`.

### Rationale
If users still use `--txlookuplimit` which is deprecated instead of `history.transactions`, then it maintains the default number of blocks to maintain the transaction index for. This may cause the node to unindex transactions, which would affect the performance.

Refer to #1999 for more details.

### Example
N/A

### Changes
- Wait 3 seconds before `os.Exit(1)`, this ensures the log message is printed before exiting. 