### PR TITLE
release: prepare for release v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 # Changelog
+## v1.3.2
+FEATURE
+* [\#1970](https://github.com/bnb-chain/bsc/pull/1970) core: enable Shanghai EIPs
+* [\#1973](https://github.com/bnb-chain/bsc/pull/1973) core/systemcontracts: include BEP-319 on kepler hardfork
+
+BUGFIX
+* [\#1964](https://github.com/bnb-chain/bsc/pull/1964) consensus/parlia: hardfork block can be epoch block
+* [\#1979](https://github.com/bnb-chain/bsc/pull/1979) fix: upgrade pebble and improve config
+* [\#1980](https://github.com/bnb-chain/bsc/pull/1980) internal/ethapi: fix null effectiveGasPrice in GetTransactionReceipt
+* [\#1986](https://github.com/bnb-chain/bsc/pull/1986) fix(cmd): check pruneancient when creating db
+
+IMPROVEMENT
+* [\#1977](https://github.com/bnb-chain/bsc/pull/1977) doc: add instructions for starting fullnode with pbss
+* [\#2000](https://github.com/bnb-chain/bsc/pull/2000) cmd/utils: exit process if txlookuplimit flag is set
+
 ## v1.3.1
 FEATURE
 * [\#1881](https://github.com/bnb-chain/bsc/pull/1881) feat: active pbss

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 3  // Minor version component of the current release
-	VersionPatch = 1  // Patch version component of the current release
+	VersionPatch = 2  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.3.2 is a hard fork release for BSC testnet.
It will enable the Kepler(Shanghai) hard fork on BSC testnet, for details of the hard fork, pls refer: [BSC Kepler Hard Fork](https://forum.bnbchain.org/t/bnb-chain-upgrades-mainnet/936#kepler-in-progress-10)

The validators and full node operators on testnet should switch their software version to v1.3.2 before ?.
#### Kepler BEPs
- [BEP-319: Optimize the incentive mechanism of the Fast Finality feature](https://github.com/bnb-chain/BEPs/pull/319)
- Part of Shanghai Upgrade: 
a.[BEP-216: Implement EIP-3855 PUSH0 instruction](https://github.com/bnb-chain/BEPs/pull/216)
b.[BEP-217: Implement EIP3860 Limit and meter initcode](https://github.com/bnb-chain/BEPs/pull/217)
c.[ BEP-311: Warm COINBASE](https://github.com/bnb-chain/BEPs/pull/311)
d.[BEP-312: Announce EIP-6049 Deprecate SELFDESTRUCT ](https://github.com/bnb-chain/BEPs/pull/312)


### Change Log
FEATURE
* [\#1970](https://github.com/bnb-chain/bsc/pull/1970) core: enable Shanghai EIPs
* [\#1973](https://github.com/bnb-chain/bsc/pull/1973) core/systemcontracts: include BEP-319 on kepler hardfork

BUGFIX
* [\#1964](https://github.com/bnb-chain/bsc/pull/1964) consensus/parlia: hardfork block can be epoch block
* [\#1979](https://github.com/bnb-chain/bsc/pull/1979) fix: upgrade pebble and improve config
* [\#1980](https://github.com/bnb-chain/bsc/pull/1980) internal/ethapi: fix null effectiveGasPrice in GetTransactionReceipt
* [\#1986](https://github.com/bnb-chain/bsc/pull/1986) fix(cmd): check pruneancient when creating db

IMPROVEMENT
* [\#1977](https://github.com/bnb-chain/bsc/pull/1977) doc: add instructions for starting fullnode with pbss
* [\#2000](https://github.com/bnb-chain/bsc/pull/2000) cmd/utils: exit process if txlookuplimit flag is set

### Example
NA

### Compatibility
NA