### PR TITLE
consensus/parlia: increase size of snapshot cache in parlia

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	inMemorySnapshots  = 128  // Number of recent snapshots to keep in memory
+	inMemorySnapshots  = 256  // Number of recent snapshots to keep in memory
 	inMemorySignatures = 4096 // Number of recent block signatures to keep in memory
 
 	checkpointInterval = 1024        // Number of blocks after which to save the snapshot to the database


### PR DESCRIPTION
### Description

consensus/parlia: increase size of snapshot cache in parlia

### Rationale

when distribute rewards for fast finality,
need to get snapshot for blocks in [currentNumber-200,currentNumber) 

but the size of `recentSnaps` is only 128, so many snapshots need to be inferred in place,
to get better performance, double 128 to 256

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
