### PR TITLE
 consensus/parlia: recover faster when snapshot of parlia is gone in disk

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -680,7 +680,7 @@ func (p *Parlia) snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 		// If we're at the genesis, snapshot the initial state. Alternatively if we have
 		// piled up more headers than allowed to be reorged (chain reinit from a freezer),
 		// consider the checkpoint trusted and snapshot it.
-		if number == 0 || (number%p.config.Epoch == 0 && (len(headers) > params.FullImmutabilityThreshold)) {
+		if number == 0 || (number%p.config.Epoch == 0 && (len(headers) > params.FullImmutabilityThreshold/10)) {
 			checkpoint := chain.GetHeaderByNumber(number)
 			if checkpoint != nil {
 				// get checkpoint data
@@ -694,10 +694,12 @@ func (p *Parlia) snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 
 				// new snapshot
 				snap = newSnapshot(p.config, p.signatures, number, hash, validators, voteAddrs, p.ethAPI)
-				if err := snap.store(p.db); err != nil {
-					return nil, err
+				if snap.Number%checkpointInterval == 0 { // snapshot will only be loaded when snap.Number%checkpointInterval == 0
+					if err := snap.store(p.db); err != nil {
+						return nil, err
+					}
+					log.Info("Stored checkpoint snapshot to disk", "number", number, "hash", hash)
 				}
-				log.Info("Stored checkpoint snapshot to disk", "number", number, "hash", hash)
 				break
 			}
 		}

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -199,6 +199,9 @@ func (s *Snapshot) updateAttestation(header *types.Header, chainConfig *params.C
 	}
 
 	// Update attestation
+	// Two scenarios for s.Attestation being nil:
+	// 1) The first attestation is assembled.
+	// 2) The snapshot on disk is missing, prompting the creation of a new snapshot using `newSnapshot`.
 	if s.Attestation != nil && attestation.Data.SourceNumber+1 != attestation.Data.TargetNumber {
 		s.Attestation.TargetNumber = attestation.Data.TargetNumber
 		s.Attestation.TargetHash = attestation.Data.TargetHash


### PR DESCRIPTION
### Description

 consensus/parlia: recover faster when snapshot of parlia is gone in disk

### Rationale

snapshots of parlia will be stored into disk every 1024 blocks.

if they are missing, just create a new one before reaching `FullImmutabilityThreshold`

for bsc, 15 blocks is usually view as the probabilistic fanlity number. 

FullImmutabilityThreshold is 90000, too large,

so only in this case , we decrease ti by 10 times to 9000

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
