### PR TITLE
feat: add `generate-proof` to geth cmd

### DIFF
--- a/cmd/geth/blsaccountcmd.go
+++ b/cmd/geth/blsaccountcmd.go
@@ -48,7 +48,7 @@ var (
 		Name:  "show-private-key",
 		Usage: "Show the BLS12-381 private key you will encrypt into a keystore file",
 	}
-	bLSAccountPasswordFileFlag = &cli.StringFlag{
+	blsAccountPasswordFileFlag = &cli.StringFlag{
 		Name:  "blsaccountpassword",
 		Usage: "File path for the BLS account password, which contains the password to encrypt private key into keystore file for managing votes in fast_finality feature",
 	}
@@ -140,7 +140,7 @@ Make sure you backup your BLS keys regularly.`,
 							privateKeyFlag,
 							showPrivateKeyFlag,
 							utils.BLSPasswordFileFlag,
-							bLSAccountPasswordFileFlag,
+							blsAccountPasswordFileFlag,
 						},
 						Description: `
 	geth bls account new
@@ -161,7 +161,7 @@ You must remember this password to unlock your account in the future.`,
 						Flags: []cli.Flag{
 							utils.DataDirFlag,
 							utils.BLSPasswordFileFlag,
-							bLSAccountPasswordFileFlag,
+							blsAccountPasswordFileFlag,
 						},
 						Description: `
 	geth bls account import <keyFile>
@@ -711,7 +711,7 @@ func GetBLSPassword(ctx *cli.Context) []string {
 }
 
 func GetBLSAccountPassword(ctx *cli.Context) []string {
-	path := ctx.String(bLSAccountPasswordFileFlag.Name)
+	path := ctx.String(blsAccountPasswordFileFlag.Name)
 	if path == "" {
 		return nil
 	}


### PR DESCRIPTION
### Description

This pr is to add cmd `generate-proof` to geth.

### Rationale

After feynman upgrade, anyone who wants to create a validator should provide a bls proof of his vote address. This cmd is to facilitate that.

### Changes

Notable changes: 
* add cmd `generate-proof` to geth
