### PR TITLE
release: prepare for release v1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,36 @@
 # Changelog
+## v1.3.5
+FEATURE
+* [\#1970](https://github.com/bnb-chain/bsc/pull/1970) core: enable Shanghai EIPs
+* [\#1973](https://github.com/bnb-chain/bsc/pull/1973) core/systemcontracts: include BEP-319 on kepler hardfork
+
+BUGFIX
+* [\#1964](https://github.com/bnb-chain/bsc/pull/1964) consensus/parlia: hardfork block can be epoch block
+* [\#1979](https://github.com/bnb-chain/bsc/pull/1979) fix: upgrade pebble and improve config
+* [\#1980](https://github.com/bnb-chain/bsc/pull/1980) internal/ethapi: fix null effectiveGasPrice in GetTransactionReceipt
+
+IMPROVEMENT
+* [\#1977](https://github.com/bnb-chain/bsc/pull/1977) doc: add instructions for starting fullnode with pbss
+
 ## v1.3.4
 BUGFIX
 * fix: remove pipecommit in miner
 * add a hard fork: Hertzfix
 
 ## v1.3.3
-IMPROVEMENT
-* [\#2000](https://github.com/bnb-chain/bsc/pull/2000) cmd/utils: exit process if txlookuplimit flag is set
-
 BUGFIX
 * [\#1986](https://github.com/bnb-chain/bsc/pull/1986) fix(cmd): check pruneancient when creating db
+
+IMPROVEMENT
+* [\#2000](https://github.com/bnb-chain/bsc/pull/2000) cmd/utils: exit process if txlookuplimit flag is set
 
 ## v1.3.2
 BUGFIX
 * fix: remove sharedPool
+
+IMPROVEMENT
+* [\#2007](https://github.com/bnb-chain/bsc/pull/2007) consensus/parlia: increase size of snapshot cache in parlia
+* [\#2008](https://github.com/bnb-chain/bsc/pull/2008) consensus/parlia: recover faster when snapshot of parlia is gone in disk
 
 ## v1.3.1
 FEATURE

--- a/params/config.go
+++ b/params/config.go
@@ -165,6 +165,9 @@ var (
 		LondonBlock:         big.NewInt(31302048),
 		HertzBlock:          big.NewInt(31302048),
 		HertzfixBlock:       big.NewInt(34140700),
+		// UnixTime: 1705996800 is January 23, 2024 8:00:00 AM UTC
+		ShanghaiTime: newUint64(1705996800),
+		KeplerTime:   newUint64(1705996800),
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -198,6 +201,9 @@ var (
 		LondonBlock:         big.NewInt(31103030),
 		HertzBlock:          big.NewInt(31103030),
 		HertzfixBlock:       big.NewInt(35682300),
+		// UnixTime: 1702972800 is December 19, 2023 8:00:00 AM UTC
+		ShanghaiTime: newUint64(1702972800),
+		KeplerTime:   newUint64(1702972800),
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -229,7 +235,7 @@ var (
 		PlatoBlock:          nil,
 		BerlinBlock:         nil,
 		HertzBlock:          nil,
-		HertzfixBlock: nil,
+		HertzfixBlock:       nil,
 
 		Parlia: &ParliaConfig{
 			Period: 3,

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 3  // Minor version component of the current release
-	VersionPatch = 4  // Patch version component of the current release
+	VersionPatch = 5  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.3.5 is a hard fork release for BSC.
It will enable the Kepler(Shanghai) hard fork on BSC testnet, for details of the hard fork, pls refer: [BSC Kepler Hard Fork](https://forum.bnbchain.org/t/bnb-chain-upgrades-mainnet/936#kepler-in-progress-10)

The target Kepler/Shanghai hardfork time will be:
- Testnet: Tuesday, December 19, 2023 8:00:00 AM UTC
- Mainnet: Tuesday, January 23, 2024 8:00:00 AM UTC

The validators and full node operators on Testnet/Mainnet should update their node to v1.3.5 before the respective hard fork time.

#### Kepler BEPs
- [BEP-319: Optimize the incentive mechanism of the Fast Finality feature](https://github.com/bnb-chain/BEPs/pull/319)
- Part of Shanghai Upgrade: 
a.[BEP-216: Implement EIP-3855 PUSH0 instruction](https://github.com/bnb-chain/BEPs/pull/216)
b.[BEP-217: Implement EIP3860 Limit and meter initcode](https://github.com/bnb-chain/BEPs/pull/217)
c.[ BEP-311: Warm COINBASE](https://github.com/bnb-chain/BEPs/pull/311)
d.[BEP-312: Announce EIP-6049 Deprecate SELFDESTRUCT ](https://github.com/bnb-chain/BEPs/pull/312)

### Change Log
FEATURE
* [\#1970](https://github.com/bnb-chain/bsc/pull/1970) core: enable Shanghai EIPs
* [\#1973](https://github.com/bnb-chain/bsc/pull/1973) core/systemcontracts: include BEP-319 on kepler hardfork

BUGFIX
* [\#1964](https://github.com/bnb-chain/bsc/pull/1964) consensus/parlia: hardfork block can be epoch block
* [\#1979](https://github.com/bnb-chain/bsc/pull/1979) fix: upgrade pebble and improve config
* [\#1980](https://github.com/bnb-chain/bsc/pull/1980) internal/ethapi: fix null effectiveGasPrice in GetTransactionReceipt

IMPROVEMENT
* [\#1977](https://github.com/bnb-chain/bsc/pull/1977) doc: add instructions for starting fullnode with pbss

### Example
NA

### Compatibility
NA