### PR TITLE
core/txpool/legacypool: respect nolocals-setting

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1027,6 +1027,9 @@ func (pool *LegacyPool) addRemoteSync(tx *types.Transaction) error {
 
 // addTxs attempts to queue a batch of transactions if they are valid.
 func (pool *LegacyPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
+	// Do not treat as local if local transactions have been disabled
+	local = local && !pool.config.NoLocals
+
 	// Filter out known ones without obtaining the pool lock or recovering signatures
 	var (
 		errs = make([]error, len(txs))


### PR DESCRIPTION
### Description

core/txpool/legacypool: respect nolocals-setting

### Rationale

details to https://github.com/ethereum/go-ethereum/pull/28435

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
