### PR TITLE
core/vote: wait some blocks beforing voting since mining begin

### DIFF
--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 )
 
+const blocksNumberSinceMining = 5 // the number of blocks need to wait before voting, counting from the validator begin to mine
+
 var votesManagerCounter = metrics.NewRegisteredCounter("votesManager/local", nil)
 
 // Backend wraps all methods required for voting.
@@ -95,6 +97,7 @@ func (voteManager *VoteManager) loop() {
 	dlEventCh := events.Chan()
 
 	startVote := true
+	blockCountSinceMining := 0
 	var once sync.Once
 	for {
 		select {
@@ -120,7 +123,13 @@ func (voteManager *VoteManager) loop() {
 				continue
 			}
 			if !voteManager.eth.IsMining() {
+				blockCountSinceMining = 0
 				log.Debug("skip voting because mining is disabled, continue")
+				continue
+			}
+			blockCountSinceMining++
+			if blockCountSinceMining <= blocksNumberSinceMining {
+				log.Debug("skip voting", "blockCountSinceMining", blockCountSinceMining, "blocksNumberSinceMining", blocksNumberSinceMining)
 				continue
 			}
 

--- a/core/vote/vote_pool_test.go
+++ b/core/vote/vote_pool_test.go
@@ -190,7 +190,7 @@ func testVotePool(t *testing.T, isValidRules bool) {
 	if _, err := chain.InsertChain(bs); err != nil {
 		panic(err)
 	}
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 10+blocksNumberSinceMining; i++ {
 		bs, _ = core.GenerateChain(params.TestChainConfig, bs[len(bs)-1], ethash.NewFaker(), db, 1, nil)
 		if _, err := chain.InsertChain(bs); err != nil {
 			panic(err)


### PR DESCRIPTION
### Description

core/vote: wait some blocks beforing voting since mining begin

### Rationale

many validators have backup machines

when they shutdown their running node and start the validator on the backup machine,
the new started node may vote for blocks in the same height with the down node voted for.

so, this PR let node wait some blocks beforing voting since it's mining begin

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
