### PR TITLE
chore: update logic of determining breathe block and returned data of `verifyDoubleSignEvidence`

### DIFF
--- a/consensus/parlia/feynmanfork.go
+++ b/consensus/parlia/feynmanfork.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
@@ -17,6 +16,19 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 )
+
+// TODO: revert to normal value
+// const SecondsPerDay uint64 = 86400
+const SecondsPerDay uint64 = 60
+
+// the parmas should be blocks' time which are timestamp
+func sameDayInUTC(first, second uint64) bool {
+	return first/SecondsPerDay == second/SecondsPerDay
+}
+
+func isBreatheBlock(lastBlockTime, blockTime uint64) bool {
+	return lastBlockTime != 0 && !sameDayInUTC(lastBlockTime, blockTime)
+}
 
 // initializeFeynmanContract initialize new contracts of Feynman fork
 func (p *Parlia) initializeFeynmanContract(state *state.StateDB, header *types.Header, chain core.ChainContext,

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1175,14 +1175,9 @@ func (p *Parlia) Finalize(chain consensus.ChainHeaderReader, header *types.Heade
 	}
 
 	// update validators every day
-	if p.chainConfig.IsFeynman(header.Number, header.Time) {
-		// TODO: revert this
-		// day of header > day of parent or day of header is 1 and day of parent is 31/30/29/28
-		// if time.Unix(int64(parent.Time), 0).Day() != time.Unix(int64(header.Time), 0).Day() {
-		if time.Unix(int64(header.Time), 0).Minute() != time.Unix(int64(parent.Time), 0).Minute() {
-			if err := p.updateValidatorSetV2(state, header, cx, txs, receipts, systemTxs, usedGas, false); err != nil {
-				return err
-			}
+	if p.chainConfig.IsFeynman(header.Number, header.Time) && isBreatheBlock(parent.Time, header.Time) {
+		if err := p.updateValidatorSetV2(state, header, cx, txs, receipts, systemTxs, usedGas, false); err != nil {
+			return err
 		}
 	}
 
@@ -1260,14 +1255,9 @@ func (p *Parlia) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *
 	}
 
 	// update validators every day
-	if p.chainConfig.IsFeynman(header.Number, header.Time) {
-		// TODO: revert this
-		// day of header > day of parent or day of header is 1 and day of parent is 31/30/29/28
-		// if time.Unix(int64(parent.Time), 0).Day() != time.Unix(int64(header.Time), 0).Day() {
-		if time.Unix(int64(header.Time), 0).Minute() != time.Unix(int64(parent.Time), 0).Minute() {
-			if err := p.updateValidatorSetV2(state, header, cx, &txs, &receipts, nil, &header.GasUsed, true); err != nil {
-				return nil, nil, err
-			}
+	if p.chainConfig.IsFeynman(header.Number, header.Time) && isBreatheBlock(parent.Time, header.Time) {
+		if err := p.updateValidatorSetV2(state, header, cx, &txs, &receipts, nil, &header.GasUsed, true); err != nil {
+			return nil, nil, err
 		}
 	}
 

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -1408,8 +1408,8 @@ type DoubleSignEvidence struct {
 
 // Run input: rlp encoded DoubleSignEvidence
 // return:
-// signer address| evidence time|
-// 20 bytes      | 32 bytes     |
+// signer address| evidence height|
+// 20 bytes      | 32 bytes       |
 func (c *verifyDoubleSignEvidence) Run(input []byte) ([]byte, error) {
 	evidence := &DoubleSignEvidence{}
 	err := rlp.DecodeBytes(input, evidence)
@@ -1445,9 +1445,9 @@ func (c *verifyDoubleSignEvidence) Run(input []byte) ([]byte, error) {
 	if bytes.Equal(sig1, sig2) {
 		return nil, ErrExecutionReverted
 	}
-	evidenceTime := header1.Time
-	if evidenceTime < header2.Time {
-		evidenceTime = header2.Time
+	evidenceHeight := header1.Number
+	if evidenceHeight.Cmp(header2.Number) == -1 {
+		evidenceHeight = header2.Number
 	}
 
 	// check sig
@@ -1470,9 +1470,9 @@ func (c *verifyDoubleSignEvidence) Run(input []byte) ([]byte, error) {
 
 	returnBz := make([]byte, 52) // 20 + 32
 	signerAddr := crypto.Keccak256(pubkey1[1:])[12:]
-	evidenceTimeBz := big.NewInt(int64(evidenceTime)).Bytes()
+	evidenceHeightBz := evidenceHeight.Bytes()
 	copy(returnBz[:20], signerAddr)
-	copy(returnBz[52-len(evidenceTimeBz):], evidenceTimeBz)
+	copy(returnBz[52-len(evidenceHeightBz):], evidenceHeightBz)
 
 	return returnBz, nil
 }


### PR DESCRIPTION
### Description

This pr is to update logic of determining breathe block and returned data of `verifyDoubleSignEvidence`

### Changes

Notable changes: 
* update logic of determining breathe block
* `verifyDoubleSignEvidence` will return block.number rather than block.timestamp now
