### PR TITLE
Set default hardfork times

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -435,7 +435,7 @@ func LoadChainConfig(db ethdb.Database, genesis *Genesis) (*params.ChainConfig, 
 // set the field in genesis config to the field in defaultConfig.
 // Reflection is used to avoid a long series of if statements with hardcoded block names.
 func (g *Genesis) setDefaultHardforkValues(defaultConfig *params.ChainConfig) {
-	// Regex to match block names or time names
+	// Regex to match Block names or Time names
 	hardforkPattern := []string{`.*Block$`, `.*Time$`}
 
 	for _, pat := range hardforkPattern {
@@ -451,7 +451,7 @@ func (g *Genesis) setDefaultHardforkValues(defaultConfig *params.ChainConfig) {
 			defaultConfigField := defaultConfigElem.Field(i)
 			fieldName := gConfigElem.Type().Field(i).Name
 
-			// Use the regex to check if the field is a Block field
+			// Use the regex to check if the field is a Block or Time field
 			if gConfigField.Kind() == reflect.Ptr && hardforkRegex.MatchString(fieldName) {
 				if gConfigField.IsNil() {
 					gConfigField.Set(defaultConfigField)
@@ -461,7 +461,7 @@ func (g *Genesis) setDefaultHardforkValues(defaultConfig *params.ChainConfig) {
 	}
 }
 
-// Hard fork block height specified in config.toml has higher priority, but
+// Hard fork field specified in config.toml has higher priority, but
 // if it is not specified in config.toml, use the default height in code.
 func (g *Genesis) configOrDefault(ghash common.Hash) *params.ChainConfig {
 	var defaultConfig *params.ChainConfig

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -258,9 +258,9 @@ func TestConfigOrDefault(t *testing.T) {
 	}
 }
 
-func TestSetDefaultBlockValues(t *testing.T) {
+func TestSetDefaultHardforkValues(t *testing.T) {
 	genesis := &Genesis{Config: &params.ChainConfig{ChainID: big.NewInt(66), HomesteadBlock: big.NewInt(11)}}
-	genesis.setDefaultBlockValues(params.BSCChainConfig)
+	genesis.setDefaultHardforkValues(params.BSCChainConfig)
 
 	// Make sure the non-nil block was not modified
 	if genesis.Config.HomesteadBlock.Cmp(big.NewInt(11)) != 0 {
@@ -278,6 +278,14 @@ func TestSetDefaultBlockValues(t *testing.T) {
 
 	if genesis.Config.PlanckBlock.Cmp(params.BSCChainConfig.PlanckBlock) != 0 {
 		t.Errorf("Nano block not matching: in genesis = %v , in defaultConfig = %v", genesis.Config.PlanckBlock, params.BSCChainConfig.PlanckBlock)
+	}
+
+	// Spot check a few times
+	if *genesis.Config.ShanghaiTime != *params.BSCChainConfig.ShanghaiTime {
+		t.Errorf("Shanghai Time not matching: in genesis = %d , in defaultConfig = %d", *genesis.Config.ShanghaiTime, *params.BSCChainConfig.ShanghaiTime)
+	}
+	if *genesis.Config.KeplerTime != *params.BSCChainConfig.KeplerTime {
+		t.Errorf("Kepler Time not matching: in genesis = %d , in defaultConfig = %d", *genesis.Config.KeplerTime, *params.BSCChainConfig.KeplerTime)
 	}
 
 	// Lastly make sure non-block fields such as ChainID have not been modified

--- a/params/config.go
+++ b/params/config.go
@@ -873,7 +873,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "platoBlock", block: c.PlatoBlock},
 		{name: "hertzBlock", block: c.HertzBlock},
 		{name: "hertzfixBlock", block: c.HertzfixBlock},
-		{name: "shanghaiTime", timestamp: c.ShanghaiTime},
+		{name: "keplerTime", timestamp: c.KeplerTime},
 		{name: "cancunTime", timestamp: c.CancunTime, optional: true},
 		{name: "pragueTime", timestamp: c.PragueTime, optional: true},
 		{name: "verkleTime", timestamp: c.VerkleTime, optional: true},


### PR DESCRIPTION
### Description

Set default hardfork times 

### Rationale

hardfork transit to time based from shanghai

we should set default values for time based hardforks as we have done for block based hardforks.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
