### PR TITLE
cmd/utils: allow HTTPHost and WSHost flags precede

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1259,8 +1259,10 @@ func SplitAndTrim(input string) (ret []string) {
 // setHTTP creates the HTTP RPC listener interface string from the set
 // command line flags, returning empty if the HTTP endpoint is disabled.
 func setHTTP(ctx *cli.Context, cfg *node.Config) {
-	if ctx.Bool(HTTPEnabledFlag.Name) && cfg.HTTPHost == "" {
-		cfg.HTTPHost = "127.0.0.1"
+	if ctx.Bool(HTTPEnabledFlag.Name) {
+		if cfg.HTTPHost == "" {
+			cfg.HTTPHost = "127.0.0.1"
+		}
 		if ctx.IsSet(HTTPListenAddrFlag.Name) {
 			cfg.HTTPHost = ctx.String(HTTPListenAddrFlag.Name)
 		}
@@ -1324,8 +1326,10 @@ func setGraphQL(ctx *cli.Context, cfg *node.Config) {
 // setWS creates the WebSocket RPC listener interface string from the set
 // command line flags, returning empty if the HTTP endpoint is disabled.
 func setWS(ctx *cli.Context, cfg *node.Config) {
-	if ctx.Bool(WSEnabledFlag.Name) && cfg.WSHost == "" {
-		cfg.WSHost = "127.0.0.1"
+	if ctx.Bool(WSEnabledFlag.Name) {
+		if cfg.WSHost == "" {
+			cfg.WSHost = "127.0.0.1"
+		}
 		if ctx.IsSet(WSListenAddrFlag.Name) {
 			cfg.WSHost = ctx.String(WSListenAddrFlag.Name)
 		}


### PR DESCRIPTION
### Description
Fixes #2052.

When users specify the `http.addr` and `ws.addr` command line flags, they will overwrite the HTTPHost and WSHost in the config file.

### Rationale

As a user, I would assume that specifying flags would overwrite the config files. While this is true for most flags, the behavior is the opposite for `http.addr` and `ws.addr`.

### Example
config.toml
```
[Node]
HTTPHost = "127.0.0.1"
WSHost = "127.0.0.1"
```

Command:
```
./geth --datadir node --mainnet --http --http.addr 0.0.0.0 --ws --ws.addr 0.0.0.0
```

Expected output:
```bash
...
INFO [12-12|14:17:21.325] HTTP server started                      endpoint=[::]:8545 auth=false prefix= cors= vhosts=localhost
INFO [12-12|14:17:21.326] WebSocket enabled                        url=ws://[::]:8546
...
```

Actual output:
```bash
...
INFO [12-12|14:16:47.073] HTTP server started                      endpoint=127.0.0.1:8545 auth=false prefix= cors= vhosts=localhost
INFO [12-12|14:16:47.073] WebSocket enabled                        url=ws://127.0.0.1:8546
...
```

### Changes
Flags will now overwrite the config file instead.