### PR TITLE
log: support to disable log rotate by hours

### DIFF
--- a/log/async_file_writer.go
+++ b/log/async_file_writer.go
@@ -17,15 +17,18 @@ type TimeTicker struct {
 
 // NewTimeTicker creates a TimeTicker that notifies based on rotateHours parameter.
 // if rotateHours is 1 and current time is 11:32 it means that the ticker will tick at 12:00
-// if rotateHours is 5 and current time is 09:12 means that the ticker will tick at 11:00
-func NewTimeTicker(rotateHours int) *TimeTicker {
+// if rotateHours is 2 and current time is 09:12 means that the ticker will tick at 11:00
+// specially, if rotateHours is 0, then no rotation
+func NewTimeTicker(rotateHours uint) *TimeTicker {
 	ch := make(chan time.Time)
 	tt := TimeTicker{
 		stop: make(chan struct{}),
 		C:    ch,
 	}
 
-	tt.startTicker(ch, rotateHours)
+	if rotateHours > 0 {
+		tt.startTicker(ch, rotateHours)
+	}
 
 	return &tt
 }
@@ -34,7 +37,7 @@ func (tt *TimeTicker) Stop() {
 	tt.stop <- struct{}{}
 }
 
-func (tt *TimeTicker) startTicker(ch chan time.Time, rotateHours int) {
+func (tt *TimeTicker) startTicker(ch chan time.Time, rotateHours uint) {
 	go func() {
 		nextRotationHour := getNextRotationHour(time.Now(), rotateHours)
 		ticker := time.NewTicker(time.Second)
@@ -53,7 +56,7 @@ func (tt *TimeTicker) startTicker(ch chan time.Time, rotateHours int) {
 	}()
 }
 
-func getNextRotationHour(now time.Time, delta int) int {
+func getNextRotationHour(now time.Time, delta uint) int {
 	return now.Add(time.Hour * time.Duration(delta)).Hour()
 }
 
@@ -68,7 +71,7 @@ type AsyncFileWriter struct {
 	timeTicker *TimeTicker
 }
 
-func NewAsyncFileWriter(filePath string, maxBytesSize int64, rotateHours int) *AsyncFileWriter {
+func NewAsyncFileWriter(filePath string, maxBytesSize int64, rotateHours uint) *AsyncFileWriter {
 	absFilePath, err := filepath.Abs(filePath)
 	if err != nil {
 		panic(fmt.Sprintf("get file path of logger error. filePath=%s, err=%s", filePath, err))

--- a/log/async_file_writer_test.go
+++ b/log/async_file_writer_test.go
@@ -29,7 +29,7 @@ func TestWriterHourly(t *testing.T) {
 func TestGetNextRotationHour(t *testing.T) {
 	tcs := []struct {
 		now          time.Time
-		delta        int
+		delta        uint
 		expectedHour int
 	}{
 		{
@@ -54,7 +54,7 @@ func TestGetNextRotationHour(t *testing.T) {
 		},
 	}
 
-	test := func(now time.Time, delta, expectedHour int) func(*testing.T) {
+	test := func(now time.Time, delta uint, expectedHour int) func(*testing.T) {
 		return func(t *testing.T) {
 			got := getNextRotationHour(now, delta)
 			if got != expectedHour {

--- a/log/handler.go
+++ b/log/handler.go
@@ -75,7 +75,7 @@ func FileHandler(path string, fmtr Format) (Handler, error) {
 // RotatingFileHandler returns a handler which writes log records to file chunks
 // at the given path. When a file's size reaches the limit, the handler creates
 // a new file named after the timestamp of the first log record it will contain.
-func RotatingFileHandler(filePath string, limit uint, formatter Format, rotateHours int) (Handler, error) {
+func RotatingFileHandler(filePath string, limit uint, formatter Format, rotateHours uint) (Handler, error) {
 	if _, err := os.Stat(path.Dir(filePath)); os.IsNotExist(err) {
 		err := os.MkdirAll(path.Dir(filePath), 0755)
 		if err != nil {

--- a/log/logger.go
+++ b/log/logger.go
@@ -290,7 +290,7 @@ func (c Ctx) toArray() []interface{} {
 	return arr
 }
 
-func NewFileLvlHandler(logPath string, maxBytesSize uint, level string, rotateHours int) Handler {
+func NewFileLvlHandler(logPath string, maxBytesSize uint, level string, rotateHours uint) Handler {
 	rfh, err := RotatingFileHandler(logPath, maxBytesSize, LogfmtFormat(), rotateHours)
 	if err != nil {
 		panic(err)

--- a/node/config.go
+++ b/node/config.go
@@ -512,7 +512,7 @@ type LogConfig struct {
 	FilePath     *string `toml:",omitempty"`
 	MaxBytesSize *uint   `toml:",omitempty"`
 	Level        *string `toml:",omitempty"`
-	RotateHours  int     `toml:",omitempty"`
+	RotateHours  *uint   `toml:",omitempty"`
 
 	// TermTimeFormat is the time format used for console logging.
 	TermTimeFormat *string `toml:",omitempty"`

--- a/node/node.go
+++ b/node/node.go
@@ -109,16 +109,16 @@ func New(conf *Config) (*Node, error) {
 				logFilePath = path.Join(*conf.LogConfig.FileRoot, *conf.LogConfig.FilePath)
 			}
 
-			if conf.LogConfig.RotateHours > 24 {
-				return nil, errors.New("Config.LogConfig.RotateHours cannot be greater than 24")
+			rotateHours := uint(1) // To maintain backwards compatibility, if RotateHours is not set, then it defaults to 1
+			if conf.LogConfig.RotateHours != nil {
+				if *conf.LogConfig.RotateHours > 24 {
+					return nil, errors.New("Config.LogConfig.RotateHours cannot be greater than 24")
+				}
+
+				rotateHours = *conf.LogConfig.RotateHours
 			}
 
-			// To maintain backwards compatibility, if RotateHours is not set or set to a negative value, then it defaults to 1
-			if conf.LogConfig.RotateHours < 1 {
-				conf.LogConfig.RotateHours = 1
-			}
-
-			log.Root().SetHandler(log.NewFileLvlHandler(logFilePath, *conf.LogConfig.MaxBytesSize, *conf.LogConfig.Level, conf.LogConfig.RotateHours))
+			log.Root().SetHandler(log.NewFileLvlHandler(logFilePath, *conf.LogConfig.MaxBytesSize, *conf.LogConfig.Level, rotateHours))
 		}
 	}
 	if conf.Logger == nil {


### PR DESCRIPTION
### Description

log: support to disable log rotate by hours

### Rationale
https://github.com/bnb-chain/bsc/issues/114 suggest that
```
So would be nice to add an option into the config file to:

1. rotate by size
2. rotate by date (daily, hourly, weekly, monthly, etc)
3. disable rotation altogether
```
to support type 1, only rotate by size, 
we should have the ablitiy to disable the default one hour rotation, this PR add this support

by setting `RotateHours=0` in config.toml, rotate by hours is disabled 


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
