### PR TITLE
log: limit rotateHours in range [0,23]

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -111,8 +111,8 @@ func New(conf *Config) (*Node, error) {
 
 			rotateHours := uint(1) // To maintain backwards compatibility, if RotateHours is not set, then it defaults to 1
 			if conf.LogConfig.RotateHours != nil {
-				if *conf.LogConfig.RotateHours > 24 {
-					return nil, errors.New("Config.LogConfig.RotateHours cannot be greater than 24")
+				if *conf.LogConfig.RotateHours > 23 {
+					return nil, errors.New("Config.LogConfig.RotateHours cannot be greater than 23")
 				}
 
 				rotateHours = *conf.LogConfig.RotateHours


### PR DESCRIPTION
### Description

log: limit rotateHours in range [0,23]

### Rationale

if rotateHours ==24, log engine will continue to recreate files every second
<img width="639" alt="image" src="https://github.com/bnb-chain/bsc/assets/7995985/fcd0e52e-9848-4371-9739-5f23c423c7c8">

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
