### PR TITLE
cmd/geth: add check func to validate state scheme

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -134,6 +134,9 @@ func loadBaseConfig(ctx *cli.Context) gethConfig {
 			utils.Fatalf("%v", err)
 		}
 	}
+	if !utils.ValidateStateScheme(cfg.Eth.StateScheme) {
+		utils.Fatalf("invalid state scheme param in config: %s", cfg.Eth.StateScheme)
+	}
 
 	// Apply flags.
 	utils.SetNodeConfig(ctx, &cfg.Node)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2487,6 +2487,9 @@ func MakeConsolePreloads(ctx *cli.Context) []string {
 }
 
 // ResolveStateScheme resolve state scheme from CLI flag, config file and persistent state.
+// The differences between ResolveStateScheme and ParseStateScheme are:
+// - ResolveStateScheme adds config to compare with CLI and persistent state to ensure correctness.
+// - ResolveStateScheme is only used in SetEthConfig function.
 //
 // 1. If config isn't provided, write hash mode to config by default, so in current function, config is nonempty.
 // 2. If persistent state and cli is empty, use config param.

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -20,6 +20,8 @@ package utils
 import (
 	"reflect"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/core/rawdb"
 )
 
 func Test_SplitTagsFlag(t *testing.T) {
@@ -58,6 +60,37 @@ func Test_SplitTagsFlag(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := SplitTagsFlag(tt.args); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("splitTagsFlag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateStateScheme(t *testing.T) {
+	tests := []struct {
+		name       string
+		arg        string
+		wantResult bool
+	}{
+		{
+			name:       "hash scheme",
+			arg:        rawdb.HashScheme,
+			wantResult: true,
+		},
+		{
+			name:       "path scheme",
+			arg:        rawdb.PathScheme,
+			wantResult: true,
+		},
+		{
+			name:       "invalid scheme",
+			arg:        "mockScheme",
+			wantResult: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateStateScheme(tt.arg); got != tt.wantResult {
+				t.Errorf("ValidateStateScheme() = %v, want %v", got, tt.wantResult)
 			}
 		})
 	}


### PR DESCRIPTION
### Description

Provide explicit for which state scheme geth can use to start or init. And add check function to validate provided state scheme.

### Rationale

Users may add `StateScheme = "path"` in `config.toml` and want to start geth without persistent state in disk, but geth is started in `hash` mode. For solving these cases, add a function, obey the following rules:

1. If config isn't provided, write hash mode to config by default, so in current function, config is nonempty.
2. If persistent state and cli is empty, use config param.
3. If persistent state is empty, provide CLI flag and config, choose CLI to return.
4. If persistent state is nonempty and CLI isn't provided, persistent state should be equal to config.
5. If all three items are provided: if any two of the three are not equal, return error.

### Example

1. `nohup ./geth --config config.toml --cache 8000 --rpc.allow-unprotected-txs --history.transactions 0 >> nohup.out 2>&1&` and add `StateScheme = "path"` in `config.toml`, geth is started in `path` mode.

### Changes

Notable changes: 
* N/A
