### PR TITLE
cmd, eth: add --disablebscprotocol flag

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -65,6 +65,7 @@ var (
 		utils.DirectBroadcastFlag,
 		utils.DisableSnapProtocolFlag,
 		utils.EnableTrustProtocolFlag,
+		utils.DisableBscProtocolFlag,
 		utils.PipeCommitFlag,
 		utils.RangeLimitFlag,
 		utils.USBFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -111,6 +111,11 @@ var (
 		Usage:    "Enable trust protocol",
 		Category: flags.FastNodeCategory,
 	}
+	DisableBscProtocolFlag = &cli.BoolFlag{
+		Name:     "disablebscprotocol",
+		Usage:    "Disable bsc protocol",
+		Category: flags.FastFinalityCategory,
+	}
 	PipeCommitFlag = &cli.BoolFlag{
 		Name:     "pipecommit",
 		Usage:    "Enable MPT pipeline commit, it will improve syncing performance. It is an experimental feature(default is false)",
@@ -1919,6 +1924,12 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(EnableTrustProtocolFlag.Name) {
 		cfg.EnableTrustProtocol = ctx.IsSet(EnableTrustProtocolFlag.Name)
+	}
+	if ctx.IsSet(DisableBscProtocolFlag.Name) {
+		if ctx.Bool(MiningEnabledFlag.Name) {
+			log.Crit("bsc protocol can't be disabled when mining is enabled")
+		}
+		cfg.DisableBscProtocol = ctx.Bool(DisableBscProtocolFlag.Name)
 	}
 	if ctx.IsSet(PipeCommitFlag.Name) {
 		log.Warn("The --pipecommit flag is deprecated and could be removed in the future!")

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -600,7 +600,9 @@ func (s *Ethereum) Protocols() []p2p.Protocol {
 	if s.config.EnableTrustProtocol {
 		protos = append(protos, trust.MakeProtocols((*trustHandler)(s.handler), s.snapDialCandidates)...)
 	}
-	protos = append(protos, bsc.MakeProtocols((*bscHandler)(s.handler), s.bscDialCandidates)...)
+	if !s.config.DisableBscProtocol {
+		protos = append(protos, bsc.MakeProtocols((*bscHandler)(s.handler), s.bscDialCandidates)...)
+	}
 
 	return protos
 }

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -115,6 +115,7 @@ type Config struct {
 	DirectBroadcast     bool
 	DisableSnapProtocol bool //Whether disable snap protocol
 	EnableTrustProtocol bool //Whether enable trust protocol
+	DisableBscProtocol  bool //Whether disable bsc protocol
 	PipeCommit          bool
 	RangeLimit          bool
 


### PR DESCRIPTION
### Description
This PR adds a new flag to disable the BSC subprotocol.

### Rationale
When setting up a local private network, users may want to disable the BSC subprotocol for development purposes.

### Example
Usage:
```
./geth --disablebscprotocol
```

### Changes
- new `--disablebscprotocol` flag