### PR TITLE
fix: fix the pebble config of level option

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -196,6 +196,7 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 			WriteStallBegin: db.onWriteStallBegin,
 			WriteStallEnd:   db.onWriteStallEnd,
 		},
+		Levels: make([]pebble.LevelOptions, 7),
 		Logger: panicLogger{}, // TODO(karalabe): Delete when this is upstreamed in Pebble
 	}
 

--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -46,6 +46,9 @@ const (
 	// metricsGatheringInterval specifies the interval to retrieve pebble database
 	// compaction, io and pause stats to report to the user.
 	metricsGatheringInterval = 3 * time.Second
+
+	// numLevels is the level number of pebble sst files
+	numLevels = 7
 )
 
 // Database is a persistent key-value store based on the pebble storage engine.
@@ -196,7 +199,7 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 			WriteStallBegin: db.onWriteStallBegin,
 			WriteStallEnd:   db.onWriteStallEnd,
 		},
-		Levels: make([]pebble.LevelOptions, 7),
+		Levels: make([]pebble.LevelOptions, numLevels),
 		Logger: panicLogger{}, // TODO(karalabe): Delete when this is upstreamed in Pebble
 	}
 


### PR DESCRIPTION
### Description

Although pebble is initialized to level 7 by default, the configuration of level options does not take effect because the level option slices has no explicit initialization.

The option file content of the chain db  is as follows after fixed which  meet expected option (block size is 32kB, indexBlock size is 256KB , and enable bloom filter) :

```
[root@tf_nodereal_dev_bsc_new_feature_testing1_ec2 chaindata]# tail -40  OPTIONS-000013 

[Level "3"]
  block_restart_interval=16
  block_size=32768
  block_size_threshold=90
  compression=Snappy
  filter_policy=rocksdb.BuiltinBloomFilter
  filter_type=table
  index_block_size=262144
  target_file_size=16777216

[Level "4"]
  block_restart_interval=16
  block_size=32768
  block_size_threshold=90
  compression=Snappy
  filter_policy=rocksdb.BuiltinBloomFilter
  filter_type=table
  index_block_size=262144
  target_file_size=33554432

[Level "5"]
  block_restart_interval=16
  block_size=32768
  block_size_threshold=90
  compression=Snappy
  filter_policy=rocksdb.BuiltinBloomFilter
  filter_type=table
  index_block_size=262144
  target_file_size=67108864

[Level "6"]
  block_restart_interval=16
  block_size=32768
  block_size_threshold=90
  compression=Snappy
  filter_policy=rocksdb.BuiltinBloomFilter
  filter_type=table
  index_block_size=262144
  target_file_size=134217728
```

### Rationale

performance is better after fixed 
(block height 3430w+ ,   500M 3000iops disk  and 16 core machine) 
<img width="1707" alt="image" src="https://github.com/bnb-chain/bsc/assets/19421226/8bd23734-85fa-48e1-b0c3-e1938fddf96d">

<img width="625" alt="image" src="https://github.com/bnb-chain/bsc/assets/19421226/7469f72a-4055-466e-bfd3-3657aa651a8a">


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
