### PR TITLE
new faucet client

### DIFF
--- a/cmd/faucet/README.md
+++ b/cmd/faucet/README.md
@@ -11,10 +11,7 @@ The `faucet` is a single binary app (everything included) with all configuration
 First things first, the `faucet` needs to connect to an Ethereum network, for which it needs the necessary genesis and network infos. Each of the following flags must be set:
 
 - `-genesis` is a path to a file containing the network `genesis.json`. or using:
-- `-network` is the devp2p network id used during connection
-- `-bootnodes` is a list of `enode://` ids to join the network through
-
-The `faucet` will use the `les` protocol to join the configured Ethereum network and will store its data in `$HOME/.faucet` (currently not configurable).
+- `-ws` is ws endpoint to what faucet will connect to
 
 ## Funding
 

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -335,10 +335,11 @@ func (f *faucet) apiHandler(w http.ResponseWriter, r *http.Request) {
 	f.lock.RLock()
 	reqs := f.reqs
 	f.lock.RUnlock()
+	peers, _ := f.client.PeerCount(context.Background())
 	if err = send(wsconn, map[string]interface{}{
 		"funds":    new(big.Int).Div(balance, ether),
 		"funded":   nonce,
-		"peers":    f.stack.Server().PeerCount(),
+		"peers":    peers,
 		"requests": reqs,
 	}, 3*time.Second); err != nil {
 		log.Warn("Failed to send initial stats to client", "err", err)
@@ -626,7 +627,7 @@ func (f *faucet) loop() {
 			log.Info("Updated faucet state", "number", head.Number, "hash", head.Hash(), "age", common.PrettyAge(timestamp), "balance", f.balance, "nonce", f.nonce, "price", f.price)
 
 			balance := new(big.Int).Div(f.balance, ether)
-			peers := f.stack.Server().PeerCount()
+			peers, _ := f.client.PeerCount(context.Background())
 
 			for _, conn := range f.conns {
 				if err := send(conn, map[string]interface{}{

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -333,15 +333,9 @@ func (f *faucet) apiHandler(w http.ResponseWriter, r *http.Request) {
 	f.lock.RLock()
 	reqs := f.reqs
 	f.lock.RUnlock()
-	ctx, _ := context.WithTimeout(context.Background(), time.Second)
-	peers, err := f.client.PeerCount(ctx)
-	if err != nil {
-		log.Warn("Failed to get peerCount on init", "err", err)
-	}
 	if err = send(wsconn, map[string]interface{}{
 		"funds":    new(big.Int).Div(balance, ether),
 		"funded":   nonce,
-		"peers":    peers,
 		"requests": reqs,
 	}, 3*time.Second); err != nil {
 		log.Warn("Failed to send initial stats to client", "err", err)
@@ -630,17 +624,10 @@ func (f *faucet) loop() {
 
 			balance := new(big.Int).Div(f.balance, ether)
 
-			ctx, _ := context.WithTimeout(context.Background(), time.Second)
-			peers, err := f.client.PeerCount(ctx)
-			if err != nil {
-				log.Warn("Failed to get peerCount", "err", err)
-			}
-
 			for _, conn := range f.conns {
 				if err := send(conn, map[string]interface{}{
 					"funds":    balance,
 					"funded":   f.nonce,
-					"peers":    peers,
 					"requests": f.reqs,
 				}, time.Second); err != nil {
 					log.Warn("Failed to send stats to client", "err", err)

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -272,7 +272,7 @@ func (f *faucet) webHandler(w http.ResponseWriter, r *http.Request) {
 
 // apiHandler handles requests for Ether grants and transaction statuses.
 func (f *faucet) apiHandler(w http.ResponseWriter, r *http.Request) {
-	upgrader := websocket.Upgrader{}
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -55,7 +55,7 @@ import (
 var (
 	genesisFlag = flag.String("genesis", "", "Genesis json file to seed the chain with")
 	apiPortFlag = flag.Int("apiport", 8080, "Listener port for the HTTP API connection")
-	rpcEndpoint = flag.String("rpc", "http://127.0.0.1:7777/", "Url to RPC endpoint")
+	wsEndpoint  = flag.String("ws", "http://127.0.0.1:7777/", "Url to ws endpoint")
 
 	netnameFlag = flag.String("faucet.name", "", "Network name to assign to the faucet")
 	payoutFlag  = flag.Int("faucet.amount", 1, "Number of Ethers to pay out per user request")
@@ -170,7 +170,7 @@ func main() {
 		log.Crit("Failed to unlock faucet signer account", "err", err)
 	}
 	// Assemble and start the faucet light service
-	faucet, err := newFaucet(genesis, rpcEndpoint, ks, website.Bytes(), bep2eInfos)
+	faucet, err := newFaucet(genesis, wsEndpoint, ks, website.Bytes(), bep2eInfos)
 	if err != nil {
 		log.Crit("Failed to start faucet", "err", err)
 	}

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -47,7 +47,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/gorilla/websocket"
 )
@@ -198,7 +197,6 @@ type bep2eInfo struct {
 // faucet represents a crypto faucet backed by an Ethereum light client.
 type faucet struct {
 	config *params.ChainConfig // Chain configurations for signing
-	stack  *node.Node          // Ethereum protocol stack
 	client *ethclient.Client   // Client connection to the Ethereum chain
 	index  []byte              // Index page to serve up on the web
 
@@ -251,8 +249,8 @@ func newFaucet(genesis *core.Genesis, url *string, ks *keystore.KeyStore, index 
 }
 
 // close terminates the Ethereum connection and tears down the faucet.
-func (f *faucet) close() error {
-	return f.stack.Close()
+func (f *faucet) close() {
+	f.client.Close()
 }
 
 // listenAndServe registers the HTTP handlers for the faucet and boots it up

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -169,7 +169,7 @@ func main() {
 		log.Crit("Failed to unlock faucet signer account", "err", err)
 	}
 	// Assemble and start the faucet light service
-	faucet, err := newFaucet(genesis, wsEndpoint, ks, website.Bytes(), bep2eInfos)
+	faucet, err := newFaucet(genesis, *wsEndpoint, ks, website.Bytes(), bep2eInfos)
 	if err != nil {
 		log.Crit("Failed to start faucet", "err", err)
 	}
@@ -225,12 +225,12 @@ type wsConn struct {
 	wlock sync.Mutex
 }
 
-func newFaucet(genesis *core.Genesis, url *string, ks *keystore.KeyStore, index []byte, bep2eInfos map[string]bep2eInfo) (*faucet, error) {
+func newFaucet(genesis *core.Genesis, url string, ks *keystore.KeyStore, index []byte, bep2eInfos map[string]bep2eInfo) (*faucet, error) {
 	bep2eAbi, err := abi.JSON(strings.NewReader(bep2eAbiJson))
 	if err != nil {
 		return nil, err
 	}
-	client, err := ethclient.Dial(*url)
+	client, err := ethclient.Dial(url)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

In this update to the faucet client, the default functionality of the faucet binary has been altered. Previously, the faucet binary utilized the Light Ethereum Subprotocol (LES) for connecting to the BSC network. However, this update changes this behavior, making the faucet connect to an already running BSC node via WebSocket (WS) protocol. This modification is aimed to support faucet after LES deprecation. 

### Rationale

The motivation behind these changes includes:

- **Resource Efficiency**: By connecting to an existing node, we reduce the resource load on the system running the faucet, as it no longer needs to maintain a full LES client.
- **Enhanced Flexibility**: This approach allows for greater flexibility in network setups, as the faucet can connect to any accessible node on the network, not just those running LES.

### Example

After implementing these changes, the faucet can be connected to a running node using a command similar to:

```
 faucet --ws <node_ws_endpoint>
```


### Changes

Notable changes in this update include:

- **Faucet Binary Modification**: Altered the default connection protocol of the faucet binary from LES to WebSocket.
- **New Command-Line Options**: Added new CLI options to specify the WebSocket endpoint of the BSC node.
