### PR TITLE
triedb/pathdb: fix async node buffer diskroot mismatches when journaling

### DIFF
--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -36,6 +36,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		TransactionHistory      uint64                 `toml:",omitempty"`
 		StateHistory            uint64                 `toml:",omitempty"`
 		StateScheme             string                 `toml:",omitempty"`
+		PathSyncFlush           bool                   `toml:",omitempty"`
 		RequiredBlocks          map[uint64]common.Hash `toml:"-"`
 		LightServ               int                    `toml:",omitempty"`
 		LightIngress            int                    `toml:",omitempty"`
@@ -91,6 +92,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.TransactionHistory = c.TransactionHistory
 	enc.StateHistory = c.StateHistory
 	enc.StateScheme = c.StateScheme
+	enc.PathSyncFlush = c.PathSyncFlush
 	enc.RequiredBlocks = c.RequiredBlocks
 	enc.LightServ = c.LightServ
 	enc.LightIngress = c.LightIngress
@@ -150,6 +152,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		TransactionHistory      *uint64                `toml:",omitempty"`
 		StateHistory            *uint64                `toml:",omitempty"`
 		StateScheme             *string                `toml:",omitempty"`
+		PathSyncFlush           *bool                  `toml:",omitempty"`
 		RequiredBlocks          map[uint64]common.Hash `toml:"-"`
 		LightServ               *int                   `toml:",omitempty"`
 		LightIngress            *int                   `toml:",omitempty"`
@@ -245,6 +248,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.StateScheme != nil {
 		c.StateScheme = *dec.StateScheme
+	}
+	if dec.PathSyncFlush != nil {
+		c.PathSyncFlush = *dec.PathSyncFlush
 	}
 	if dec.RequiredBlocks != nil {
 		c.RequiredBlocks = dec.RequiredBlocks

--- a/trie/triedb/pathdb/disklayer.go
+++ b/trie/triedb/pathdb/disklayer.go
@@ -73,7 +73,7 @@ type trienodebuffer interface {
 	// getLayers return the size of cached difflayers.
 	getLayers() uint64
 
-	// waitFlushing will block unit writing the trie nodes of trienodebuffer to disk
+	// waitAndStopFlushing will block unit writing the trie nodes of trienodebuffer to disk.
 	waitAndStopFlushing()
 }
 

--- a/trie/triedb/pathdb/disklayer.go
+++ b/trie/triedb/pathdb/disklayer.go
@@ -72,6 +72,9 @@ type trienodebuffer interface {
 
 	// getLayers return the size of cached difflayers.
 	getLayers() uint64
+
+	// waitFlushing will block unit writing the trie nodes of trienodebuffer to disk
+	waitAndStopFlushing()
 }
 
 func NewTrieNodeBuffer(sync bool, limit int, nodes map[common.Hash]map[string]*trienode.Node, layers uint64) trienodebuffer {

--- a/trie/triedb/pathdb/journal.go
+++ b/trie/triedb/pathdb/journal.go
@@ -242,7 +242,7 @@ func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 }
 
 // journal implements the layer interface, marshaling the un-flushed trie nodes
-// along with layer meta data into provided byte buffer.
+// along with layer metadata into provided byte buffer.
 func (dl *diskLayer) journal(w io.Writer) error {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
@@ -355,7 +355,7 @@ func (db *Database) Journal(root common.Hash) error {
 	}
 	start := time.Now()
 
-	// wait and stop the flush trienodebuffer, for async node buffer need fixed diskroot
+	// wait and stop the flush trienodebuffer, for asyncnodebuffer need fixed diskroot
 	disk.buffer.waitAndStopFlushing()
 	// Short circuit if the database is in read only mode.
 	if db.readOnly {

--- a/trie/triedb/pathdb/journal.go
+++ b/trie/triedb/pathdb/journal.go
@@ -338,6 +338,10 @@ func (dl *diffLayer) journal(w io.Writer) error {
 // flattening everything down (bad for reorgs). And this function will mark the
 // database as read-only to prevent all following mutation to disk.
 func (db *Database) Journal(root common.Hash) error {
+	// Run the journaling
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
 	// Retrieve the head layer to journal from.
 	l := db.tree.get(root)
 	if l == nil {
@@ -351,10 +355,8 @@ func (db *Database) Journal(root common.Hash) error {
 	}
 	start := time.Now()
 
-	// Run the journaling
-	db.lock.Lock()
-	defer db.lock.Unlock()
-
+	// wait and stop the flush trienodebuffer, for async node buffer need fixed diskroot
+	disk.buffer.waitAndStopFlushing()
 	// Short circuit if the database is in read only mode.
 	if db.readOnly {
 		return errSnapshotReadOnly

--- a/trie/triedb/pathdb/nodebuffer.go
+++ b/trie/triedb/pathdb/nodebuffer.go
@@ -221,7 +221,7 @@ func (b *nodebuffer) flush(db ethdb.KeyValueStore, clean *fastcache.Cache, id ui
 		start = time.Now()
 		// Although the calculation of b.size has been as accurate as possible,
 		// some omissions were still found during testing and code review, but
-		// we are still not sure it is completely accurate. For better protection,
+		// we are still not sure if it is completely accurate. For better protection,
 		// some redundancy is added here.
 		batch = db.NewBatchWithSize(int(float64(b.size) * DefaultBatchRedundancyRate))
 	)
@@ -241,9 +241,7 @@ func (b *nodebuffer) flush(db ethdb.KeyValueStore, clean *fastcache.Cache, id ui
 	return nil
 }
 
-func (b *nodebuffer) waitAndStopFlushing() {
-	return
-}
+func (b *nodebuffer) waitAndStopFlushing() {}
 
 // writeNodes writes the trie nodes into the provided database batch.
 // Note this function will also inject all the newly written nodes

--- a/trie/triedb/pathdb/nodebuffer.go
+++ b/trie/triedb/pathdb/nodebuffer.go
@@ -241,6 +241,10 @@ func (b *nodebuffer) flush(db ethdb.KeyValueStore, clean *fastcache.Cache, id ui
 	return nil
 }
 
+func (b *nodebuffer) waitAndStopFlushing() {
+	return
+}
+
 // writeNodes writes the trie nodes into the provided database batch.
 // Note this function will also inject all the newly written nodes
 // into clean cache.


### PR DESCRIPTION
### Description

When running `TestJournal` UT in `trie/triedb/pathdb`, there is a certain probability that this error will occur: `Invalid state, err: state 0xdda0214f6c0c6ea546cdbf3db74a31f8337a01b41908b3b8ea27a8fde0011294 is not available`. 

The reason of this error is that the journal loaded from disk is wrong, the error message of `loadJournal` function: `unmatched journal want c3bd21026750db0009399463f5947e1663c7057cb4aaabeb0b39ed68dedd4d0b got 6d574af1033459ae676316a1262a5d89edb7bbd515ecd253b4319a3161093153`.

### Rationale

When geth calls `Journal` function to commit entire diff hierarchy to disk into a single journal entry, the flush process of `asyncnodebuffer` maybe doesn't end, so we should stop, wait it and journal.

### Example

N/A

### Changes

Notable changes: 
* N/A
