### PR TITLE
rpc: fix ns/µs mismatch in metrics (#28649)

### DIFF
--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -225,20 +225,18 @@ func (t *StandardTimer) Time(f func()) {
 	t.Update(time.Since(ts))
 }
 
-// Record the duration of an event.
+// Record the duration of an event, in nanoseconds.
 func (t *StandardTimer) Update(d time.Duration) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
-	t.histogram.Update(int64(d))
+	t.histogram.Update(d.Nanoseconds())
 	t.meter.Mark(1)
 }
 
 // Record the duration of an event that started at a time and ends now.
+// The record uses nanoseconds.
 func (t *StandardTimer) UpdateSince(ts time.Time) {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
-	t.histogram.Update(int64(time.Since(ts)))
-	t.meter.Mark(1)
+	t.Update(time.Since(ts))
 }
 
 // Variance returns the variance of the values in the sample.

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -46,7 +46,7 @@ func updateServeTimeHistogram(method string, success bool, elapsed time.Duration
 			metrics.NewExpDecaySample(1028, 0.015),
 		)
 	}
-	metrics.GetOrRegisterHistogramLazy(h, nil, sampler).Update(elapsed.Microseconds())
+	metrics.GetOrRegisterHistogramLazy(h, nil, sampler).Update(elapsed.Nanoseconds())
 }
 
 func newRPCRequestGauge(method string) metrics.Gauge {


### PR DESCRIPTION
### Description

The rpc/duration/all meter was in nanoseconds, the individual meter in microseconds. This PR changes it so both of them use nanoseconds.

### Rationale


### Example

<img width="759" alt="image" src="https://github.com/bnb-chain/bsc/assets/45141191/31778fd1-914e-47ab-b922-618110e2e1fd">

After Fix
<img width="542" alt="image" src="https://github.com/bnb-chain/bsc/assets/45141191/a259874c-8b9c-49be-a90c-2a543744cf3a">

### Changes

Notable changes: 
* metrics/timer.go
* rpc/metrics.go
