### PR TITLE
tests: revive evm test cases

### DIFF
--- a/.github/workflows/evm-tests.yml
+++ b/.github/workflows/evm-tests.yml
@@ -1,4 +1,4 @@
-name: Unit Test
+name: EVM Test
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
       - develop
 
 jobs:
-  unit-test:
+  evm-test:
     strategy:
       matrix:
         go-version: [1.20.x]
@@ -43,12 +43,14 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - name: Unit Test
+    - name: EVM Test
       env:
         CGO_CFLAGS: "-O -D__BLST_PORTABLE__"
         CGO_CFLAGS_ALLOW: "-O -D__BLST_PORTABLE__"
         ANDROID_HOME: "" # Skip android test
       run: |
+        git submodule update --init --depth 1 --recursive
         go mod download
-        make test
-
+        cd tests
+        sed -i -e 's/\/\/ bt.skipLoad/bt.skipLoad/g' block_test.go
+        bash -x run-evm-tests.sh

--- a/consensus/misc/eip1559/eip1559.go
+++ b/consensus/misc/eip1559/eip1559.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -31,6 +32,16 @@ import (
 // - gas limit check
 // - basefee check
 func VerifyEIP1559Header(config *params.ChainConfig, parent, header *types.Header) error {
+	if config.Parlia == nil {
+		// Verify that the gas limit remains within allowed bounds
+		parentGasLimit := parent.GasLimit
+		if !config.IsLondon(parent.Number) {
+			parentGasLimit = parent.GasLimit * config.ElasticityMultiplier()
+		}
+		if err := misc.VerifyGaslimit(parentGasLimit, header.GasLimit); err != nil {
+			return err
+		}
+	}
 	// Verify the header is not malformed
 	if header.BaseFee == nil {
 		return errors.New("header is missing baseFee")

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -205,6 +205,10 @@ func (b *BlockGen) AddUncle(h *types.Header) {
 	h.GasLimit = parent.GasLimit
 	if b.config.IsLondon(h.Number) {
 		h.BaseFee = eip1559.CalcBaseFee(b.config, parent)
+		if b.config.Parlia == nil && !b.config.IsLondon(parent.Number) {
+			parentGasLimit := parent.GasLimit * b.config.ElasticityMultiplier()
+			h.GasLimit = CalcGasLimit(parentGasLimit, parentGasLimit)
+		}
 	}
 	b.uncles = append(b.uncles, h)
 }
@@ -386,6 +390,10 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.S
 	}
 	if chain.Config().IsLondon(header.Number) {
 		header.BaseFee = eip1559.CalcBaseFee(chain.Config(), parent.Header())
+		if chain.Config().Parlia == nil && !chain.Config().IsLondon(parent.Number()) {
+			parentGasLimit := parent.GasLimit() * chain.Config().ElasticityMultiplier()
+			header.GasLimit = CalcGasLimit(parentGasLimit, parentGasLimit)
+		}
 	}
 	return header
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -894,10 +894,10 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
 	if w.chainConfig.IsLondon(header.Number) {
 		header.BaseFee = eip1559.CalcBaseFee(w.chainConfig, parent)
-		// if !w.chainConfig.IsLondon(parent.Number) {
-		// 	parentGasLimit := parent.GasLimit * w.chainConfig.ElasticityMultiplier()
-		// 	header.GasLimit = core.CalcGasLimit(parentGasLimit, w.config.GasCeil)
-		// }
+		if w.chainConfig.Parlia == nil && !w.chainConfig.IsLondon(parent.Number) {
+			parentGasLimit := parent.GasLimit * w.chainConfig.ElasticityMultiplier()
+			header.GasLimit = core.CalcGasLimit(parentGasLimit, w.config.GasCeil)
+		}
 	}
 	// Run the consensus preparation with the default or customized consensus engine.
 	if err := w.engine.Prepare(w.chain, header); err != nil {

--- a/tests/0001-diff-go-ethereum.patch
+++ b/tests/0001-diff-go-ethereum.patch
@@ -1,0 +1,67 @@
+From a1fe21e9b999b60705b7310737f2b6bbb680969d Mon Sep 17 00:00:00 2001
+From: buddh0 <galaxystroller@gmail.com>
+Date: Mon, 8 Jan 2024 17:16:29 +0800
+Subject: [PATCH] diff go-ethereum
+
+---
+ core/vm/contracts.go      | 3 ---
+ core/vm/jump_table.go     | 2 +-
+ params/protocol_params.go | 8 ++++----
+ 3 files changed, 5 insertions(+), 8 deletions(-)
+
+diff --git a/core/vm/contracts.go b/core/vm/contracts.go
+index 482c020a6..7d9a59a92 100644
+--- a/core/vm/contracts.go
++++ b/core/vm/contracts.go
+@@ -78,9 +78,6 @@ var PrecompiledContractsIstanbul = map[common.Address]PrecompiledContract{
+ 	common.BytesToAddress([]byte{7}): &bn256ScalarMulIstanbul{},
+ 	common.BytesToAddress([]byte{8}): &bn256PairingIstanbul{},
+ 	common.BytesToAddress([]byte{9}): &blake2F{},
+-
+-	common.BytesToAddress([]byte{100}): &tmHeaderValidate{},
+-	common.BytesToAddress([]byte{101}): &iavlMerkleProofValidate{},
+ }
+ 
+ var PrecompiledContractsNano = map[common.Address]PrecompiledContract{
+diff --git a/core/vm/jump_table.go b/core/vm/jump_table.go
+index 38a0a7653..702b18661 100644
+--- a/core/vm/jump_table.go
++++ b/core/vm/jump_table.go
+@@ -90,7 +90,7 @@ func newCancunInstructionSet() JumpTable {
+ }
+ 
+ func newShanghaiInstructionSet() JumpTable {
+-	instructionSet := newLondonInstructionSet()
++	instructionSet := newMergeInstructionSet()
+ 	enable3855(&instructionSet) // PUSH0 instruction
+ 	enable3860(&instructionSet) // Limit and meter initcode
+ 
+diff --git a/params/protocol_params.go b/params/protocol_params.go
+index 2b5cf8996..e14a2f414 100644
+--- a/params/protocol_params.go
++++ b/params/protocol_params.go
+@@ -19,7 +19,7 @@ package params
+ import "math/big"
+ 
+ const (
+-	GasLimitBoundDivisor uint64 = 256                // The bound divisor of the gas limit, used in update calculations.
++	GasLimitBoundDivisor uint64 = 1024               // The bound divisor of the gas limit, used in update calculations.
+ 	MinGasLimit          uint64 = 5000               // Minimum the gas limit may ever be.
+ 	MaxGasLimit          uint64 = 0x7fffffffffffffff // Maximum the gas limit (2^63-1).
+ 	GenesisGasLimit      uint64 = 4712388            // Gas limit of the Genesis block.
+@@ -122,9 +122,9 @@ const (
+ 	// Introduced in Tangerine Whistle (Eip 150)
+ 	CreateBySelfdestructGas uint64 = 25000
+ 
+-	DefaultBaseFeeChangeDenominator = 8 // Bounds the amount the base fee can change between blocks.
+-	DefaultElasticityMultiplier     = 2 // Bounds the maximum gas limit an EIP-1559 block may have.
+-	InitialBaseFee                  = 0 // Initial base fee for EIP-1559 blocks.
++	DefaultBaseFeeChangeDenominator = 8          // Bounds the amount the base fee can change between blocks.
++	DefaultElasticityMultiplier     = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
++	InitialBaseFee                  = 1000000000 // Initial base fee for EIP-1559 blocks.
+ 
+ 	MaxCodeSize     = 24576           // Maximum bytecode to permit for a contract
+ 	MaxInitCodeSize = 2 * MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions
+-- 
+2.41.0
+

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -44,13 +44,11 @@ func TestBlockchain(t *testing.T) {
 	bt.slow(`.*/bcWalletTest/`)
 
 	// Very slow test
+	bt.skipLoad(`^GeneralStateTests/VMTests/vmPerformance/.*`)
 	bt.skipLoad(`.*/stTimeConsuming/.*`)
 	// test takes a lot for time and goes easily OOM because of sha3 calculation on a huge range,
 	// using 4.6 TGas
 	bt.skipLoad(`.*randomStatetest94.json.*`)
-
-	bt.runonly(`^GeneralStateTests/Shanghai`)
-	bt.runonly(`^Pyspecs/shanghai/eip3.*`)
 
 	bt.walk(t, blockTestDir, func(t *testing.T, name string, test *BlockTest) {
 		if err := bt.checkFailure(t, test.Run(false, rawdb.HashScheme, nil)); err != nil {

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -136,7 +136,7 @@ func (t *BlockTest) Run(snapshotter bool, scheme string, tracer vm.EVMLogger) er
 	// Wrap the original engine within the beacon-engine
 	engine := beacon.New(ethash.NewFaker())
 
-	cache := &core.CacheConfig{TrieCleanLimit: 0, StateScheme: scheme}
+	cache := &core.CacheConfig{TrieCleanLimit: 0, TriesInMemory: 128, StateScheme: scheme}
 	if snapshotter {
 		cache.SnapshotLimit = 1
 		cache.SnapshotWait = true

--- a/tests/run-evm-tests.sh
+++ b/tests/run-evm-tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+cd ..
+git apply tests/0001-diff-go-ethereum.patch
+cd tests
+go test -run . -v >test.log
+PASS=`cat test.log |grep "PASS:" |wc -l`
+cat test.log|grep FAIL > fail.log
+FAIL=`cat fail.log |grep "FAIL:" |wc -l`
+echo "PASS",$PASS,"FAIL",$FAIL
+if [ $FAIL -ne 0 ]
+then
+    cat fail.log
+fi

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -68,8 +68,6 @@ func TestState(t *testing.T) {
 	st.fails(`stEIP4844-blobtransactions/opcodeBlobhashOutOfRange.json`, "test has incorrect state root")
 	st.fails(`stEIP4844-blobtransactions/opcodeBlobhBounds.json`, "test has incorrect state root")
 
-	st.runonly(`^Shanghai`)
-
 	// For Istanbul, older tests were moved into LegacyTests
 	for _, dir := range []string{
 		filepath.Join(baseDir, "EIPTests", "StateTests"),


### PR DESCRIPTION
### Description

tests: revive evm test cases

### Rationale

there are a ton of [evm test cases](https://github.com/ethereum/tests) maintained by ethereum office, but It's not run by bsc.
this PR is to revive these test cases and add them as a CI,
<img width="281" alt="image" src="https://github.com/bnb-chain/bsc/assets/7995985/50819432-3c3d-4ba5-838f-da725a0b26a9">
this will help a lot for quaility assurance.

PS: in block_test.go and state_test.go, the test scope is not less in go-thereum.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
