### PR TITLE
fix:  fix pebble mem table size boundary error

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -156,8 +156,15 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 	// including a frozen memory table and another live one.
 	memTableLimit := 2
 	memTableSize := cache * 1024 * 1024 / 2 / memTableLimit
-	if memTableSize > maxMemTableSize {
-		memTableSize = maxMemTableSize
+
+	// The memory table size is currently capped at maxMemTableSize-1 due to a
+	// known bug in the pebble where maxMemTableSize is not recognized as a
+	// valid size.
+	//
+	// TODO use the maxMemTableSize as the maximum table size once the issue
+	// in pebble is fixed.
+	if memTableSize >= maxMemTableSize {
+		memTableSize = maxMemTableSize - 1
 	}
 
 	logger.Info("Allocated cache and file handles", "cache", common.StorageSize(cache*1024*1024),


### PR DESCRIPTION
### Description
If mem table size  exceeds 4G, the memtable will be set to 4G in bsc code .  But Pebble has not handled this boundary well , it require less than 4G but not equal 4G . (https://github.com/cockroachdb/pebble/pull/3008)
 
### Rationale

solve issue(https://github.com/bnb-chain/bsc/issues/2091)

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
