### PR TITLE
p2p, eth: improve logs

### DIFF
--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -645,7 +645,7 @@ func (q *queue) expire(peer string, pendPool map[string]*fetchRequest, taskQueue
 	// as there's no order of events that should lead to such expirations.
 	req := pendPool[peer]
 	if req == nil {
-		log.Error("Expired request does not exist", "peer", peer)
+		log.Trace("Expired request does not exist", "peer", peer)
 		return 0
 	}
 	delete(pendPool, peer)

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -151,7 +151,7 @@ func ListenV4(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
 	go tab.loop()
 
 	t.wg.Add(2)
-	go t.loop()
+	go t.loop(cfg.IsBootnode)
 	go t.readLoop(cfg.Unhandled)
 	return t, nil
 }
@@ -405,7 +405,7 @@ func (t *UDPv4) handleReply(from enode.ID, fromIP net.IP, req v4wire.Packet) boo
 
 // loop runs in its own goroutine. it keeps track of
 // the refresh timer and the pending reply queue.
-func (t *UDPv4) loop() {
+func (t *UDPv4) loop(isBootNode bool) {
 	defer t.wg.Done()
 
 	var (
@@ -442,7 +442,9 @@ func (t *UDPv4) loop() {
 	}
 
 	logStatistic := func() {
-		t.log.Info("Current status", "table_size", t.tab.len(), "pending_size", plist.Len(), "db_size", t.db.Size())
+		if isBootNode {
+			t.log.Info("Discovery status", "table_size", t.tab.len(), "pending_size", plist.Len(), "db_size", t.db.Size())
+		}
 	}
 
 	for {


### PR DESCRIPTION
### Description
This PR improves user experience by modifying logs output, mainly on:
1. Do not show `Current status` for regular nodes, only used for bootnodes
2. Change log level for `Expired request does not exist` from `Error` to `Trace`

### Rationale
For the 1st log change, `Current status` log is meant for bootnodes to monitor the discovery status. For regular nodes, the information is not useful.

For the 2nd log change, when `*queue.Revoke()` and `*queue.expire()` happen concurrently, the resulting pending pool will no longer contain the peer request. Hence, `Expired request does not exist` will be shown. It's not a useful log for an average user, so its log level can be changed to `Trace`. 
