### PR TITLE
feat: enable NoDial should still dial static nodes

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -169,7 +169,7 @@ type Config struct {
 	// is used to dial outbound peer connections.
 	Dialer NodeDialer `toml:"-"`
 
-	// If NoDial is true, the server will not dial any peers.
+	// If NoDial is true, the server will not dial any peers, except for pre-configured static nodes.
 	NoDial bool `toml:",omitempty"`
 
 	// If EnableMsgEvents is set then the server will emit PeerEvents
@@ -676,7 +676,10 @@ func (srv *Server) SetFilter(f forkid.Filter) {
 }
 
 func (srv *Server) maxDialedConns() (limit int) {
-	if srv.NoDial || srv.MaxPeers == 0 {
+	if srv.NoDial {
+		return len(srv.StaticNodes) + len(srv.VerifyNodes)
+	}
+	if srv.MaxPeers == 0 {
 		return 0
 	}
 	if srv.DialRatio == 0 {


### PR DESCRIPTION
### Description
Resolves #2149

### Changes
Previously, when `NoDial` is set to true, then the maximum dial peers is always going to be 0. Hence, the node is never going to dial static nodes.

With this code change, when `NoDial` is set to true, the maximum dial peers will be set to the number of static peers. With this, the dial scheduler knows that there are available slots to dial the static peers.

One concern regarding this design is that, if the node doesn't dial the static nodes successfully, will it then dial the other peers, since there are available dial slots?

Fortunately, the answer is no. Based on the code [here](https://github.com/bnb-chain/bsc/blob/master/p2p/dial.go#L405-L414), it's guaranteed to return the number of static nodes. Therefore, there will be [no available slots](https://github.com/bnb-chain/bsc/blob/master/p2p/dial.go#L238-L244) to dial other peers.
