### PR TITLE
code: remove IsEuler check from worker.go

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -711,7 +711,7 @@ func (w *worker) commitTransactions(env *environment, txs *transactionsByPriceAn
 	gasLimit := env.header.GasLimit
 	if env.gasPool == nil {
 		env.gasPool = new(core.GasPool).AddGas(gasLimit)
-		env.gasPool.SubGas(params.SystemTxsGas * 3)
+		env.gasPool.SubGas(params.SystemTxsGas)
 	}
 
 	var coalescedLogs []*types.Log

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -711,11 +711,7 @@ func (w *worker) commitTransactions(env *environment, txs *transactionsByPriceAn
 	gasLimit := env.header.GasLimit
 	if env.gasPool == nil {
 		env.gasPool = new(core.GasPool).AddGas(gasLimit)
-		if w.chain.Config().IsEuler(env.header.Number) {
-			env.gasPool.SubGas(params.SystemTxsGas * 3)
-		} else {
-			env.gasPool.SubGas(params.SystemTxsGas)
-		}
+		env.gasPool.SubGas(params.SystemTxsGas * 3)
 	}
 
 	var coalescedLogs []*types.Log

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -24,19 +24,19 @@ const (
 	MaxGasLimit          uint64 = 0x7fffffffffffffff // Maximum the gas limit (2^63-1).
 	GenesisGasLimit      uint64 = 4712388            // Gas limit of the Genesis block.
 
-	MaximumExtraDataSize  uint64 = 32     // Maximum size extra data may be after Genesis.
-	ForkIDSize            uint64 = 4      // The length of fork id
-	ExpByteGas            uint64 = 10     // Times ceil(log256(exponent)) for the EXP instruction.
-	SloadGas              uint64 = 50     // Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.
-	CallValueTransferGas  uint64 = 9000   // Paid for CALL when the value transfer is non-zero.
-	CallNewAccountGas     uint64 = 25000  // Paid for CALL when the destination address didn't exist prior.
-	TxGas                 uint64 = 21000  // Per transaction not creating a contract. NOTE: Not payable on data of calls between transactions.
-	SystemTxsGas          uint64 = 500000 // The gas reserved for system txs; only for parlia consensus
-	TxGasContractCreation uint64 = 53000  // Per transaction that creates a contract. NOTE: Not payable on data of calls between transactions.
-	TxDataZeroGas         uint64 = 4      // Per byte of data attached to a transaction that equals zero. NOTE: Not payable on data of calls between transactions.
-	QuadCoeffDiv          uint64 = 512    // Divisor for the quadratic particle of the memory cost equation.
-	LogDataGas            uint64 = 8      // Per byte in a LOG* operation's data.
-	CallStipend           uint64 = 2300   // Free gas given at beginning of call.
+	MaximumExtraDataSize  uint64 = 32      // Maximum size extra data may be after Genesis.
+	ForkIDSize            uint64 = 4       // The length of fork id
+	ExpByteGas            uint64 = 10      // Times ceil(log256(exponent)) for the EXP instruction.
+	SloadGas              uint64 = 50      // Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.
+	CallValueTransferGas  uint64 = 9000    // Paid for CALL when the value transfer is non-zero.
+	CallNewAccountGas     uint64 = 25000   // Paid for CALL when the destination address didn't exist prior.
+	TxGas                 uint64 = 21000   // Per transaction not creating a contract. NOTE: Not payable on data of calls between transactions.
+	SystemTxsGas          uint64 = 1500000 // The gas reserved for system txs; only for parlia consensus
+	TxGasContractCreation uint64 = 53000   // Per transaction that creates a contract. NOTE: Not payable on data of calls between transactions.
+	TxDataZeroGas         uint64 = 4       // Per byte of data attached to a transaction that equals zero. NOTE: Not payable on data of calls between transactions.
+	QuadCoeffDiv          uint64 = 512     // Divisor for the quadratic particle of the memory cost equation.
+	LogDataGas            uint64 = 8       // Per byte in a LOG* operation's data.
+	CallStipend           uint64 = 2300    // Free gas given at beginning of call.
 
 	Keccak256Gas     uint64 = 30 // Once per KECCAK256 operation.
 	Keccak256WordGas uint64 = 6  // Once per word of the KECCAK256 operation's data.


### PR DESCRIPTION
### Description
In mine phase, it is useless to check the passed hard fork, remove it could simplify the code.

Keep other hard fork checks in mine phase, like `IsLondon`, `IsEIP155`, as they are more complicated and could be used in some test environment.

### Rationale
To simplify the code.

### Example
NA

### Changes
NA