### PR TITLE
improve: remove sharedpool from miner

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1022,11 +1022,6 @@ func (bc *BlockChain) SnapSyncCommitHead(hash common.Hash) error {
 	return nil
 }
 
-// StateAtWithSharedPool returns a new mutable state based on a particular point in time with sharedStorage
-func (bc *BlockChain) StateAtWithSharedPool(root common.Hash) (*state.StateDB, error) {
-	return state.NewWithSharedPool(root, bc.stateCache, bc.snaps)
-}
-
 // Reset purges the entire blockchain, restoring it to its genesis state.
 func (bc *BlockChain) Reset() error {
 	return bc.ResetWithGenesisBlock(bc.genesisBlock)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -650,7 +650,7 @@ func (w *worker) makeEnv(parent *types.Header, header *types.Header, coinbase co
 	prevEnv *environment) (*environment, error) {
 	// Retrieve the parent state to execute on top and start a prefetcher for
 	// the miner to speed block sealing up a bit
-	state, err := w.chain.StateAtWithSharedPool(parent.Root)
+	state, err := w.chain.StateAt(parent.Root)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description
SharedPool was introduced since [v1.1.9](https://github.com/bnb-chain/bsc/releases/tag/v1.1.9), but it has a potential bug and is no longer supported since [hertzFix](https://forum.bnbchain.org/t/about-the-hertzfix/2400).

This PR is to remove the sharedPool code in miner module, which was introduced in this PR https://github.com/bnb-chain/bsc/pull/818 and is useless now.

It has no impact to the current logic, but just code improve

### Rationale
NA

### Example
NA

### Changes
NA
