### PR TITLE
consensus/parlia: set nonce before evm run

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1751,7 +1751,6 @@ func (p *Parlia) applyTransaction(
 	receipt.BlockNumber = header.Number
 	receipt.TransactionIndex = uint(state.TxIndex())
 	*receipts = append(*receipts, receipt)
-	state.SetNonce(msg.From(), nonce+1)
 	return nil
 }
 
@@ -1975,6 +1974,8 @@ func applyMessage(
 	// about the transaction and calling mechanisms.
 	vmenv := vm.NewEVM(context, vm.TxContext{Origin: msg.From(), GasPrice: big.NewInt(0)}, state, chainConfig, vm.Config{})
 	// Apply the transaction to the current state (included in the env)
+	// Increment the nonce for the next transaction
+	state.SetNonce(msg.From(), state.GetNonce(msg.From())+1)
 	ret, returnGas, err := vmenv.Call(
 		vm.AccountRef(msg.From()),
 		*msg.To(),


### PR DESCRIPTION
### Description

consensus/parlia: set nonce before evm run

### Rationale

It's strange to set nonce after execute tx, so align with it in TransitionDb
no need to use hardfork to control, there are 3 reasons:
```
1. The GetNonce function will not be invoked during the execution process of the virtual machine, so placing it before or after the call execution has no impact.

2. Modifications to the state occur on a per-block basis, so placing them after Finalise also does not affect the overall result of block execution.

3. The journal is used for rollback purposes; transactions in Parlia will not revert, so the impact can be ignored.
```

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
