### PR TITLE
txpool/legacypool: deprecate already known error

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -57,10 +57,6 @@ const (
 )
 
 var (
-	// ErrAlreadyKnown is returned if the transactions is already contained
-	// within the pool.
-	ErrAlreadyKnown = errors.New("already known")
-
 	// ErrTxPoolOverflow is returned if the transaction pool is full and can't accept
 	// another remote transaction.
 	ErrTxPoolOverflow = errors.New("txpool is full")
@@ -715,7 +711,7 @@ func (pool *LegacyPool) add(tx *types.Transaction, local bool) (replaced bool, e
 	if pool.all.Get(hash) != nil {
 		log.Trace("Discarding already known transaction", "hash", hash)
 		knownTxMeter.Mark(1)
-		return false, ErrAlreadyKnown
+		return false, txpool.ErrAlreadyKnown
 	}
 	// Make the local flag. If it's from local source or it's from the network but
 	// the sender is marked as local previously, treat it as the local transaction.
@@ -1038,7 +1034,7 @@ func (pool *LegacyPool) addTxs(txs []*types.Transaction, local, sync bool) []err
 	for i, tx := range txs {
 		// If the transaction is known, pre-set the error slot
 		if pool.all.Get(tx.Hash()) != nil {
-			errs[i] = ErrAlreadyKnown
+			errs[i] = txpool.ErrAlreadyKnown
 			knownTxMeter.Mark(1)
 			continue
 		}


### PR DESCRIPTION
### Description
This PR deprecates the usage of `ErrAlreadyKnown` in the `legacypool` package. Existing dependencies on this error type should use `txpool.ErrAlreadyKnown` instead.

### Rationale
Originally, upon triggering `legacypool.ErrAlreadyKnown`, this error will be propagated back to the initial caller functions.
For example, in [this code](https://github.com/bnb-chain/bsc/blob/master/eth/fetcher/tx_fetcher.go#L323), the expected behavior is that the metrics will be bumped if `txpool.ErrAlreadyKnown` function is used. However, `legacypool.ErrAlreadyKnown` and `txpool.ErrAlreadyKnown` are 2 different error types with the same error messages. Hence, the case of checking if the error is of `txpool.ErrAlreadyKnown` will not be triggered so it will go to the default case instead.
