### PR TITLE
eth/fetcher: downgrade state tx log

### DIFF
--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -338,7 +338,7 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 		// If 'other reject' is >25% of the deliveries in any batch, sleep a bit.
 		if otherreject > 128/4 {
 			time.Sleep(200 * time.Millisecond)
-			log.Warn("Peer delivering stale transactions", "peer", peer, "rejected", otherreject)
+			log.Debug("Peer delivering stale transactions", "peer", peer, "rejected", otherreject)
 		}
 	}
 	select {


### PR DESCRIPTION
### Description
This PR downgrades the `Peer delivering stale transactions` from `warn` to `debug`.

### Rationale
This log frequently appears in the node logs, but users can't do anything about it, so it's best to downgrade it and use it for debug purposes only.