### PR TITLE
fix: add check for block number

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -1399,7 +1399,8 @@ func (c *verifyDoubleSignEvidence) RequiredGas(input []byte) uint64 {
 }
 
 var (
-	extraSeal = 65
+	extraSeal  = 65
+	maxUnit256 = new(big.Int).SetUint64(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
 )
 
 type DoubleSignEvidence struct {
@@ -1432,6 +1433,9 @@ func (c *verifyDoubleSignEvidence) Run(input []byte) ([]byte, error) {
 	}
 
 	// basic check
+	if header1.Number.Cmp(maxUnit256) == 1 || header2.Number.Cmp(maxUnit256) == 1 {
+		return nil, ErrExecutionReverted
+	}
 	if header1.Number.Cmp(header2.Number) != 0 {
 		return nil, ErrExecutionReverted
 	}


### PR DESCRIPTION
### Description

This pr is to fix a bug within precompile contract `verifyDoubleSignEvidence`

### Rationale

An arbitrary block number that is bigger than 2^256 could overwrite the address in the returned bytes.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add check for block number in `verifyDoubleSignEvidence`
