### PR TITLE
vote: lazy init vote manager's signer;

### DIFF
--- a/core/vote/vote_pool_test.go
+++ b/core/vote/vote_pool_test.go
@@ -179,6 +179,7 @@ func testVotePool(t *testing.T, isValidRules bool) {
 	if err != nil {
 		t.Fatalf("failed to create vote managers")
 	}
+	voteManager.SetupSigner()
 
 	voteJournal := voteManager.journal
 


### PR DESCRIPTION
### Description

vote: lazy init vote manager's signer;

### Rationale

If the node not config to mine

### Example

If the node does not set `--mine`, then the vote singer should not be initialized directly, but when the mine is enabled through flags or RPC, then the specified account is initialized for voting.

This change may facilitate configuration optimization and avoid configuration complexity.

### Changes

Notable changes: 
* vote: lazy init vote manager's signer;
