### PR TITLE
fix: change the wrong precompile contract

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -233,7 +233,7 @@ var PrecompiledContractsFeynman = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{2}): &sha256hash{},
 	common.BytesToAddress([]byte{3}): &ripemd160hash{},
 	common.BytesToAddress([]byte{4}): &dataCopy{},
-	common.BytesToAddress([]byte{5}): &bigModExp{},
+	common.BytesToAddress([]byte{5}): &bigModExp{eip2565: true},
 	common.BytesToAddress([]byte{6}): &bn256AddIstanbul{},
 	common.BytesToAddress([]byte{7}): &bn256ScalarMulIstanbul{},
 	common.BytesToAddress([]byte{8}): &bn256PairingIstanbul{},
@@ -242,7 +242,7 @@ var PrecompiledContractsFeynman = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{100}): &tmHeaderValidate{},
 	common.BytesToAddress([]byte{101}): &iavlMerkleProofValidatePlato{},
 	common.BytesToAddress([]byte{102}): &blsSignatureVerify{},
-	common.BytesToAddress([]byte{103}): &cometBFTLightBlockValidate{},
+	common.BytesToAddress([]byte{103}): &cometBFTLightBlockValidateHertz{},
 	common.BytesToAddress([]byte{104}): &verifyDoubleSignEvidence{},
 	common.BytesToAddress([]byte{105}): &secp256k1SignatureRecover{},
 }

--- a/core/vm/contracts_lightclient.go
+++ b/core/vm/contracts_lightclient.go
@@ -408,23 +408,23 @@ func (c *secp256k1SignatureRecover) RequiredGas(input []byte) uint64 {
 }
 
 const (
-	tmPubKeyLength           uint8 = 33
-	tmSignatureLength        uint8 = 64
-	tmSignatureMsgHashLength uint8 = 32
+	secp256k1PubKeyLength           uint8 = 33
+	secp256k1SignatureLength        uint8 = 64
+	secp256k1SignatureMsgHashLength uint8 = 32
 )
 
 // input:
-// | tmPubKey | tmSignature  |  tmSignatureMsgHash  |
+// | PubKey | Signature  |  SignatureMsgHash  |
 // | 33 bytes |  64 bytes    |       32 bytes       |
 func (c *secp256k1SignatureRecover) Run(input []byte) (result []byte, err error) {
-	if len(input) != int(tmPubKeyLength)+int(tmSignatureLength)+int(tmSignatureMsgHashLength) {
+	if len(input) != int(secp256k1PubKeyLength)+int(secp256k1SignatureLength)+int(secp256k1SignatureMsgHashLength) {
 		return nil, fmt.Errorf("invalid input")
 	}
 
 	return c.runTMSecp256k1Signature(
-		input[:tmPubKeyLength],
-		input[tmPubKeyLength:tmPubKeyLength+tmSignatureLength],
-		input[tmPubKeyLength+tmSignatureLength:],
+		input[:secp256k1PubKeyLength],
+		input[secp256k1PubKeyLength:secp256k1PubKeyLength+secp256k1SignatureLength],
+		input[secp256k1PubKeyLength+secp256k1SignatureLength:],
 	)
 }
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -135,16 +135,16 @@ const (
 	IAVLMerkleProofValidateGas    uint64 = 3000 // Gas for validate merkle proof
 	CometBFTLightBlockValidateGas uint64 = 3000 // Gas for validate cometBFT light block
 
-	EcrecoverGas                uint64 = 3000 // Elliptic curve sender recovery gas price
-	Sha256BaseGas               uint64 = 60   // Base price for a SHA256 operation
-	Sha256PerWordGas            uint64 = 12   // Per-word price for a SHA256 operation
-	Ripemd160BaseGas            uint64 = 600  // Base price for a RIPEMD160 operation
-	Ripemd160PerWordGas         uint64 = 120  // Per-word price for a RIPEMD160 operation
-	IdentityBaseGas             uint64 = 15   // Base price for a data copy operation
-	IdentityPerWordGas          uint64 = 3    // Per-work price for a data copy operation
-	BlsSignatureVerifyBaseGas   uint64 = 1000 // base price for a BLS signature verify operation
-	BlsSignatureVerifyPerKeyGas uint64 = 3500 // Per-key price for a BLS signature verify operation
-	DoubleSignEvidenceVerifyGas uint64 = 1000 // Gas for verify double sign evidence
+	EcrecoverGas                uint64 = 3000  // Elliptic curve sender recovery gas price
+	Sha256BaseGas               uint64 = 60    // Base price for a SHA256 operation
+	Sha256PerWordGas            uint64 = 12    // Per-word price for a SHA256 operation
+	Ripemd160BaseGas            uint64 = 600   // Base price for a RIPEMD160 operation
+	Ripemd160PerWordGas         uint64 = 120   // Per-word price for a RIPEMD160 operation
+	IdentityBaseGas             uint64 = 15    // Base price for a data copy operation
+	IdentityPerWordGas          uint64 = 3     // Per-work price for a data copy operation
+	BlsSignatureVerifyBaseGas   uint64 = 1000  // base price for a BLS signature verify operation
+	BlsSignatureVerifyPerKeyGas uint64 = 3500  // Per-key price for a BLS signature verify operation
+	DoubleSignEvidenceVerifyGas uint64 = 10000 // Gas for verify double sign evidence
 
 	Bn256AddGasByzantium             uint64 = 500    // Byzantium gas needed for an elliptic curve addition
 	Bn256AddGasIstanbul              uint64 = 150    // Gas needed for an elliptic curve addition


### PR DESCRIPTION
### Description
This PR fix three things:

1. The wrong precompile contracts for Feyman upgrade;
2. Adjust the gas for doubleSignVerfify precompile contract;
3. Change the name of some const.

### Rationale

Fix the review comment.
### Example

None

### Changes

None
