### PR TITLE
feat: support MEV

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -326,6 +326,11 @@ func (beacon *Beacon) verifyHeaders(chain consensus.ChainHeaderReader, headers [
 	return abort, results
 }
 
+// NextInTurnValidator return the next in-turn validator for header
+func (beacon *Beacon) NextInTurnValidator(chain consensus.ChainHeaderReader, header *types.Header) (common.Address, error) {
+	return common.Address{}, errors.New("not implemented")
+}
+
 // Prepare implements consensus.Engine, initializing the difficulty field of a
 // header to conform to the beacon protocol. The changes are done inline.
 func (beacon *Beacon) Prepare(chain consensus.ChainHeaderReader, header *types.Header) error {

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -498,6 +498,11 @@ func (c *Clique) verifySeal(snap *Snapshot, header *types.Header, parents []*typ
 	return nil
 }
 
+// NextInTurnValidator return the next in-turn validator for header
+func (c *Clique) NextInTurnValidator(chain consensus.ChainHeaderReader, header *types.Header) (common.Address, error) {
+	return common.Address{}, errors.New("not implemented")
+}
+
 // Prepare implements consensus.Engine, preparing all the consensus fields of the
 // header for running the transactions on top.
 func (c *Clique) Prepare(chain consensus.ChainHeaderReader, header *types.Header) error {

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -91,6 +91,9 @@ type Engine interface {
 	// rules of a given engine.
 	VerifyUncles(chain ChainReader, block *types.Block) error
 
+	// NextInTurnValidator return the next in-turn validator for header
+	NextInTurnValidator(chain ChainHeaderReader, header *types.Header) (common.Address, error)
+
 	// Prepare initializes the consensus fields of a block header according to the
 	// rules of a particular engine. The changes are executed inline.
 	Prepare(chain ChainHeaderReader, header *types.Header) error

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -475,6 +475,11 @@ var FrontierDifficultyCalculator = calcDifficultyFrontier
 var HomesteadDifficultyCalculator = calcDifficultyHomestead
 var DynamicDifficultyCalculator = makeDifficultyCalculator
 
+// NextInTurnValidator return the next in-turn validator for header
+func (ethash *Ethash) NextInTurnValidator(chain consensus.ChainHeaderReader, header *types.Header) (common.Address, error) {
+	return common.Address{}, errors.New("not implemented")
+}
+
 // Prepare implements consensus.Engine, initializing the difficulty field of a
 // header to conform to the ethash protocol. The changes are done inline.
 func (ethash *Ethash) Prepare(chain consensus.ChainHeaderReader, header *types.Header) error {

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -933,6 +933,16 @@ func (p *Parlia) assembleVoteAttestation(chain consensus.ChainHeaderReader, head
 	return nil
 }
 
+// NextInTurnValidator return the next in-turn validator for header
+func (p *Parlia) NextInTurnValidator(chain consensus.ChainHeaderReader, header *types.Header) (common.Address, error) {
+	snap, err := p.snapshot(chain, header.Number.Uint64(), header.Hash(), nil)
+	if err != nil {
+		return common.Address{}, err
+	}
+
+	return snap.inturnValidator(), nil
+}
+
 // Prepare implements consensus.Engine, preparing all the consensus fields of the
 // header for running the transactions on top.
 func (p *Parlia) Prepare(chain consensus.ChainHeaderReader, header *types.Header) error {

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -338,6 +338,13 @@ func (s *Snapshot) inturn(validator common.Address) bool {
 	return validators[offset] == validator
 }
 
+// inturnValidator returns the validator at a given block height.
+func (s *Snapshot) inturnValidator() common.Address {
+	validators := s.validators()
+	offset := (s.Number + 1) % uint64(len(validators))
+	return validators[offset]
+}
+
 func (s *Snapshot) enoughDistance(validator common.Address, header *types.Header) bool {
 	idx := s.indexOfVal(validator)
 	if idx < 0 {

--- a/core/types/bid.go
+++ b/core/types/bid.go
@@ -1,0 +1,86 @@
+package types
+
+import (
+	"fmt"
+	"math/big"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// BidArgs represents the arguments to submit a bid.
+type BidArgs struct {
+	// bid
+	Bid *RawBid
+	// signed signature of the bid
+	Signature hexutil.Bytes `json:"signature"`
+
+	// PayBidTx pays to builder
+	PayBidTx        hexutil.Bytes `json:"payBidTx"`
+	PayBidTxGasUsed uint64        `json:"payBidTxGasUsed"`
+}
+
+// RawBid represents a raw bid.
+type RawBid struct {
+	BlockNumber uint64          `json:"blockNumber"`
+	ParentHash  common.Hash     `json:"parentHash"`
+	Txs         []hexutil.Bytes `json:"txs"`
+	GasUsed     uint64          `json:"gasUsed"`
+	GasFee      *big.Int        `json:"gasFee"`
+	BuilderFee  *big.Int        `json:"builderFee"`
+}
+
+func EcrecoverBuilder(args *BidArgs) (common.Address, error) {
+	bid, err := rlp.EncodeToBytes(args.Bid)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("fail to encode bid, %v", err)
+	}
+
+	pk, err := crypto.SigToPub(crypto.Keccak256(bid), args.Signature)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("fail to extract pubkey, %v", err)
+	}
+
+	return crypto.PubkeyToAddress(*pk), nil
+}
+
+// Bid represents a bid.
+type Bid struct {
+	Builder     common.Address
+	BlockNumber uint64
+	ParentHash  common.Hash
+	Txs         Transactions
+	GasUsed     uint64
+	GasFee      *big.Int
+	BuilderFee  *big.Int
+
+	// caches
+	hash atomic.Value
+}
+
+// Hash returns the transaction hash.
+func (b *Bid) Hash() common.Hash {
+	if hash := b.hash.Load(); hash != nil {
+		return hash.(common.Hash)
+	}
+
+	var h common.Hash
+	h = rlpHash(b)
+
+	b.hash.Store(h)
+	return h
+}
+
+// BidIssue represents a bid issue.
+type BidIssue struct {
+	// TODO put validator and builder here or parsing by header?
+	Validator   common.Address
+	Builder     common.Address
+	BlockNumber uint64
+	ParentHash  common.Hash
+	BidHash     common.Hash
+	Message     string
+}

--- a/core/types/bid_error.go
+++ b/core/types/bid_error.go
@@ -1,0 +1,45 @@
+package types
+
+import "errors"
+
+const (
+	InvalidBidParamError = -38001
+	InvalidPayBidTxError = -38002
+	MevNotRunningError   = -38003
+	MevBusyError         = -38004
+	MevNotInTurnError    = -38005
+)
+
+var (
+	ErrMevNotRunning = newBidError(errors.New("the validator stop serving mev for now, try again later"), MevNotRunningError)
+	ErrMevBusy       = newBidError(errors.New("the validator is working on too many bids, try again later"), MevBusyError)
+	ErrMevNotInTurn  = newBidError(errors.New("the validator is not in-turn to propose currently, try again later"), MevNotInTurnError)
+)
+
+// bidError is an API error that encompasses an invalid bid with JSON error
+// code and a binary data blob.
+type bidError struct {
+	error
+	code int
+}
+
+// ErrorCode returns the JSON error code for an invalid bid.
+// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+func (e *bidError) ErrorCode() int {
+	return e.code
+}
+
+func NewInvalidBidError(message string) *bidError {
+	return newBidError(errors.New(message), InvalidBidParamError)
+}
+
+func NewInvalidPayBidTxError(message string) *bidError {
+	return newBidError(errors.New(message), InvalidPayBidTxError)
+}
+
+func newBidError(err error, code int) *bidError {
+	return &bidError{
+		error: err,
+		code:  code,
+	}
+}

--- a/eth/api_admin.go
+++ b/eth/api_admin.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -136,4 +137,32 @@ func (api *AdminAPI) ImportChain(file string) (bool, error) {
 		blocks = blocks[:0]
 	}
 	return true, nil
+}
+
+// MevRunning returns true if mev is running
+func (api *AdminAPI) MevRunning() bool {
+	return api.eth.APIBackend.MevRunning()
+}
+
+// StartMev starts mev. It notifies the miner to start to receive bids.
+func (api *AdminAPI) StartMev() {
+	api.eth.APIBackend.StartMev()
+}
+
+// StopMev stops mev. It notifies the miner to stop receiving bids from this moment,
+// but the bids before this moment would still been taken into consideration by mev.
+func (api *AdminAPI) StopMev() {
+	api.eth.APIBackend.StopMev()
+}
+
+// AddBuilder adds a builder to the bid simulator.
+// url is the endpoint of the builder, for example, "https://mev-builder.amazonaws.com",
+// if validator is equipped with sentry, ignore the url.
+func (api *AdminAPI) AddBuilder(builder common.Address, url string) error {
+	return api.eth.APIBackend.AddBuilder(builder, url)
+}
+
+// RemoveBuilder removes a builder from the bid simulator.
+func (api *AdminAPI) RemoveBuilder(builder common.Address) error {
+	return api.eth.APIBackend.RemoveBuilder(builder)
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -432,3 +432,31 @@ func (b *EthAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
 	return b.eth.stateAtTransaction(ctx, block, txIndex, reexec)
 }
+
+func (b *EthAPIBackend) MevRunning() bool {
+	return b.Miner().MevRunning()
+}
+
+func (b *EthAPIBackend) StartMev() {
+	b.Miner().StartMev()
+}
+
+func (b *EthAPIBackend) StopMev() {
+	b.Miner().StopMev()
+}
+
+func (b *EthAPIBackend) AddBuilder(builder common.Address, url string) error {
+	return b.Miner().AddBuilder(builder, url)
+}
+
+func (b *EthAPIBackend) RemoveBuilder(builder common.Address) error {
+	return b.Miner().RemoveBuilder(builder)
+}
+
+func (b *EthAPIBackend) SendBid(ctx context.Context, bid *types.BidArgs) (common.Hash, error) {
+	return b.Miner().SendBid(ctx, bid)
+}
+
+func (b *EthAPIBackend) MinerInTurn() bool {
+	return b.Miner().InTurn()
+}

--- a/internal/ethapi/api_mev.go
+++ b/internal/ethapi/api_mev.go
@@ -1,0 +1,87 @@
+package ethapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const (
+	TransferTxGasLimit = 25000
+)
+
+// MevAPI implements the interfaces that defined in the BEP-322.
+// It offers methods for the interaction between builders and validators.
+type MevAPI struct {
+	b Backend
+}
+
+// NewMevAPI creates a new MevAPI.
+func NewMevAPI(b Backend) *MevAPI {
+	return &MevAPI{b}
+}
+
+// SendBid receives bid from the builders.
+// If mev is not running or bid is invalid, return error.
+// Otherwise, creates a builder bid for the given argument, submit it to the miner.
+func (m *MevAPI) SendBid(ctx context.Context, args types.BidArgs) (common.Hash, error) {
+	if !m.b.MevRunning() {
+		return common.Hash{}, types.ErrMevNotRunning
+	}
+
+	if !m.b.MinerInTurn() {
+		return common.Hash{}, types.ErrMevNotInTurn
+	}
+
+	var (
+		bid           = args.Bid
+		currentHeader = m.b.CurrentHeader()
+	)
+
+	// only support bidding for the next block not for the future block
+	if bid.BlockNumber != currentHeader.Number.Uint64()+1 {
+		return common.Hash{}, types.NewInvalidBidError("stale block number or block in future")
+	}
+
+	if bid.ParentHash != currentHeader.Hash() {
+		return common.Hash{}, types.NewInvalidBidError(
+			fmt.Sprintf("non-aligned parent hash: %v", currentHeader.Hash()))
+	}
+
+	if bid.BuilderFee != nil {
+		builderFee := bid.BuilderFee
+		if builderFee.Cmp(common.Big0) < 0 {
+			return common.Hash{}, types.NewInvalidBidError("builder fee should not be less than 0")
+		}
+
+		if builderFee.Cmp(common.Big0) == 0 {
+			if len(args.PayBidTx) != 0 || args.PayBidTxGasUsed != 0 {
+				return common.Hash{}, types.NewInvalidPayBidTxError("payBidTx should be nil when builder fee is 0")
+			}
+		}
+
+		if builderFee.Cmp(bid.GasFee) >= 0 {
+			return common.Hash{}, types.NewInvalidBidError("builder fee must be less than gas fee")
+		}
+
+		if builderFee.Cmp(common.Big0) > 0 {
+			if args.PayBidTxGasUsed >= TransferTxGasLimit {
+				return common.Hash{}, types.NewInvalidBidError(
+					fmt.Sprintf("transfer tx gas used must be less than %v", TransferTxGasLimit))
+			}
+		}
+	} else {
+		if len(args.PayBidTx) != 0 || args.PayBidTxGasUsed != 0 {
+			return common.Hash{}, types.NewInvalidPayBidTxError("payBidTx should be nil when builder fee is nil")
+		}
+	}
+
+	return m.b.SendBid(ctx, &args)
+}
+
+// Running returns true if mev is running
+func (m *MevAPI) Running() bool {
+	return m.b.MevRunning()
+}

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -27,6 +27,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -45,9 +49,6 @@ import (
 	"github.com/ethereum/go-ethereum/internal/blocktest"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestTransaction_RoundTripRpcJSON(t *testing.T) {
@@ -545,6 +546,16 @@ func (b testBackend) BloomStatus() (uint64, uint64) { panic("implement me") }
 func (b testBackend) ServiceFilter(ctx context.Context, session *bloombits.MatcherSession) {
 	panic("implement me")
 }
+
+func (b *testBackend) MevRunning() bool                                           { return false }
+func (b *testBackend) StartMev()                                                  {}
+func (b *testBackend) StopMev()                                                   {}
+func (b *testBackend) AddBuilder(builder common.Address, builderUrl string) error { return nil }
+func (b *testBackend) RemoveBuilder(builder common.Address) error                 { return nil }
+func (b *testBackend) SendBid(ctx context.Context, bid *types.BidArgs) (common.Hash, error) {
+	panic("implement me")
+}
+func (b *testBackend) MinerInTurn() bool { return false }
 
 func TestEstimateGas(t *testing.T) {
 	t.Parallel()

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -101,6 +101,21 @@ type Backend interface {
 	ServiceFilter(ctx context.Context, session *bloombits.MatcherSession)
 	SubscribeFinalizedHeaderEvent(ch chan<- core.FinalizedHeaderEvent) event.Subscription
 	SubscribeNewVoteEvent(chan<- core.NewVoteEvent) event.Subscription
+
+	// MevRunning return true if mev is running
+	MevRunning() bool
+	// StartMev starts mev
+	StartMev()
+	// StopMev stops mev
+	StopMev()
+	// AddBuilder adds a builder to the bid simulator.
+	AddBuilder(builder common.Address, builderUrl string) error
+	// RemoveBuilder removes a builder from the bid simulator.
+	RemoveBuilder(builder common.Address) error
+	// SendBid receives bid from the builders.
+	SendBid(ctx context.Context, bid *types.BidArgs) (common.Hash, error)
+	// MinerInTurn returns true if the validator is in turn to propose the block.
+	MinerInTurn() bool
 }
 
 func GetAPIs(apiBackend Backend) []rpc.API {
@@ -127,6 +142,9 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 		}, {
 			Namespace: "personal",
 			Service:   NewPersonalAccountAPI(apiBackend, nonceLock),
+		}, {
+			Namespace: "mev",
+			Service:   NewMevAPI(apiBackend),
 		},
 	}
 }

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -351,3 +351,13 @@ func (b *backendMock) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent)
 }
 
 func (b *backendMock) Engine() consensus.Engine { return nil }
+
+func (b *backendMock) MevRunning() bool                                           { return false }
+func (b *backendMock) StartMev()                                                  {}
+func (b *backendMock) StopMev()                                                   {}
+func (b *backendMock) AddBuilder(builder common.Address, builderUrl string) error { return nil }
+func (b *backendMock) RemoveBuilder(builder common.Address) error                 { return nil }
+func (b *backendMock) SendBid(ctx context.Context, bid *types.BidArgs) (common.Hash, error) {
+	panic("implement me")
+}
+func (b *backendMock) MinerInTurn() bool { return false }

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -1,0 +1,656 @@
+package miner
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+const (
+	// maxBidPerBuilder is the max bid number per builder
+	maxBidPerBuilder = 3
+
+	commitInterruptBetterBid = 1
+)
+
+var (
+	diffInTurn = big.NewInt(2) // the difficulty of a block that proposed by an in-turn validator
+)
+
+var (
+	dialer = &net.Dialer{
+		Timeout:   time.Second,
+		KeepAlive: 60 * time.Second,
+	}
+
+	transport = &http.Transport{
+		DialContext:         dialer.DialContext,
+		MaxIdleConnsPerHost: 50,
+		MaxConnsPerHost:     50,
+		IdleConnTimeout:     90 * time.Second,
+		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
+	}
+
+	client = &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: transport,
+	}
+)
+
+type WorkPreparer interface {
+	prepareWork(params *generateParams) (*environment, error)
+}
+
+// simBidReq is the request for simulating a bid
+type simBidReq struct {
+	bid         *BidRuntime
+	interruptCh chan int32
+}
+
+// bidSimulator is in charge of receiving bid from builders, reporting issue to builders.
+// And take care of bid simulation, rewards computing, best bid maintaining.
+type bidSimulator struct {
+	config        *MevConfig
+	delayLeftOver time.Duration
+	chain         *core.BlockChain
+	chainConfig   *params.ChainConfig
+	workPreparer  WorkPreparer
+
+	running atomic.Bool // controlled by miner
+	exitCh  chan struct{}
+
+	bidReceiving atomic.Bool // controlled by config and eth.AdminAPI
+
+	chainHeadCh  chan core.ChainHeadEvent
+	chainHeadSub event.Subscription
+
+	sentryCli *ethclient.Client
+
+	// builder info (warning: only keep status in memory!)
+	buildersMu sync.RWMutex
+	builders   map[common.Address]*ethclient.Client
+
+	// channels
+	// TODO(renee) some buffer with ch?
+	simBidCh chan *simBidReq
+	newBidCh chan *types.Bid
+
+	pendingMu sync.RWMutex
+	pending   map[common.Hash]map[common.Address]map[common.Hash]struct{} // prevBlockHash -> builder -> bidHash -> struct{}
+
+	bestBidMu sync.RWMutex
+	bestBid   map[common.Hash]*BidRuntime // prevBlockHash -> bidRuntime
+
+	simBidMu      sync.RWMutex
+	simulatingBid map[common.Hash]*BidRuntime // prevBlockHash -> bidRuntime, in the process of simulation
+}
+
+func newBidSimulator(
+	config *MevConfig,
+	delayLeftOver time.Duration,
+	chainConfig *params.ChainConfig,
+	chain *core.BlockChain,
+	workPreparer WorkPreparer,
+) *bidSimulator {
+	b := &bidSimulator{
+		config:        config,
+		delayLeftOver: delayLeftOver,
+		chainConfig:   chainConfig,
+		chain:         chain,
+		workPreparer:  workPreparer,
+		exitCh:        make(chan struct{}),
+		chainHeadCh:   make(chan core.ChainHeadEvent, chainHeadChanSize),
+		builders:      make(map[common.Address]*ethclient.Client),
+		simBidCh:      make(chan *simBidReq),
+		newBidCh:      make(chan *types.Bid),
+		pending:       make(map[common.Hash]map[common.Address]map[common.Hash]struct{}),
+		bestBid:       make(map[common.Hash]*BidRuntime),
+		simulatingBid: make(map[common.Hash]*BidRuntime),
+	}
+
+	b.chainHeadSub = chain.SubscribeChainHeadEvent(b.chainHeadCh)
+
+	if config.Enabled {
+		b.bidReceiving.Store(true)
+		b.dialSentryAndBuilders()
+
+		if len(b.builders) == 0 {
+			log.Warn("BidSimulator: no validReward builders")
+		}
+	}
+
+	go b.clearLoop()
+	go b.mainLoop()
+	go b.newBidLoop()
+
+	return b
+}
+
+func (b *bidSimulator) dialSentryAndBuilders() {
+	var sentryCli *ethclient.Client
+	var err error
+
+	if b.config.SentryURL != "" {
+		sentryCli, err = ethclient.DialOptions(context.Background(), b.config.SentryURL, rpc.WithHTTPClient(client))
+		if err != nil {
+			log.Error("BidSimulator: failed to dial sentry", "url", b.config.SentryURL, "err", err)
+		}
+	}
+
+	b.sentryCli = sentryCli
+
+	for _, v := range b.config.Builders {
+		var builderCli *ethclient.Client
+
+		if b.sentryCli != nil {
+			builderCli = b.sentryCli
+		} else {
+			builderCli, err = ethclient.DialOptions(context.Background(), v.URL, rpc.WithHTTPClient(client))
+			if err != nil {
+				log.Error("BidSimulator: failed to dial builder", "url", v.URL, "err", err)
+				continue
+			}
+		}
+
+		b.builders[v.Address] = builderCli
+	}
+}
+
+func (b *bidSimulator) start() {
+	b.running.Store(true)
+}
+
+func (b *bidSimulator) stop() {
+	b.running.Store(false)
+}
+
+func (b *bidSimulator) close() {
+	b.running.Store(false)
+	close(b.exitCh)
+}
+
+func (b *bidSimulator) isRunning() bool {
+	return b.running.Load()
+}
+
+func (b *bidSimulator) receivingBid() bool {
+	return b.bidReceiving.Load()
+}
+
+func (b *bidSimulator) startReceivingBid() {
+	b.bidReceiving.Store(true)
+	b.dialSentryAndBuilders()
+}
+
+func (b *bidSimulator) stopReceivingBid() {
+	b.bidReceiving.Store(false)
+}
+
+func (b *bidSimulator) AddBuilder(builder common.Address, url string) error {
+	b.buildersMu.Lock()
+	defer b.buildersMu.Unlock()
+
+	if b.sentryCli != nil {
+		b.builders[builder] = b.sentryCli
+	} else {
+		var builderCli *ethclient.Client
+
+		if url != "" {
+			var err error
+
+			builderCli, err = ethclient.DialOptions(context.Background(), url, rpc.WithHTTPClient(client))
+			if err != nil {
+				log.Error("BidSimulator: failed to dial builder", "url", url, "err", err)
+				return err
+			}
+		}
+
+		b.builders[builder] = builderCli
+	}
+
+	return nil
+}
+
+func (b *bidSimulator) RemoveBuilder(builder common.Address) error {
+	b.buildersMu.Lock()
+	defer b.buildersMu.Unlock()
+
+	delete(b.builders, builder)
+
+	return nil
+}
+
+func (b *bidSimulator) ExistBuilder(builder common.Address) bool {
+	b.buildersMu.RLock()
+	defer b.buildersMu.RUnlock()
+
+	_, ok := b.builders[builder]
+
+	return ok
+}
+
+func (b *bidSimulator) SetBestBid(prevBlockHash common.Hash, bid *BidRuntime) {
+	b.bestBidMu.Lock()
+	defer b.bestBidMu.Unlock()
+
+	b.bestBid[prevBlockHash] = bid
+}
+
+func (b *bidSimulator) GetBestBid(prevBlockHash common.Hash) *BidRuntime {
+	b.bestBidMu.RLock()
+	defer b.bestBidMu.RUnlock()
+
+	return b.bestBid[prevBlockHash]
+}
+
+func (b *bidSimulator) GetSimulatingBid(prevBlockHash common.Hash) *BidRuntime {
+	b.simBidMu.RLock()
+	defer b.simBidMu.RUnlock()
+
+	return b.simulatingBid[prevBlockHash]
+}
+
+func (b *bidSimulator) mainLoop() {
+	defer b.chainHeadSub.Unsubscribe()
+
+	for {
+		select {
+		case req := <-b.simBidCh:
+			if !b.isRunning() {
+				continue
+			}
+
+			b.simBid(req.interruptCh, req.bid)
+
+		// System stopped
+		case <-b.exitCh:
+			return
+
+		case <-b.chainHeadSub.Err():
+			return
+		}
+	}
+}
+
+func (b *bidSimulator) newBidLoop() {
+	var (
+		interruptCh chan int32
+	)
+
+	// commit aborts in-flight bid execution with given signal and resubmits a new one.
+	commit := func(reason int32, bidRuntime *BidRuntime) {
+		// if the left time is not enough to do simulation, return
+		var simDuration time.Duration
+		if lastBid := b.GetBestBid(bidRuntime.bid.ParentHash); lastBid != nil && lastBid.duration != 0 {
+			simDuration = lastBid.duration
+		}
+		// simulatingBid's duration is longer than bestBid's duration in most case
+		if lastBid := b.GetSimulatingBid(bidRuntime.bid.ParentHash); lastBid != nil && lastBid.duration != 0 {
+			simDuration = lastBid.duration
+		}
+		if time.Until(b.bidMustBefore(bidRuntime.bid.ParentHash)) <= simDuration {
+			return
+		}
+
+		if interruptCh != nil {
+			// each commit work will have its own interruptCh to stop work with a reason
+			interruptCh <- reason
+			close(interruptCh)
+		}
+		interruptCh = make(chan int32, 1)
+		select {
+		case b.simBidCh <- &simBidReq{interruptCh: interruptCh, bid: bidRuntime}:
+		case <-b.exitCh:
+			return
+		}
+	}
+
+	for {
+		select {
+		case newBid := <-b.newBidCh:
+			if !b.isRunning() {
+				continue
+			}
+
+			// check the block reward and validator reward of the newBid
+			expectedBlockReward := newBid.GasFee
+			expectedValidatorReward := new(big.Int).Mul(expectedBlockReward, big.NewInt(b.config.ValidatorCommission))
+			expectedValidatorReward.Div(expectedValidatorReward, big.NewInt(10000))
+			expectedValidatorReward.Sub(expectedValidatorReward, newBid.BuilderFee)
+
+			if expectedValidatorReward.Cmp(big.NewInt(0)) < 0 {
+				// damage self profit, ignore
+				continue
+			}
+
+			bidRuntime := &BidRuntime{
+				bid:                     newBid,
+				expectedBlockReward:     expectedBlockReward,
+				expectedValidatorReward: expectedValidatorReward,
+				packedBlockReward:       big.NewInt(0),
+				packedValidatorReward:   big.NewInt(0),
+			}
+
+			// TODO(renee-) opt bid comparation
+
+			simulatingBid := b.GetSimulatingBid(newBid.ParentHash)
+			// simulatingBid is nil means there is no bid in simulation
+			if simulatingBid == nil {
+				// bestBid is nil means bid is the first bid
+				bestBid := b.GetBestBid(newBid.ParentHash)
+				if bestBid == nil {
+					commit(commitInterruptBetterBid, bidRuntime)
+					continue
+				}
+
+				// if bestBid is not nil, check if newBid is better than bestBid
+				if bidRuntime.expectedBlockReward.Cmp(bestBid.expectedBlockReward) > 0 &&
+					bidRuntime.expectedValidatorReward.Cmp(bestBid.expectedValidatorReward) > 0 {
+					// if both reward are better than last simulating newBid, commit for simulation
+					commit(commitInterruptBetterBid, bidRuntime)
+					continue
+				}
+
+				continue
+			}
+
+			// simulatingBid must be better than bestBid, if newBid is better than simulatingBid, commit for simulation
+			if bidRuntime.expectedBlockReward.Cmp(simulatingBid.expectedBlockReward) > 0 &&
+				bidRuntime.expectedValidatorReward.Cmp(simulatingBid.expectedValidatorReward) > 0 {
+				// if both reward are better than last simulating newBid, commit for simulation
+				commit(commitInterruptBetterBid, bidRuntime)
+				continue
+			}
+
+		case <-b.exitCh:
+			return
+		}
+	}
+}
+
+func (b *bidSimulator) bidMustBefore(parentHash common.Hash) time.Time {
+	parentHeader := b.chain.GetHeaderByHash(parentHash)
+	nextHeaderTimestamp := parentHeader.Time + b.chainConfig.Parlia.Period
+	return time.Unix(int64(nextHeaderTimestamp), 0).Add(-b.delayLeftOver)
+}
+
+func (b *bidSimulator) clearLoop() {
+	clearFn := func(parentHash common.Hash) {
+		b.pendingMu.Lock()
+		delete(b.pending, parentHash)
+		b.pendingMu.Unlock()
+
+		b.bestBidMu.Lock()
+		if bid, ok := b.bestBid[parentHash]; ok {
+			bid.env.discard()
+		}
+		delete(b.bestBid, parentHash)
+		b.bestBidMu.Unlock()
+
+		b.simBidMu.Lock()
+		if bid, ok := b.simulatingBid[parentHash]; ok {
+			bid.env.discard()
+		}
+		delete(b.simulatingBid, parentHash)
+		b.simBidMu.Unlock()
+	}
+
+	for {
+		select {
+		// TODO(renee) check more suitable clear condition
+		case head := <-b.chainHeadCh:
+			if !b.isRunning() {
+				continue
+			}
+
+			clearFn(head.Block.ParentHash())
+		}
+	}
+}
+
+// sendBid checks if the bid is already exists or if the builder sends too many bids,
+// if yes, return error, if not, add bid into newBid chan waiting for judge profit.
+func (b *bidSimulator) sendBid(ctx context.Context, bid *types.Bid) error {
+	if !b.ExistBuilder(bid.Builder) {
+		return errors.New("builder is not registered")
+	}
+
+	err := b.pendingCheck(bid)
+	if err != nil {
+		return err
+	}
+
+	// pass checking, add bid into alternative chan waiting for judge profit
+	b.newBidCh <- bid
+
+	return nil
+}
+
+func (b *bidSimulator) pendingCheck(bid *types.Bid) error {
+	var (
+		builder    = bid.Builder
+		parentHash = bid.ParentHash
+	)
+
+	b.pendingMu.Lock()
+	defer b.pendingMu.Unlock()
+
+	// check if bid exists or if builder sends too many bids
+	if _, ok := b.pending[parentHash]; !ok {
+		b.pending[parentHash] = make(map[common.Address]map[common.Hash]struct{})
+	}
+
+	if _, ok := b.pending[parentHash][builder]; !ok {
+		b.pending[parentHash][builder] = make(map[common.Hash]struct{})
+	}
+
+	if _, ok := b.pending[parentHash][builder][bid.Hash()]; ok {
+		return errors.New("bid already exists")
+	}
+
+	if len(b.pending[parentHash][builder]) >= maxBidPerBuilder {
+		return errors.New("too many bids")
+	}
+
+	b.pending[parentHash][builder][bid.Hash()] = struct{}{}
+
+	return nil
+}
+
+// simBid simulates a newBid with txs.
+// simBid does not enable state prefetching when commit transaction.
+func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
+	// prevent from stopping happen in time interval from sendBid to simBid
+	if !b.isRunning() || !b.receivingBid() {
+		return
+	}
+
+	var (
+		blockNumber = bidRuntime.bid.BlockNumber
+		parentHash  = bidRuntime.bid.ParentHash
+		builder     = bidRuntime.bid.Builder
+		err         error
+		success     bool
+	)
+
+	// ensure simulation exited then start next simulation
+	// TODO(renee) lock last too long
+	b.simBidMu.Lock()
+	b.simulatingBid[parentHash] = bidRuntime
+
+	defer func(simStart time.Time) {
+		logCtx := []any{
+			"blockNumber", blockNumber,
+			"parentHash", parentHash,
+			"builder", builder,
+			"gasUsed", bidRuntime.bid.GasUsed,
+		}
+
+		if bidRuntime.env != nil {
+			logCtx = append(logCtx, "gasLimit", bidRuntime.env.header.GasLimit)
+
+			if err != nil || !success {
+				bidRuntime.env.discard()
+			}
+		}
+
+		if err != nil {
+			logCtx = append(logCtx, "err", err)
+			log.Debug("bid simulation failed", logCtx...)
+
+			go b.reportIssue(bidRuntime, err)
+		}
+
+		if success {
+			bidRuntime.duration = time.Since(simStart)
+		}
+
+		delete(b.simulatingBid, parentHash)
+		b.simBidMu.Unlock()
+	}(time.Now())
+
+	// prepareWork will configure header with a suitable time according to consensus
+	// prepareWork will start trie prefetching
+	if bidRuntime.env, err = b.workPreparer.prepareWork(&generateParams{
+		parentHash: bidRuntime.bid.ParentHash,
+	}); err != nil {
+		return
+	}
+
+	gasLimit := bidRuntime.env.header.GasLimit
+	if bidRuntime.env.gasPool == nil {
+		bidRuntime.env.gasPool = new(core.GasPool).AddGas(gasLimit)
+		bidRuntime.env.gasPool.SubGas(params.SystemTxsGas)
+	}
+
+	if bidRuntime.bid.GasUsed > bidRuntime.env.gasPool.Gas() {
+		err = errors.New("gas used exceeds gas limit")
+		return
+	}
+
+	for _, tx := range bidRuntime.bid.Txs {
+		select {
+		case _ = <-interruptCh:
+			err = errors.New("simulation abort due to better bid arrived")
+			return
+
+		case <-b.exitCh:
+			err = errors.New("miner exit")
+			return
+
+		default:
+		}
+
+		_, err = bidRuntime.commitTransaction(b.chain, b.chainConfig, tx)
+		if err != nil {
+			err = fmt.Errorf("invalid tx in bid, %v", err)
+			return
+		}
+
+		bidRuntime.env.tcount++
+	}
+
+	bidRuntime.packReward(b.config.ValidatorCommission)
+
+	// return if bid is invalid, reportIssue issue to mev-sentry/builder if simulation is fully done
+	if !bidRuntime.validReward() {
+		err = errors.New("reward does not achieve the expectation")
+		return
+	}
+
+	bestBid := b.GetBestBid(parentHash)
+
+	if bestBid == nil {
+		b.SetBestBid(bidRuntime.bid.ParentHash, bidRuntime)
+		success = true
+		return
+	}
+
+	// TODO(renee-) opt bid comparation
+	if bidRuntime.packedBlockReward.Cmp(bestBid.packedBlockReward) > 0 {
+		b.SetBestBid(bidRuntime.bid.ParentHash, bidRuntime)
+		success = true
+		return
+	}
+}
+
+// reportIssue reports the issue to the mev-sentry
+func (b *bidSimulator) reportIssue(bidRuntime *BidRuntime, err error) {
+	cli := b.builders[bidRuntime.bid.Builder]
+	if cli != nil {
+		cli.ReportIssue(context.Background(), &types.BidIssue{
+			Validator:   bidRuntime.env.header.Coinbase,
+			Builder:     bidRuntime.bid.Builder,
+			BlockNumber: bidRuntime.bid.BlockNumber,
+			ParentHash:  bidRuntime.bid.ParentHash,
+			Message:     err.Error(),
+		})
+	}
+}
+
+type BidRuntime struct {
+	bid *types.Bid
+
+	env *environment
+
+	expectedBlockReward     *big.Int
+	expectedValidatorReward *big.Int
+
+	packedBlockReward     *big.Int
+	packedValidatorReward *big.Int
+
+	duration time.Duration
+}
+
+func (r *BidRuntime) validReward() bool {
+	return r.packedBlockReward.Cmp(r.expectedBlockReward) >= 0 &&
+		r.packedValidatorReward.Cmp(r.expectedValidatorReward) >= 0
+}
+
+// packReward calculates packedBlockReward and packedValidatorReward
+func (r *BidRuntime) packReward(validatorCommission int64) {
+	r.packedBlockReward = r.env.state.GetBalance(consensus.SystemAddress)
+	r.packedValidatorReward = new(big.Int).Mul(r.packedBlockReward, big.NewInt(validatorCommission))
+	r.packedValidatorReward.Div(r.packedValidatorReward, big.NewInt(10000))
+	r.packedValidatorReward.Sub(r.packedBlockReward, r.bid.BuilderFee)
+}
+
+func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *params.ChainConfig, tx *types.Transaction) (
+	*types.Receipt, error,
+) {
+	var (
+		env  = r.env
+		snap = env.state.Snapshot()
+		gp   = env.gasPool.Gas()
+	)
+
+	receipt, err := core.ApplyTransaction(chainConfig, chain, &env.coinbase, env.gasPool, env.state, env.header, tx,
+		&env.header.GasUsed, *chain.GetVMConfig(), core.NewReceiptBloomGenerator())
+	if err != nil {
+		env.state.RevertToSnapshot(snap)
+		env.gasPool.SetGas(gp)
+		return nil, err
+	}
+
+	env.txs = append(env.txs, tx)
+	env.receipts = append(env.receipts, receipt)
+
+	return receipt, nil
+}

--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -1,0 +1,139 @@
+package miner
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const MevRoutineLimit = 10000
+
+type BuilderConfig struct {
+	Address common.Address
+	URL     string
+}
+
+type MevConfig struct {
+	Enabled   bool            // Whether to enable Mev or not
+	SentryURL string          // The url of Mev sentry
+	Builders  []BuilderConfig // The list of builders
+
+	ValidatorCommission int64 // 100 means 1%
+}
+
+// MevRunning return true if mev is running.
+func (miner *Miner) MevRunning() bool {
+	return miner.bidSimulator.isRunning() && miner.bidSimulator.receivingBid()
+}
+
+// StartMev starts mev.
+func (miner *Miner) StartMev() {
+	miner.bidSimulator.startReceivingBid()
+}
+
+// StopMev stops mev.
+func (miner *Miner) StopMev() {
+	miner.bidSimulator.stopReceivingBid()
+}
+
+// AddBuilder adds a builder to the bid simulator.
+func (miner *Miner) AddBuilder(builder common.Address, url string) error {
+	return miner.bidSimulator.AddBuilder(builder, url)
+}
+
+// RemoveBuilder removes a builder from the bid simulator.
+func (miner *Miner) RemoveBuilder(builderAddr common.Address) error {
+	return miner.bidSimulator.RemoveBuilder(builderAddr)
+}
+
+func (miner *Miner) SendBid(ctx context.Context, bid *types.BidArgs) (common.Hash, error) {
+	builder, err := types.EcrecoverBuilder(bid)
+	if err != nil {
+		return common.Hash{}, types.NewInvalidBidError(fmt.Sprintf("invalid signature:%v", err))
+	}
+
+	bidTxs := make([]*types.Transaction, len(bid.Bid.Txs))
+	signer := types.MakeSigner(miner.worker.chainConfig, big.NewInt(int64(bid.Bid.BlockNumber)), uint64(time.Now().Unix()))
+
+	var wg sync.WaitGroup
+	for i, encodedTx := range bid.Bid.Txs {
+		i := i
+		encodedTx := encodedTx
+		wg.Add(1)
+
+		err = miner.antsPool.Submit(func() {
+			defer wg.Done()
+
+			var er error
+			tx := new(types.Transaction)
+			er = tx.UnmarshalBinary(encodedTx)
+			if er != nil {
+				return
+			}
+
+			_, er = types.Sender(signer, tx)
+			if er != nil {
+				return
+			}
+
+			bidTxs[i] = tx
+		})
+
+		if err != nil {
+			return common.Hash{}, types.ErrMevBusy
+		}
+	}
+
+	wg.Wait()
+
+	for _, v := range bidTxs {
+		if v == nil {
+			return common.Hash{}, types.NewInvalidBidError("invalid tx in bid")
+		}
+	}
+
+	txs := make([]*types.Transaction, 0)
+	txs = append(txs, bidTxs...)
+	if len(bid.PayBidTx) != 0 {
+		var payBidTx = new(types.Transaction)
+		if err = payBidTx.UnmarshalBinary(bid.PayBidTx); err != nil {
+			return common.Hash{}, types.NewInvalidBidError(fmt.Sprintf("unmarshal transfer tx err:%v", err))
+		}
+		txs = append(txs, payBidTx)
+	}
+
+	innerBid := &types.Bid{
+		Builder:     builder,
+		BlockNumber: bid.Bid.BlockNumber,
+		ParentHash:  bid.Bid.ParentHash,
+		Txs:         txs,
+		GasUsed:     bid.Bid.GasUsed + bid.PayBidTxGasUsed,
+		GasFee:      bid.Bid.GasFee,
+		BuilderFee:  big.NewInt(0),
+	}
+
+	if bid.Bid.BuilderFee != nil {
+		innerBid.BuilderFee = bid.Bid.BuilderFee
+	}
+
+	bidMustBefore := miner.bidSimulator.bidMustBefore(bid.Bid.ParentHash)
+	timeout := time.Until(bidMustBefore)
+
+	if timeout <= 0 {
+		return common.Hash{}, fmt.Errorf("too late, expected befor %s, appeared %s later", bidMustBefore,
+			common.PrettyDuration(timeout))
+	}
+
+	err = miner.bidSimulator.sendBid(ctx, innerBid)
+
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return innerBid.Hash(), nil
+}


### PR DESCRIPTION
### Description

* core/types:  define Bid and related error message
* internal/eth_api: add MevAPI to receive bids from builder
* eth/api_admin: add API to support start and stop mev dynamically
* miner: add bidSimulator to maintain bid simulation and fetch best bid from
* consensus: add func to query the next inturn validator
* ethclient: add clients for MevAPI

### Rationale

https://github.com/bnb-chain/BEPs/pull/322#5-references

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
