### PR TITLE
types: fix header nil withdraw decode bug;

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -108,14 +108,16 @@ type Header struct {
 	// BaseFee was added by EIP-1559 and is ignored in legacy headers.
 	BaseFee *big.Int `json:"baseFeePerGas" rlp:"optional"`
 
-	// WithdrawalsHash was added by EIP-4895 and is ignored in legacy headers.
-	WithdrawalsHash *common.Hash `json:"withdrawalsRoot" rlp:"optional"`
-
 	// BlobGasUsed was added by EIP-4844 and is ignored in legacy headers.
 	BlobGasUsed *uint64 `json:"blobGasUsed" rlp:"optional"`
 
 	// ExcessBlobGas was added by EIP-4844 and is ignored in legacy headers.
 	ExcessBlobGas *uint64 `json:"excessBlobGas" rlp:"optional"`
+
+	// Leave fields not used by BSC last to avoid being serialized by RLP
+	// and WithdrawalsHash & ParentBeaconRoot is always nil in BSC.
+	// WithdrawalsHash was added by EIP-4895 and is ignored in legacy headers.
+	WithdrawalsHash *common.Hash `json:"withdrawalsRoot" rlp:"optional"`
 
 	// ParentBeaconRoot was added by EIP-4788 and is ignored in legacy headers.
 	ParentBeaconRoot *common.Hash `json:"parentBeaconBlockRoot" rlp:"optional"`

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"bytes"
+	"github.com/stretchr/testify/assert"
 	"math/big"
 	"reflect"
 	"testing"
@@ -192,6 +193,39 @@ func TestEIP2718BlockEncoding(t *testing.T) {
 	if !bytes.Equal(ourBlockEnc, blockEnc) {
 		t.Errorf("encoded block mismatch:\ngot:  %x\nwant: %x", ourBlockEnc, blockEnc)
 	}
+}
+
+func TestEIP4844BlockEncoding(t *testing.T) {
+	tmp := uint64(10000)
+	h := Header{
+		ParentHash:       common.HexToHash("0xb60aef25ac1462d29d30c9d510d0e7be87382ac94ceca24cd66d29ad6efdc076"),
+		UncleHash:        common.HexToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"),
+		Coinbase:         common.HexToAddress("0x70f657164e5b75689b64b7fd1fa275f334f28e18"),
+		Root:             common.HexToHash("0x270657d19ad0be68f564e76d7e5dedf6eb39478f45317bf61034fd863046484b"),
+		TxHash:           common.HexToHash("0x7ae624153142e61339a61ebbaa297654ca07dd58e59b05b34bfeefacba0ac34e"),
+		ReceiptHash:      common.HexToHash("0xd76c75f7431e82027a64d9c9f7d6cd8dc195f6c1efed6e04fa36816d0ab30d0b"),
+		Bloom:            Bloom{},
+		Difficulty:       big.NewInt(1),
+		Number:           big.NewInt(36295817),
+		GasLimit:         140000000,
+		GasUsed:          7828582,
+		Time:             uint64(1426516743),
+		Extra:            common.Hex2Bytes("0x5ba3225c4e91e2a02f0e696cc4d992f91db2a53fc738f94adbb8a104088a921d"),
+		MixDigest:        common.Hash{},
+		Nonce:            BlockNonce{},
+		BaseFee:          big.NewInt(1),
+		WithdrawalsHash:  nil,
+		BlobGasUsed:      &tmp,
+		ExcessBlobGas:    &tmp,
+		ParentBeaconRoot: nil,
+	}
+
+	enc, err := rlp.EncodeToBytes(&h)
+	assert.NoError(t, err)
+	var nh Header
+	err = rlp.DecodeBytes(enc, &nh)
+	assert.NoError(t, err)
+	assert.Equal(t, h, nh)
 }
 
 func TestUncleHash(t *testing.T) {

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -32,9 +32,9 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		MixDigest        common.Hash     `json:"mixHash"`
 		Nonce            BlockNonce      `json:"nonce"`
 		BaseFee          *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
-		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
 		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
 		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
 		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 		Hash             common.Hash     `json:"hash"`
 	}
@@ -55,9 +55,9 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.MixDigest = h.MixDigest
 	enc.Nonce = h.Nonce
 	enc.BaseFee = (*hexutil.Big)(h.BaseFee)
-	enc.WithdrawalsHash = h.WithdrawalsHash
 	enc.BlobGasUsed = (*hexutil.Uint64)(h.BlobGasUsed)
 	enc.ExcessBlobGas = (*hexutil.Uint64)(h.ExcessBlobGas)
+	enc.WithdrawalsHash = h.WithdrawalsHash
 	enc.ParentBeaconRoot = h.ParentBeaconRoot
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
@@ -82,9 +82,9 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		MixDigest        *common.Hash    `json:"mixHash"`
 		Nonce            *BlockNonce     `json:"nonce"`
 		BaseFee          *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
-		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
 		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
 		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
 		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 	}
 	var dec Header
@@ -151,14 +151,14 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	if dec.BaseFee != nil {
 		h.BaseFee = (*big.Int)(dec.BaseFee)
 	}
-	if dec.WithdrawalsHash != nil {
-		h.WithdrawalsHash = dec.WithdrawalsHash
-	}
 	if dec.BlobGasUsed != nil {
 		h.BlobGasUsed = (*uint64)(dec.BlobGasUsed)
 	}
 	if dec.ExcessBlobGas != nil {
 		h.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
+	}
+	if dec.WithdrawalsHash != nil {
+		h.WithdrawalsHash = dec.WithdrawalsHash
 	}
 	if dec.ParentBeaconRoot != nil {
 		h.ParentBeaconRoot = dec.ParentBeaconRoot

--- a/core/types/gen_header_rlp.go
+++ b/core/types/gen_header_rlp.go
@@ -38,9 +38,9 @@ func (obj *Header) EncodeRLP(_w io.Writer) error {
 	w.WriteBytes(obj.MixDigest[:])
 	w.WriteBytes(obj.Nonce[:])
 	_tmp1 := obj.BaseFee != nil
-	_tmp2 := obj.WithdrawalsHash != nil
-	_tmp3 := obj.BlobGasUsed != nil
-	_tmp4 := obj.ExcessBlobGas != nil
+	_tmp2 := obj.BlobGasUsed != nil
+	_tmp3 := obj.ExcessBlobGas != nil
+	_tmp4 := obj.WithdrawalsHash != nil
 	_tmp5 := obj.ParentBeaconRoot != nil
 	if _tmp1 || _tmp2 || _tmp3 || _tmp4 || _tmp5 {
 		if obj.BaseFee == nil {
@@ -53,24 +53,24 @@ func (obj *Header) EncodeRLP(_w io.Writer) error {
 		}
 	}
 	if _tmp2 || _tmp3 || _tmp4 || _tmp5 {
-		if obj.WithdrawalsHash == nil {
-			w.Write([]byte{0x80})
-		} else {
-			w.WriteBytes(obj.WithdrawalsHash[:])
-		}
-	}
-	if _tmp3 || _tmp4 || _tmp5 {
 		if obj.BlobGasUsed == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteUint64((*obj.BlobGasUsed))
 		}
 	}
-	if _tmp4 || _tmp5 {
+	if _tmp3 || _tmp4 || _tmp5 {
 		if obj.ExcessBlobGas == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteUint64((*obj.ExcessBlobGas))
+		}
+	}
+	if _tmp4 || _tmp5 {
+		if obj.WithdrawalsHash == nil {
+			w.Write([]byte{0x80})
+		} else {
+			w.WriteBytes(obj.WithdrawalsHash[:])
 		}
 	}
 	if _tmp5 {


### PR DESCRIPTION
### Description

types: fix header nil withdraw decode bug;

### Rationale

When `BlobGasUsed` is set but `WithdrawalsHash` is left nil, the error occurs `rlp:' is reported in deserialization. input string too short for common.Hash, decoding into (types.Header).WithdrawalsHash`.

Everything was fine after repair.

### Changes

Notable changes: 
* types: fix header nil withdraw decode bug;
