### PR TITLE
core: rephrase TriesInMemory log

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -312,9 +312,9 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	if cacheConfig == nil {
 		cacheConfig = defaultCacheConfig
 	}
-	if cacheConfig.TriesInMemory != 128 {
-		log.Warn("TriesInMemory isn't the default value(128), you need specify exact same TriesInMemory when prune data",
-			"triesInMemory", cacheConfig.TriesInMemory)
+	if cacheConfig.StateScheme == rawdb.HashScheme && cacheConfig.TriesInMemory != 128 {
+		log.Warn("TriesInMemory isn't the default value (128), you need specify the same TriesInMemory when pruning data",
+			"triesInMemory", cacheConfig.TriesInMemory, "scheme", cacheConfig.StateScheme)
 	}
 
 	diffLayerCache, _ := exlru.New(diffLayerCacheLimit)


### PR DESCRIPTION
### Description
This PR rephrases the log message of `TriesInMemory` when it differs from the default value.

### Rationale
The original intention is to inform users that they must use the same `TriesInMemory` value to prune data. However, with the introduction of PBSS, offline pruning is no longer required. Therefore, this log message should only be applied when users are running with hash-based state scheme.