### PR TITLE
feat: support blob storage & miscs;

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -172,6 +172,7 @@ var (
 		utils.VoteJournalDirFlag,
 		utils.LogDebugFlag,
 		utils.LogBacktraceAtFlag,
+		utils.BlobExtraReserveFlag,
 	}, utils.NetworkFlags, utils.DatabaseFlags)
 
 	rpcFlags = []cli.Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1094,6 +1094,13 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Usage:    "Path for the voteJournal dir in fast finality feature (default = inside the datadir)",
 		Category: flags.FastFinalityCategory,
 	}
+
+	// Blob setting
+	BlobExtraReserveFlag = &cli.Int64Flag{
+		Name:  "blob.extra-reserve",
+		Usage: "Extra reserve threshold for blob, blob never expires when -1 is set, default 28800",
+		Value: params.BlobExtraReserveThreshold,
+	}
 )
 
 var (
@@ -2111,6 +2118,11 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	log.Info("Initializing the KZG library", "backend", ctx.String(CryptoKZGFlag.Name))
 	if err := kzg4844.UseCKZG(ctx.String(CryptoKZGFlag.Name) == "ckzg"); err != nil {
 		Fatalf("Failed to set KZG library implementation to %s: %v", ctx.String(CryptoKZGFlag.Name), err)
+	}
+
+	// blob setting
+	if ctx.IsSet(BlobExtraReserveFlag.Name) {
+		cfg.BlobExtraReserve = ctx.Int64(BlobExtraReserveFlag.Name)
 	}
 }
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -154,5 +154,5 @@ type PoSA interface {
 	GetFinalizedHeader(chain ChainHeaderReader, header *types.Header) *types.Header
 	VerifyVote(chain ChainHeaderReader, vote *types.VoteEnvelope) error
 	IsActiveValidatorAt(chain ChainHeaderReader, header *types.Header, checkVoteKeyFn func(bLSPublicKey *types.BLSPublicKey) bool) bool
-	IsDataAvailable(chain ChainHeaderReader, block *types.Block, blobs types.BlobTxSidecars) error
+	IsDataAvailable(chain ChainHeaderReader, block *types.Block) error
 }

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -154,4 +154,5 @@ type PoSA interface {
 	GetFinalizedHeader(chain ChainHeaderReader, header *types.Header) *types.Header
 	VerifyVote(chain ChainHeaderReader, vote *types.VoteEnvelope) error
 	IsActiveValidatorAt(chain ChainHeaderReader, header *types.Header, checkVoteKeyFn func(bLSPublicKey *types.BLSPublicKey) bool) bool
+	IsDataAvailable(chain ChainHeaderReader, block *types.Block, blobs types.BlobTxSidecars) error
 }

--- a/consensus/parlia/blob_sidecar.go
+++ b/consensus/parlia/blob_sidecar.go
@@ -1,0 +1,40 @@
+package parlia
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+)
+
+// validateBlobSidecar it is same as validateBlobSidecar in core/txpool/validation.go
+func validateBlobSidecar(hashes []common.Hash, sidecar *types.BlobTxSidecar) error {
+	if len(sidecar.Blobs) != len(hashes) {
+		return fmt.Errorf("invalid number of %d blobs compared to %d blob hashes", len(sidecar.Blobs), len(hashes))
+	}
+	if len(sidecar.Commitments) != len(hashes) {
+		return fmt.Errorf("invalid number of %d blob commitments compared to %d blob hashes", len(sidecar.Commitments), len(hashes))
+	}
+	if len(sidecar.Proofs) != len(hashes) {
+		return fmt.Errorf("invalid number of %d blob proofs compared to %d blob hashes", len(sidecar.Proofs), len(hashes))
+	}
+	// Blob quantities match up, validate that the provers match with the
+	// transaction hash before getting to the cryptography
+	hasher := sha256.New()
+	for i, vhash := range hashes {
+		computed := kzg4844.CalcBlobHashV1(hasher, &sidecar.Commitments[i])
+		if vhash != computed {
+			return fmt.Errorf("blob %d: computed hash %#x mismatches transaction one %#x", i, computed, vhash)
+		}
+	}
+	// Blob commitments match with the hashes in the transaction, verify the
+	// blobs themselves via KZG
+	for i := range sidecar.Blobs {
+		if err := kzg4844.VerifyBlobProof(sidecar.Blobs[i], sidecar.Commitments[i], sidecar.Proofs[i]); err != nil {
+			return fmt.Errorf("invalid blob %d: %v", i, err)
+		}
+	}
+	return nil
+}

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -350,6 +350,12 @@ func (p *Parlia) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*typ
 	return abort, results
 }
 
+// IsDataAvailable it checks that the blobTx block has available blob data
+// TODO(GalaIO): implement it later
+func (p *Parlia) IsDataAvailable(chain consensus.ChainHeaderReader, block *types.Block, blobs types.BlobTxSidecars) error {
+	return nil
+}
+
 // getValidatorBytesFromHeader returns the validators bytes extracted from the header's extra field if exists.
 // The validators bytes would be contained only in the epoch block's header, and its each validator bytes length is fixed.
 // On luban fork, we introduce vote attestation into the header's extra field, so extra format is different from before.

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -351,7 +351,7 @@ func (p *Parlia) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*typ
 }
 
 // IsDataAvailable it checks that the blobTx block has available blob data
-func (p *Parlia) IsDataAvailable(chain consensus.ChainHeaderReader, block *types.Block, blobs types.BlobTxSidecars) error {
+func (p *Parlia) IsDataAvailable(chain consensus.ChainHeaderReader, block *types.Block) error {
 	if !p.chainConfig.IsCancun(block.Number(), block.Time()) {
 		return nil
 	}
@@ -366,6 +366,7 @@ func (p *Parlia) IsDataAvailable(chain consensus.ChainHeaderReader, block *types
 	for _, tx := range block.Transactions() {
 		versionedHashes = append(versionedHashes, tx.BlobHashes())
 	}
+	blobs := block.Blobs()
 	if len(versionedHashes) != len(blobs) {
 		return errors.New("blobs do not match the versionedHashes length")
 	}

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -355,9 +355,9 @@ func (p *Parlia) IsDataAvailable(chain consensus.ChainHeaderReader, block *types
 	if !p.chainConfig.IsCancun(block.Number(), block.Time()) {
 		return nil
 	}
-	// only required to check within BlobLocalAvailableThreshold block's DA
+	// only required to check within BlobReserveThreshold block's DA
 	currentHeader := chain.CurrentHeader()
-	if block.NumberU64() < currentHeader.Number.Uint64()-params.BlobLocalAvailableThreshold {
+	if block.NumberU64() < currentHeader.Number.Uint64()-params.BlobReserveThreshold {
 		return nil
 	}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1358,7 +1358,8 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		if first.NumberU64() == 1 {
 			if frozen, _ := bc.db.Ancients(); frozen == 0 {
 				td := bc.genesisBlock.Difficulty()
-				writeSize, err := rawdb.WriteAncientBlocks(bc.db, []*types.Block{bc.genesisBlock}, []types.Receipts{nil}, td)
+				// TODO(GalaIO): when sync the history block, it needs store blobs too.
+				writeSize, err := rawdb.WriteAncientBlocks(bc.db, []*types.Block{bc.genesisBlock}, []types.Receipts{nil}, td, nil)
 				if err != nil {
 					log.Error("Error writing genesis to ancients", "err", err)
 					return 0, err
@@ -1376,7 +1377,8 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 
 		// Write all chain data to ancients.
 		td := bc.GetTd(first.Hash(), first.NumberU64())
-		writeSize, err := rawdb.WriteAncientBlocks(bc.db, blockChain, receiptChain, td)
+		// TODO(GalaIO): when sync the history block, it needs store blobs too.
+		writeSize, err := rawdb.WriteAncientBlocks(bc.db, blockChain, receiptChain, td, nil)
 		if err != nil {
 			log.Error("Error importing chain data to ancients", "err", err)
 			return 0, err

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -247,6 +247,23 @@ func (bc *BlockChain) GetReceiptsByHash(hash common.Hash) types.Receipts {
 	return receipts
 }
 
+// GetBlobsByHash retrieves the blobs for all transactions in a given block.
+func (bc *BlockChain) GetBlobsByHash(hash common.Hash) types.BlobTxSidecars {
+	if blobs, ok := bc.blobsCache.Get(hash); ok {
+		return blobs
+	}
+	number := rawdb.ReadHeaderNumber(bc.db, hash)
+	if number == nil {
+		return nil
+	}
+	blobs := rawdb.ReadRawBlobs(bc.db, hash, *number)
+	if blobs == nil {
+		return nil
+	}
+	bc.blobsCache.Add(hash, blobs)
+	return blobs
+}
+
 // GetUnclesInChain retrieves all the uncles from a given block backwards until
 // a specific distance is reached.
 func (bc *BlockChain) GetUnclesInChain(block *types.Block, length int) []*types.Header {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -457,6 +457,9 @@ func (cm *chainMaker) makeHeader(parent *types.Block, state *state.StateDB, engi
 		header.ExcessBlobGas = &excessBlobGas
 		header.BlobGasUsed = new(uint64)
 		header.ParentBeaconRoot = new(common.Hash)
+		if cm.config.Parlia != nil {
+			header.WithdrawalsHash = new(common.Hash)
+		}
 	}
 	return header
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -509,6 +509,9 @@ func (g *Genesis) ToBlock() *types.Block {
 			if head.BlobGasUsed == nil {
 				head.BlobGasUsed = new(uint64)
 			}
+			if conf.Parlia != nil {
+				head.WithdrawalsHash = new(common.Hash)
+			}
 		}
 	}
 	return types.NewBlock(head, nil, nil, nil, trie.NewStackTrie(nil)).WithWithdrawals(withdrawals)

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -946,8 +946,12 @@ func writeAncientBlob(op ethdb.AncientWriteOp, num uint64, blobs types.BlobTxSid
 // Attention: The caller must set blobs after cancun
 func writeAncientBlockWithBlob(op ethdb.AncientWriteOp, block *types.Block, header *types.Header, receipts []*types.ReceiptForStorage, td *big.Int, blobs types.BlobTxSidecars) error {
 	num := block.NumberU64()
-	writeAncientBlock(op, block, header, receipts, td)
-	writeAncientBlob(op, num, blobs)
+	if err := writeAncientBlock(op, block, header, receipts, td); err != nil {
+		return err
+	}
+	if err := writeAncientBlob(op, num, blobs); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -832,10 +832,10 @@ func WriteAncientBlocksWithBlobs(db ethdb.AncientStore, blocks []*types.Block, r
 
 	// do some sanity check
 	if len(blocks) != len(blobs) {
-		return 0, fmt.Errorf("the blobs len is different with blobks, %v:%v", len(blobs), len(blocks))
+		return 0, fmt.Errorf("the blobs len is different with blocks, %v:%v", len(blobs), len(blocks))
 	}
 	if len(blocks) != len(receipts) {
-		return 0, fmt.Errorf("the receipts len is different with blobks, %v:%v", len(receipts), len(blocks))
+		return 0, fmt.Errorf("the receipts len is different with blocks, %v:%v", len(receipts), len(blocks))
 	}
 	// try reset empty blob ancient table
 	if err := ResetEmptyBlobAncientTable(db, blocks[0].NumberU64()); err != nil {

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -21,14 +21,16 @@ import (
 	rand2 "crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"github.com/ethereum/go-ethereum/crypto/kzg4844"
-	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 	"io"
 	"math/big"
 	"math/rand"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -545,7 +547,8 @@ func TestAncientStorage(t *testing.T) {
 	}
 
 	// Write and verify the header in the database
-	WriteAncientBlocks(db, []*types.Block{block}, []types.Receipts{nil}, big.NewInt(100))
+	_, err = WriteAncientBlocks(db, []*types.Block{block}, []types.Receipts{nil}, big.NewInt(100))
+	require.NoError(t, err)
 
 	if blob := ReadHeaderRLP(db, hash, number); len(blob) == 0 {
 		t.Fatalf("no header returned")

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -21,13 +21,14 @@ import (
 	rand2 "crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io"
 	"math/big"
 	"math/rand"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/holiman/uint256"

--- a/core/rawdb/ancient_scheme.go
+++ b/core/rawdb/ancient_scheme.go
@@ -34,6 +34,9 @@ const (
 
 	// ChainFreezerDifficultyTable indicates the name of the freezer total difficulty table.
 	ChainFreezerDifficultyTable = "diffs"
+
+	// ChainFreezerBlobTable indicates the name of the freezer total blob table.
+	ChainFreezerBlobTable = "blobs"
 )
 
 // chainFreezerNoSnappy configures whether compression is disabled for the ancient-tables.
@@ -44,6 +47,7 @@ var chainFreezerNoSnappy = map[string]bool{
 	ChainFreezerBodiesTable:     false,
 	ChainFreezerReceiptTable:    false,
 	ChainFreezerDifficultyTable: true,
+	ChainFreezerBlobTable:       false,
 }
 
 const (

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -231,7 +231,7 @@ func NewDatabase(db ethdb.KeyValueStore) ethdb.Database {
 // NewFreezerDb only create a freezer without statedb.
 func NewFreezerDb(db ethdb.KeyValueStore, frz, namespace string, readonly bool, newOffSet uint64) (*Freezer, error) {
 	// Create the idle freezer instance, this operation should be atomic to avoid mismatch between offset and acientDB.
-	frdb, err := NewFreezer(frz, namespace, readonly, newOffSet, freezerTableSize, chainFreezerNoSnappy)
+	frdb, err := NewFreezer(frz, namespace, readonly, newOffSet, freezerTableSize, chainFreezerNoSnappy, ChainFreezerBlobTable)
 	if err != nil {
 		return nil, err
 	}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/params"
-
 	"github.com/olekukonko/tablewriter"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -104,8 +102,8 @@ func (frdb *freezerdb) Freeze(threshold uint64) error {
 	return nil
 }
 
-func (frdb *freezerdb) SetupFreezerEnv(chainCfg *params.ChainConfig) error {
-	return frdb.AncientFreezer.SetupFreezerEnv(chainCfg)
+func (frdb *freezerdb) SetupFreezerEnv(env *ethdb.FreezerEnv) error {
+	return frdb.AncientFreezer.SetupFreezerEnv(env)
 }
 
 // nofreezedb is a database wrapper that disables freezer data retrievals.
@@ -212,7 +210,7 @@ func (db *nofreezedb) AncientDatadir() (string, error) {
 	return "", errNotSupported
 }
 
-func (db *nofreezedb) SetupFreezerEnv(chainCfg *params.ChainConfig) error {
+func (db *nofreezedb) SetupFreezerEnv(env *ethdb.FreezerEnv) error {
 	return nil
 }
 

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -78,7 +78,7 @@ type Freezer struct {
 	closeOnce    sync.Once
 	offset       uint64 // Starting BlockNumber in current freezer
 
-	additionTableKinds []string
+	additionTableKinds []string // additionTableKinds are post-filled tables that start as empty
 }
 
 // NewChainFreezer is a small utility method around NewFreezer that sets the

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -365,6 +365,7 @@ func (f *Freezer) validate() error {
 	)
 	// Hack to get boundary of any table
 	for kind, table := range f.tables {
+		// TODO(GalaIO): blobs table must be skipped
 		head = table.items.Load()
 		tail = table.itemHidden.Load()
 		name = kind
@@ -372,6 +373,7 @@ func (f *Freezer) validate() error {
 	}
 	// Now check every table against those boundaries.
 	for kind, table := range f.tables {
+		// TODO(GalaIO): blobs table is special for freezerDB, it must be 0 before cancun, and match head with others after cancun.
 		if head != table.items.Load() {
 			return fmt.Errorf("freezer tables %s and %s have differing head: %d != %d", kind, name, table.items.Load(), head)
 		}
@@ -391,6 +393,7 @@ func (f *Freezer) repair() error {
 		tail = uint64(0)
 	)
 	for _, table := range f.tables {
+		// TODO(GalaIO): blobs table must be skipped
 		items := table.items.Load()
 		if head > items {
 			head = items
@@ -401,6 +404,7 @@ func (f *Freezer) repair() error {
 		}
 	}
 	for _, table := range f.tables {
+		// TODO(GalaIO): blobs table is special for freezerDB, it must be 0 before cancun, and match head with others after cancun.
 		if err := table.truncateHead(head); err != nil {
 			return err
 		}

--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -18,8 +18,9 @@ package rawdb
 
 import (
 	"fmt"
-	"golang.org/x/exp/slices"
 	"sync/atomic"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -33,7 +34,7 @@ const freezerBatchBufferLimit = 2 * 1024 * 1024
 // freezerBatch is a write operation of multiple items on a freezer.
 type freezerBatch struct {
 	tables             map[string]*freezerTableBatch
-	additionTableKinds []string
+	additionTableKinds []string // additionTableKinds are post-filled tables that start as empty
 }
 
 func newFreezerBatch(f *Freezer) *freezerBatch {

--- a/core/rawdb/freezer_resettable.go
+++ b/core/rawdb/freezer_resettable.go
@@ -187,6 +187,13 @@ func (f *ResettableFreezer) ModifyAncients(fn func(ethdb.AncientWriteOp) error) 
 	return f.freezer.ModifyAncients(fn)
 }
 
+func (f *ResettableFreezer) TableAncients(kind string) (uint64, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	return f.freezer.TableAncients(kind)
+}
+
 // TruncateHead discards any recent data above the provided threshold number.
 // It returns the previous head number.
 func (f *ResettableFreezer) TruncateHead(items uint64) (uint64, error) {
@@ -220,6 +227,12 @@ func (f *ResettableFreezer) MigrateTable(kind string, convert convertLegacyFn) e
 	defer f.lock.RUnlock()
 
 	return f.freezer.MigrateTable(kind, convert)
+}
+
+func (f *ResettableFreezer) ResetTable(kind string, tail, head uint64) error {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.freezer.ResetTable(kind, tail, head)
 }
 
 // cleanup removes the directory located in the specified path

--- a/core/rawdb/freezer_resettable.go
+++ b/core/rawdb/freezer_resettable.go
@@ -187,11 +187,11 @@ func (f *ResettableFreezer) ModifyAncients(fn func(ethdb.AncientWriteOp) error) 
 	return f.freezer.ModifyAncients(fn)
 }
 
-func (f *ResettableFreezer) TableAncients(kind string) (uint64, error) {
+func (f *ResettableFreezer) ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 
-	return f.freezer.TableAncients(kind)
+	return f.freezer.ResetTable(kind, tail, head, onlyEmpty)
 }
 
 // TruncateHead discards any recent data above the provided threshold number.
@@ -227,12 +227,6 @@ func (f *ResettableFreezer) MigrateTable(kind string, convert convertLegacyFn) e
 	defer f.lock.RUnlock()
 
 	return f.freezer.MigrateTable(kind, convert)
-}
-
-func (f *ResettableFreezer) ResetTable(kind string, tail, head uint64) error {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
-	return f.freezer.ResetTable(kind, tail, head)
 }
 
 // cleanup removes the directory located in the specified path

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -1026,3 +1026,54 @@ func (t *freezerTable) ResetItemsOffset(virtualTail uint64) error {
 
 	return nil
 }
+
+// resetItems reset freezer table head & tail
+func (t *freezerTable) resetItems(tail, head uint64) (*freezerTable, error) {
+	if t.readonly {
+		return nil, errors.New("resetItems in readonly mode")
+	}
+	itemHidden := t.itemHidden.Load()
+	items := t.items.Load()
+	if tail != head && (itemHidden > tail || items < head) {
+		return nil, errors.New("cannot reset to non-exist range")
+	}
+
+	var err error
+	if tail != head {
+		if err = t.truncateHead(head); err != nil {
+			return nil, err
+		}
+		if err = t.truncateTail(tail); err != nil {
+			return nil, err
+		}
+		return t, nil
+	}
+
+	// if tail == head, it means table reset to 0 item
+	t.releaseFilesAfter(t.tailId-1, true)
+	t.head.Close()
+	os.Remove(t.head.Name())
+	t.index.Close()
+	os.Remove(t.index.Name())
+	t.meta.Close()
+	os.Remove(t.meta.Name())
+
+	var idxName string
+	if t.noCompression {
+		idxName = fmt.Sprintf("%s.ridx", t.name) // raw index file
+	} else {
+		idxName = fmt.Sprintf("%s.cidx", t.name) // compressed index file
+	}
+	index, err := openFreezerFileForAppend(filepath.Join(t.path, idxName))
+	if err != nil {
+		return nil, err
+	}
+	tailIndex := indexEntry{
+		offset: uint32(tail),
+	}
+	if _, err = index.Write(tailIndex.append(nil)); err != nil {
+		return nil, err
+	}
+
+	return newFreezerTable(t.path, t.name, t.noCompression, t.readonly)
+}

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -1396,7 +1395,7 @@ func TestResetItems(t *testing.T) {
 
 	// nothing to do, all the items should still be there.
 	f, err = f.resetItems(0, 7)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	fmt.Println(f.dumpIndexString(0, 1000))
 	checkRetrieve(t, f, map[uint64][]byte{
 		0: getChunk(20, 0xFF),
@@ -1409,11 +1408,11 @@ func TestResetItems(t *testing.T) {
 	})
 
 	f, err = f.resetItems(1, 5)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = f.resetItems(0, 5)
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = f.resetItems(1, 6)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	fmt.Println(f.dumpIndexString(0, 1000))
 	checkRetrieveError(t, f, map[uint64]error{
@@ -1427,7 +1426,7 @@ func TestResetItems(t *testing.T) {
 	})
 
 	f, err = f.resetItems(4, 4)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	checkRetrieveError(t, f, map[uint64]error{
 		4: errOutOfBounds,
 	})

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -370,7 +370,7 @@ func TestFreezer_AdditionTables(t *testing.T) {
 	f, err = NewFreezer(dir, "", false, 0, 2049, map[string]bool{"o1": true, "o2": true, "a1": true}, "a1")
 	require.NoError(t, err)
 	frozen, err := f.Ancients()
-	f.ResetTable("a1", frozen, frozen)
+	f.ResetTable("a1", frozen, frozen, true)
 	_, err = f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
 		if err := op.AppendRaw("o1", 2, item); err != nil {
 			return err
@@ -384,9 +384,9 @@ func TestFreezer_AdditionTables(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
-	actual, err := f.Ancient("a1", 1)
+	_, err = f.Ancient("a1", 1)
 	require.Error(t, err)
-	actual, err = f.Ancient("a1", 2)
+	actual, err := f.Ancient("a1", 2)
 	require.NoError(t, err)
 	require.Equal(t, item, actual)
 	require.NoError(t, f.Close())

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -369,7 +369,7 @@ func TestFreezer_AdditionTables(t *testing.T) {
 
 	f, err = NewFreezer(dir, "", false, 0, 2049, map[string]bool{"o1": true, "o2": true, "a1": true}, "a1")
 	require.NoError(t, err)
-	frozen, err := f.Ancients()
+	frozen, _ := f.Ancients()
 	f.ResetTable("a1", frozen, frozen, true)
 	_, err = f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
 		if err := op.AppendRaw("o1", 2, item); err != nil {

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -312,6 +312,10 @@ func (f *prunedfreezer) freeze() {
 	}
 }
 
+func (f *prunedfreezer) AncientFreeze(src ethdb.KeyValueStore, chainCfg *params.ChainConfig) {
+	go f.freeze()
+}
+
 func (f *prunedfreezer) ReadAncients(fn func(ethdb.AncientReaderOp) error) (err error) {
 	return fn(f)
 }
@@ -322,4 +326,12 @@ func (f *prunedfreezer) AncientRange(kind string, start, count, maxBytes uint64)
 
 func (f *prunedfreezer) ModifyAncients(func(ethdb.AncientWriteOp) error) (int64, error) {
 	return 0, errNotSupported
+}
+
+func (f *prunedfreezer) TableAncients(kind string) (uint64, error) {
+	return 0, errNotSupported
+}
+
+func (f *prunedfreezer) ResetTable(kind string, tail, head uint64) error {
+	return errNotSupported
 }

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -312,8 +312,8 @@ func (f *prunedfreezer) freeze() {
 	}
 }
 
-func (f *prunedfreezer) AncientFreeze(src ethdb.KeyValueStore, chainCfg *params.ChainConfig) {
-	go f.freeze()
+func (f *prunedfreezer) SetupFreezerEnv(chainCfg *params.ChainConfig) error {
+	return nil
 }
 
 func (f *prunedfreezer) ReadAncients(fn func(ethdb.AncientReaderOp) error) (err error) {
@@ -328,10 +328,6 @@ func (f *prunedfreezer) ModifyAncients(func(ethdb.AncientWriteOp) error) (int64,
 	return 0, errNotSupported
 }
 
-func (f *prunedfreezer) TableAncients(kind string) (uint64, error) {
-	return 0, errNotSupported
-}
-
-func (f *prunedfreezer) ResetTable(kind string, tail, head uint64) error {
+func (f *prunedfreezer) ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error {
 	return errNotSupported
 }

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -312,7 +312,7 @@ func (f *prunedfreezer) freeze() {
 	}
 }
 
-func (f *prunedfreezer) SetupFreezerEnv(chainCfg *params.ChainConfig) error {
+func (f *prunedfreezer) SetupFreezerEnv(env *ethdb.FreezerEnv) error {
 	return nil
 }
 

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -205,7 +205,7 @@ func blockReceiptsKey(number uint64, hash common.Hash) []byte {
 	return append(append(blockReceiptsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
 }
 
-// blockBlobsKey = BlockBlobsPrefix + num (uint64 big endian) + hash
+// blockBlobsKey = BlockBlobsPrefix + blockNumber (uint64 big endian) + blockHash
 func blockBlobsKey(number uint64, hash common.Hash) []byte {
 	return append(append(BlockBlobsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
 }

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -149,6 +149,8 @@ var (
 	CliqueSnapshotPrefix = []byte("clique-")
 	ParliaSnapshotPrefix = []byte("parlia-")
 
+	BlockBlobsPrefix = []byte("blobs")
+
 	preimageCounter    = metrics.NewRegisteredCounter("db/preimage/total", nil)
 	preimageHitCounter = metrics.NewRegisteredCounter("db/preimage/hits", nil)
 )
@@ -201,6 +203,11 @@ func blockBodyKey(number uint64, hash common.Hash) []byte {
 // blockReceiptsKey = blockReceiptsPrefix + num (uint64 big endian) + hash
 func blockReceiptsKey(number uint64, hash common.Hash) []byte {
 	return append(append(blockReceiptsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+}
+
+// blockBlobsKey = BlockBlobsPrefix + num (uint64 big endian) + hash
+func blockBlobsKey(number uint64, hash common.Hash) []byte {
+	return append(append(BlockBlobsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
 }
 
 // diffLayerKey = diffLayerKeyPrefix + hash

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -18,7 +18,6 @@ package rawdb
 
 import (
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 // table is a wrapper around a database that prefixes each key access with a pre-
@@ -230,7 +229,7 @@ func (t *table) NewSnapshot() (ethdb.Snapshot, error) {
 	return t.db.NewSnapshot()
 }
 
-func (t *table) SetupFreezerEnv(chainCfg *params.ChainConfig) error {
+func (t *table) SetupFreezerEnv(env *ethdb.FreezerEnv) error {
 	return nil
 }
 

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -18,6 +18,7 @@ package rawdb
 
 import (
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // table is a wrapper around a database that prefixes each key access with a pre-
@@ -134,6 +135,14 @@ func (t *table) AncientDatadir() (string, error) {
 	return t.db.AncientDatadir()
 }
 
+func (t *table) TableAncients(kind string) (uint64, error) {
+	return t.db.TableAncients(kind)
+}
+
+func (t *table) ResetTable(kind string, tail, head uint64) error {
+	return t.db.ResetTable(kind, tail, head)
+}
+
 // Put inserts the given value into the database at a prefixed version of the
 // provided key.
 func (t *table) Put(key []byte, value []byte) error {
@@ -223,6 +232,9 @@ func (t *table) NewBatchWithSize(size int) ethdb.Batch {
 // happened on the database.
 func (t *table) NewSnapshot() (ethdb.Snapshot, error) {
 	return t.db.NewSnapshot()
+}
+
+func (t *table) AncientFreeze(src ethdb.KeyValueStore, chainCfg *params.ChainConfig) {
 }
 
 // tableBatch is a wrapper around a database batch that prefixes each key access

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -102,6 +102,10 @@ func (t *table) ModifyAncients(fn func(ethdb.AncientWriteOp) error) (int64, erro
 	return t.db.ModifyAncients(fn)
 }
 
+func (t *table) ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error {
+	return t.db.ResetTable(kind, tail, head, onlyEmpty)
+}
+
 func (t *table) ReadAncients(fn func(reader ethdb.AncientReaderOp) error) (err error) {
 	return t.db.ReadAncients(fn)
 }
@@ -133,14 +137,6 @@ func (t *table) MigrateTable(kind string, convert convertLegacyFn) error {
 // AncientDatadir returns the ancient datadir of the underlying database.
 func (t *table) AncientDatadir() (string, error) {
 	return t.db.AncientDatadir()
-}
-
-func (t *table) TableAncients(kind string) (uint64, error) {
-	return t.db.TableAncients(kind)
-}
-
-func (t *table) ResetTable(kind string, tail, head uint64) error {
-	return t.db.ResetTable(kind, tail, head)
 }
 
 // Put inserts the given value into the database at a prefixed version of the
@@ -234,7 +230,8 @@ func (t *table) NewSnapshot() (ethdb.Snapshot, error) {
 	return t.db.NewSnapshot()
 }
 
-func (t *table) AncientFreeze(src ethdb.KeyValueStore, chainCfg *params.ChainConfig) {
+func (t *table) SetupFreezerEnv(chainCfg *params.ChainConfig) error {
+	return nil
 }
 
 // tableBatch is a wrapper around a database batch that prefixes each key access

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -441,7 +441,8 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 			return consensus.ErrUnknownAncestor
 		}
 		// Write into new ancient_back db.
-		if _, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td, nil); err != nil {
+		// TODO(GalaIO): if there has blobs, it needs to backup too.
+		if _, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td); err != nil {
 			log.Error("failed to write new ancient", "error", err)
 			return err
 		}

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -441,7 +441,7 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 			return consensus.ErrUnknownAncestor
 		}
 		// Write into new ancient_back db.
-		if _, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td); err != nil {
+		if _, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td, nil); err != nil {
 			log.Error("failed to write new ancient", "error", err)
 			return err
 		}

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -440,11 +440,20 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 		if td == nil {
 			return consensus.ErrUnknownAncestor
 		}
-		// Write into new ancient_back db.
-		// TODO(GalaIO): if there has blobs, it needs to backup too.
-		if _, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td); err != nil {
-			log.Error("failed to write new ancient", "error", err)
-			return err
+		// if there has blobs, it needs to back up too.
+		blobs := rawdb.ReadRawBlobs(chainDb, blockHash, blockNumber)
+		if blobs != nil {
+			// Write into new ancient_back db.
+			if _, err := rawdb.WriteAncientBlocksWithBlobs(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td, []types.BlobTxSidecars{blobs}); err != nil {
+				log.Error("failed to write new ancient", "error", err)
+				return err
+			}
+		} else {
+			// Write into new ancient_back db.
+			if _, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td); err != nil {
+				log.Error("failed to write new ancient", "error", err)
+				return err
+			}
 		}
 		// Print the log every 5s for better trace.
 		if common.PrettyDuration(time.Since(start)) > common.PrettyDuration(5*time.Second) {

--- a/core/txindexer_test.go
+++ b/core/txindexer_test.go
@@ -213,7 +213,7 @@ func TestTxIndexer(t *testing.T) {
 	for _, c := range cases {
 		frdir := t.TempDir()
 		db, _ := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false, false)
-		rawdb.WriteAncientBlocks(db, append([]*types.Block{gspec.ToBlock()}, blocks...), append([]types.Receipts{{}}, receipts...), big.NewInt(0), nil)
+		rawdb.WriteAncientBlocks(db, append([]*types.Block{gspec.ToBlock()}, blocks...), append([]types.Receipts{{}}, receipts...), big.NewInt(0))
 
 		// Index the initial blocks from ancient store
 		indexer := &txIndexer{

--- a/core/txindexer_test.go
+++ b/core/txindexer_test.go
@@ -213,7 +213,7 @@ func TestTxIndexer(t *testing.T) {
 	for _, c := range cases {
 		frdir := t.TempDir()
 		db, _ := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false, false)
-		rawdb.WriteAncientBlocks(db, append([]*types.Block{gspec.ToBlock()}, blocks...), append([]types.Receipts{{}}, receipts...), big.NewInt(0))
+		rawdb.WriteAncientBlocks(db, append([]*types.Block{gspec.ToBlock()}, blocks...), append([]types.Receipts{{}}, receipts...), big.NewInt(0), nil)
 
 		// Index the initial blocks from ancient store
 		indexer := &txIndexer{

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -232,6 +232,9 @@ type Block struct {
 	// inter-peer block relay.
 	ReceivedAt   time.Time
 	ReceivedFrom interface{}
+
+	// blobs provides DA check
+	blobs BlobTxSidecars
 }
 
 // "external" block encoding. used for eth protocol, etc.
@@ -451,6 +454,10 @@ func (b *Block) SanityCheck() error {
 	return b.header.SanityCheck()
 }
 
+func (b *Block) Blobs() BlobTxSidecars {
+	return b.blobs
+}
+
 type writeCounter uint64
 
 func (c *writeCounter) Write(b []byte) (int, error) {
@@ -508,6 +515,17 @@ func (b *Block) WithWithdrawals(withdrawals []*Withdrawal) *Block {
 	if withdrawals != nil {
 		block.withdrawals = make([]*Withdrawal, len(withdrawals))
 		copy(block.withdrawals, withdrawals)
+	}
+	return block
+}
+
+// WithBlobs returns a block containing the given blobs.
+func (b *Block) WithBlobs(blobs BlobTxSidecars) *Block {
+	block := &Block{
+		header:       b.header,
+		transactions: b.transactions,
+		uncles:       b.uncles,
+		blobs:        blobs,
 	}
 	return block
 }

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -52,6 +52,8 @@ type BlobTx struct {
 	S *uint256.Int `json:"s" gencodec:"required"`
 }
 
+type BlobTxSidecars []*BlobTxSidecar
+
 // BlobTxSidecar contains the blobs of a blob transaction.
 type BlobTxSidecar struct {
 	Blobs       []kzg4844.Blob       // Blobs needed by the blob pool

--- a/core/types/tx_blob_test.go
+++ b/core/types/tx_blob_test.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"crypto/ecdsa"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -87,4 +89,27 @@ func createEmptyBlobTx(key *ecdsa.PrivateKey, withSidecar bool) *Transaction {
 	}
 	signer := NewCancunSigner(blobtx.ChainID.ToBig())
 	return MustSignNewTx(key, signer, blobtx)
+}
+
+func TestBlobTxSidecars_Encode(t *testing.T) {
+	bs := BlobTxSidecars{
+		&BlobTxSidecar{
+			Blobs:       []kzg4844.Blob{emptyBlob},
+			Commitments: []kzg4844.Commitment{emptyBlobCommit},
+			Proofs:      []kzg4844.Proof{emptyBlobProof},
+		},
+		&BlobTxSidecar{
+			Blobs:       []kzg4844.Blob{emptyBlob},
+			Commitments: []kzg4844.Commitment{emptyBlobCommit},
+			Proofs:      []kzg4844.Proof{emptyBlobProof},
+		},
+		nil,
+	}
+
+	enc, err := rlp.EncodeToBytes(bs)
+	assert.NoError(t, err)
+	var nbs BlobTxSidecars
+	err = rlp.DecodeBytes(enc, &nbs)
+	assert.NoError(t, err)
+	assert.Equal(t, bs, nbs)
 }

--- a/core/types/tx_blob_test.go
+++ b/core/types/tx_blob_test.go
@@ -2,13 +2,13 @@ package types
 
 import (
 	"crypto/ecdsa"
-	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
 )
 
@@ -103,13 +103,12 @@ func TestBlobTxSidecars_Encode(t *testing.T) {
 			Commitments: []kzg4844.Commitment{emptyBlobCommit},
 			Proofs:      []kzg4844.Proof{emptyBlobProof},
 		},
-		nil,
 	}
 
 	enc, err := rlp.EncodeToBytes(bs)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var nbs BlobTxSidecars
 	err = rlp.DecodeBytes(enc, &nbs)
-	assert.NoError(t, err)
-	assert.Equal(t, bs, nbs)
+	require.NoError(t, err)
+	require.Equal(t, bs, nbs)
 }

--- a/core/types/tx_blob_test.go
+++ b/core/types/tx_blob_test.go
@@ -2,8 +2,9 @@ package types
 
 import (
 	"crypto/ecdsa"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -195,6 +195,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		overrides.OverrideFeynman = config.OverrideFeynman
 	}
 
+	// startup ancient freeze
+	chainDb.AncientFreeze(chainDb, chainConfig)
+
 	networkID := config.NetworkId
 	if networkID == 0 {
 		networkID = chainConfig.ChainID.Uint64()

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -196,7 +196,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 
 	// startup ancient freeze
-	chainDb.AncientFreeze(chainDb, chainConfig)
+	if err = chainDb.SetupFreezerEnv(chainConfig); err != nil {
+		return nil, err
+	}
 
 	networkID := config.NetworkId
 	if networkID == 0 {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -196,7 +196,10 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 
 	// startup ancient freeze
-	if err = chainDb.SetupFreezerEnv(chainConfig); err != nil {
+	if err = chainDb.SetupFreezerEnv(&ethdb.FreezerEnv{
+		ChainCfg:         chainConfig,
+		BlobExtraReserve: config.BlobExtraReserve,
+	}); err != nil {
 		return nil, err
 	}
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -70,7 +70,8 @@ var Defaults = Config{
 	RPCGasCap:          50000000,
 	RPCEVMTimeout:      5 * time.Second,
 	GPO:                FullNodeGPO,
-	RPCTxFeeCap:        1, // 1 ether
+	RPCTxFeeCap:        1,                                // 1 ether
+	BlobExtraReserve:   params.BlobExtraReserveThreshold, // Extra reserve threshold for blob, blob never expires when -1 is set, default 28800
 }
 
 //go:generate go run github.com/fjl/gencodec -type Config -formats toml -out gen_config.go
@@ -200,6 +201,9 @@ type Config struct {
 
 	// OverrideFeynman (TODO: remove after the fork)
 	OverrideFeynman *uint64 `toml:",omitempty"`
+
+	// blob setting
+	BlobExtraReserve int64
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -17,7 +17,10 @@
 // Package ethdb defines the interfaces for an Ethereum data store.
 package ethdb
 
-import "io"
+import (
+	"github.com/ethereum/go-ethereum/params"
+	"io"
+)
 
 // KeyValueReader wraps the Has and Get method of a backing data store.
 type KeyValueReader interface {
@@ -88,6 +91,9 @@ type AncientReaderOp interface {
 	// Ancients returns the ancient item numbers in the ancient store.
 	Ancients() (uint64, error)
 
+	// TableAncients returns the ancient item numbers in the certain table.
+	TableAncients(kind string) (uint64, error)
+
 	// Tail returns the number of first stored item in the freezer.
 	// This number can also be interpreted as the total deleted item numbers.
 	Tail() (uint64, error)
@@ -136,6 +142,13 @@ type AncientWriter interface {
 	// The second argument is a function that takes a raw entry and returns it
 	// in the newest format.
 	MigrateTable(string, func([]byte) ([]byte, error)) error
+
+	// ResetTable it allows reset to tail=head
+	ResetTable(kind string, tail, head uint64) error
+}
+
+type AncientFreezer interface {
+	AncientFreeze(src KeyValueStore, chainCfg *params.ChainConfig)
 }
 
 // AncientWriteOp is given to the function argument of ModifyAncients.
@@ -200,5 +213,6 @@ type Database interface {
 	Stater
 	Compacter
 	Snapshotter
+	AncientFreezer
 	io.Closer
 }

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -145,7 +145,9 @@ type AncientWriter interface {
 	ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error
 }
 
+// AncientFreezer defines the help functions for freezing ancient data
 type AncientFreezer interface {
+	// SetupFreezerEnv provides params.ChainConfig for checking hark forks, like isCancun.
 	SetupFreezerEnv(chainCfg *params.ChainConfig) error
 }
 

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -145,10 +145,15 @@ type AncientWriter interface {
 	ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error
 }
 
+type FreezerEnv struct {
+	ChainCfg         *params.ChainConfig
+	BlobExtraReserve int64
+}
+
 // AncientFreezer defines the help functions for freezing ancient data
 type AncientFreezer interface {
 	// SetupFreezerEnv provides params.ChainConfig for checking hark forks, like isCancun.
-	SetupFreezerEnv(chainCfg *params.ChainConfig) error
+	SetupFreezerEnv(env *FreezerEnv) error
 }
 
 // AncientWriteOp is given to the function argument of ModifyAncients.

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -18,8 +18,9 @@
 package ethdb
 
 import (
-	"github.com/ethereum/go-ethereum/params"
 	"io"
+
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // KeyValueReader wraps the Has and Get method of a backing data store.
@@ -91,9 +92,6 @@ type AncientReaderOp interface {
 	// Ancients returns the ancient item numbers in the ancient store.
 	Ancients() (uint64, error)
 
-	// TableAncients returns the ancient item numbers in the certain table.
-	TableAncients(kind string) (uint64, error)
-
 	// Tail returns the number of first stored item in the freezer.
 	// This number can also be interpreted as the total deleted item numbers.
 	Tail() (uint64, error)
@@ -143,12 +141,12 @@ type AncientWriter interface {
 	// in the newest format.
 	MigrateTable(string, func([]byte) ([]byte, error)) error
 
-	// ResetTable it allows reset to tail=head
-	ResetTable(kind string, tail, head uint64) error
+	// ResetTable will reset certain table to new boundary
+	ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error
 }
 
 type AncientFreezer interface {
-	AncientFreeze(src KeyValueStore, chainCfg *params.ChainConfig)
+	SetupFreezerEnv(chainCfg *params.ChainConfig) error
 }
 
 // AncientWriteOp is given to the function argument of ModifyAncients.

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -24,7 +24,6 @@ package remotedb
 import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -172,7 +171,7 @@ func (db *Database) Close() error {
 	return nil
 }
 
-func (db *Database) SetupFreezerEnv(chainCfg *params.ChainConfig) error {
+func (db *Database) SetupFreezerEnv(env *ethdb.FreezerEnv) error {
 	panic("not supported")
 }
 

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -24,6 +24,7 @@ package remotedb
 import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -114,6 +115,10 @@ func (db *Database) ModifyAncients(f func(ethdb.AncientWriteOp) error) (int64, e
 	panic("not supported")
 }
 
+func (db *Database) AncientReset(tail, head uint64) error {
+	panic("not supported")
+}
+
 func (db *Database) TruncateHead(n uint64) (uint64, error) {
 	panic("not supported")
 }
@@ -127,6 +132,10 @@ func (db *Database) Sync() error {
 }
 
 func (db *Database) MigrateTable(s string, f func([]byte) ([]byte, error)) error {
+	panic("not supported")
+}
+
+func (db *Database) TableAncients(kind string) (uint64, error) {
 	panic("not supported")
 }
 
@@ -161,6 +170,14 @@ func (db *Database) NewSnapshot() (ethdb.Snapshot, error) {
 func (db *Database) Close() error {
 	db.remote.Close()
 	return nil
+}
+
+func (db *Database) AncientFreeze(src ethdb.KeyValueStore, chainCfg *params.ChainConfig) {
+	panic("not supported")
+}
+
+func (db *Database) ResetTable(kind string, tail, head uint64) error {
+	panic("not supported")
 }
 
 func New(client *rpc.Client) ethdb.Database {

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -115,6 +115,10 @@ func (db *Database) ModifyAncients(f func(ethdb.AncientWriteOp) error) (int64, e
 	panic("not supported")
 }
 
+func (db *Database) ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error {
+	panic("not supported")
+}
+
 func (db *Database) AncientReset(tail, head uint64) error {
 	panic("not supported")
 }
@@ -132,10 +136,6 @@ func (db *Database) Sync() error {
 }
 
 func (db *Database) MigrateTable(s string, f func([]byte) ([]byte, error)) error {
-	panic("not supported")
-}
-
-func (db *Database) TableAncients(kind string) (uint64, error) {
 	panic("not supported")
 }
 
@@ -172,11 +172,7 @@ func (db *Database) Close() error {
 	return nil
 }
 
-func (db *Database) AncientFreeze(src ethdb.KeyValueStore, chainCfg *params.ChainConfig) {
-	panic("not supported")
-}
-
-func (db *Database) ResetTable(kind string, tail, head uint64) error {
+func (db *Database) SetupFreezerEnv(chainCfg *params.ChainConfig) error {
 	panic("not supported")
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -959,6 +959,9 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		header.BlobGasUsed = new(uint64)
 		header.ExcessBlobGas = &excessBlobGas
 		header.ParentBeaconRoot = genParams.beaconRoot
+		if w.chainConfig.Parlia != nil {
+			header.WithdrawalsHash = new(common.Hash)
+		}
 	}
 	// Run the consensus preparation with the default or customized consensus engine.
 	if err := w.engine.Prepare(w.chain, header); err != nil {

--- a/params/config.go
+++ b/params/config.go
@@ -149,6 +149,8 @@ var (
 		// UnixTime: 1705996800 is January 23, 2024 8:00:00 AM UTC
 		ShanghaiTime: newUint64(1705996800),
 		KeplerTime:   newUint64(1705996800),
+		// TODO(GalaIO): enable cancun fork time later
+		//CancunTime: newUint64(),
 
 		// TODO
 		FeynmanTime: nil,
@@ -189,6 +191,8 @@ var (
 		ShanghaiTime: newUint64(1702972800),
 		KeplerTime:   newUint64(1702972800),
 		FeynmanTime:  newUint64(1710136800),
+		// TODO(GalaIO): enable cancun fork time later
+		//CancunTime: newUint64(),
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -226,6 +230,7 @@ var (
 		ShanghaiTime:        newUint64(0),
 		KeplerTime:          newUint64(0),
 		FeynmanTime:         newUint64(0),
+		CancunTime:          newUint64(0),
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -589,7 +594,12 @@ func (c *ChainConfig) String() string {
 		FeynmanTime = big.NewInt(0).SetUint64(*c.FeynmanTime)
 	}
 
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Planck: %v,Luban: %v, Plato: %v, Hertz: %v, Hertzfix: %v, ShanghaiTime: %v, KeplerTime: %v, FeynmanTime: %v, Engine: %v}",
+	var CancunTime *big.Int
+	if c.CancunTime != nil {
+		CancunTime = big.NewInt(0).SetUint64(*c.CancunTime)
+	}
+
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Planck: %v,Luban: %v, Plato: %v, Hertz: %v, Hertzfix: %v, ShanghaiTime: %v, KeplerTime: %v, FeynmanTime: %v, CancunTime: %v, Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -624,6 +634,7 @@ func (c *ChainConfig) String() string {
 		ShanghaiTime,
 		KeplerTime,
 		FeynmanTime,
+		CancunTime,
 		engine,
 	)
 }
@@ -938,7 +949,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "hertzfixBlock", block: c.HertzfixBlock},
 		{name: "keplerTime", timestamp: c.KeplerTime},
 		{name: "feynmanTime", timestamp: c.FeynmanTime},
-		{name: "cancunTime", timestamp: c.CancunTime, optional: true},
+		{name: "cancunTime", timestamp: c.CancunTime},
 		{name: "pragueTime", timestamp: c.PragueTime, optional: true},
 		{name: "verkleTime", timestamp: c.VerkleTime, optional: true},
 	} {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -183,6 +183,8 @@ const (
 
 	BlobTxTargetBlobGasPerBlock = 3 * BlobTxBlobGasPerBlob // Target consumable blob gas for data blobs per block (for 1559-like pricing)
 	MaxBlobGasPerBlock          = 6 * BlobTxBlobGasPerBlob // Maximum consumable blob gas for data blobs per block
+
+	BlobLocalAvailableThreshold = 518400 // it keeps blob data available for 18 days in local.
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -184,8 +184,8 @@ const (
 	BlobTxTargetBlobGasPerBlock = 3 * BlobTxBlobGasPerBlob // Target consumable blob gas for data blobs per block (for 1559-like pricing)
 	MaxBlobGasPerBlock          = 6 * BlobTxBlobGasPerBlob // Maximum consumable blob gas for data blobs per block
 
-	BlobLocalAvailableThreshold      = 18 * (24 * 3600) / 3 // it keeps blob data available for 18 days in local.
-	BlobLocalAvailableExtraThreshold = 2 * 200              // it adds more time for expired blobs for some request cases, like expiry blob when remote peer is syncing, default 2 epochs.
+	BlobReserveThreshold      = 18 * (24 * 3600) / 3 // it keeps blob data available for 18 days in local.
+	BlobExtraReserveThreshold = 1 * (24 * 3600) / 3  // it adds more time for expired blobs for some request cases, like expiry blob when remote peer is syncing, default 1 day.
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -184,8 +184,8 @@ const (
 	BlobTxTargetBlobGasPerBlock = 3 * BlobTxBlobGasPerBlob // Target consumable blob gas for data blobs per block (for 1559-like pricing)
 	MaxBlobGasPerBlock          = 6 * BlobTxBlobGasPerBlob // Maximum consumable blob gas for data blobs per block
 
-	BlobLocalAvailableThreshold      = 518400 // it keeps blob data available for 18 days in local.
-	BlobLocalAvailableExtraThreshold = 400    // it adds more time for expired blobs for some request cases, like expiry blob when remote peer is syncing.
+	BlobLocalAvailableThreshold      = 18 * (24 * 3600) / 3 // it keeps blob data available for 18 days in local.
+	BlobLocalAvailableExtraThreshold = 2 * 200              // it adds more time for expired blobs for some request cases, like expiry blob when remote peer is syncing, default 2 epochs.
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -184,7 +184,8 @@ const (
 	BlobTxTargetBlobGasPerBlock = 3 * BlobTxBlobGasPerBlob // Target consumable blob gas for data blobs per block (for 1559-like pricing)
 	MaxBlobGasPerBlock          = 6 * BlobTxBlobGasPerBlob // Maximum consumable blob gas for data blobs per block
 
-	BlobLocalAvailableThreshold = 518400 // it keeps blob data available for 18 days in local.
+	BlobLocalAvailableThreshold      = 518400 // it keeps blob data available for 18 days in local.
+	BlobLocalAvailableExtraThreshold = 400    // it adds more time for expired blobs for some request cases, like expiry blob when remote peer is syncing.
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations


### PR DESCRIPTION
### Description

The PR mainly implements blob storage for BSC blobtx feature. It uses KVDB & freezerDB to support blob CRUD, and implement blob expiry, and block DA verification.

### Rationale

We can use `--override.cancun` to enable cancun fork.

### Changes

Notable changes: 
* blob: support config blob extra reserve;
* rawdb: support to CRUD blobs;
* freezer: support to freeze block blobs;
* chainconfig: use cancun fork for BSC;
* feat: fill WithdrawalsHash when BSC enable cancun fork;
...
