### PR TITLE
cmd/utils: disable snap protocol for fast node

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1953,6 +1953,11 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		if cfg.TriesVerifyMode.NeedRemoteVerify() {
 			cfg.EnableTrustProtocol = true
 		}
+		// A node without trie is not able to provide snap data, so it should disable snap protocol.
+		if cfg.TriesVerifyMode != core.LocalVerify {
+			log.Info("Automatically disables snap protocol due to verify mode", "mode", cfg.TriesVerifyMode)
+			cfg.DisableSnapProtocol = true
+		}
 
 		if cfg.SyncMode == downloader.SnapSync && cfg.TriesVerifyMode.NoTries() {
 			log.Warn("Only local TriesVerifyMode can support snap sync, resetting to full sync", "mode", cfg.TriesVerifyMode)


### PR DESCRIPTION
### Description
This PR adds a logic check such that if the node is fast node (i.e. `--tries-verify-mode` is not `local`), then it will disable the snap protocol by default.

### Rationale
When serving snap data (i.e. `AccountRange`, `StorageRange`, `TrieNodes`), access to a complete state trie is necessary. However, for fast nodes, since they only store the snapshot, they can't service these requests. Disabling this snap protocol by default may help reduce network calls and processing time for the nodes in general.
