### PR TITLE
release: prepare for release v1.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v1.3.10
+FEATURE
+* [\#2047](https://github.com/bnb-chain/bsc/pull/2047) feat: add new fork block and precompile contract for BEP294 and BEP299
+
 ## v1.3.9
 FEATURE
 * [\#2186](https://github.com/bnb-chain/bsc/pull/2186) log: support maxBackups in config.toml

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 3  // Minor version component of the current release
-	VersionPatch = 9  // Patch version component of the current release
+	VersionPatch = 10 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.3.10 is hard fork release for **BSC Chapel Testnet**, the HF name is: Feynman, it includes these 2 BEPs:
https://github.com/bnb-chain/BEPs/pull/294: BSC Native Staking after BC Fusion
https://github.com/bnb-chain/BEPs/pull/299: Token Migration after BC Fusion

The target Feynman hard fork time will be:
- Testnet: Monday, 2024-03-11 6:00:00 AM UTC
- Mainnet: To be determined, could be around  Mid of Apr 2024

Feynman hard fork is for BC(Beacon Chain) Fusion, which is critical upgrade for BNB Chain, for more about BC-Fusion, pls may refer:
https://www.bnbchain.org/en/bnb-chain-fusion
https://www.bnbchain.org/en/blog/bnb-chain-fusion-roadmap

### Change Log
It only includes 1 PR, which mainly upgrade some critical system contracts and also the Parlia consensus engine.
FEATURE
* [\#2047](https://github.com/bnb-chain/bsc/pull/2047) feat: add new fork block and precompile contract for BEP294 and BEP299

### Example
NA

### Compatibility
NA