### PR TITLE
core/state: fix taskResult typo

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1621,11 +1621,11 @@ func (s *StateDB) Commit(block uint64, failPostCommitFunc func(), postCommitFunc
 			}
 
 			tasks := make(chan func())
-			type tastResult struct {
+			type taskResult struct {
 				err     error
 				nodeSet *trienode.NodeSet
 			}
-			taskResults := make(chan tastResult, len(s.stateObjectsDirty))
+			taskResults := make(chan taskResult, len(s.stateObjectsDirty))
 			tasksNum := 0
 			finishCh := make(chan struct{})
 
@@ -1652,13 +1652,13 @@ func (s *StateDB) Commit(block uint64, failPostCommitFunc func(), postCommitFunc
 						// Write any storage changes in the state object to its storage trie
 						if !s.noTrie {
 							if set, err := obj.commit(); err != nil {
-								taskResults <- tastResult{err, nil}
+								taskResults <- taskResult{err, nil}
 								return
 							} else {
-								taskResults <- tastResult{nil, set}
+								taskResults <- taskResult{nil, set}
 							}
 						} else {
-							taskResults <- tastResult{nil, nil}
+							taskResults <- taskResult{nil, nil}
 						}
 					}
 					tasksNum++


### PR DESCRIPTION
Replaces `tastResult` with `taskResult`.