### PR TITLE
cmd/utils, core/rawdb, triedb/pathdb: flip hash to path scheme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ truffle-test:
 	docker build . -f ./docker/Dockerfile.truffle -t truffle-test
 	docker-compose -f ./tests/truffle/docker-compose.yml up genesis
 	docker-compose -f ./tests/truffle/docker-compose.yml up -d bsc-rpc bsc-validator1
-	sleep 30
+	sleep 200
 	docker-compose -f ./tests/truffle/docker-compose.yml up --exit-code-from truffle-test truffle-test
 	docker-compose -f ./tests/truffle/docker-compose.yml down
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2089,7 +2089,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			if rawdb.ReadCanonicalHash(chaindb, 0) != (common.Hash{}) {
 				cfg.Genesis = nil // fallback to db content
 
-				//validate genesis has PoS enabled in block 0
+				// validate genesis has PoS enabled in block 0
 				genesis, err := core.ReadGenesis(chaindb)
 				if err != nil {
 					Fatalf("Could not read genesis from database: %v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1938,6 +1938,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.String(GCModeFlag.Name) == "archive" && cfg.TransactionHistory != 0 {
 		cfg.TransactionHistory = 0
 		log.Warn("Disabled transaction unindexing for archive node")
+
+		cfg.StateScheme = rawdb.HashScheme
+		log.Warn("Forcing hash state-scheme for archive mode")
 	}
 	if ctx.IsSet(CacheFlag.Name) || ctx.IsSet(CacheTrieFlag.Name) {
 		cfg.TrieCleanCache = ctx.Int(CacheFlag.Name) * ctx.Int(CacheTrieFlag.Name) / 100

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2008,7 +2008,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			go throwaway.TriePrefetchInAdvance(block, signer)
 		}
 
-		//Process block using the parent state as reference point
+		// Process block using the parent state as reference point
 		if bc.pipeCommit {
 			statedb.EnablePipeCommit()
 		}

--- a/core/rawdb/accessors_trie.go
+++ b/core/rawdb/accessors_trie.go
@@ -324,7 +324,7 @@ func ValidateStateScheme(stateScheme string) bool {
 // the stored state.
 //
 //   - If the provided scheme is none, use the scheme consistent with persistent
-//     state, or fallback to hash-based scheme if state is empty.
+//     state, or fallback to path-based scheme if state is empty.
 //
 //   - If the provided scheme is hash, use hash-based scheme or error out if not
 //     compatible with persistent state scheme.
@@ -338,10 +338,8 @@ func ParseStateScheme(provided string, disk ethdb.Database) (string, error) {
 	stored := ReadStateScheme(disk)
 	if provided == "" {
 		if stored == "" {
-			// use default scheme for empty database, flip it when
-			// path mode is chosen as default
-			log.Info("State scheme set to default", "scheme", "hash")
-			return HashScheme, nil
+			log.Info("State scheme set to default", "scheme", "path")
+			return PathScheme, nil // use default scheme for empty database
 		}
 		log.Info("State scheme set to already existing disk db", "scheme", stored)
 		return stored, nil // reuse scheme of persistent scheme

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -452,6 +453,7 @@ func newGQLService(t *testing.T, stack *node.Node, shanghai bool, gspec *core.Ge
 		TrieDirtyCache: 5,
 		TrieTimeout:    60 * time.Minute,
 		SnapshotCache:  5,
+		StateScheme:    rawdb.HashScheme,
 	}
 	var engine consensus.Engine = ethash.NewFaker()
 	if shanghai {

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -132,12 +132,12 @@ func NewDatabase(diskdb ethdb.Database, config *Config) *Database {
 	 */
 	if config.HashDB != nil {
 		if rawdb.ReadStateScheme(triediskdb) == rawdb.PathScheme {
-			log.Warn("incompatible state scheme", "old", rawdb.PathScheme, "new", rawdb.HashScheme)
+			log.Warn("Incompatible state scheme", "old", rawdb.PathScheme, "new", rawdb.HashScheme)
 		}
 		db.backend = hashdb.New(triediskdb, config.HashDB, trie.MerkleResolver{})
 	} else if config.PathDB != nil {
 		if rawdb.ReadStateScheme(triediskdb) == rawdb.HashScheme {
-			log.Warn("incompatible state scheme", "old", rawdb.HashScheme, "new", rawdb.PathScheme)
+			log.Warn("Incompatible state scheme", "old", rawdb.HashScheme, "new", rawdb.PathScheme)
 		}
 		db.backend = pathdb.New(triediskdb, config.PathDB)
 	} else if strings.Compare(dbScheme, rawdb.PathScheme) == 0 {

--- a/triedb/pathdb/asyncnodebuffer.go
+++ b/triedb/pathdb/asyncnodebuffer.go
@@ -72,7 +72,7 @@ func (a *asyncnodebuffer) commit(nodes map[common.Hash]map[string]*trienode.Node
 
 	err := a.current.commit(nodes)
 	if err != nil {
-		log.Crit("[BUG] failed to commit nodes to asyncnodebuffer", "error", err)
+		log.Crit("[BUG] Failed to commit nodes to asyncnodebuffer", "error", err)
 	}
 	return a
 }
@@ -87,7 +87,7 @@ func (a *asyncnodebuffer) revert(db ethdb.KeyValueReader, nodes map[common.Hash]
 	var err error
 	a.current, err = a.current.merge(a.background)
 	if err != nil {
-		log.Crit("[BUG] failed to merge node cache under revert async node buffer", "error", err)
+		log.Crit("[BUG] Failed to merge node cache under revert async node buffer", "error", err)
 	}
 	a.background.reset()
 	return a.current.revert(db, nodes)
@@ -129,7 +129,7 @@ func (a *asyncnodebuffer) flush(db ethdb.KeyValueStore, clean *fastcache.Cache, 
 		for {
 			if atomic.LoadUint64(&a.background.immutable) == 1 {
 				time.Sleep(time.Duration(DefaultBackgroundFlushInterval) * time.Second)
-				log.Info("waiting background memory table flushed into disk for forcing flush node buffer")
+				log.Info("Waiting background memory table flushed into disk for forcing flush node buffer")
 				continue
 			}
 			atomic.StoreUint64(&a.current.immutable, 1)
@@ -155,10 +155,10 @@ func (a *asyncnodebuffer) flush(db ethdb.KeyValueStore, clean *fastcache.Cache, 
 		for {
 			err := a.background.flush(db, clean, persistID)
 			if err == nil {
-				log.Debug("succeed to flush background nodecache to disk", "state_id", persistID)
+				log.Debug("Succeed to flush background nodecache to disk", "state_id", persistID)
 				return
 			}
-			log.Error("failed to flush background nodecache to disk", "state_id", persistID, "error", err)
+			log.Error("Failed to flush background nodecache to disk", "state_id", persistID, "error", err)
 		}
 	}(id)
 	return nil
@@ -168,7 +168,7 @@ func (a *asyncnodebuffer) waitAndStopFlushing() {
 	a.stopFlushing.Store(true)
 	for a.isFlushing.Load() {
 		time.Sleep(time.Second)
-		log.Warn("waiting background memory table flushed into disk")
+		log.Warn("Waiting background memory table flushed into disk")
 	}
 }
 
@@ -178,7 +178,7 @@ func (a *asyncnodebuffer) getAllNodes() map[common.Hash]map[string]*trienode.Nod
 
 	cached, err := a.current.merge(a.background)
 	if err != nil {
-		log.Crit("[BUG] failed to merge node cache under revert async node buffer", "error", err)
+		log.Crit("[BUG] Failed to merge node cache under revert async node buffer", "error", err)
 	}
 	return cached.nodes
 }

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -215,7 +215,6 @@ func New(diskdb ethdb.Database, config *Config) *Database {
 			log.Crit("Failed to disable database", "err", err) // impossible to happen
 		}
 	}
-	log.Warn("Path-based state scheme is an experimental feature", "sync", db.config.SyncFlush)
 	return db
 }
 


### PR DESCRIPTION
### Description

This PR flips the default state-scheme from hash to path, though it also adds a fallback for archive mode which force sets hash mode.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* N/A
