### PR TITLE
Errors new

### DIFF
--- a/cmd/extradump/main.go
+++ b/cmd/extradump/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -78,7 +79,7 @@ func parseExtra(hexData string) (*Extra, error) {
 	// decode hex into bytes
 	data, err := hex.DecodeString(strings.TrimPrefix(hexData, "0x"))
 	if err != nil {
-		return nil, fmt.Errorf("invalid hex data")
+		return nil, errors.New("invalid hex data")
 	}
 
 	// parse ExtraVanity and ExtraSeal
@@ -99,7 +100,7 @@ func parseExtra(hexData string) (*Extra, error) {
 			validatorNum := int(data[0])
 			validatorBytesTotalLength := validatorNumberSize + validatorNum*validatorBytesLength
 			if dataLength < validatorBytesTotalLength {
-				return nil, fmt.Errorf("parse validators failed")
+				return nil, errors.New("parse validators failed")
 			}
 			extra.ValidatorSize = uint8(validatorNum)
 			data = data[validatorNumberSize:]
@@ -117,7 +118,7 @@ func parseExtra(hexData string) (*Extra, error) {
 		// parse Vote Attestation
 		if dataLength > 0 {
 			if err := rlp.Decode(bytes.NewReader(data), &extra.VoteAttestation); err != nil {
-				return nil, fmt.Errorf("parse voteAttestation failed")
+				return nil, errors.New("parse voteAttestation failed")
 			}
 			if extra.ValidatorSize > 0 {
 				validatorsBitSet := bitset.From([]uint64{uint64(extra.VoteAddressSet)})

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -651,7 +651,7 @@ func parseDumpConfig(ctx *cli.Context, stack *node.Node) (*state.DumpConfig, eth
 			if stateRoot := triedb.Head(); stateRoot != (common.Hash{}) {
 				header.Root = stateRoot
 			} else {
-				return nil, nil, common.Hash{}, fmt.Errorf("no top state root hash in path db")
+				return nil, nil, common.Hash{}, errors.New("no top state root hash in path db")
 			}
 		} else {
 			header = rawdb.ReadHeadHeader(db)

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -377,7 +378,7 @@ func inspectTrie(ctx *cli.Context) error {
 		if blockNumber != math.MaxUint64 {
 			headerBlockHash = rawdb.ReadCanonicalHash(db, blockNumber)
 			if headerBlockHash == (common.Hash{}) {
-				return fmt.Errorf("ReadHeadBlockHash empry hash")
+				return errors.New("ReadHeadBlockHash empry hash")
 			}
 			blockHeader := rawdb.ReadHeader(db, headerBlockHash, blockNumber)
 			trieRootHash = blockHeader.Root
@@ -1065,7 +1066,7 @@ func hbss2pbss(ctx *cli.Context) error {
 		if *blockNumber != math.MaxUint64 {
 			headerBlockHash = rawdb.ReadCanonicalHash(db, *blockNumber)
 			if headerBlockHash == (common.Hash{}) {
-				return fmt.Errorf("ReadHeadBlockHash empty hash")
+				return errors.New("ReadHeadBlockHash empty hash")
 			}
 			blockHeader := rawdb.ReadHeader(db, headerBlockHash, *blockNumber)
 			trieRootHash = blockHeader.Root
@@ -1073,7 +1074,7 @@ func hbss2pbss(ctx *cli.Context) error {
 		}
 		if (trieRootHash == common.Hash{}) {
 			log.Error("Empty root hash")
-			return fmt.Errorf("Empty root hash.")
+			return errors.New("Empty root hash.")
 		}
 
 		id := trie.StateTrieID(trieRootHash)

--- a/consensus/parlia/feynmanfork.go
+++ b/consensus/parlia/feynmanfork.go
@@ -3,6 +3,7 @@ package parlia
 import (
 	"container/heap"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -159,7 +160,7 @@ func (p *Parlia) getValidatorElectionInfo(blockNr rpc.BlockNumberOrHash) ([]Vali
 		return nil, err
 	}
 	if totalLength.Int64() != int64(len(validators)) || totalLength.Int64() != int64(len(votingPowers)) || totalLength.Int64() != int64(len(voteAddrs)) {
-		return nil, fmt.Errorf("validator length not match")
+		return nil, errors.New("validator length not match")
 	}
 
 	validatorItems := make([]ValidatorItem, len(validators))

--- a/consensus/parlia/feynmanfork.go
+++ b/consensus/parlia/feynmanfork.go
@@ -4,7 +4,6 @@ import (
 	"container/heap"
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"math/big"
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -3058,7 +3058,7 @@ func (bc *BlockChain) GetTrustedDiffLayer(blockHash common.Hash) *types.DiffLaye
 
 func CalculateDiffHash(d *types.DiffLayer) (common.Hash, error) {
 	if d == nil {
-		return common.Hash{}, fmt.Errorf("nil diff layer")
+		return common.Hash{}, errors.New("nil diff layer")
 	}
 
 	diff := &types.ExtDiffLayer{

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -985,7 +985,7 @@ func (t *freezerTable) ResetItemsOffset(virtualTail uint64) error {
 	}
 
 	if stat.Size() == 0 {
-		return fmt.Errorf("Stat size is zero when ResetVirtualTail.")
+		return errors.New("Stat size is zero when ResetVirtualTail.")
 	}
 
 	var firstIndex indexEntry

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -792,7 +792,7 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 		if s.trie == nil {
 			tr, err := s.db.OpenTrie(s.originalRoot)
 			if err != nil {
-				s.setError(fmt.Errorf("failed to open trie tree"))
+				s.setError(errors.New("failed to open trie tree"))
 				return nil
 			}
 			s.trie = tr
@@ -1088,7 +1088,7 @@ func (s *StateDB) WaitPipeVerification() error {
 	// Need to wait for the parent trie to commit
 	if s.snap != nil {
 		if valid := s.snap.WaitAndGetVerifyRes(); !valid {
-			return fmt.Errorf("verification on parent snap failed")
+			return errors.New("verification on parent snap failed")
 		}
 	}
 	return nil

--- a/core/state_prefetcher_test.go
+++ b/core/state_prefetcher_test.go
@@ -80,7 +80,7 @@ func CheckNoGoroutines(key, value string) error {
 	var pb bytes.Buffer
 	profiler := pprof.Lookup("goroutine")
 	if profiler == nil {
-		return fmt.Errorf("unable to find profile")
+		return errors.New("unable to find profile")
 	}
 	err := profiler.WriteTo(&pb, 0)
 	if err != nil {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -76,7 +76,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 
 	lastBlock := p.bc.GetBlockByHash(block.ParentHash())
 	if lastBlock == nil {
-		return statedb, nil, nil, 0, fmt.Errorf("could not get parent block")
+		return statedb, nil, nil, 0, errors.New("could not get parent block")
 	}
 	if !p.config.IsFeynman(block.Number(), block.Time()) {
 		// Handle upgrade build-in system contract code

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -382,10 +382,10 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if st.evm.ChainConfig().IsNano(st.evm.Context.BlockNumber) {
 		for _, blackListAddr := range types.NanoBlackList {
 			if blackListAddr == msg.From {
-				return nil, fmt.Errorf("block blacklist account")
+				return nil, errors.New("block blacklist account")
 			}
 			if msg.To != nil && *msg.To == blackListAddr {
-				return nil, fmt.Errorf("block blacklist account")
+				return nil, errors.New("block blacklist account")
 			}
 		}
 	}

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -18,6 +18,7 @@ package txpool
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -114,7 +115,7 @@ func ValidateTransaction(tx *types.Transaction, blobs []kzg4844.Blob, commits []
 		// data match up before doing any expensive validations
 		hashes := tx.BlobHashes()
 		if len(hashes) == 0 {
-			return fmt.Errorf("blobless blob transaction")
+			return errors.New("blobless blob transaction")
 		}
 		if len(hashes) > params.BlobTxMaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob {
 			return fmt.Errorf("too many blobs in transaction: have %d, permitted %d", len(hashes), params.BlobTxMaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob)

--- a/core/vm/contracts_lightclient.go
+++ b/core/vm/contracts_lightclient.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -68,7 +69,7 @@ func (c *tmHeaderValidate) Run(input []byte) (result []byte, err error) {
 	}()
 
 	if uint64(len(input)) <= precompileContractInputMetaDataLength {
-		return nil, fmt.Errorf("invalid input")
+		return nil, errors.New("invalid input")
 	}
 
 	payloadLength := binary.BigEndian.Uint64(input[precompileContractInputMetaDataLength-uint64TypeLength : precompileContractInputMetaDataLength])
@@ -132,7 +133,7 @@ func (c *tmHeaderValidateNano) RequiredGas(input []byte) uint64 {
 }
 
 func (c *tmHeaderValidateNano) Run(input []byte) (result []byte, err error) {
-	return nil, fmt.Errorf("suspend")
+	return nil, errors.New("suspend")
 }
 
 type iavlMerkleProofValidateNano struct{}
@@ -142,7 +143,7 @@ func (c *iavlMerkleProofValidateNano) RequiredGas(_ []byte) uint64 {
 }
 
 func (c *iavlMerkleProofValidateNano) Run(_ []byte) (result []byte, err error) {
-	return nil, fmt.Errorf("suspend")
+	return nil, errors.New("suspend")
 }
 
 // ------------------------------------------------------------------------------------------------------------------------------------------------
@@ -250,7 +251,7 @@ func (c *basicIavlMerkleProofValidate) Run(input []byte) (result []byte, err err
 
 	valid := kvmp.Validate()
 	if !valid {
-		return nil, fmt.Errorf("invalid merkle proof")
+		return nil, errors.New("invalid merkle proof")
 	}
 
 	return successfulMerkleResult(), nil
@@ -418,7 +419,7 @@ const (
 // | 33 bytes |  64 bytes    |       32 bytes       |
 func (c *secp256k1SignatureRecover) Run(input []byte) (result []byte, err error) {
 	if len(input) != int(secp256k1PubKeyLength)+int(secp256k1SignatureLength)+int(secp256k1SignatureMsgHashLength) {
-		return nil, fmt.Errorf("invalid input")
+		return nil, errors.New("invalid input")
 	}
 
 	return c.runTMSecp256k1Signature(
@@ -432,7 +433,7 @@ func (c *secp256k1SignatureRecover) runTMSecp256k1Signature(pubkey, signatureStr
 	tmPubKey := secp256k1.PubKeySecp256k1(pubkey)
 	ok := tmPubKey.VerifyBytesWithMsgHash(msgHash, signatureStr)
 	if !ok {
-		return nil, fmt.Errorf("invalid signature")
+		return nil, errors.New("invalid signature")
 	}
 	return tmPubKey.Address().Bytes(), nil
 }

--- a/core/vm/lightclient/v1/ics23_proof.go
+++ b/core/vm/lightclient/v1/ics23_proof.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/bnb-chain/ics23"
@@ -71,7 +72,7 @@ func (op CommitmentOp) GetKey() []byte {
 // in the CommitmentOp and return the CommitmentRoot of the proof.
 func (op CommitmentOp) Run(args [][]byte) ([][]byte, error) {
 	if _, ok := op.Proof.Proof.(*ics23.CommitmentProof_Exist); !ok {
-		return nil, fmt.Errorf("only exist proof supported")
+		return nil, errors.New("only exist proof supported")
 	}
 
 	// calculate root from proof

--- a/core/vm/lightclient/v1/types.go
+++ b/core/vm/lightclient/v1/types.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -97,7 +98,7 @@ func (cs ConsensusState) EncodeConsensusState() ([]byte, error) {
 
 	pos := uint64(0)
 	if uint64(len(cs.ChainID)) > chainIDLength {
-		return nil, fmt.Errorf("chainID length should be no more than 32")
+		return nil, errors.New("chainID length should be no more than 32")
 	}
 	copy(encodingBytes[pos:pos+chainIDLength], cs.ChainID)
 	pos += chainIDLength
@@ -115,7 +116,7 @@ func (cs ConsensusState) EncodeConsensusState() ([]byte, error) {
 		validator := cs.NextValidatorSet.Validators[index]
 		pubkey, ok := validator.PubKey.(ed25519.PubKeyEd25519)
 		if !ok {
-			return nil, fmt.Errorf("invalid pubkey type")
+			return nil, errors.New("invalid pubkey type")
 		}
 
 		copy(encodingBytes[pos:pos+validatorPubkeyLength], pubkey[:])
@@ -177,16 +178,16 @@ func (h *Header) Validate(chainID string) error {
 		return err
 	}
 	if h.ValidatorSet == nil {
-		return fmt.Errorf("invalid header: validator set is nil")
+		return errors.New("invalid header: validator set is nil")
 	}
 	if h.NextValidatorSet == nil {
-		return fmt.Errorf("invalid header: next validator set is nil")
+		return errors.New("invalid header: next validator set is nil")
 	}
 	if !bytes.Equal(h.ValidatorsHash, h.ValidatorSet.Hash()) {
-		return fmt.Errorf("invalid header: validator set does not match hash")
+		return errors.New("invalid header: validator set does not match hash")
 	}
 	if !bytes.Equal(h.NextValidatorsHash, h.NextValidatorSet.Hash()) {
-		return fmt.Errorf("invalid header: next validator set does not match hash")
+		return errors.New("invalid header: next validator set does not match hash")
 	}
 	return nil
 }

--- a/core/vm/lightclient/v2/lightclient.go
+++ b/core/vm/lightclient/v2/lightclient.go
@@ -4,6 +4,7 @@ package v2
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/cometbft/cometbft/crypto/ed25519"
@@ -49,7 +50,7 @@ func (cs ConsensusState) EncodeConsensusState() ([]byte, error) {
 
 	pos := uint64(0)
 	if uint64(len(cs.ChainID)) > chainIDLength {
-		return nil, fmt.Errorf("chainID length should be no more than 32")
+		return nil, errors.New("chainID length should be no more than 32")
 	}
 	copy(encodingBytes[pos:pos+chainIDLength], cs.ChainID)
 	pos += chainIDLength
@@ -197,7 +198,7 @@ func DecodeConsensusState(input []byte) (ConsensusState, error) {
 // 32 bytes               |                 |             |
 func DecodeLightBlockValidationInput(input []byte) (*ConsensusState, *types.LightBlock, error) {
 	if uint64(len(input)) <= consensusStateLengthBytesLength {
-		return nil, nil, fmt.Errorf("invalid input")
+		return nil, nil, errors.New("invalid input")
 	}
 
 	csLen := binary.BigEndian.Uint64(input[consensusStateLengthBytesLength-uint64TypeLength : consensusStateLengthBytesLength])

--- a/core/vote/vote_pool_test.go
+++ b/core/vote/vote_pool_test.go
@@ -81,13 +81,13 @@ func (b *testBackend) EventMux() *event.TypeMux { return b.eventMux }
 func (p *mockPOSA) GetJustifiedNumberAndHash(chain consensus.ChainHeaderReader, headers []*types.Header) (uint64, common.Hash, error) {
 	parentHeader := chain.GetHeaderByHash(headers[len(headers)-1].ParentHash)
 	if parentHeader == nil {
-		return 0, common.Hash{}, fmt.Errorf("unexpected error")
+		return 0, common.Hash{}, errors.New("unexpected error")
 	}
 	return parentHeader.Number.Uint64(), parentHeader.Hash(), nil
 }
 
 func (p *mockInvalidPOSA) GetJustifiedNumberAndHash(chain consensus.ChainHeaderReader, headers []*types.Header) (uint64, common.Hash, error) {
-	return 0, common.Hash{}, fmt.Errorf("not supported")
+	return 0, common.Hash{}, errors.New("not supported")
 }
 
 func (m *mockPOSA) VerifyVote(chain consensus.ChainHeaderReader, vote *types.VoteEnvelope) error {

--- a/core/vote/vote_signer.go
+++ b/core/vote/vote_signer.go
@@ -2,7 +2,6 @@ package vote
 
 import (
 	"context"
-	"errors"
 	"os"
 	"time"
 

--- a/core/vote/vote_signer.go
+++ b/core/vote/vote_signer.go
@@ -2,7 +2,7 @@ package vote
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"time"
 
@@ -38,7 +38,7 @@ func NewVoteSigner(blsPasswordPath, blsWalletPath string) (*VoteSigner, error) {
 	}
 	if !dirExists {
 		log.Error("BLS wallet did not exists.")
-		return nil, fmt.Errorf("BLS wallet did not exists")
+		return nil, errors.New("BLS wallet did not exists")
 	}
 
 	walletPassword, err := os.ReadFile(blsPasswordPath)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -324,7 +324,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 				parlia.VotePool = votePool
 			}
 		} else {
-			return nil, fmt.Errorf("Engine is not Parlia type")
+			return nil, errors.New("Engine is not Parlia type")
 		}
 		log.Info("Create votePool successfully")
 		eth.handler.votepool = votePool

--- a/eth/handler_trust.go
+++ b/eth/handler_trust.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/core"
@@ -44,7 +45,7 @@ func (h *trustHandler) Handle(peer *trust.Peer, packet trust.Packet) error {
 			vm.HandleRootResponse(verifyResult, peer.ID())
 			return nil
 		}
-		return fmt.Errorf("verify manager is nil which is unexpected")
+		return errors.New("verify manager is nil which is unexpected")
 
 	default:
 		return fmt.Errorf("unexpected trust packet type: %T", packet)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1520,7 +1520,7 @@ func (s *BlockChainAPI) replay(ctx context.Context, block *types.Block, accounts
 // GetDiffAccountsWithScope returns detailed changes of some interested accounts in a specific block number.
 func (s *BlockChainAPI) GetDiffAccountsWithScope(ctx context.Context, blockNr rpc.BlockNumber, accounts []common.Address) (*types.DiffAccountsInBlock, error) {
 	if s.b.Chain() == nil {
-		return nil, fmt.Errorf("blockchain not support get diff accounts")
+		return nil, errors.New("blockchain not support get diff accounts")
 	}
 
 	block, err := s.b.BlockByNumber(ctx, blockNr)
@@ -2005,7 +2005,7 @@ func (s *TransactionAPI) GetTransactionReceiptsByBlockNumber(ctx context.Context
 	}
 	txs := block.Transactions()
 	if len(txs) != len(receipts) {
-		return nil, fmt.Errorf("txs length doesn't equal to receipts' length")
+		return nil, errors.New("txs length doesn't equal to receipts' length")
 	}
 
 	txReceipts := make([]map[string]interface{}, 0, len(txs))

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -858,7 +858,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	if genParams.parentHash != (common.Hash{}) {
 		block := w.chain.GetBlockByHash(genParams.parentHash)
 		if block == nil {
-			return nil, fmt.Errorf("missing parent")
+			return nil, errors.New("missing parent")
 		}
 		parent = block.Header()
 	}

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -19,6 +19,7 @@ package node
 import (
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -298,7 +299,7 @@ func (h *httpServer) enableRPC(apis []rpc.API, config httpConfig) error {
 	defer h.mu.Unlock()
 
 	if h.rpcAllowed() {
-		return fmt.Errorf("JSON-RPC over HTTP is already enabled")
+		return errors.New("JSON-RPC over HTTP is already enabled")
 	}
 
 	// Create RPC server and handler.

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -25,6 +25,7 @@ package discover
 import (
 	crand "crypto/rand"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	mrand "math/rand"
 	"net"

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -380,7 +380,7 @@ func (tab *Table) doRevalidate(done chan<- struct{}) {
 			if tab.enrFilter != nil {
 				if !tab.enrFilter(n.Record()) {
 					tab.log.Trace("ENR record filter out", "id", last.ID(), "addr", last.addr())
-					err = fmt.Errorf("filtered node")
+					err = errors.New("filtered node")
 				}
 			}
 			last = &node{Node: *n, addedAt: last.addedAt, livenessChecks: last.livenessChecks}

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -365,7 +365,7 @@ func (t *UDPv4) RequestENR(n *enode.Node) (*enode.Node, error) {
 		return nil, err
 	}
 	if respN.ID() != n.ID() {
-		return nil, fmt.Errorf("invalid ID in response record")
+		return nil, errors.New("invalid ID in response record")
 	}
 	if respN.Seq() < n.Seq() {
 		return n, nil // response record is older

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -442,7 +442,7 @@ func (t *UDPv5) verifyResponseNode(c *callV5, r *enr.Record, distances []uint, s
 		}
 	}
 	if _, ok := seen[node.ID()]; ok {
-		return nil, fmt.Errorf("duplicate record")
+		return nil, errors.New("duplicate record")
 	}
 	seen[node.ID()] = struct{}{}
 	return node, nil

--- a/p2p/discover/v5wire/encoding.go
+++ b/p2p/discover/v5wire/encoding.go
@@ -367,11 +367,11 @@ func (c *Codec) makeHandshakeAuth(toID enode.ID, addr string, challenge *Whoarey
 	// key is part of the ID nonce signature.
 	var remotePubkey = new(ecdsa.PublicKey)
 	if err := challenge.Node.Load((*enode.Secp256k1)(remotePubkey)); err != nil {
-		return nil, nil, fmt.Errorf("can't find secp256k1 key for recipient")
+		return nil, nil, errors.New("can't find secp256k1 key for recipient")
 	}
 	ephkey, err := c.sc.ephemeralKeyGen()
 	if err != nil {
-		return nil, nil, fmt.Errorf("can't generate ephemeral key")
+		return nil, nil, errors.New("can't generate ephemeral key")
 	}
 	ephpubkey := EncodePubkey(&ephkey.PublicKey)
 	auth.pubkey = ephpubkey[:]
@@ -395,7 +395,7 @@ func (c *Codec) makeHandshakeAuth(toID enode.ID, addr string, challenge *Whoarey
 	// Create session keys.
 	sec := deriveKeys(sha256.New, ephkey, remotePubkey, c.localnode.ID(), challenge.Node.ID(), cdata)
 	if sec == nil {
-		return nil, nil, fmt.Errorf("key derivation failed")
+		return nil, nil, errors.New("key derivation failed")
 	}
 	return auth, sec, err
 }

--- a/p2p/dnsdisc/client.go
+++ b/p2p/dnsdisc/client.go
@@ -191,7 +191,7 @@ func (c *Client) resolveEntry(ctx context.Context, domain, hash string) (entry, 
 func (c *Client) doResolveEntry(ctx context.Context, domain, hash string) (entry, error) {
 	wantHash, err := b32format.DecodeString(hash)
 	if err != nil {
-		return nil, fmt.Errorf("invalid base32 hash")
+		return nil, errors.New("invalid base32 hash")
 	}
 	name := hash + "." + domain
 	txts, err := c.cfg.Resolver.LookupTXT(ctx, hash+"."+domain)

--- a/p2p/dnsdisc/tree.go
+++ b/p2p/dnsdisc/tree.go
@@ -21,6 +21,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/base32"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"strings"

--- a/p2p/dnsdisc/tree.go
+++ b/p2p/dnsdisc/tree.go
@@ -341,7 +341,7 @@ func parseLinkEntry(e string) (entry, error) {
 
 func parseLink(e string) (*linkEntry, error) {
 	if !strings.HasPrefix(e, linkPrefix) {
-		return nil, fmt.Errorf("wrong/missing scheme 'enrtree' in URL")
+		return nil, errors.New("wrong/missing scheme 'enrtree' in URL")
 	}
 	e = e[len(linkPrefix):]
 	pos := strings.IndexByte(e, '@')

--- a/p2p/enode/idscheme.go
+++ b/p2p/enode/idscheme.go
@@ -18,7 +18,7 @@ package enode
 
 import (
 	"crypto/ecdsa"
-	"fmt"
+	"errors"
 	"io"
 
 	"github.com/ethereum/go-ethereum/common/math"

--- a/p2p/enode/idscheme.go
+++ b/p2p/enode/idscheme.go
@@ -67,7 +67,7 @@ func (V4ID) Verify(r *enr.Record, sig []byte) error {
 	if err := r.Load(&entry); err != nil {
 		return err
 	} else if len(entry) != 33 {
-		return fmt.Errorf("invalid public key")
+		return errors.New("invalid public key")
 	}
 
 	h := sha3.NewLegacyKeccak256()

--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -17,6 +17,7 @@
 package nat
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -47,7 +48,7 @@ func (n *pmp) ExternalIP() (net.IP, error) {
 
 func (n *pmp) AddMapping(protocol string, extport, intport int, name string, lifetime time.Duration) (uint16, error) {
 	if lifetime <= 0 {
-		return 0, fmt.Errorf("lifetime must not be <= 0")
+		return 0, errors.New("lifetime must not be <= 0")
 	}
 	// Note order of port arguments is switched between our
 	// AddMapping and the client's AddPortMapping.

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -992,13 +992,13 @@ func (srv *Server) checkInboundConn(remoteIP net.IP) error {
 
 	// Reject connections that do not match NetRestrict.
 	if srv.NetRestrict != nil && !srv.NetRestrict.Contains(remoteIP) {
-		return fmt.Errorf("not in netrestrict list")
+		return errors.New("not in netrestrict list")
 	}
 	// Reject Internet peers that try too often.
 	now := srv.clock.Now()
 	srv.inboundHistory.expire(now, nil)
 	if !netutil.IsLAN(remoteIP) && srv.inboundHistory.contains(remoteIP.String()) {
-		return fmt.Errorf("too many attempts")
+		return errors.New("too many attempts")
 	}
 	srv.inboundHistory.add(remoteIP.String(), now.Add(inboundThrottleTime))
 	return nil

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -19,6 +19,7 @@ package p2p
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -158,7 +159,7 @@ func readProtocolHandshake(rw MsgReader) (*protoHandshake, error) {
 		return nil, err
 	}
 	if msg.Size > baseProtocolMaxMsgSize {
-		return nil, fmt.Errorf("message too big")
+		return nil, errors.New("message too big")
 	}
 	if msg.Code == discMsg {
 		// Disconnect before protocol handshake is valid according to the

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -19,6 +19,7 @@ package rpc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -104,7 +105,7 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if blckNum > math.MaxInt64 {
-		return fmt.Errorf("block number larger than int64")
+		return errors.New("block number larger than int64")
 	}
 	*bn = BlockNumber(blckNum)
 	return nil
@@ -202,7 +203,7 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 				return err
 			}
 			if blckNum > math.MaxInt64 {
-				return fmt.Errorf("blocknumber too high")
+				return errors.New("blocknumber too high")
 			}
 			bn := BlockNumber(blckNum)
 			bnh.BlockNumber = &bn

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -712,7 +712,7 @@ func formatPrimitiveValue(encType string, encValue interface{}) (string, error) 
 func (t Types) validate() error {
 	for typeKey, typeArr := range t {
 		if len(typeKey) == 0 {
-			return fmt.Errorf("empty type key")
+			return errors.New("empty type key")
 		}
 		for i, typeObj := range typeArr {
 			if len(typeObj.Type) == 0 {

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -531,7 +531,7 @@ func runRandTest(rt randTest) bool {
 				checktr.MustUpdate(it.Key, it.Value)
 			}
 			if tr.Hash() != checktr.Hash() {
-				rt[i].err = fmt.Errorf("hash mismatch in opItercheckhash")
+				rt[i].err = errors.New("hash mismatch in opItercheckhash")
 			}
 		case opNodeDiff:
 			var (
@@ -569,19 +569,19 @@ func runRandTest(rt randTest) bool {
 				}
 			}
 			if len(insertExp) != len(tr.tracer.inserts) {
-				rt[i].err = fmt.Errorf("insert set mismatch")
+				rt[i].err = errors.New("insert set mismatch")
 			}
 			if len(deleteExp) != len(tr.tracer.deletes) {
-				rt[i].err = fmt.Errorf("delete set mismatch")
+				rt[i].err = errors.New("delete set mismatch")
 			}
 			for insert := range tr.tracer.inserts {
 				if _, present := insertExp[insert]; !present {
-					rt[i].err = fmt.Errorf("missing inserted node")
+					rt[i].err = errors.New("missing inserted node")
 				}
 			}
 			for del := range tr.tracer.deletes {
 				if _, present := deleteExp[del]; !present {
-					rt[i].err = fmt.Errorf("missing deleted node")
+					rt[i].err = errors.New("missing deleted node")
 				}
 			}
 		}

--- a/trie/triedb/pathdb/history.go
+++ b/trie/triedb/pathdb/history.go
@@ -215,7 +215,7 @@ func (m *meta) encode() []byte {
 // decode unpacks the meta object from byte stream.
 func (m *meta) decode(blob []byte) error {
 	if len(blob) < 1 {
-		return fmt.Errorf("no version tag")
+		return errors.New("no version tag")
 	}
 	switch blob[0] {
 	case stateHistoryVersion:


### PR DESCRIPTION
### Description

There are many fmt.Errorf() with no param.

### Rationale

Parameterless errors should be using errors.New instead of fmt.Errorf.

### Example

```
errors.New("invalid hex data")
```

### Changes

Notable changes: 
* replace fmt.Errorf which has no param with errors.New
