### PR TITLE
fix: add missing arg of `bls account generate-proof` cmd

### DIFF
--- a/cmd/geth/blsaccountcmd.go
+++ b/cmd/geth/blsaccountcmd.go
@@ -199,7 +199,7 @@ Delete the selected BLS account from the BLS wallet.`,
 						Name:      "generate-proof",
 						Usage:     "Generate ownership proof for the selected BLS account from the BLS wallet",
 						Action:    blsAccountGenerateProof,
-						ArgsUsage: "<BLS pubkey>",
+						ArgsUsage: "<operator address> <BLS pubkey>",
 						Category:  "BLS ACCOUNT COMMANDS",
 						Flags: []cli.Flag{
 							utils.DataDirFlag,


### PR DESCRIPTION
### Description

This pr is to add a missing arg of `bls account generate-proof` cmd

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add missing arg of `bls account generate-proof` cmd
