### PR TITLE
core: skip checking state root existence when do snapsync by fast node 

### DIFF
--- a/cmd/geth/blsaccountcmd.go
+++ b/cmd/geth/blsaccountcmd.go
@@ -199,7 +199,7 @@ Delete the selected BLS account from the BLS wallet.`,
 						Name:      "generate-proof",
 						Usage:     "Generate ownership proof for the selected BLS account from the BLS wallet",
 						Action:    blsAccountGenerateProof,
-						ArgsUsage: "<BLS pubkey>",
+						ArgsUsage: "<operator address> <BLS pubkey>",
 						Category:  "BLS ACCOUNT COMMANDS",
 						Flags: []cli.Flag{
 							utils.DataDirFlag,

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -406,7 +406,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	// Make sure the state associated with the block is available, or log out
 	// if there is no available state, waiting for state sync.
 	head := bc.CurrentBlock()
-	if !bc.HasState(head.Root) {
+	if !bc.NoTries() && !bc.HasState(head.Root) {
 		if head.Number.Uint64() == 0 {
 			// The genesis state is missing, which is only possible in the path-based
 			// scheme. This situation occurs when the initial state sync is not finished
@@ -1011,7 +1011,7 @@ func (bc *BlockChain) SnapSyncCommitHead(hash common.Hash) error {
 			return err
 		}
 	}
-	if !bc.HasState(root) {
+	if !bc.NoTries() && !bc.HasState(root) {
 		return fmt.Errorf("non existent state [%x..]", root[:4])
 	}
 	// If all checks out, manually set the head block.


### PR DESCRIPTION
### Description

fast node doesn't have a state merkle trie

and when do inited snap sync,  `Snapshot maintenance disabled`

so `if !bc.HasState(root)` always return true

To solve this ,skip checking state root existence when do snapsync by fast node 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
