### PR TITLE
draft release v1.4.1-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+## v1.4.1
+FEATURE
+NA
+
+BUGFIX
+* [\#2258](https://github.com/bnb-chain/bsc/pull/2258) core: skip checking state root existence when do snapsync by fast node
+* [\#2252](https://github.com/bnb-chain/bsc/pull/2252) fix: add missing args of `bls account generate-proof` cmd (#2252)
+
+IMPROVEMENT
+NA
+
 ## v1.4.0
 #### RPC
 [internal/ethapi: implement eth_getBlockReceipts (#27702)](https://github.com/bnb-chain/bsc/commit/f1801a9feda8f81532c92077d2c9a8b785fd699b)

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 4  // Minor version component of the current release
-	VersionPatch = 0  // Patch version component of the current release
+	VersionPatch = 1  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## Description
Release v1.4.1-alpha is a maintenance release, which only applies 2 fixes based on v1.4.0-alpha.

## Rationale
NA

## Example
NA

## Changes
### FEATURE
NA

### BUGFIX
* [\#2258](https://github.com/bnb-chain/bsc/pull/2258) core: skip checking state root existence when do snapsync by fast node
* [\#2252](https://github.com/bnb-chain/bsc/pull/2252) fix: add missing args of `bls account generate-proof` cmd (#2252)

### IMPROVEMENT
NA
