### PR TITLE
cmd/utils, core: only full sync for fast nodes

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1955,6 +1955,11 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		if cfg.TriesVerifyMode.NeedRemoteVerify() {
 			cfg.EnableTrustProtocol = true
 		}
+
+		if cfg.SyncMode == downloader.SnapSync && cfg.TriesVerifyMode.NoTries() {
+			log.Warn("Only local TriesVerifyMode can support snap sync, resetting to full sync", "mode", cfg.TriesVerifyMode)
+			cfg.SyncMode = downloader.FullSync
+		}
 	}
 	if ctx.IsSet(CacheFlag.Name) || ctx.IsSet(CacheSnapshotFlag.Name) {
 		cfg.SnapshotCache = ctx.Int(CacheFlag.Name) * ctx.Int(CacheSnapshotFlag.Name) / 100

--- a/core/remote_state_verifier.go
+++ b/core/remote_state_verifier.go
@@ -444,6 +444,10 @@ func (mode VerifyMode) NeedRemoteVerify() bool {
 	return mode == FullVerify || mode == InsecureVerify
 }
 
+func (mode VerifyMode) NoTries() bool {
+	return mode != LocalVerify
+}
+
 func newVerifyMsgTypeGauge(msgType uint16, peerId string) metrics.Gauge {
 	m := fmt.Sprintf("verifymanager/message/%d/peer/%s", msgType, peerId)
 	return metrics.GetOrRegisterGauge(m, nil)

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -79,10 +79,10 @@ type trienodebuffer interface {
 
 func NewTrieNodeBuffer(sync bool, limit int, nodes map[common.Hash]map[string]*trienode.Node, layers uint64) trienodebuffer {
 	if sync {
-		log.Info("new sync node buffer", "limit", common.StorageSize(limit), "layers", layers)
+		log.Info("New sync node buffer", "limit", common.StorageSize(limit), "layers", layers)
 		return newNodeBuffer(limit, nodes, layers)
 	}
-	log.Info("new async node buffer", "limit", common.StorageSize(limit), "layers", layers)
+	log.Info("New async node buffer", "limit", common.StorageSize(limit), "layers", layers)
 	return newAsyncNodeBuffer(limit, nodes, layers)
 }
 


### PR DESCRIPTION
### Description
This PR enforces a rule such that when `tries-verify-mode` is not `local`, it will always default to full sync instead of snap sync.

### Rationale
Snap sync is not supported on fast nodes.

### Example
```
INFO [03-13|13:52:26.157] Starting Geth on BSC mainnet...
INFO [03-13|13:52:26.157] Bumping default cache on mainnet         provided=1024 updated=4096
INFO [03-13|13:52:26.159] Maximum peer count                       ETH=50 total=50
WARN [03-13|13:52:26.163] Only local TriesVerifyMode can support snap sync, resetting to full sync mode=none
...
```

### Changes
- Fixed minor typo