### PR TITLE
rollback define of NewBlockPacket

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -104,7 +104,7 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 				if hash := types.DeriveSha(block.Withdrawals(), trie.NewStackTrie(nil)); hash != *header.WithdrawalsHash {
 					return fmt.Errorf("withdrawals root hash mismatch (header value %x, calculated %x)", *header.WithdrawalsHash, hash)
 				}
-			} else if block.Withdrawals() != nil {
+			} else if len(block.Withdrawals()) != 0 {
 				// Withdrawals are not allowed prior to shanghai fork
 				return errors.New("withdrawals present in block body")
 			}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -242,7 +242,8 @@ type extblock struct {
 	Header      *Header
 	Txs         []*Transaction
 	Uncles      []*Header
-	Withdrawals []*Withdrawal `rlp:"optional"`
+	Withdrawals []*Withdrawal  `rlp:"optional"`
+	Blobs       BlobTxSidecars `rlp:"optional"`
 }
 
 // NewBlock creates a new block. The input data is copied, changes to header and to the
@@ -345,7 +346,7 @@ func (b *Block) DecodeRLP(s *rlp.Stream) error {
 	if err := s.Decode(&eb); err != nil {
 		return err
 	}
-	b.header, b.uncles, b.transactions, b.withdrawals = eb.Header, eb.Uncles, eb.Txs, eb.Withdrawals
+	b.header, b.uncles, b.transactions, b.withdrawals, b.blobs = eb.Header, eb.Uncles, eb.Txs, eb.Withdrawals, eb.Blobs
 	b.size.Store(rlp.ListSize(size))
 	return nil
 }
@@ -357,6 +358,7 @@ func (b *Block) EncodeRLP(w io.Writer) error {
 		Txs:         b.transactions,
 		Uncles:      b.uncles,
 		Withdrawals: b.withdrawals,
+		Blobs:       b.blobs,
 	})
 }
 

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -65,7 +65,7 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 		return h.handleBlockAnnounces(peer, hashes, numbers)
 
 	case *eth.NewBlockPacket:
-		return h.handleBlockBroadcast(peer, packet)
+		return h.handleBlockBroadcast(peer, packet.Block, packet.TD)
 
 	case *eth.NewPooledTransactionHashesPacket:
 		return h.txFetcher.Notify(peer.ID(), packet.Types, packet.Sizes, packet.Hashes)
@@ -115,20 +115,13 @@ func (h *ethHandler) handleBlockAnnounces(peer *eth.Peer, hashes []common.Hash, 
 
 // handleBlockBroadcast is invoked from a peer's message handler when it transmits a
 // block broadcast for the local node to process.
-func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, packet *eth.NewBlockPacket) error {
+func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block, td *big.Int) error {
 	// Drop all incoming block announces from the p2p network if
 	// the chain already entered the pos stage and disconnect the
 	// remote peer.
 	if h.merger.PoSFinalized() {
 		return errors.New("disallowed block broadcast")
 	}
-	block := packet.Block
-	td := packet.TD
-	sidecars := packet.Sidecars
-	if sidecars != nil {
-		block = block.WithBlobs(sidecars)
-	}
-
 	// Schedule the block for import
 	h.blockFetcher.Enqueue(peer.ID(), block)
 

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -551,17 +551,15 @@ func TestHandleNewBlock(t *testing.T) {
 		ReceiptHash: types.EmptyReceiptsHash,
 	})
 	dataNil := NewBlockPacket{
-		Block:    block,
-		TD:       big.NewInt(1),
-		Sidecars: nil,
+		Block: block,
+		TD:    big.NewInt(1),
 	}
+	sizeNil, rNil, _ := rlp.EncodeToReader(dataNil)
 	dataNonNil := NewBlockPacket{
-		Block:    block,
-		TD:       big.NewInt(1),
-		Sidecars: sidecars,
+		Block: block.WithBlobs(sidecars),
+		TD:    big.NewInt(1),
 	}
 	sizeNonNil, rNonNil, _ := rlp.EncodeToReader(dataNonNil)
-	sizeNil, rNil, _ := rlp.EncodeToReader(dataNil)
 
 	// Define the test cases
 	testCases := []struct {
@@ -592,10 +590,6 @@ func TestHandleNewBlock(t *testing.T) {
 	protos := []p2p.Protocol{
 		{
 			Name:    "eth",
-			Version: ETH67,
-		},
-		{
-			Name:    "eth",
 			Version: ETH68,
 		},
 		{
@@ -604,10 +598,6 @@ func TestHandleNewBlock(t *testing.T) {
 		},
 	}
 	caps := []p2p.Cap{
-		{
-			Name:    "eth",
-			Version: ETH67,
-		},
 		{
 			Name:    "eth",
 			Version: ETH68,

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -306,22 +306,16 @@ func (p *Peer) SendNewBlock(block *types.Block, td *big.Int) error {
 	// Mark all the block hash as known, but ensure we don't overflow our limits
 	p.knownBlocks.Add(block.Hash())
 	return p2p.Send(p.rw, NewBlockMsg, &NewBlockPacket{
-		Block:    block,
-		TD:       td,
-		Sidecars: block.Blobs(),
+		Block: block,
+		TD:    td,
 	})
 }
 
 // AsyncSendNewBlock queues an entire block for propagation to a remote peer. If
 // the peer's broadcast queue is full, the event is silently dropped.
 func (p *Peer) AsyncSendNewBlock(block *types.Block, td *big.Int) {
-	bp := &blockPropagation{
-		block: block,
-		td:    td,
-	}
-
 	select {
-	case p.queuedBlocks <- bp:
+	case p.queuedBlocks <- &blockPropagation{block: block, td: td}:
 		// Mark all the block hash as known, but ensure we don't overflow our limits
 		p.knownBlocks.Add(block.Hash())
 	default:

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -215,9 +215,8 @@ type BlockHeadersRLPPacket struct {
 
 // NewBlockPacket is the network packet for the block propagation message.
 type NewBlockPacket struct {
-	Block    *types.Block
-	TD       *big.Int
-	Sidecars []*types.BlobTxSidecar `rlp:"optional"`
+	Block *types.Block
+	TD    *big.Int
 }
 
 // sanityCheck verifies that the values are reasonable, as a DoS protection
@@ -231,15 +230,13 @@ func (request *NewBlockPacket) sanityCheck() error {
 		return fmt.Errorf("too large block TD: bitlen %d", tdlen)
 	}
 
-	if len(request.Sidecars) > 0 {
-		// todo 4844 do full sanity check for blob
-		for _, sidecar := range request.Sidecars {
-			lProofs := len(sidecar.Proofs)
-			lBlobs := len(sidecar.Blobs)
-			lCommitments := len(sidecar.Commitments)
-			if lProofs != lBlobs || lProofs != lCommitments || lCommitments != lBlobs {
-				return fmt.Errorf("mismatch of lengths of sidecar proofs %d, blobs %d, commitments %d", lProofs, lBlobs, lCommitments)
-			}
+	// todo 4844 do full sanity check for blob
+	for _, sidecar := range request.Block.Blobs() {
+		lProofs := len(sidecar.Proofs)
+		lBlobs := len(sidecar.Blobs)
+		lCommitments := len(sidecar.Commitments)
+		if lProofs != lBlobs || lProofs != lCommitments || lCommitments != lBlobs {
+			return fmt.Errorf("mismatch of lengths of sidecar proofs %d, blobs %d, commitments %d", lProofs, lBlobs, lCommitments)
 		}
 	}
 


### PR DESCRIPTION
### Description

sidecar is already carried by struct `block`
no need to add sidecars outside `block` again in NewBlockPacket

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
