### PR TITLE
config: reduce sidecar cache to 1024 and rename

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -110,7 +110,7 @@ const (
 	blockCacheLimit     = 256
 	diffLayerCacheLimit = 1024
 	receiptsCacheLimit  = 10000
-	blobsCacheLimit     = 10000
+	sidecarsCacheLimit  = 1024
 	txLookupCacheLimit  = 1024
 	maxBadBlockLimit    = 16
 	maxFutureBlocks     = 256
@@ -362,7 +362,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		bodyCache:          lru.NewCache[common.Hash, *types.Body](bodyCacheLimit),
 		bodyRLPCache:       lru.NewCache[common.Hash, rlp.RawValue](bodyCacheLimit),
 		receiptsCache:      lru.NewCache[common.Hash, []*types.Receipt](receiptsCacheLimit),
-		sidecarsCache:      lru.NewCache[common.Hash, types.BlobTxSidecars](blobsCacheLimit),
+		sidecarsCache:      lru.NewCache[common.Hash, types.BlobTxSidecars](sidecarsCacheLimit),
 		blockCache:         lru.NewCache[common.Hash, *types.Block](blockCacheLimit),
 		txLookupCache:      lru.NewCache[common.Hash, txLookup](txLookupCacheLimit),
 		futureBlocks:       lru.NewCache[common.Hash, *types.Block](maxFutureBlocks),

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -569,7 +569,7 @@ func (b testBackend) GetBlobSidecars(ctx context.Context, hash common.Hash) (typ
 	if header == nil || err != nil {
 		return nil, err
 	}
-	blobSidecars := rawdb.ReadRawBlobs(b.db, hash, header.Number.Uint64())
+	blobSidecars := rawdb.ReadRawBlobSidecars(b.db, hash, header.Number.Uint64())
 	return blobSidecars, nil
 }
 func (b testBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {


### PR DESCRIPTION
### Description
Sidecars could be large, reduce the cache size to avoid too much memory usage.

### Rationale
NA

### Example
NA

### Changes
NA