### PR TITLE
fix: Withdrawals turn into empty from nil when BlockBody has Sidecars

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -104,7 +104,7 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 				if hash := types.DeriveSha(block.Withdrawals(), trie.NewStackTrie(nil)); hash != *header.WithdrawalsHash {
 					return fmt.Errorf("withdrawals root hash mismatch (header value %x, calculated %x)", *header.WithdrawalsHash, hash)
 				}
-			} else if block.Withdrawals() != nil {
+			} else if len(block.Withdrawals()) != 0 { // Withdrawals turn into empty from nil when BlockBody has Sidecars
 				// Withdrawals are not allowed prior to shanghai fork
 				return errors.New("withdrawals present in block body")
 			}


### PR DESCRIPTION
### Description

add a description of your changes here...

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
