### PR TITLE
cmd/geth, core/rawdb: add dbDeleteTrieState

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -285,7 +285,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	// is initialized with an external ancient store. Commit genesis state
 	// in this case.
 	header := rawdb.ReadHeader(db, stored, 0)
-	if header.Root != types.EmptyRootHash && !triedb.Initialized(header.Root) {
+	if header.Root != types.EmptyRootHash && !triedb.Initialized(header.Root) && !triedb.Config().NoTries {
 		if genesis == nil {
 			genesis = DefaultBSCGenesisBlock()
 		}


### PR DESCRIPTION
### Description
This PR adds a feature to convert full node to fast node by introducing a new CLI tool called `delete-trie-state`. The tool will delete all PBSS key-value pairs and ancient state stores from the database.

### Rationale
This is particularly useful when users want to switch from full node to fast node by deleting the trie state from the database, reducing disk space occupied.

### Example
Usage: `./geth --datadir db delete-trie-state`
```
...
INFO [03-18|16:06:39.783] Opened ancient database                  database=/datadir_test/geth/chaindata/ancient/chain readonly=false frozen=909,979
INFO [03-18|16:06:43.759] Deleted trie state                       count=1,683,851 elapsed=3.971s
INFO [03-18|16:06:43.759] Removing ancient state database          path=/datadir_test/geth/chaindata/ancient/state
INFO [03-18|16:06:43.862] State database successfully deleted      path=/datadir_test/geth/chaindata/ancient/state elapsed=103.202ms
```

### Changes
Also added an additional `NoTries` logic check in `SetupGenesisBlockWithOverride` to prevent committing the genesis block again. For custom networks, this will result in an error because `!triedb.Initialized(header.Root)` returns true due to an empty trie database, so we need to skip committing if it's a fast node.