### PR TITLE
eth/ethconfig: remove overridekepler and overrideshanghai

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -183,14 +183,6 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		params.RialtoGenesisHash = common.HexToHash(v)
 	}
 
-	if ctx.IsSet(utils.OverrideShanghai.Name) {
-		v := ctx.Uint64(utils.OverrideShanghai.Name)
-		cfg.Eth.OverrideShanghai = &v
-	}
-	if ctx.IsSet(utils.OverrideKepler.Name) {
-		v := ctx.Uint64(utils.OverrideKepler.Name)
-		cfg.Eth.OverrideKepler = &v
-	}
 	if ctx.IsSet(utils.OverrideCancun.Name) {
 		v := ctx.Uint64(utils.OverrideCancun.Name)
 		cfg.Eth.OverrideCancun = &v

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -70,8 +70,6 @@ var (
 		utils.USBFlag,
 		utils.SmartCardDaemonPathFlag,
 		utils.RialtoHash,
-		utils.OverrideShanghai,
-		utils.OverrideKepler,
 		utils.OverrideCancun,
 		utils.OverrideVerkle,
 		utils.OverrideFeynman,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -299,16 +299,6 @@ var (
 		Usage:    "Manually specify the Rialto Genesis Hash, to trigger builtin network logic",
 		Category: flags.EthCategory,
 	}
-	OverrideShanghai = &cli.Uint64Flag{
-		Name:     "override.shanghai",
-		Usage:    "Manually specify the Shanghai fork timestamp, overriding the bundled setting",
-		Category: flags.EthCategory,
-	}
-	OverrideKepler = &cli.Uint64Flag{
-		Name:     "override.kepler",
-		Usage:    "Manually specify the Kepler fork timestamp, overriding the bundled setting",
-		Category: flags.EthCategory,
-	}
 	OverrideCancun = &cli.Uint64Flag{
 		Name:     "override.cancun",
 		Usage:    "Manually specify the Cancun fork timestamp, overriding the bundled setting",

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -216,8 +216,6 @@ func (e *GenesisMismatchError) Error() string {
 // ChainOverrides contains the changes to chain config
 // Typically, these modifications involve hardforks that are not enabled on the BSC mainnet, intended for testing purposes.
 type ChainOverrides struct {
-	OverrideShanghai   *uint64
-	OverrideKepler     *uint64
 	OverrideCancun     *uint64
 	OverrideVerkle     *uint64
 	OverrideFeynman    *uint64
@@ -247,12 +245,6 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	}
 	applyOverrides := func(config *params.ChainConfig) {
 		if config != nil {
-			if overrides != nil && overrides.OverrideShanghai != nil {
-				config.ShanghaiTime = overrides.OverrideShanghai
-			}
-			if overrides != nil && overrides.OverrideKepler != nil {
-				config.KeplerTime = overrides.OverrideKepler
-			}
 			if overrides != nil && overrides.OverrideCancun != nil {
 				config.CancunTime = overrides.OverrideCancun
 			}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -178,14 +178,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	// Override the chain config with provided settings.
 	var overrides core.ChainOverrides
-	if config.OverrideShanghai != nil {
-		chainConfig.ShanghaiTime = config.OverrideShanghai
-		overrides.OverrideShanghai = config.OverrideShanghai
-	}
-	if config.OverrideKepler != nil {
-		chainConfig.KeplerTime = config.OverrideKepler
-		overrides.OverrideKepler = config.OverrideKepler
-	}
 	if config.OverrideCancun != nil {
 		chainConfig.CancunTime = config.OverrideCancun
 		overrides.OverrideCancun = config.OverrideCancun

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -186,12 +186,6 @@ type Config struct {
 	// send-transaction variants. The unit is ether.
 	RPCTxFeeCap float64
 
-	// OverrideShanghai (TODO: remove after the fork)
-	OverrideShanghai *uint64 `toml:",omitempty"`
-
-	// OverrideKepler (TODO: remove after the fork)
-	OverrideKepler *uint64 `toml:",omitempty"`
-
 	// OverrideCancun (TODO: remove after the fork)
 	OverrideCancun *uint64 `toml:",omitempty"`
 

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -69,10 +69,10 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCGasCap               uint64
 		RPCEVMTimeout           time.Duration
 		RPCTxFeeCap             float64
-		OverrideShanghai        *uint64 `toml:",omitempty"`
-		OverrideKepler          *uint64 `toml:",omitempty"`
 		OverrideCancun          *uint64 `toml:",omitempty"`
 		OverrideVerkle          *uint64 `toml:",omitempty"`
+		OverrideFeynman         *uint64 `toml:",omitempty"`
+		OverrideFeynmanFix      *uint64 `toml:",omitempty"`
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -127,10 +127,10 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RPCGasCap = c.RPCGasCap
 	enc.RPCEVMTimeout = c.RPCEVMTimeout
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
-	enc.OverrideShanghai = c.OverrideShanghai
-	enc.OverrideKepler = c.OverrideKepler
 	enc.OverrideCancun = c.OverrideCancun
 	enc.OverrideVerkle = c.OverrideVerkle
+	enc.OverrideFeynman = c.OverrideFeynman
+	enc.OverrideFeynmanFix = c.OverrideFeynmanFix
 	return &enc, nil
 }
 
@@ -189,10 +189,10 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCGasCap               *uint64
 		RPCEVMTimeout           *time.Duration
 		RPCTxFeeCap             *float64
-		OverrideShanghai        *uint64 `toml:",omitempty"`
-		OverrideKepler          *uint64 `toml:",omitempty"`
 		OverrideCancun          *uint64 `toml:",omitempty"`
 		OverrideVerkle          *uint64 `toml:",omitempty"`
+		OverrideFeynman         *uint64 `toml:",omitempty"`
+		OverrideFeynmanFix      *uint64 `toml:",omitempty"`
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -354,17 +354,17 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.RPCTxFeeCap != nil {
 		c.RPCTxFeeCap = *dec.RPCTxFeeCap
 	}
-	if dec.OverrideShanghai != nil {
-		c.OverrideShanghai = dec.OverrideShanghai
-	}
-	if dec.OverrideKepler != nil {
-		c.OverrideKepler = dec.OverrideKepler
-	}
 	if dec.OverrideCancun != nil {
 		c.OverrideCancun = dec.OverrideCancun
 	}
 	if dec.OverrideVerkle != nil {
 		c.OverrideVerkle = dec.OverrideVerkle
+	}
+	if dec.OverrideFeynman != nil {
+		c.OverrideFeynman = dec.OverrideFeynman
+	}
+	if dec.OverrideFeynmanFix != nil {
+		c.OverrideFeynmanFix = dec.OverrideFeynmanFix
 	}
 	return nil
 }


### PR DESCRIPTION
### Description
1. remove overridekepler and overrideshanghai , they are enabled on mainnet now
2. fix OverrideFeynman and OverrideFeynmanFix in gen_config.go

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
