### PR TITLE
fix: fix the wrong version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## v1.3.12
+BUGFIX
+* [\#2305](https://github.com/bnb-chain/bsc/pull/2305) fix: fix the wrong version number
+
 ## v1.3.11
 BUGFIX
 * [\#2288](https://github.com/bnb-chain/bsc/pull/2288) fix: add FeynmanFix upgrade for a testnet issue

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 3  // Minor version component of the current release
-	VersionPatch = 10 // Patch version component of the current release
+	VersionPatch = 12 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
The current version number is not correct.

### Rationale
Update the patch version number to 12.

### Example
None

### Changes
None

