### PR TITLE
internal/ethapi: add net_nodeInfo

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2527,6 +2527,16 @@ func (s *NetAPI) Version() string {
 	return fmt.Sprintf("%d", s.networkVersion)
 }
 
+// NodeInfo retrieves all the information we know about the host node at the
+// protocol granularity. This is the same as the `admin_nodeInfo` method.
+func (s *NetAPI) NodeInfo() (*p2p.NodeInfo, error) {
+	server := s.net
+	if server == nil {
+		return nil, errors.New("server not found")
+	}
+	return s.net.NodeInfo(), nil
+}
+
 // checkTxFee is an internal function used to check whether the fee of
 // the given transaction is _reasonable_(under the cap).
 func checkTxFee(gasPrice *big.Int, gas uint64, cap float64) error {


### PR DESCRIPTION
### Description
This PR adds a new `net_nodeInfo` RPC method. It is the same as `admin_nodeInfo`.

### Rationale
The reason why `net_nodeInfo` is introduced even though `admin_nodeInfo` already exists is because some admin methods can control the behavior of the node. If a node were to be compromised with the admin namespace enabled, then the node could potentially stop functioning.

On the other hand, having access to retrieving the node information is extremely useful, especially when running an infrastructure. The content of the node info doesn't reveal sensitive information as well, so it could be added to the net namespace safely.

Another consideration is to remove `admin_nodeInfo` and replace with `net_nodeInfo`. This is possible, but this will contradict with the documentation of geth upstream. So in my opinion, there's no harm keeping both.

### Example
```
curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"net_nodeInfo","params":[],"id":83}' 127.0.0.1:8575
```