### PR TITLE
cmd/utils, node: switch to Pebble as the default db if none exists

### DIFF
--- a/cmd/geth/genesis_test.go
+++ b/cmd/geth/genesis_test.go
@@ -151,8 +151,8 @@ func TestCustomBackend(t *testing.T) {
 		return nil
 	}
 	for i, tt := range []backendTest{
-		{ // When not specified, it should default to leveldb
-			execArgs:   []string{"--db.engine", "leveldb"},
+		{ // When not specified, it should default to pebble
+			execArgs:   []string{"--db.engine", "pebble"},
 			execExpect: "0x0000000000001338",
 		},
 		{ // Explicit leveldb

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -506,7 +506,7 @@ type OpenOptions struct {
 //
 //	                      type == null          type != null
 //	                   +----------------------------------------
-//	db is non-existent |  leveldb default  |  specified type
+//	db is non-existent |  pebble default  |  specified type
 //	db is existent     |  from db         |  specified type (if compatible)
 func openKeyValueDatabase(o OpenOptions) (ethdb.Database, error) {
 	// Reject any unsupported database type
@@ -527,12 +527,9 @@ func openKeyValueDatabase(o OpenOptions) (ethdb.Database, error) {
 		log.Info("Using leveldb as the backing database")
 		return NewLevelDBDatabase(o.Directory, o.Cache, o.Handles, o.Namespace, o.ReadOnly)
 	}
-	// No pre-existing database, no user-requested one either. Default to Pebble
-	// on supported platforms and LevelDB on anything else.
-	// 	log.Info("Defaulting to pebble as the backing database")
-	// 	return NewPebbleDBDatabase(o.Directory, o.Cache, o.Handles, o.Namespace, o.ReadOnly)
-	log.Info("Defaulting to leveldb as the backing database")
-	return NewLevelDBDatabase(o.Directory, o.Cache, o.Handles, o.Namespace, o.ReadOnly)
+	// No pre-existing database, no user-requested one either. Default to Pebble.
+	log.Info("Defaulting to pebble as the backing database")
+	return NewPebbleDBDatabase(o.Directory, o.Cache, o.Handles, o.Namespace, o.ReadOnly, o.Ephemeral)
 }
 
 // Open opens both a disk-based key-value database such as leveldb or pebble, but also

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -73,7 +73,7 @@ var DefaultConfig = Config{
 		MaxPeersPerIP: 0, // by default, it will be same as MaxPeers
 		NAT:           nat.Any(),
 	},
-	DBEngine: "", // Use whatever exists, will default to Leveldb if non-existent and supported
+	DBEngine: "", // Use whatever exists, will default to Pebble if non-existent and supported
 }
 
 // DefaultDataDir is the default data directory to use for the databases and other


### PR DESCRIPTION
### Description

Switch to Pebble as the default db if none exists.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* N/A
