### PR TITLE
test: use full syncmode to run rpc node

### DIFF
--- a/tests/truffle/scripts/bootstrap.sh
+++ b/tests/truffle/scripts/bootstrap.sh
@@ -35,7 +35,7 @@ function generate_genesis() {
 function init_genesis_data() {
      node_type=$1
      node_id=$2
-     geth --datadir ${workspace}/storage/${node_id} init --state.scheme "hash" ${workspace}/genesis/genesis.json
+     geth --datadir ${workspace}/storage/${node_id} init ${workspace}/genesis/genesis.json
      cp ${workspace}/config/config-${node_type}.toml  ${workspace}/storage/${node_id}/config.toml
      sed -i -e "s/{{NetworkId}}/${BSC_CHAIN_ID}/g" ${workspace}/storage/${node_id}/config.toml
      if [ "${node_id}" == "bsc-rpc" ]; then

--- a/tests/truffle/scripts/bsc-rpc.sh
+++ b/tests/truffle/scripts/bsc-rpc.sh
@@ -11,6 +11,6 @@ while [ "$i" -lt ${account_cnt} ]; do
 done 
 
 geth --config ${DATA_DIR}/config.toml --datadir ${DATA_DIR} --netrestrict ${CLUSTER_CIDR} \
-    --verbosity ${VERBOSE} --nousb \
+    --verbosity ${VERBOSE} --nousb --syncmode "full"\
     --rpc.allow-unprotected-txs --history.transactions 15768000 \
     -unlock ${unlock_sequences} --password /dev/null  >${DATA_DIR}/bscnode-rpc.log


### PR DESCRIPTION
### Description

Trufle test would start a validator node and rpc node for smart contract test, but in snap mode path state scheme will need more time to prepare environment and it's unstable. Therefore, use full syncmode in path mode.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* N/A
