### PR TITLE
4844: bugfix and improve

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
-*                               @zzzckck
-*                               @zjubfd
+*                               @zzzckck @zjubfd

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -701,10 +701,8 @@ func (p *Parlia) snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 			}
 		}
 
-		// If we're at the genesis, snapshot the initial state. Alternatively if we have
-		// piled up more headers than allowed to be reorged (chain reinit from a freezer),
-		// consider the checkpoint trusted and snapshot it.
-		if number == 0 || (number%p.config.Epoch == 0 && (len(headers) > int(params.FullImmutabilityThreshold)/10)) {
+		// If we're at the genesis, snapshot the initial state.
+		if number == 0 {
 			checkpoint := chain.GetHeaderByNumber(number)
 			if checkpoint != nil {
 				// get checkpoint data
@@ -718,12 +716,10 @@ func (p *Parlia) snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 
 				// new snapshot
 				snap = newSnapshot(p.config, p.signatures, number, hash, validators, voteAddrs, p.ethAPI)
-				if snap.Number%checkpointInterval == 0 { // snapshot will only be loaded when snap.Number%checkpointInterval == 0
-					if err := snap.store(p.db); err != nil {
-						return nil, err
-					}
-					log.Info("Stored checkpoint snapshot to disk", "number", number, "hash", hash)
+				if err := snap.store(p.db); err != nil {
+					return nil, err
 				}
+				log.Info("Stored checkpoint snapshot to disk", "number", number, "hash", hash)
 				break
 			}
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1341,6 +1341,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 	lastBlk := blockChain[len(blockChain)-1]
 	if bc.chainConfig.Parlia != nil && bc.chainConfig.IsCancun(lastBlk.Number(), lastBlk.Time()) {
 		if _, err := CheckDataAvailableInBatch(bc, blockChain); err != nil {
+			log.Debug("CheckDataAvailableInBatch", "err", err)
 			return 0, err
 		}
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -973,6 +973,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 			// The header, total difficulty and canonical hash will be
 			// removed in the hc.SetHead function.
 			rawdb.DeleteBody(db, hash, num)
+			rawdb.DeleteBlobSidecars(db, hash, num)
 			rawdb.DeleteReceipts(db, hash, num)
 		}
 		// Todo(rjl493456442) txlookup, bloombits, etc
@@ -1405,7 +1406,6 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		// Write all chain data to ancients.
 		td := bc.GetTd(first.Hash(), first.NumberU64())
 		writeSize, err := rawdb.WriteAncientBlocks(bc.db, blockChain, receiptChain, td)
-
 		if err != nil {
 			log.Error("Error importing chain data to ancients", "err", err)
 			return 0, err

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1406,7 +1406,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 
 		// Write all chain data to ancients.
 		td := bc.GetTd(first.Hash(), first.NumberU64())
-		writeSize, err := rawdb.WriteAncientBlocks(bc.db, blockChain, receiptChain, td)
+		writeSize, err := rawdb.WriteAncientBlocksWithBlobs(bc.db, blockChain, receiptChain, td)
 		if err != nil {
 			log.Error("Error importing chain data to ancients", "err", err)
 			return 0, err

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -256,7 +256,7 @@ func (bc *BlockChain) GetSidecarsByHash(hash common.Hash) types.BlobSidecars {
 	if number == nil {
 		return nil
 	}
-	sidecars := rawdb.ReadRawBlobSidecars(bc.db, hash, *number)
+	sidecars := rawdb.ReadBlobSidecars(bc.db, hash, *number)
 	if sidecars == nil {
 		return nil
 	}

--- a/core/data_availability.go
+++ b/core/data_availability.go
@@ -65,7 +65,7 @@ func IsDataAvailable(chain consensus.ChainHeaderReader, block *types.Block) (err
 		highest = current
 	}
 	defer func() {
-		log.Info("IsDataAvailable", "block", block.Number(), "hash", block.Hash(), "highest", highest.Number, "sidecars", len(block.Sidecars()), "err", err)
+		log.Debug("IsDataAvailable", "block", block.Number(), "hash", block.Hash(), "highest", highest.Number, "sidecars", len(block.Sidecars()), "err", err)
 	}()
 	if block.NumberU64()+params.MinBlocksForBlobRequests < highest.Number.Uint64() {
 		// if we needn't check DA of this block, just clean it

--- a/core/data_availability.go
+++ b/core/data_availability.go
@@ -48,13 +48,10 @@ func validateBlobSidecar(hashes []common.Hash, sidecar *types.BlobSidecar) error
 func IsDataAvailable(chain consensus.ChainHeaderReader, block *types.Block) (err error) {
 	// refer logic in ValidateBody
 	if !chain.Config().IsCancun(block.Number(), block.Time()) {
-		if block.Sidecars() == nil {
-			return nil
-		} else {
+		if block.Sidecars() != nil {
 			return errors.New("sidecars present in block body before cancun")
 		}
-	} else if block.Sidecars() == nil {
-		return errors.New("missing sidecars in block body after cancun")
+		return nil
 	}
 
 	// only required to check within MinBlocksForBlobRequests block's DA
@@ -69,6 +66,10 @@ func IsDataAvailable(chain consensus.ChainHeaderReader, block *types.Block) (err
 		return nil
 	}
 
+	// if sidecar is nil, just clean it. And it will be used for saving in ancient.
+	if block.Sidecars() == nil {
+		block.CleanSidecars()
+	}
 	sidecars := block.Sidecars()
 	for _, s := range sidecars {
 		if err := s.SanityCheck(block.Number(), block.Hash()); err != nil {

--- a/core/data_availability.go
+++ b/core/data_availability.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -64,9 +63,6 @@ func IsDataAvailable(chain consensus.ChainHeaderReader, block *types.Block) (err
 	if highest == nil || highest.Number.Cmp(current.Number) < 0 {
 		highest = current
 	}
-	defer func() {
-		log.Debug("IsDataAvailable", "block", block.Number(), "hash", block.Hash(), "highest", highest.Number, "sidecars", len(block.Sidecars()), "err", err)
-	}()
 	if block.NumberU64()+params.MinBlocksForBlobRequests < highest.Number.Uint64() {
 		// if we needn't check DA of this block, just clean it
 		block.CleanSidecars()

--- a/core/data_availability_test.go
+++ b/core/data_availability_test.go
@@ -121,7 +121,7 @@ func TestIsDataAvailable(t *testing.T) {
 			}, nil),
 			chasingHead: params.MinBlocksForBlobRequests + 1,
 			withSidecar: false,
-			err:         true,
+			err:         false,
 		},
 	}
 

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -853,8 +853,8 @@ func ReadBlobSidecarsRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.R
 	return data
 }
 
-// ReadRawBlobSidecars retrieves all the transaction blobs belonging to a block.
-func ReadRawBlobSidecars(db ethdb.Reader, hash common.Hash, number uint64) types.BlobSidecars {
+// ReadBlobSidecars retrieves all the transaction blobs belonging to a block.
+func ReadBlobSidecars(db ethdb.Reader, hash common.Hash, number uint64) types.BlobSidecars {
 	data := ReadBlobSidecarsRLP(db, hash, number)
 	if len(data) == 0 {
 		return nil

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -839,7 +839,6 @@ func WriteAncientBlocks(db ethdb.AncientWriter, blocks []*types.Block, receipts 
 		if err != nil {
 			return preSize, err
 		}
-		blocks = blocks[cancunIndex:]
 	}
 
 	// It will reset blob ancient table at cancunIndex
@@ -847,6 +846,7 @@ func WriteAncientBlocks(db ethdb.AncientWriter, blocks []*types.Block, receipts 
 		if err = ResetEmptyBlobAncientTable(db, blocks[cancunIndex].NumberU64()); err != nil {
 			return 0, err
 		}
+		blocks = blocks[cancunIndex:]
 	}
 
 	postSize, err := db.ModifyAncients(func(op ethdb.AncientWriteOp) error {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -836,6 +836,9 @@ func WriteAncientBlocks(db ethdb.AncientWriter, blocks []*types.Block, receipts 
 			}
 			return nil
 		})
+		if err != nil {
+			return preSize, err
+		}
 		blocks = blocks[cancunIndex:]
 	}
 

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -455,13 +455,13 @@ func TestBlockBlobSidecarsStorage(t *testing.T) {
 	sidecars := types.BlobSidecars{types.NewBlobSidecarFromTx(tx1)}
 
 	// Check that no sidecars entries are in a pristine database
-	if bs := ReadRawBlobSidecars(db, blkHash, 0); len(bs) != 0 {
+	if bs := ReadBlobSidecars(db, blkHash, 0); len(bs) != 0 {
 		t.Fatalf("non existent sidecars returned: %v", bs)
 	}
 	WriteBody(db, blkHash, 0, body)
 	WriteBlobSidecars(db, blkHash, 0, sidecars)
 
-	if bs := ReadRawBlobSidecars(db, blkHash, 0); len(bs) == 0 {
+	if bs := ReadBlobSidecars(db, blkHash, 0); len(bs) == 0 {
 		t.Fatalf("no sidecars returned")
 	} else {
 		if err := checkBlobSidecarsRLP(bs, sidecars); err != nil {
@@ -470,7 +470,7 @@ func TestBlockBlobSidecarsStorage(t *testing.T) {
 	}
 
 	DeleteBlobSidecars(db, blkHash, 0)
-	if bs := ReadRawBlobSidecars(db, blkHash, 0); len(bs) != 0 {
+	if bs := ReadBlobSidecars(db, blkHash, 0); len(bs) != 0 {
 		t.Fatalf("deleted sidecars returned: %v", bs)
 	}
 }

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -312,9 +312,8 @@ func (f *chainFreezer) freezeRangeWithBlobs(nfdb *nofreezedb, number, limit uint
 
 	var (
 		cancunNumber uint64
-		found        bool
+		preHashes    []common.Hash
 	)
-
 	for i := number; i <= limit; i++ {
 		hash := ReadCanonicalHash(nfdb, i)
 		if hash == (common.Hash{}) {
@@ -326,16 +325,12 @@ func (f *chainFreezer) freezeRangeWithBlobs(nfdb *nofreezedb, number, limit uint
 		}
 		if isCancun(env, h.Number, h.Time) {
 			cancunNumber = i
-			found = true
 			break
 		}
 	}
-	if !found {
-		return f.freezeRange(nfdb, number, limit)
-	}
 
 	// freeze pre cancun
-	preHashes, err := f.freezeRange(nfdb, number, cancunNumber-1)
+	preHashes, err = f.freezeRange(nfdb, number, cancunNumber-1)
 	if err != nil {
 		return preHashes, err
 	}

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -273,13 +273,8 @@ func (f *chainFreezer) tryPruneBlobAncient(env *ethdb.FreezerEnv, num uint64) {
 		return
 	}
 	expectTail := num - reserveThreshold
-	h, err := f.TableAncients(ChainFreezerBlobSidecarTable)
-	if err != nil {
-		log.Error("Cannot get blob ancient head when prune", "block", num)
-		return
-	}
 	start := time.Now()
-	if err = f.ResetTable(ChainFreezerBlobSidecarTable, expectTail, h, false); err != nil {
+	if _, err := f.TruncateTableTail(ChainFreezerBlobSidecarTable, expectTail); err != nil {
 		log.Error("Cannot prune blob ancient", "block", num, "expectTail", expectTail, "err", err)
 		return
 	}
@@ -427,5 +422,5 @@ func isCancun(env *ethdb.FreezerEnv, num *big.Int, time uint64) bool {
 }
 
 func ResetEmptyBlobAncientTable(db ethdb.AncientWriter, next uint64) error {
-	return db.ResetTable(ChainFreezerBlobSidecarTable, next, next, true)
+	return db.ResetTable(ChainFreezerBlobSidecarTable, next, true)
 }

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -252,7 +252,7 @@ func (f *chainFreezer) freeze(db ethdb.KeyValueStore) {
 		env, _ := f.freezeEnv.Load().(*ethdb.FreezerEnv)
 		// try prune blob data after cancun fork
 		if isCancun(env, head.Number, head.Time) {
-			f.tryPruneBlobAncient(env, *number)
+			f.tryPruneBlobAncientTable(env, *number)
 		}
 
 		// Avoid database thrashing with tiny writes
@@ -262,7 +262,7 @@ func (f *chainFreezer) freeze(db ethdb.KeyValueStore) {
 	}
 }
 
-func (f *chainFreezer) tryPruneBlobAncient(env *ethdb.FreezerEnv, num uint64) {
+func (f *chainFreezer) tryPruneBlobAncientTable(env *ethdb.FreezerEnv, num uint64) {
 	extraReserve := getBlobExtraReserveFromEnv(env)
 	// It means that there is no need for pruning
 	if extraReserve == 0 {

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -177,10 +177,6 @@ func (db *nofreezedb) ModifyAncients(func(ethdb.AncientWriteOp) error) (int64, e
 	return 0, errNotSupported
 }
 
-func (db *nofreezedb) ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error {
-	return errNotSupported
-}
-
 // TruncateHead returns an error as we don't have a backing chain freezer.
 func (db *nofreezedb) TruncateHead(items uint64) (uint64, error) {
 	return 0, errNotSupported
@@ -189,6 +185,16 @@ func (db *nofreezedb) TruncateHead(items uint64) (uint64, error) {
 // TruncateTail returns an error as we don't have a backing chain freezer.
 func (db *nofreezedb) TruncateTail(items uint64) (uint64, error) {
 	return 0, errNotSupported
+}
+
+// TruncateTableTail will truncate certain table to new tail
+func (db *nofreezedb) TruncateTableTail(kind string, tail uint64) (uint64, error) {
+	return 0, errNotSupported
+}
+
+// ResetTable will reset certain table with new start point
+func (db *nofreezedb) ResetTable(kind string, startAt uint64, onlyEmpty bool) error {
+	return errNotSupported
 }
 
 // Sync returns an error as we don't have a backing chain freezer.

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -734,9 +734,6 @@ func (f *Freezer) ResetTable(kind string, startAt uint64, onlyEmpty bool) error 
 	if f.readonly {
 		return errReadOnly
 	}
-	if err := f.Sync(); err != nil {
-		return err
-	}
 
 	t, exist := f.tables[kind]
 	if !exist {
@@ -746,6 +743,10 @@ func (f *Freezer) ResetTable(kind string, startAt uint64, onlyEmpty bool) error 
 	// if you reset a non empty table just skip
 	if onlyEmpty && !EmptyTable(t) {
 		return nil
+	}
+
+	if err := f.Sync(); err != nil {
+		return err
 	}
 	nt, err := t.resetItems(startAt - f.offset)
 	if err != nil {

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -700,12 +700,12 @@ func (f *Freezer) MigrateTable(kind string, convert convertLegacyFn) error {
 
 // TruncateTableTail will truncate certain table to new tail
 func (f *Freezer) TruncateTableTail(kind string, tail uint64) (uint64, error) {
-	f.writeLock.Lock()
-	defer f.writeLock.Unlock()
-
 	if f.readonly {
 		return 0, errReadOnly
 	}
+
+	f.writeLock.Lock()
+	defer f.writeLock.Unlock()
 
 	if !slices.Contains(additionTables, kind) {
 		return 0, errors.New("only new added table could be truncated independently")
@@ -728,12 +728,12 @@ func (f *Freezer) TruncateTableTail(kind string, tail uint64) (uint64, error) {
 // ResetTable will reset certain table with new start point
 // only used for ChainFreezerBlobSidecarTable now
 func (f *Freezer) ResetTable(kind string, startAt uint64, onlyEmpty bool) error {
-	f.writeLock.Lock()
-	defer f.writeLock.Unlock()
-
 	if f.readonly {
 		return errReadOnly
 	}
+
+	f.writeLock.Lock()
+	defer f.writeLock.Unlock()
 
 	t, exist := f.tables[kind]
 	if !exist {

--- a/core/rawdb/freezer_resettable.go
+++ b/core/rawdb/freezer_resettable.go
@@ -187,13 +187,6 @@ func (f *ResettableFreezer) ModifyAncients(fn func(ethdb.AncientWriteOp) error) 
 	return f.freezer.ModifyAncients(fn)
 }
 
-func (f *ResettableFreezer) ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
-
-	return f.freezer.ResetTable(kind, tail, head, onlyEmpty)
-}
-
 // TruncateHead discards any recent data above the provided threshold number.
 // It returns the previous head number.
 func (f *ResettableFreezer) TruncateHead(items uint64) (uint64, error) {
@@ -210,6 +203,22 @@ func (f *ResettableFreezer) TruncateTail(tail uint64) (uint64, error) {
 	defer f.lock.RUnlock()
 
 	return f.freezer.TruncateTail(tail)
+}
+
+// TruncateTableTail will truncate certain table to new tail
+func (f *ResettableFreezer) TruncateTableTail(kind string, tail uint64) (uint64, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	return f.freezer.TruncateTableTail(kind, tail)
+}
+
+// ResetTable will reset certain table with new start point
+func (f *ResettableFreezer) ResetTable(kind string, startAt uint64, onlyEmpty bool) error {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	return f.freezer.ResetTable(kind, startAt, onlyEmpty)
 }
 
 // Sync flushes all data tables to disk.

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -371,34 +371,68 @@ func TestFreezer_AdditionTables(t *testing.T) {
 	f, err = NewFreezer(dir, "", false, 0, 2049, map[string]bool{"o1": true, "o2": true, "a1": true})
 	require.NoError(t, err)
 	frozen, _ := f.Ancients()
-	f.ResetTable("a1", frozen, frozen, true)
+	require.NoError(t, f.ResetTable("a1", frozen, true))
 	_, err = f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
-		if err := op.AppendRaw("o1", 2, item); err != nil {
+		if err := appendSameItem(op, []string{"o1", "o2", "a1"}, 2, item); err != nil {
 			return err
 		}
-		if err := op.AppendRaw("o2", 2, item); err != nil {
+		if err := appendSameItem(op, []string{"o1", "o2", "a1"}, 3, item); err != nil {
 			return err
 		}
-		if err := op.AppendRaw("a1", 2, item); err != nil {
+		if err := appendSameItem(op, []string{"o1", "o2", "a1"}, 4, item); err != nil {
 			return err
 		}
 		return nil
 	})
 	require.NoError(t, err)
+
+	// check additional table boundary
 	_, err = f.Ancient("a1", 1)
 	require.Error(t, err)
 	actual, err := f.Ancient("a1", 2)
 	require.NoError(t, err)
 	require.Equal(t, item, actual)
+
+	// truncate additional table, and check boundary
+	_, err = f.TruncateTableTail("o1", 3)
+	require.Error(t, err)
+	_, err = f.TruncateTableTail("a1", 3)
+	require.NoError(t, err)
+	_, err = f.Ancient("a1", 2)
+	require.Error(t, err)
+	actual, err = f.Ancient("a1", 3)
+	require.NoError(t, err)
+	require.Equal(t, item, actual)
+
+	// check additional table head
+	ancients, err := f.TableAncients("a1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), ancients)
 	require.NoError(t, f.Close())
 
 	// reopen and read
 	f, err = NewFreezer(dir, "", true, 0, 2049, map[string]bool{"o1": true, "o2": true, "a1": true})
 	require.NoError(t, err)
+
+	// recheck additional table boundary
 	actual, err = f.Ancient("a1", 2)
+	require.Error(t, err)
+	actual, err = f.Ancient("a1", 3)
 	require.NoError(t, err)
 	require.Equal(t, item, actual)
+	ancients, err = f.TableAncients("a1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), ancients)
 	require.NoError(t, f.Close())
+}
+
+func appendSameItem(op ethdb.AncientWriteOp, tables []string, i uint64, item []byte) error {
+	for _, t := range tables {
+		if err := op.AppendRaw(t, i, item); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func newFreezerForTesting(t *testing.T, tables map[string]bool) (*Freezer, string) {

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -415,7 +415,7 @@ func TestFreezer_AdditionTables(t *testing.T) {
 	require.NoError(t, err)
 
 	// recheck additional table boundary
-	actual, err = f.Ancient("a1", 2)
+	_, err = f.Ancient("a1", 2)
 	require.Error(t, err)
 	actual, err = f.Ancient("a1", 3)
 	require.NoError(t, err)

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -328,6 +328,12 @@ func (f *prunedfreezer) ModifyAncients(func(ethdb.AncientWriteOp) error) (int64,
 	return 0, errNotSupported
 }
 
-func (f *prunedfreezer) ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error {
+// TruncateTableTail will truncate certain table to new tail
+func (f *prunedfreezer) TruncateTableTail(kind string, tail uint64) (uint64, error) {
+	return 0, errNotSupported
+}
+
+// ResetTable will reset certain table with new start point
+func (f *prunedfreezer) ResetTable(kind string, startAt uint64, onlyEmpty bool) error {
 	return errNotSupported
 }

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -101,8 +101,14 @@ func (t *table) ModifyAncients(fn func(ethdb.AncientWriteOp) error) (int64, erro
 	return t.db.ModifyAncients(fn)
 }
 
-func (t *table) ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error {
-	return t.db.ResetTable(kind, tail, head, onlyEmpty)
+// TruncateTableTail will truncate certain table to new tail
+func (t *table) TruncateTableTail(kind string, tail uint64) (uint64, error) {
+	return t.db.TruncateTableTail(kind, tail)
+}
+
+// ResetTable will reset certain table with new start point
+func (t *table) ResetTable(kind string, startAt uint64, onlyEmpty bool) error {
+	return t.db.ResetTable(kind, startAt, onlyEmpty)
 }
 
 func (t *table) ReadAncients(fn func(reader ethdb.AncientReaderOp) error) (err error) {

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -457,7 +457,7 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 		blobs := rawdb.ReadBlobSidecars(chainDb, blockHash, blockNumber)
 		block = block.WithSidecars(blobs)
 		// Write into new ancient_back db.
-		if _, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td); err != nil {
+		if _, err := rawdb.WriteAncientBlocksWithBlobs(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td); err != nil {
 			log.Error("failed to write new ancient", "error", err)
 			return err
 		}

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -454,7 +454,7 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 			return consensus.ErrUnknownAncestor
 		}
 		// if there has blobs, it needs to back up too.
-		blobs := rawdb.ReadRawBlobSidecars(chainDb, blockHash, blockNumber)
+		blobs := rawdb.ReadBlobSidecars(chainDb, blockHash, blockNumber)
 		block = block.WithSidecars(blobs)
 		// Write into new ancient_back db.
 		if _, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, td); err != nil {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -183,7 +183,7 @@ func (h *Header) SanityCheck() error {
 // that is: no transactions, no uncles and no withdrawals.
 func (h *Header) EmptyBody() bool {
 	if h.WithdrawalsHash != nil {
-		return h.TxHash == EmptyTxsHash && *h.WithdrawalsHash == EmptyWithdrawalsHash
+		return h.TxHash == EmptyTxsHash && (*h.WithdrawalsHash == EmptyWithdrawalsHash || *h.WithdrawalsHash == common.Hash{})
 	}
 	return h.TxHash == EmptyTxsHash && h.UncleHash == EmptyUncleHash
 }

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -827,7 +827,7 @@ func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, txListH
 			if want := *header.BlobGasUsed / params.BlobTxBlobGasPerBlob; uint64(blobs) != want { // div because the header is surely good vs the body might be bloated
 				return errInvalidBody
 			}
-			if blobs > params.MaxBlobGasPerBlock {
+			if blobs > params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob {
 				return errInvalidBody
 			}
 		} else {

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -141,8 +141,11 @@ type AncientWriter interface {
 	// in the newest format.
 	MigrateTable(string, func([]byte) ([]byte, error)) error
 
-	// ResetTable will reset certain table to new boundary
-	ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error
+	// TruncateTableTail will truncate certain table to new tail
+	TruncateTableTail(kind string, tail uint64) (uint64, error)
+
+	// ResetTable will reset certain table with new start point
+	ResetTable(kind string, startAt uint64, onlyEmpty bool) error
 }
 
 type FreezerEnv struct {

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -126,10 +126,6 @@ func (db *Database) ModifyAncients(f func(ethdb.AncientWriteOp) error) (int64, e
 	panic("not supported")
 }
 
-func (db *Database) ResetTable(kind string, tail uint64, head uint64, onlyEmpty bool) error {
-	panic("not supported")
-}
-
 func (db *Database) AncientReset(tail, head uint64) error {
 	panic("not supported")
 }
@@ -139,6 +135,16 @@ func (db *Database) TruncateHead(n uint64) (uint64, error) {
 }
 
 func (db *Database) TruncateTail(n uint64) (uint64, error) {
+	panic("not supported")
+}
+
+// TruncateTableTail will truncate certain table to new tail
+func (db *Database) TruncateTableTail(kind string, tail uint64) (uint64, error) {
+	panic("not supported")
+}
+
+// ResetTable will reset certain table with new start point
+func (db *Database) ResetTable(kind string, startAt uint64, onlyEmpty bool) error {
 	panic("not supported")
 }
 

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -574,7 +574,7 @@ func (b testBackend) GetBlobSidecars(ctx context.Context, hash common.Hash) (typ
 	if header == nil || err != nil {
 		return nil, err
 	}
-	blobSidecars := rawdb.ReadRawBlobSidecars(b.db, hash, header.Number.Uint64())
+	blobSidecars := rawdb.ReadBlobSidecars(b.db, hash, header.Number.Uint64())
 	return blobSidecars, nil
 }
 func (b testBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {


### PR DESCRIPTION
### Description

bugfix
1. DeleteBlobSidecars when setHeadBeyondRoot
2. fix blob number check when downloading block body
3. modify resetItems
	a. add lock
	b. remove all data files and prevent from overflow
	c. set metadata
	d. sync index file before reopen
4. only newSnapshot for genesis block
5. ResetEmptyBlobAncientTable in proper order
6. accept nil sidecars in block after cancun, but reset it to empty slices, this also solve the stuck issue in QA env
7.  fix EmptyBody

improvement
1. rename ReadRawBlobSidecars to ReadBlobSidecars
2. delete dead code in freezeRangeWithBlobs
3. narrow the semantics of resetItems and ResetTable

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
