### PR TITLE
cmd: include more node info in metrics

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -245,8 +245,8 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	git, _ := version.VCS()
 	utils.SetupMetrics(ctx,
 		utils.EnableBuildInfo(git.Commit, git.Date),
-		utils.EnableMinerInfo(ctx, cfg.Eth.Miner),
-		utils.EnableNodeInfo(cfg.Eth.TxPool),
+		utils.EnableMinerInfo(ctx, &cfg.Eth.Miner),
+		utils.EnableNodeInfo(&cfg.Eth.TxPool, stack.Server().NodeInfo()),
 	)
 	return stack, backend
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2230,7 +2230,7 @@ func EnableBuildInfo(gitCommit, gitDate string) SetupMetricsOption {
 	}
 }
 
-func EnableMinerInfo(ctx *cli.Context, minerConfig miner.Config) SetupMetricsOption {
+func EnableMinerInfo(ctx *cli.Context, minerConfig *miner.Config) SetupMetricsOption {
 	return func() {
 		if ctx.Bool(MiningEnabledFlag.Name) {
 			// register miner info into metrics
@@ -2253,10 +2253,13 @@ func RegisterFilterAPI(stack *node.Node, backend ethapi.Backend, ethcfg *ethconf
 	return filterSystem
 }
 
-func EnableNodeInfo(poolConfig legacypool.Config) SetupMetricsOption {
+func EnableNodeInfo(poolConfig *legacypool.Config, nodeInfo *p2p.NodeInfo) SetupMetricsOption {
 	return func() {
 		// register node info into metrics
 		metrics.NewRegisteredLabel("node-info", nil).Mark(map[string]interface{}{
+			"Enode":        nodeInfo.Enode,
+			"ENR":          nodeInfo.ENR,
+			"ID":           nodeInfo.ID,
 			"PriceLimit":   poolConfig.PriceLimit,
 			"PriceBump":    poolConfig.PriceBump,
 			"AccountSlots": poolConfig.AccountSlots,


### PR DESCRIPTION
### Description
This PR adds additional fields (i.e. enodeID, ENR, ID) to the `node-info` metrics label.

### Rationale
It's useful to have that information visible at all times, instead of creating a custom script to pull that data.
