### PR TITLE
p2p: add metrics for inbound/outbound peers

### DIFF
--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -37,7 +37,9 @@ const (
 )
 
 var (
-	activePeerGauge metrics.Gauge = metrics.NilGauge{}
+	activePeerGauge         metrics.Gauge = metrics.NilGauge{}
+	activeInboundPeerGauge  metrics.Gauge = metrics.NilGauge{}
+	activeOutboundPeerGauge metrics.Gauge = metrics.NilGauge{}
 
 	ingressTrafficMeter = metrics.NewRegisteredMeter("p2p/ingress", nil)
 	egressTrafficMeter  = metrics.NewRegisteredMeter("p2p/egress", nil)
@@ -74,6 +76,8 @@ func init() {
 	}
 
 	activePeerGauge = metrics.NewRegisteredGauge("p2p/peers", nil)
+	activeInboundPeerGauge = metrics.NewRegisteredGauge("p2p/peers/inbound", nil)
+	activeOutboundPeerGauge = metrics.NewRegisteredGauge("p2p/peers/outbound", nil)
 	serveMeter = metrics.NewRegisteredMeter("p2p/serves", nil)
 	serveSuccessMeter = metrics.NewRegisteredMeter("p2p/serves/success", nil)
 	dialMeter = metrics.NewRegisteredMeter("p2p/dials", nil)

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -840,8 +840,10 @@ running:
 				if p.Inbound() {
 					inboundCount++
 					serveSuccessMeter.Mark(1)
+					activeInboundPeerGauge.Inc(1)
 				} else {
 					dialSuccessMeter.Mark(1)
+					activeOutboundPeerGauge.Inc(1)
 				}
 				activePeerGauge.Inc(1)
 			}
@@ -858,6 +860,9 @@ running:
 			srv.dialsched.peerRemoved(pd.rw)
 			if pd.Inbound() {
 				inboundCount--
+				activeInboundPeerGauge.Dec(1)
+			} else {
+				activeOutboundPeerGauge.Dec(1)
 			}
 			activePeerGauge.Dec(1)
 		}


### PR DESCRIPTION
### Description
This PR adds additional metrics to measure inbound and outbound peers.

### Example
Here's an example of the Grafana dashboard:
<img width="463" alt="image" src="https://github.com/bnb-chain/bsc/assets/47109095/a2ef06e7-618d-49d7-bf9b-6a09ddacc6df">
