### PR TITLE
cancun: change empty withdrawHash value of header;

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -600,8 +600,8 @@ func (p *Parlia) verifyHeader(chain consensus.ChainHeaderReader, header *types.H
 		case header.ParentBeaconRoot != nil:
 			return fmt.Errorf("invalid parentBeaconRoot, have %#x, expected nil", header.ParentBeaconRoot)
 		// types.EmptyWithdrawalsHash represents a empty value when EIP-4895 enabled,
-		// here, EIP-4895 still be disabled, value expected to be `common.Hash{}` is only to feet the demand of rlp encode/decode
-		case header.WithdrawalsHash == nil || *header.WithdrawalsHash != common.Hash{}:
+		// here, EIP-4895 still be disabled, value expected to be `types.EmptyWithdrawalsHash` is only to feet the demand of rlp encode/decode
+		case header.WithdrawalsHash == nil || *header.WithdrawalsHash != types.EmptyWithdrawalsHash:
 			return errors.New("header has wrong WithdrawalsHash")
 		}
 		if err := eip4844.VerifyEIP4844Header(parent, header); err != nil {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -481,8 +481,7 @@ func (cm *chainMaker) makeHeader(parent *types.Block, state *state.StateDB, engi
 		header.ExcessBlobGas = &excessBlobGas
 		header.BlobGasUsed = new(uint64)
 		if cm.config.Parlia != nil {
-			header.WithdrawalsHash = new(common.Hash)
-			*header.WithdrawalsHash = types.EmptyWithdrawalsHash
+			header.WithdrawalsHash = &types.EmptyWithdrawalsHash
 		}
 		if cm.config.Parlia == nil {
 			header.ParentBeaconRoot = new(common.Hash)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -482,6 +482,7 @@ func (cm *chainMaker) makeHeader(parent *types.Block, state *state.StateDB, engi
 		header.BlobGasUsed = new(uint64)
 		if cm.config.Parlia != nil {
 			header.WithdrawalsHash = new(common.Hash)
+			*header.WithdrawalsHash = types.EmptyWithdrawalsHash
 		}
 		if cm.config.Parlia == nil {
 			header.ParentBeaconRoot = new(common.Hash)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -446,8 +446,7 @@ func (g *Genesis) ToBlock() *types.Block {
 		}
 		if conf.IsCancun(num, g.Timestamp) {
 			if conf.Parlia != nil {
-				head.WithdrawalsHash = new(common.Hash)
-				*head.WithdrawalsHash = types.EmptyWithdrawalsHash
+				head.WithdrawalsHash = &types.EmptyWithdrawalsHash
 			}
 
 			// EIP-4788: The parentBeaconBlockRoot of the genesis block is always

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -447,6 +447,7 @@ func (g *Genesis) ToBlock() *types.Block {
 		if conf.IsCancun(num, g.Timestamp) {
 			if conf.Parlia != nil {
 				head.WithdrawalsHash = new(common.Hash)
+				*head.WithdrawalsHash = types.EmptyWithdrawalsHash
 			}
 
 			// EIP-4788: The parentBeaconBlockRoot of the genesis block is always

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -183,7 +183,7 @@ func (h *Header) SanityCheck() error {
 // that is: no transactions, no uncles and no withdrawals.
 func (h *Header) EmptyBody() bool {
 	if h.WithdrawalsHash != nil {
-		return h.TxHash == EmptyTxsHash && (*h.WithdrawalsHash == EmptyWithdrawalsHash || *h.WithdrawalsHash == common.Hash{})
+		return h.TxHash == EmptyTxsHash && *h.WithdrawalsHash == EmptyWithdrawalsHash
 	}
 	return h.TxHash == EmptyTxsHash && h.UncleHash == EmptyUncleHash
 }
@@ -195,8 +195,7 @@ func (h *Header) EmptyReceipts() bool {
 
 // EmptyWithdrawalsHash returns true if there are no WithdrawalsHash for this header/block.
 func (h *Header) EmptyWithdrawalsHash() bool {
-	// TODO(GalaIO): if check EmptyWithdrawalsHash in here?
-	return h.WithdrawalsHash == nil || *h.WithdrawalsHash == common.Hash{}
+	return h.WithdrawalsHash == nil || *h.WithdrawalsHash == EmptyWithdrawalsHash
 }
 
 // Body is a simple (mutable, non-safe) data container for storing and moving

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -874,7 +874,7 @@ func getBody(block *types.Block) *engine.ExecutionPayloadBodyV1 {
 	}
 
 	// Post-shanghai withdrawals MUST be set to empty slice instead of nil
-	if withdrawals == nil && !block.Header().EmptyWithdrawalsHash() {
+	if withdrawals == nil && block.Header().WithdrawalsHash != nil {
 		withdrawals = make([]*types.Withdrawal, 0)
 	}
 

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1041,7 +1041,7 @@ func (b *Block) WithdrawalsRoot(ctx context.Context) (*common.Hash, error) {
 		return nil, err
 	}
 	// Pre-shanghai blocks
-	if header.EmptyWithdrawalsHash() {
+	if header.WithdrawalsHash == nil {
 		return nil, nil
 	}
 	return header.WithdrawalsHash, nil

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1517,7 +1517,7 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 	if head.BaseFee != nil {
 		result["baseFeePerGas"] = (*hexutil.Big)(head.BaseFee)
 	}
-	if !head.EmptyWithdrawalsHash() {
+	if head.WithdrawalsHash != nil {
 		result["withdrawalsRoot"] = head.WithdrawalsHash
 	}
 	if head.BlobGasUsed != nil {
@@ -1561,7 +1561,7 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 		uncleHashes[i] = uncle.Hash()
 	}
 	fields["uncles"] = uncleHashes
-	if !block.Header().EmptyWithdrawalsHash() {
+	if block.Header().WithdrawalsHash != nil {
 		fields["withdrawals"] = block.Withdrawals()
 	}
 	return fields

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1014,8 +1014,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		header.BlobGasUsed = new(uint64)
 		header.ExcessBlobGas = &excessBlobGas
 		if w.chainConfig.Parlia != nil {
-			header.WithdrawalsHash = new(common.Hash)
-			*header.WithdrawalsHash = types.EmptyWithdrawalsHash
+			header.WithdrawalsHash = &types.EmptyWithdrawalsHash
 		}
 		if w.chainConfig.Parlia == nil {
 			header.ParentBeaconRoot = genParams.beaconRoot

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1015,6 +1015,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		header.ExcessBlobGas = &excessBlobGas
 		if w.chainConfig.Parlia != nil {
 			header.WithdrawalsHash = new(common.Hash)
+			*header.WithdrawalsHash = types.EmptyWithdrawalsHash
 		}
 		if w.chainConfig.Parlia == nil {
 			header.ParentBeaconRoot = genParams.beaconRoot


### PR DESCRIPTION
### Description

This PR uses `types.EmptyWithdrawalsHash` as default empty withdrawal hash for parlia cancun.


Notable changes: 
* cancun: change empty withdrawHash value of header;
* ...
