### PR TITLE
core: fix block report when chain is not setHead

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2136,7 +2136,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			snapDiffItems, snapBufItems, _ = bc.snaps.Size()
 		}
 		trieDiffNodes, trieBufNodes, trieImmutableBufNodes, _ := bc.triedb.Size()
-		stats.report(chain, it.index, snapDiffItems, snapBufItems, trieDiffNodes, trieBufNodes, trieImmutableBufNodes, setHead)
+		stats.report(chain, it.index, snapDiffItems, snapBufItems, trieDiffNodes, trieBufNodes, trieImmutableBufNodes, status == CanonStatTy)
 
 		if !setHead {
 			// After merge we expect few side chains. Simply count


### PR DESCRIPTION
### Description

core: fix block report when chain is not setHead

### Rationale

logInfo `Imported new chain segment` is misleading
to address issue https://github.com/bnb-chain/bsc/issues/2212

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
