### PR TITLE
docs: add changelog and new version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v1.3.13
+* [\#2358](https://github.com/bnb-chain/bsc/pull/2358) doc: add Feynman upgrade for mainnet
+* [\#2335](https://github.com/bnb-chain/bsc/pull/2335) upgrade: update system contracts bytes code and hardfork time of Feynman upgrade
 
 ## v1.3.12
 BUGFIX

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 3  // Minor version component of the current release
-	VersionPatch = 12 // Patch version component of the current release
+	VersionPatch = 13 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
This PR prepare for the release v1.3.13.

### Rationale

Change logs:
* [\#2358](https://github.com/bnb-chain/bsc/pull/2358) doc: add Feynman upgrade for mainnet
* [\#2335](https://github.com/bnb-chain/bsc/pull/2335) upgrade: update system contracts bytes code and hardfork time of Feynman upgrade


### Example
None
### Changes

All client on BSC mainnet should upgrade to this version
