### PR TITLE
triedb: do not open state freezer under notries

### DIFF
--- a/triedb/database.go
+++ b/triedb/database.go
@@ -116,6 +116,9 @@ func NewDatabase(diskdb ethdb.Database, config *Config) *Database {
 			config.HashDB = hashdb.Defaults
 		}
 	}
+	if config.PathDB != nil && config.NoTries {
+		config.PathDB.NoTries = true
+	}
 	var preimages *preimageStore
 	if config.Preimages {
 		preimages = newPreimageStore(triediskdb)

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -101,6 +101,7 @@ type Config struct {
 	CleanCacheSize int    // Maximum memory allowance (in bytes) for caching clean nodes
 	DirtyCacheSize int    // Maximum memory allowance (in bytes) for caching dirty nodes
 	ReadOnly       bool   // Flag whether the database is opened in read only mode.
+	NoTries        bool
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -174,7 +175,7 @@ func New(diskdb ethdb.Database, config *Config) *Database {
 	// Because the freezer can only be opened once at the same time, this
 	// mechanism also ensures that at most one **non-readOnly** database
 	// is opened at the same time to prevent accidental mutation.
-	if ancient, err := diskdb.AncientDatadir(); err == nil && ancient != "" && !db.readOnly {
+	if ancient, err := diskdb.AncientDatadir(); err == nil && ancient != "" && !db.readOnly && !config.NoTries {
 		offset := uint64(0) // differ from in block data, only metadata is used in state data
 		freezer, err := rawdb.NewStateFreezer(ancient, false, offset)
 		if err != nil {


### PR DESCRIPTION
### Description
This PR fixes a bug on v1.4.x BSC version where a pruned fast node cannot be initialized properly.

### Rationale
State freezer is introduced in PBSS. When a full node is converted to a fast node (i.e. via prune state), state freezer is no longer needed. However, the current implementation still opens a state freezer even though it's a fast node, which immediately throws an error and causes the node to not be able to start at all. This fix adds a rule such that if the configuration states that `NoTries = true`, then the node doesn't need to open the state freezer.