### PR TITLE
fix: don't switch to snapsync for fast node

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -218,7 +218,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 			}
 			h.snapSync.Store(true)
 			log.Warn("Switch sync mode from full sync to snap sync", "reason", "snap sync incomplete")
-		} else if !h.chain.HasState(fullBlock.Root) {
+		} else if !h.chain.NoTries() && !h.chain.HasState(fullBlock.Root) {
 			h.snapSync.Store(true)
 			log.Warn("Switch sync mode from full sync to snap sync", "reason", "head state missing")
 		}

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -213,7 +213,7 @@ func (cs *chainSyncer) modeAndLocalHead() (downloader.SyncMode, *big.Int) {
 	// We are in a full sync, but the associated head state is missing. To complete
 	// the head state, forcefully rerun the snap sync. Note it doesn't mean the
 	// persistent state is corrupted, just mismatch with the head block.
-	if !cs.handler.chain.HasState(head.Root) {
+	if !cs.handler.chain.NoTries() && !cs.handler.chain.HasState(head.Root) {
 		block := cs.handler.chain.CurrentSnapBlock()
 		td := cs.handler.chain.GetTd(block.Hash(), block.Number.Uint64())
 		log.Info("Reenabled snap sync as chain is stateless")


### PR DESCRIPTION
### Description
Noticed fast node printed this log and switched to snap sync:
```
Switch sync mode from full sync to snap sync reason="head state missing"
```
But fast node can not support snap sync, as it does not have trie node.
Actually it is bug caused by this commit, which removed the NoTrie() check by mistake: https://github.com/bnb-chain/bsc/pull/2200/commits/93d652bad37f6e5d369f2bf2dcdcbf1984f68e67

### Rationale
NA

### Example
NA
### Changes
NA