### PR TITLE
core: stateDb has no trie and no snap return err

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -396,7 +396,20 @@ func (bc *BlockChain) State() (*state.StateDB, error) {
 
 // StateAt returns a new mutable state based on a particular point in time.
 func (bc *BlockChain) StateAt(root common.Hash) (*state.StateDB, error) {
-	return state.New(root, bc.stateCache, bc.snaps)
+	stateDb, err := state.New(root, bc.stateCache, bc.snaps)
+	if err != nil {
+		return nil, err
+	}
+
+	// If there's no trie and the specified snapshot is not available, getting
+	// any state will by default return nil.
+	// Instead of that, it will be more useful to return an error to indicate
+	// the state is not available.
+	if stateDb.NoTrie() && stateDb.GetSnap() == nil {
+		return nil, errors.New("state is not available")
+	}
+
+	return stateDb, err
 }
 
 // Config retrieves the chain's fork configuration.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1896,6 +1896,10 @@ func (s *StateDB) convertAccountSet(set map[common.Address]*types.StateAccount) 
 	return ret
 }
 
+func (s *StateDB) GetSnap() snapshot.Snapshot {
+	return s.snap
+}
+
 // copySet returns a deep-copied set.
 func copySet[k comparable](set map[k][]byte) map[k][]byte {
 	copied := make(map[k][]byte, len(set))


### PR DESCRIPTION
### Description
This PR adds a check to `Blockchain.StateAt()` such that if the node is a fast node (i.e. NoTrie = true) and the snap layer cannot be found, then it will return an error. 

### Rationale
Refer to #2331.

By default, a fast node will have an empty trie for any state. Retrieving a value from an empty trie will give `0x00...00`. It may be confusing for users as `0x00...00` could also be the actual value. Hence, it's more useful to throw an error when the state is not available. 

### Example
Command
```
curl -H 'Content-Type: application/json'  -X POST --data '{"jsonrpc":"2.0", "method": "eth_getStorageAt", "params": ["0x00020F14443e103A0B72F1f2DFDaac07DDAa6Df5", "0x0", "0x237f199"], "id": 1}' http://127.0.0.1:8545
```

Output
```
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"state is not available"}}
```

### Changes
- Add `StateDB.GetSnap()`