### PR TITLE
Draft release v1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+## v1.4.5
+### FEATURE
+* [\#2378](https://github.com/bnb-chain/bsc/pull/2378) config: setup Testnet Tycho(Cancun) hardfork date
+
+### IMPROVEMENT
+* [\#2333](https://github.com/bnb-chain/bsc/pull/2333) remove code that will not be executed
+* [\#2369](https://github.com/bnb-chain/bsc/pull/2369) core: stateDb has no trie and no snap return err
+
+### BUGFIX
+* [\#2359](https://github.com/bnb-chain/bsc/pull/2359) triedb: do not open state freezer under notries
+
 ## v1.4.4
 ### FEATURE
 * [\#2279](https://github.com/bnb-chain/bsc/pull/2279) BlobTx: implement EIP-4844 on BSC

--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -358,7 +358,6 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	// Now replace file contents
 	if err := forceCopyFile(file, cachetestAccounts[1].URL.Path); err != nil {
 		t.Fatal(err)
-		return
 	}
 	wantAccounts = []accounts.Account{cachetestAccounts[1]}
 	wantAccounts[0].URL = accounts.URL{Scheme: KeyStoreScheme, Path: file}
@@ -374,7 +373,6 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	// Now replace file contents again
 	if err := forceCopyFile(file, cachetestAccounts[2].URL.Path); err != nil {
 		t.Fatal(err)
-		return
 	}
 	wantAccounts = []accounts.Account{cachetestAccounts[2]}
 	wantAccounts[0].URL = accounts.URL{Scheme: KeyStoreScheme, Path: file}
@@ -390,7 +388,6 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	// Now replace file contents with crap
 	if err := os.WriteFile(file, []byte("foo"), 0600); err != nil {
 		t.Fatal(err)
-		return
 	}
 	if err := waitForAccounts([]accounts.Account{}, ks); err != nil {
 		t.Errorf("Emptying account file failed")

--- a/consensus/clique/snapshot_test.go
+++ b/consensus/clique/snapshot_test.go
@@ -467,7 +467,6 @@ func (tt *cliqueTest) run(t *testing.T) {
 	for j := 0; j < len(batches)-1; j++ {
 		if k, err := chain.InsertChain(batches[j]); err != nil {
 			t.Fatalf("failed to import batch %d, block %d: %v", j, k, err)
-			break
 		}
 	}
 	if _, err = chain.InsertChain(batches[len(batches)-1]); err != tt.failure {

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -396,7 +396,20 @@ func (bc *BlockChain) State() (*state.StateDB, error) {
 
 // StateAt returns a new mutable state based on a particular point in time.
 func (bc *BlockChain) StateAt(root common.Hash) (*state.StateDB, error) {
-	return state.New(root, bc.stateCache, bc.snaps)
+	stateDb, err := state.New(root, bc.stateCache, bc.snaps)
+	if err != nil {
+		return nil, err
+	}
+
+	// If there's no trie and the specified snapshot is not available, getting
+	// any state will by default return nil.
+	// Instead of that, it will be more useful to return an error to indicate
+	// the state is not available.
+	if stateDb.NoTrie() && stateDb.GetSnap() == nil {
+		return nil, errors.New("state is not available")
+	}
+
+	return stateDb, err
 }
 
 // Config retrieves the chain's fork configuration.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1896,6 +1896,10 @@ func (s *StateDB) convertAccountSet(set map[common.Address]*types.StateAccount) 
 	return ret
 }
 
+func (s *StateDB) GetSnap() snapshot.Snapshot {
+	return s.snap
+}
+
 // copySet returns a deep-copied set.
 func copySet[k comparable](set map[k][]byte) map[k][]byte {
 	copied := make(map[k][]byte, len(set))

--- a/eth/fetcher/block_fetcher_test.go
+++ b/eth/fetcher/block_fetcher_test.go
@@ -851,7 +851,6 @@ func testInvalidNumberAnnouncement(t *testing.T, light bool) {
 				continue
 			case <-time.After(1 * time.Second):
 				t.Fatal("announce timeout")
-				return
 			}
 		}
 	}

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -95,7 +95,6 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 			hash := rawdb.ReadCanonicalHash(db, i)
 			if header = rawdb.ReadHeader(db, hash, i); header == nil {
 				b.Fatalf("Error creating bloomBits data")
-				return
 			}
 			bc.AddBloom(uint(i-sectionIdx*sectionSize), header.Bloom)
 		}

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -822,12 +822,10 @@ func (test *udpV5Test) waitPacketOut(validate interface{}) (closed bool) {
 	}
 	if err == errTimeout {
 		test.t.Fatalf("timed out waiting for %v", exptype)
-		return false
 	}
 	ln := test.nodesByIP[string(dgram.to.IP)]
 	if ln == nil {
 		test.t.Fatalf("attempt to send to non-existing node %v", &dgram.to)
-		return false
 	}
 	codec := &testCodec{test: test, id: ln.ID()}
 	frame, p, err := codec.decodeFrame(dgram.data)

--- a/params/config.go
+++ b/params/config.go
@@ -187,13 +187,11 @@ var (
 		LondonBlock:         big.NewInt(31103030),
 		HertzBlock:          big.NewInt(31103030),
 		HertzfixBlock:       big.NewInt(35682300),
-		// UnixTime: 1702972800 is December 19, 2023 8:00:00 AM UTC
-		ShanghaiTime:   newUint64(1702972800),
-		KeplerTime:     newUint64(1702972800),
-		FeynmanTime:    newUint64(1710136800),
-		FeynmanFixTime: newUint64(1711342800),
-		// TODO(GalaIO): enable cancun fork time later
-		//CancunTime: newUint64(),
+		ShanghaiTime:        newUint64(1702972800), // 2023-12-19 8:00:00 AM UTC
+		KeplerTime:          newUint64(1702972800),
+		FeynmanTime:         newUint64(1710136800), // 2024-03-11 6:00:00 AM UTC
+		FeynmanFixTime:      newUint64(1711342800), // 2024-03-25 5:00:00 AM UTC
+		CancunTime:          newUint64(1713330442), // 2024-04-17 05:07:22 AM UTC
 
 		Parlia: &ParliaConfig{
 			Period: 3,

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 4  // Minor version component of the current release
-	VersionPatch = 4  // Patch version component of the current release
+	VersionPatch = 5  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -219,11 +219,9 @@ func runBenchmarkFile(b *testing.B, path string) {
 	m := make(map[string]StateTest)
 	if err := readJSONFile(path, &m); err != nil {
 		b.Fatal(err)
-		return
 	}
 	if len(m) != 1 {
 		b.Fatal("expected single benchmark in a file")
-		return
 	}
 	for _, t := range m {
 		t := t

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -116,6 +116,9 @@ func NewDatabase(diskdb ethdb.Database, config *Config) *Database {
 			config.HashDB = hashdb.Defaults
 		}
 	}
+	if config.PathDB != nil && config.NoTries {
+		config.PathDB.NoTries = true
+	}
 	var preimages *preimageStore
 	if config.Preimages {
 		preimages = newPreimageStore(triediskdb)

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -101,6 +101,7 @@ type Config struct {
 	CleanCacheSize int    // Maximum memory allowance (in bytes) for caching clean nodes
 	DirtyCacheSize int    // Maximum memory allowance (in bytes) for caching dirty nodes
 	ReadOnly       bool   // Flag whether the database is opened in read only mode.
+	NoTries        bool
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -174,7 +175,7 @@ func New(diskdb ethdb.Database, config *Config) *Database {
 	// Because the freezer can only be opened once at the same time, this
 	// mechanism also ensures that at most one **non-readOnly** database
 	// is opened at the same time to prevent accidental mutation.
-	if ancient, err := diskdb.AncientDatadir(); err == nil && ancient != "" && !db.readOnly {
+	if ancient, err := diskdb.AncientDatadir(); err == nil && ancient != "" && !db.readOnly && !config.NoTries {
 		offset := uint64(0) // differ from in block data, only metadata is used in state data
 		freezer, err := rawdb.NewStateFreezer(ancient, false, offset)
 		if err != nil {


### PR DESCRIPTION
### Description
Release v1.4.5 is a hard fork release for **BSC Chapel Testnet**, the HF name is: Tycho, it mainly support Cancun EIPs on BSC:
- a.[BEP-336: Implement EIP-4844: ProtoDanksharding](https://github.com/bnb-chain/BEPs/pull/336)
- b.[BEP-343: Implement EIP-1153: Transient storage opcodes](https://github.com/bnb-chain/BEPs/pull/343)
- c.[BEP-344: Implement EIP-6780: SELFDESTRUCT only in same transaction](https://github.com/bnb-chain/BEPs/pull/344)
- d.[BEP-342: Implement EIP-5656: MCOPY](https://github.com/bnb-chain/BEPs/pull/342)
- e.[BEP-345: Implement EIP-7516: BLOBBASEFEE opcode](https://github.com/bnb-chain/BEPs/pull/345)

But BSC won’t support “EIP-4788: BeaconRoot”, as there is no CL on BSC.

The target Tycho hard fork time will be:
- Testnet: 2024-04-17 05:07:22 AM UTC
- Mainnet: To be determined, could be around  Mid of Jun 2024

After `Tycho` hard fork, BSC will also support Blob Transaction, which will provide similar mechanism as Ethereum EIP-4844.  And BSC L2 rollup could take advantage of it to reduce the rollup cost.
If you have any question about it, pls refer: [FAQ: About EIP-4844 on BSC](https://forum.bnbchain.org/t/faq-about-eip-4844-on-bsc/2620)


### Change Log

**FEATURE**
* [\#2378](https://github.com/bnb-chain/bsc/pull/2378) config: setup Testnet Tycho(Cancun) hardfork date

**IMPROVEMENT**
* [\#2333](https://github.com/bnb-chain/bsc/pull/2333) remove code that will not be executed
* [\#2369](https://github.com/bnb-chain/bsc/pull/2369) core: stateDb has no trie and no snap return err

**BUGFIX**
* [\#2359](https://github.com/bnb-chain/bsc/pull/2359) triedb: do not open state freezer under notries


### Example
NA

### Compatibility
NA