### PR TITLE
internal/api: return empty array rather than nil

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1018,7 +1018,7 @@ func (s *BlockChainAPI) GetBlobSidecars(ctx context.Context, blockNrOrHash rpc.B
 		return nil, nil
 	}
 	blobSidecars, err := s.b.GetBlobSidecars(ctx, header.Hash())
-	if err != nil || len(blobSidecars) == 0 {
+	if err != nil {
 		return nil, nil
 	}
 	result := make([]map[string]interface{}, len(blobSidecars))


### PR DESCRIPTION
### Description

internal/api: return empty array rather than nil

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* internal/api: return empty array rather than nil
* ...
