### PR TITLE
fix: print value instead of pointer in ConfigCompatError

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -1270,7 +1270,7 @@ func newTimestampCompatError(what string, storedtime, newtime *uint64) *ConfigCo
 		NewTime:      newtime,
 		RewindToTime: 0,
 	}
-	if rew != nil {
+	if rew != nil && *rew != 0 {
 		err.RewindToTime = *rew - 1
 	}
 	return err
@@ -1280,7 +1280,13 @@ func (err *ConfigCompatError) Error() string {
 	if err.StoredBlock != nil {
 		return fmt.Sprintf("mismatching %s in database (have block %d, want block %d, rewindto block %d)", err.What, err.StoredBlock, err.NewBlock, err.RewindToBlock)
 	}
-	return fmt.Sprintf("mismatching %s in database (have timestamp %d, want timestamp %d, rewindto timestamp %d)", err.What, err.StoredTime, err.NewTime, err.RewindToTime)
+
+	if err.StoredTime == nil {
+		return fmt.Sprintf("mismatching %s in database (have timestamp nil, want timestamp %d, rewindto timestamp %d)", err.What, *err.NewTime, err.RewindToTime)
+	} else if err.NewTime == nil {
+		return fmt.Sprintf("mismatching %s in database (have timestamp %d, want timestamp nil, rewindto timestamp %d)", err.What, *err.StoredTime, err.RewindToTime)
+	}
+	return fmt.Sprintf("mismatching %s in database (have timestamp %d, want timestamp %d, rewindto timestamp %d)", err.What, *err.StoredTime, *err.NewTime, err.RewindToTime)
 }
 
 // Rules wraps ChainConfig and is merely syntactic sugar or can be used for functions


### PR DESCRIPTION
### Description

fix: print value instead of pointer in ConfigCompatError

### Rationale

two errors in func ConfigCompatError as error info in the above picture
1. RewindToTime overflow
for dev testnet, often set timebased hardfork to `0`, so they will be enabled same with London Block at genesis
for example in genesis.json
`
 "shanghaiTime": 0,
`
then we change it 
`
 "shanghaiTime": 1712889032,
`
and run `geth --datadir ./ init ./genesis.json,  then RewindToTime will overflow to the max of uint64 type

2.  err.StoredTime and err.NewTime are pointers, print them is meaningless, their value are desired

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
