### PR TITLE
fix: trieJournal format compatible old db format

### DIFF
--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -92,7 +92,7 @@ type layer interface {
 	// journal commits an entire diff hierarchy to disk into a single journal entry.
 	// This is meant to be used during shutdown to persist the layer without
 	// flattening everything down (bad for reorgs).
-	journal(w io.Writer) error
+	journal(w io.Writer, file bool) error
 }
 
 // Config contains the settings for database.
@@ -525,6 +525,13 @@ func (db *Database) GetAllRooHash() [][]string {
 
 	data = append(data, []string{"-1", db.tree.bottom().rootHash().String()})
 	return data
+}
+
+func (db *Database) IsEnableJournalFile() bool {
+	if len(db.config.JournalFilePath) == 0 {
+		return false
+	}
+	return true
 }
 
 func (db *Database) DeleteTrieJournal(writer ethdb.KeyValueWriter) error {

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -92,7 +92,7 @@ type layer interface {
 	// journal commits an entire diff hierarchy to disk into a single journal entry.
 	// This is meant to be used during shutdown to persist the layer without
 	// flattening everything down (bad for reorgs).
-	journal(w io.Writer, file bool) error
+	journal(w io.Writer, journalFile bool) error
 }
 
 // Config contains the settings for database.
@@ -528,10 +528,7 @@ func (db *Database) GetAllRooHash() [][]string {
 }
 
 func (db *Database) IsEnableJournalFile() bool {
-	if len(db.config.JournalFilePath) == 0 {
-		return false
-	}
-	return true
+	return len(db.config.JournalFilePath) != 0
 }
 
 func (db *Database) DeleteTrieJournal(writer ethdb.KeyValueWriter) error {

--- a/triedb/pathdb/difflayer_test.go
+++ b/triedb/pathdb/difflayer_test.go
@@ -165,6 +165,6 @@ func BenchmarkJournal(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		layer.journal(new(bytes.Buffer))
+		layer.journal(new(bytes.Buffer), false)
 	}
 }


### PR DESCRIPTION
### Description

If trieJournal is stored in the database, it retains the old journal format; if trieJournal writes to the journal file using the new journal format;

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
