### PR TITLE
fix: no import blocks before or equal to the finalized height

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -363,7 +363,6 @@ func (f *BlockFetcher) loop() {
 		}
 		// Import any queued blocks that could potentially fit
 		height := f.chainHeight()
-		finalizedHeight := f.chainFinalizedHeight()
 		for !f.queue.Empty() {
 			op := f.queue.PopItem()
 			hash := op.hash()
@@ -380,6 +379,7 @@ func (f *BlockFetcher) loop() {
 				break
 			}
 			// Otherwise if fresh and still unknown, try and import
+			finalizedHeight := f.chainFinalizedHeight()
 			if (number+maxUncleDist < height) || number <= finalizedHeight || (f.light && f.getHeader(hash) != nil) || (!f.light && f.getBlock(hash) != nil) {
 				f.forgetBlock(hash)
 				continue


### PR DESCRIPTION
### Description

fix: no import blocks before or equal to the finalized height

### Rationale

[Block imported below final block](https://github.com/bnb-chain/bsc/issues/2212) reported
this PR is to solve it

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
