### PR TITLE
cmd, p2p: filter peers by regex on name

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -145,6 +145,7 @@ var (
 		// utils.MinerNewPayloadTimeout,
 		utils.NATFlag,
 		utils.NoDiscoverFlag,
+		utils.PeerFilterPatternsFlag,
 		utils.DiscoveryV4Flag,
 		utils.DiscoveryV5Flag,
 		utils.InstanceFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -882,6 +882,11 @@ var (
 		Usage:    "Disables the peer discovery mechanism (manual peer addition)",
 		Category: flags.NetworkingCategory,
 	}
+	PeerFilterPatternsFlag = &cli.StringSliceFlag{
+		Name:     "peerfilter",
+		Usage:    "Disallow peers connection if peer name matches the given regular expressions",
+		Category: flags.NetworkingCategory,
+	}
 	DiscoveryV4Flag = &cli.BoolFlag{
 		Name:     "discovery.v4",
 		Aliases:  []string{"discv4"},
@@ -1547,6 +1552,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	}
 	if ctx.IsSet(NoDiscoverFlag.Name) {
 		cfg.NoDiscovery = true
+	}
+	if ctx.IsSet(PeerFilterPatternsFlag.Name) {
+		cfg.PeerFilterPatterns = ctx.StringSlice(PeerFilterPatternsFlag.Name)
 	}
 
 	CheckExclusive(ctx, DiscoveryV4Flag, NoDiscoverFlag)


### PR DESCRIPTION
### Description
This PR adds a new feature to filter peers by their names based on a set of customized regex patterns.

### Rationale
Some outdated versions of nodes running on BSC may keep connecting to a healthy set of peers and only consume information, but not return any useful data. Such nodes should be filtered out to save network bandwidth.

### Example
In the config file:
```
...
[Node.P2P]
PeerFilterPatterns = ["(?!)geth"]
...
```

An example of a false regexp pattern error message:
```
t=2024-04-18T06:02:10+0000 lvl=error msg="Failed to compile peer filter patterns" err="error parsing regexp: missing closing ): `abc(def`"

```
