### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters will much better. 

### DIFF
--- a/cmd/era/main.go
+++ b/cmd/era/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -182,7 +183,7 @@ func open(ctx *cli.Context, epoch uint64) (*era.Era, error) {
 // that the accumulator matches the expected value.
 func verify(ctx *cli.Context) error {
 	if ctx.Args().Len() != 1 {
-		return fmt.Errorf("missing accumulators file")
+		return errors.New("missing accumulators file")
 	}
 
 	roots, err := readHashes(ctx.Args().First())
@@ -203,7 +204,7 @@ func verify(ctx *cli.Context) error {
 	}
 
 	if len(entries) != len(roots) {
-		return fmt.Errorf("number of era1 files should match the number of accumulator hashes")
+		return errors.New("number of era1 files should match the number of accumulator hashes")
 	}
 
 	// Verify each epoch matches the expected root.


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters.