### PR TITLE
Add query limit to defend DDoS attack

### DIFF
--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -42,6 +42,7 @@ const (
 	// maxBlockFetchers is the max number of goroutines to spin up to pull blocks
 	// for the fee history calculation (mostly relevant for LES).
 	maxBlockFetchers = 4
+	maxQueryLimit    = 100
 )
 
 // blockFees represents a single block for processing
@@ -218,6 +219,9 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedL
 	maxFeeHistory := oracle.maxHeaderHistory
 	if len(rewardPercentiles) != 0 {
 		maxFeeHistory = oracle.maxBlockHistory
+	}
+	if len(rewardPercentiles) > maxQueryLimit {
+		return common.Big0, nil, nil, nil, fmt.Errorf("%w: over the query limit %d", errInvalidPercentile, maxQueryLimit)
 	}
 	if blocks > maxFeeHistory {
 		log.Warn("Sanitizing fee history length", "requested", blocks, "truncated", maxFeeHistory)


### PR DESCRIPTION
### Description

Add query limit to defend DDoS attack. Max allow 100 different percentiles in rewardPercentiles.

### Rationale

More bigger rewardPercentiles will enough to crash the serve. 

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* eth/gasprice/feehistory.go: add maxQueryLimit
