### PR TITLE
release: prepare for release v1.4.6

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,21 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
-*                               @zzzckck @zjubfd
+accounts/usbwallet              @karalabe
+accounts/scwallet               @gballet
+accounts/abi                    @gballet @MariusVanDerWijden
+cmd/clef                        @holiman
+consensus                       @karalabe
+core/                           @karalabe @holiman @rjl493456442
+eth/                            @karalabe @holiman @rjl493456442
+eth/catalyst/                   @gballet
+eth/tracers/                    @s1na
+graphql/                        @s1na
+les/                            @zsfelfoldi @rjl493456442
+light/                          @zsfelfoldi @rjl493456442
+node/                           @fjl
+p2p/                            @fjl @zsfelfoldi
+rpc/                            @fjl @holiman
+p2p/simulations                 @fjl
+p2p/protocols                   @fjl
+p2p/testing                     @fjl
+signer/                         @holiman

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,34 @@
 # Changelog
+## v1.4.6
+### FEATURE
+* [\#2227](https://github.com/bnb-chain/bsc/pull/2227) core: separated databases for block data
+* [\#2404](https://github.com/bnb-chain/bsc/pull/2404) cmd, p2p: filter peers by regex on name
+
+### IMPROVEMENT
+* [\#2201](https://github.com/bnb-chain/bsc/pull/2201) chore: render system bytecode by go:embed
+* [\#2363](https://github.com/bnb-chain/bsc/pull/2363) feat: greedy merge tx in bid
+* [\#2389](https://github.com/bnb-chain/bsc/pull/2389) deps: update prsym to solve warning about quic-go version
+* [\#2341](https://github.com/bnb-chain/bsc/pull/2341) core/trie: persist TrieJournal to journal file instead of kv database
+* [\#2395](https://github.com/bnb-chain/bsc/pull/2395) fix: trieJournal format compatible old db format
+* [\#2406](https://github.com/bnb-chain/bsc/pull/2406) feat: adaptive for loading journal file or journal kv during loadJournal
+* [\#2390](https://github.com/bnb-chain/bsc/pull/2390) chore: fix function names in comment
+* [\#2399](https://github.com/bnb-chain/bsc/pull/2399) chore: fix some typos in comments
+* [\#2408](https://github.com/bnb-chain/bsc/pull/2408) chore: fix some typos in comments
+* [\#2416](https://github.com/bnb-chain/bsc/pull/2416) fix: fix function names
+* [\#2424](https://github.com/bnb-chain/bsc/pull/2424) feat: recommit bid when newBidCh is empty to maximize mev reward
+* [\#2430](https://github.com/bnb-chain/bsc/pull/2430) fix: oom caused by non-discarded mev simulation env
+* [\#2428](https://github.com/bnb-chain/bsc/pull/2428) chore: add metric & log for blobTx
+* [\#2419](https://github.com/bnb-chain/bsc/pull/2419) metrics: add doublesign counter
+
+### BUGFIX
+* [\#2244](https://github.com/bnb-chain/bsc/pull/2244) cmd/geth: fix importBlock
+* [\#2391](https://github.com/bnb-chain/bsc/pull/2391) fix: print value instead of pointer in ConfigCompatError
+* [\#2398](https://github.com/bnb-chain/bsc/pull/2398) fix: no import blocks before or equal to the finalized height
+* [\#2401](https://github.com/bnb-chain/bsc/pull/2401) fix: allow fast node to rewind after abnormal shutdown
+* [\#2403](https://github.com/bnb-chain/bsc/pull/2403) fix: NPE
+* [\#2423](https://github.com/bnb-chain/bsc/pull/2423) eth/gasprice: add query limit to defend DDOS attack
+* [\#2425](https://github.com/bnb-chain/bsc/pull/2425) fix: adapt journal for cmd
+
 ## v1.4.5
 ### FEATURE
 * [\#2378](https://github.com/bnb-chain/bsc/pull/2378) config: setup Testnet Tycho(Cancun) hardfork date

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 4  // Minor version component of the current release
-	VersionPatch = 5  // Patch version component of the current release
+	VersionPatch = 6  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.4.6 is a maintenance release. It mainly includes 2 features and several enhancements.
The 2 features are:
- feature 1: [separated databases for block data](https://github.com/bnb-chain/bsc/pull/2227), it is an experimental feature for performance,  it is disabled by default.
- feature 2: [p2p: filter peers by regex on name](https://github.com/bnb-chain/bsc/pull/2404), it is for P2P connection,  to filter unwanted peers based on their names.

You may check the Change Log for detail.

### Change Log
FEATURE
* [\#2227](https://github.com/bnb-chain/bsc/pull/2227) core: separated databases for block data
* [\#2404](https://github.com/bnb-chain/bsc/pull/2404) cmd, p2p: filter peers by regex on name

IMPROVEMENT
* [\#2201](https://github.com/bnb-chain/bsc/pull/2201) chore: render system bytecode by go:embed
* [\#2363](https://github.com/bnb-chain/bsc/pull/2363) feat: greedy merge tx in bid
* [\#2389](https://github.com/bnb-chain/bsc/pull/2389) deps: update prsym to solve warning about quic-go version
* [\#2341](https://github.com/bnb-chain/bsc/pull/2341) core/trie: persist TrieJournal to journal file instead of kv database
* [\#2395](https://github.com/bnb-chain/bsc/pull/2395) fix: trieJournal format compatible old db format
* [\#2406](https://github.com/bnb-chain/bsc/pull/2406) feat: adaptive for loading journal file or journal kv during loadJournal
* [\#2424](https://github.com/bnb-chain/bsc/pull/2424) feat: recommit bid when newBidCh is empty to maximize mev reward
* [\#2430](https://github.com/bnb-chain/bsc/pull/2430) fix: oom caused by non-discarded mev simulation env
* [\#2428](https://github.com/bnb-chain/bsc/pull/2428) chore: add metric & log for blobTx
* [\#2419](https://github.com/bnb-chain/bsc/pull/2419) metrics: add doublesign counter

BUGFIX
* [\#2244](https://github.com/bnb-chain/bsc/pull/2244) cmd/geth: fix importBlock
* [\#2391](https://github.com/bnb-chain/bsc/pull/2391) fix: print value instead of pointer in ConfigCompatError
* [\#2398](https://github.com/bnb-chain/bsc/pull/2398) fix: no import blocks before or equal to the finalized height
* [\#2401](https://github.com/bnb-chain/bsc/pull/2401) fix: allow fast node to rewind after abnormal shutdown
* [\#2403](https://github.com/bnb-chain/bsc/pull/2403) fix: NPE
* [\#2423](https://github.com/bnb-chain/bsc/pull/2423) eth/gasprice: add query limit to defend DDOS attack
* [\#2425](https://github.com/bnb-chain/bsc/pull/2425) fix: adapt journal for cmd


### Example
NA

### Compatibility
NA