### PR TITLE
chore: add metric & log for blobTx;

### DIFF
--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -48,16 +48,19 @@ func (st *insertStats) report(chain []*types.Block, index int, snapDiffItems, sn
 	// If we're at the last block of the batch or report period reached, log
 	if index == len(chain)-1 || elapsed >= statsReportLimit {
 		// Count the number of transactions in this segment
-		var txs int
+		var txs, blobs int
 		for _, block := range chain[st.lastIndex : index+1] {
 			txs += len(block.Transactions())
+			for _, sidecar := range block.Sidecars() {
+				blobs += len(sidecar.Blobs)
+			}
 		}
 		end := chain[index]
 
 		// Assemble the log context and send it to the logger
 		context := []interface{}{
 			"number", end.Number(), "hash", end.Hash(), "miner", end.Coinbase(),
-			"blocks", st.processed, "txs", txs, "mgas", float64(st.usedGas) / 1000000,
+			"blocks", st.processed, "txs", txs, "blobs", blobs, "mgas", float64(st.usedGas) / 1000000,
 			"elapsed", common.PrettyDuration(elapsed), "mgasps", float64(st.usedGas) * 1000 / float64(elapsed),
 		}
 		if timestamp := time.Unix(int64(end.Time()), 0); time.Since(timestamp) > time.Minute {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -115,6 +115,7 @@ func (env *environment) copy() *environment {
 	if env.sidecars != nil {
 		cpy.sidecars = make(types.BlobSidecars, len(env.sidecars))
 		copy(cpy.sidecars, env.sidecars)
+		cpy.blobs = env.blobs
 	}
 
 	return cpy
@@ -1420,7 +1421,7 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 			select {
 			case w.taskCh <- &task{receipts: receipts, state: env.state, block: block, createdAt: time.Now()}:
 				log.Info("Commit new sealing work", "number", block.Number(), "sealhash", w.engine.SealHash(block.Header()),
-					"txs", env.tcount, "gas", block.GasUsed(), "fees", feesInEther, "elapsed", common.PrettyDuration(time.Since(start)))
+					"txs", env.tcount, "blobs", env.blobs, "gas", block.GasUsed(), "fees", feesInEther, "elapsed", common.PrettyDuration(time.Since(start)))
 
 			case <-w.exitCh:
 				log.Info("Worker has exited")


### PR DESCRIPTION
### Description

chore: add metric & log for blobTx;

The `IsDataAvaliblity` method costs fixed time for a certain node. However, the time may vary from machine to machine, adding the cost time metric for tracking. 

This PR also adds the number of blobs in the insert log.

### Changes

Notable changes: 
* chore: add metric & log for blobTx;
* ...
