### PR TITLE
release: prepare for release v1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+## v1.4.7
+### FEATURE
+* [\#2439](https://github.com/bnb-chain/bsc/pull/2439) config: setup Mainnet Tycho(Cancun) hardfork date
+
+### IMPROVEMENT
+* [\#2396](https://github.com/bnb-chain/bsc/pull/2396) metrics: add blockInsertMgaspsGauge to trace mgasps
+* [\#2411](https://github.com/bnb-chain/bsc/pull/2411) build(deps): bump golang.org/x/net from 0.19.0 to 0.23.0
+* [\#2435](https://github.com/bnb-chain/bsc/pull/2435) txpool: limit max gas when mining is enabled
+* [\#2438](https://github.com/bnb-chain/bsc/pull/2438) fix: performance issue when load journal
+* [\#2440](https://github.com/bnb-chain/bsc/pull/2440) nancy: add files .nancy-ignore
+
+### BUGFIX
+NA
+
 ## v1.4.6
 ### FEATURE
 * [\#2227](https://github.com/bnb-chain/bsc/pull/2227) core: separated databases for block data

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -110,7 +110,7 @@ type Config struct {
 	PipeCommit          bool
 	RangeLimit          bool
 
-	// Deprecated: use 'TransactionHistory' instead.
+	// Deprecated, use 'TransactionHistory' instead.
 	TxLookupLimit      uint64 `toml:",omitempty"` // The maximum number of blocks from head whose tx indices are reserved.
 	TransactionHistory uint64 `toml:",omitempty"` // The maximum number of blocks from head whose tx indices are reserved.
 	StateHistory       uint64 `toml:",omitempty"` // The maximum number of blocks from head whose state histories are reserved.

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 4  // Minor version component of the current release
-	VersionPatch = 6  // Patch version component of the current release
+	VersionPatch = 7  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.4.7 is a hard fork release for **BSC Mainnet**, the HF name is: Tycho, it mainly support Cancun EIPs on BSC:
- a.[BEP-336: Implement EIP-4844: ProtoDanksharding](https://github.com/bnb-chain/BEPs/pull/336)
- b.[BEP-343: Implement EIP-1153: Transient storage opcodes](https://github.com/bnb-chain/BEPs/pull/343)
- c.[BEP-344: Implement EIP-6780: SELFDESTRUCT only in same transaction](https://github.com/bnb-chain/BEPs/pull/344)
- d.[BEP-342: Implement EIP-5656: MCOPY](https://github.com/bnb-chain/BEPs/pull/342)
- e.[BEP-345: Implement EIP-7516: BLOBBASEFEE opcode](https://github.com/bnb-chain/BEPs/pull/345)

But BSC won’t support “EIP-4788: BeaconRoot”, as there is no CL on BSC.

The target Tycho hard fork time will be:
- Mainnet:  2024-06-20 06:05:00 AM UTC

After `Tycho` hard fork, BSC will also support Blob Transaction, which will provide similar mechanism as Ethereum EIP-4844.  And BSC L2 rollup could take advantage of it to reduce the rollup cost.
If you have any question about it, pls refer: [FAQ: About EIP-4844 on BSC](https://forum.bnbchain.org/t/faq-about-eip-4844-on-bsc/2620)

### Change Log

**FEATURE**
* [\#2439](https://github.com/bnb-chain/bsc/pull/2439) config: setup Mainnet Tycho(Cancun) hardfork date

**IMPROVEMENT**
* [\#2396](https://github.com/bnb-chain/bsc/pull/2396) metrics: add blockInsertMgaspsGauge to trace mgasps
* [\#2411](https://github.com/bnb-chain/bsc/pull/2411) build(deps): bump golang.org/x/net from 0.19.0 to 0.23.0
* [\#2435](https://github.com/bnb-chain/bsc/pull/2435) txpool: limit max gas when mining is enabled
* [\#2438](https://github.com/bnb-chain/bsc/pull/2438) fix: performance issue when load journal
* [\#2440](https://github.com/bnb-chain/bsc/pull/2440) nancy: add files .nancy-ignore

**BUGFIX**
NA

### Example
NA

### Compatibility
NA