### PR TITLE
core/forkchoice: improve stability when inturn block not generated

### DIFF
--- a/core/forkchoice.go
+++ b/core/forkchoice.go
@@ -114,7 +114,9 @@ func (f *ForkChoice) ReorgNeeded(current *types.Header, extern *types.Header) (b
 		if f.preserve != nil {
 			currentPreserve, externPreserve = f.preserve(current), f.preserve(extern)
 		}
-		reorg = !currentPreserve && (externPreserve || f.rand.Float64() < 0.5)
+		reorg = !currentPreserve && (externPreserve ||
+			extern.Time < current.Time ||
+			extern.Time == current.Time && f.rand.Float64() < 0.5)
 	}
 	return reorg, nil
 }


### PR DESCRIPTION
### Description

core/forkchoice: improve stablity when inturn block not generated

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
