### PR TITLE
eth/handler: check lists in body before broadcast blocks

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -66,6 +66,31 @@ func NewBlockValidator(config *params.ChainConfig, blockchain *BlockChain, engin
 	return validator
 }
 
+// ValidateListsInBody validates that UncleHash, WithdrawalsHash, and WithdrawalsHash correspond to the lists in the block body, respectively.
+func ValidateListsInBody(block *types.Block) error {
+	header := block.Header()
+	if hash := types.CalcUncleHash(block.Uncles()); hash != header.UncleHash {
+		return fmt.Errorf("uncle root hash mismatch (header value %x, calculated %x)", header.UncleHash, hash)
+	}
+	if hash := types.DeriveSha(block.Transactions(), trie.NewStackTrie(nil)); hash != header.TxHash {
+		return fmt.Errorf("transaction root hash mismatch: have %x, want %x", hash, header.TxHash)
+	}
+	// Withdrawals are present after the Shanghai fork.
+	if header.WithdrawalsHash != nil {
+		// Withdrawals list must be present in body after Shanghai.
+		if block.Withdrawals() == nil {
+			return errors.New("missing withdrawals in block body")
+		}
+		if hash := types.DeriveSha(block.Withdrawals(), trie.NewStackTrie(nil)); hash != *header.WithdrawalsHash {
+			return fmt.Errorf("withdrawals root hash mismatch (header value %x, calculated %x)", *header.WithdrawalsHash, hash)
+		}
+	} else if block.Withdrawals() != nil { // Withdrawals turn into empty from nil when BlockBody has Sidecars
+		// Withdrawals are not allowed prior to shanghai fork
+		return errors.New("withdrawals present in block body")
+	}
+	return nil
+}
+
 // ValidateBody validates the given block's uncles and verifies the block
 // header's transaction and uncle roots. The headers are assumed to be already
 // validated at this point.
@@ -83,31 +108,12 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	if err := v.engine.VerifyUncles(v.bc, block); err != nil {
 		return err
 	}
-	if hash := types.CalcUncleHash(block.Uncles()); hash != header.UncleHash {
-		return fmt.Errorf("uncle root hash mismatch (header value %x, calculated %x)", header.UncleHash, hash)
-	}
 
 	validateFuns := []func() error{
 		func() error {
-			if hash := types.DeriveSha(block.Transactions(), trie.NewStackTrie(nil)); hash != header.TxHash {
-				return fmt.Errorf("transaction root hash mismatch: have %x, want %x", hash, header.TxHash)
-			}
-			return nil
+			return ValidateListsInBody(block)
 		},
 		func() error {
-			// Withdrawals are present after the Shanghai fork.
-			if header.WithdrawalsHash != nil {
-				// Withdrawals list must be present in body after Shanghai.
-				if block.Withdrawals() == nil {
-					return errors.New("missing withdrawals in block body")
-				}
-				if hash := types.DeriveSha(block.Withdrawals(), trie.NewStackTrie(nil)); hash != *header.WithdrawalsHash {
-					return fmt.Errorf("withdrawals root hash mismatch (header value %x, calculated %x)", *header.WithdrawalsHash, hash)
-				}
-			} else if block.Withdrawals() != nil { // Withdrawals turn into empty from nil when BlockBody has Sidecars
-				// Withdrawals are not allowed prior to shanghai fork
-				return errors.New("withdrawals present in block body")
-			}
 			// Blob transactions may be present after the Cancun fork.
 			var blobs int
 			for i, tx := range block.Transactions() {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -320,26 +320,22 @@ func newHandler(config *handlerConfig) (*handler, error) {
 	}
 
 	broadcastBlockWithCheck := func(block *types.Block, propagate bool) {
-		// All the block fetcher activities should be disabled
-		// after the transition. Print the warning log.
-		if h.merger.PoSFinalized() {
-			log.Warn("Unexpected validation activity", "hash", block.Hash(), "number", block.Number())
-			return
-		}
-		// Reject all the PoS style headers in the first place. No matter
-		// the chain has finished the transition or not, the PoS headers
-		// should only come from the trusted consensus layer instead of
-		// p2p network.
-		if beacon, ok := h.chain.Engine().(*beacon.Beacon); ok {
-			if beacon.IsPoSHeader(block.Header()) {
-				log.Warn("unexpected post-merge header")
-				return
-			}
-		}
 		if propagate {
-			if err := core.IsDataAvailable(h.chain, block); err != nil {
-				log.Error("Propagating block with invalid sidecars", "number", block.Number(), "hash", block.Hash(), "err", err)
-				return
+			checkErrs := make(chan error, 2)
+
+			go func() {
+				checkErrs <- core.ValidateListsInBody(block)
+			}()
+			go func() {
+				checkErrs <- core.IsDataAvailable(h.chain, block)
+			}()
+
+			for i := 0; i < len(checkErrs); i++ {
+				err := <-checkErrs
+				if err != nil {
+					log.Error("Propagating invalid block", "number", block.Number(), "hash", block.Hash(), "err", err)
+					return
+				}
 			}
 		}
 		h.BroadcastBlock(block, propagate)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -330,7 +330,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 				checkErrs <- core.IsDataAvailable(h.chain, block)
 			}()
 
-			for i := 0; i < len(checkErrs); i++ {
+			for i := 0; i < cap(checkErrs); i++ {
 				err := <-checkErrs
 				if err != nil {
 					log.Error("Propagating invalid block", "number", block.Number(), "hash", block.Hash(), "err", err)


### PR DESCRIPTION
### Description

eth/handler: check lists in body before broadcast blocks

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
