### PR TITLE
sync: fix some sync issues caused by prune-block.

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -511,3 +511,12 @@ func (bc *BlockChain) SubscribeBlockProcessingEvent(ch chan<- bool) event.Subscr
 func (bc *BlockChain) SubscribeFinalizedHeaderEvent(ch chan<- FinalizedHeaderEvent) event.Subscription {
 	return bc.scope.Track(bc.finalizedHeaderFeed.Subscribe(ch))
 }
+
+// AncientTail retrieves the tail the ancients blocks
+func (bc *BlockChain) AncientTail() (uint64, error) {
+	tail, err := bc.db.Tail()
+	if err != nil {
+		return 0, err
+	}
+	return tail, nil
+}

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -239,7 +239,7 @@ func (f *Freezer) Ancient(kind string, number uint64) ([]byte, error) {
 //   - if maxBytes is not specified, 'count' items will be returned if they are present.
 func (f *Freezer) AncientRange(kind string, start, count, maxBytes uint64) ([][]byte, error) {
 	if table := f.tables[kind]; table != nil {
-		return table.RetrieveItems(start, count, maxBytes)
+		return table.RetrieveItems(start-f.offset, count, maxBytes)
 	}
 	return nil, errUnknownTable
 }
@@ -252,7 +252,7 @@ func (f *Freezer) Ancients() (uint64, error) {
 func (f *Freezer) TableAncients(kind string) (uint64, error) {
 	f.writeLock.RLock()
 	defer f.writeLock.RUnlock()
-	return f.tables[kind].items.Load(), nil
+	return f.tables[kind].items.Load() + f.offset, nil
 }
 
 // ItemAmountInAncient returns the actual length of current ancientDB.


### PR DESCRIPTION
### Description

When user prunes block too much, the node will not sync again. This PR reset the sync `floor`, and fixed the ancient query bug.

### Changes

Notable changes: 
* freezer: fix offset issues when query ancient;
* sync: opt pruned node sync logic;
