### PR TITLE
internal/ethapi: add optional parameter for blobSidecars

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -131,9 +131,9 @@ func (ec *Client) BlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumb
 }
 
 // BlobSidecars return the Sidecars of a given block number or hash.
-func (ec *Client) BlobSidecars(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, fullBlob bool) ([]*types.BlobTxSidecar, error) {
+func (ec *Client) BlobSidecars(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.BlobTxSidecar, error) {
 	var r []*types.BlobTxSidecar
-	err := ec.c.CallContext(ctx, &r, "eth_getBlobSidecars", blockNrOrHash.String(), fullBlob)
+	err := ec.c.CallContext(ctx, &r, "eth_getBlobSidecars", blockNrOrHash.String(), true)
 	if err == nil && r == nil {
 		return nil, ethereum.NotFound
 	}
@@ -141,9 +141,9 @@ func (ec *Client) BlobSidecars(ctx context.Context, blockNrOrHash rpc.BlockNumbe
 }
 
 // BlobSidecarByTxHash return a sidecar of a given blob transaction
-func (ec *Client) BlobSidecarByTxHash(ctx context.Context, hash common.Hash, fullBlob bool) (*types.BlobTxSidecar, error) {
+func (ec *Client) BlobSidecarByTxHash(ctx context.Context, hash common.Hash) (*types.BlobTxSidecar, error) {
 	var r *types.BlobTxSidecar
-	err := ec.c.CallContext(ctx, &r, "eth_getBlockSidecarByTxHash", hash, fullBlob)
+	err := ec.c.CallContext(ctx, &r, "eth_getBlockSidecarByTxHash", hash, true)
 	if err == nil && r == nil {
 		return nil, ethereum.NotFound
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1010,7 +1010,11 @@ func (s *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.
 	return result, nil
 }
 
-func (s *BlockChainAPI) GetBlobSidecars(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, fullBlob bool) ([]map[string]interface{}, error) {
+func (s *BlockChainAPI) GetBlobSidecars(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, fullBlob *bool) ([]map[string]interface{}, error) {
+	showBlob := true
+	if fullBlob != nil {
+		showBlob = *fullBlob
+	}
 	header, err := s.b.HeaderByNumberOrHash(ctx, blockNrOrHash)
 	if header == nil || err != nil {
 		// When the block doesn't exist, the RPC method should return JSON null
@@ -1023,12 +1027,16 @@ func (s *BlockChainAPI) GetBlobSidecars(ctx context.Context, blockNrOrHash rpc.B
 	}
 	result := make([]map[string]interface{}, len(blobSidecars))
 	for i, sidecar := range blobSidecars {
-		result[i] = marshalBlobSidecar(sidecar, fullBlob)
+		result[i] = marshalBlobSidecar(sidecar, showBlob)
 	}
 	return result, nil
 }
 
-func (s *BlockChainAPI) GetBlobSidecarByTxHash(ctx context.Context, hash common.Hash, fullBlob bool) (map[string]interface{}, error) {
+func (s *BlockChainAPI) GetBlobSidecarByTxHash(ctx context.Context, hash common.Hash, fullBlob *bool) (map[string]interface{}, error) {
+	showBlob := true
+	if fullBlob != nil {
+		showBlob = *fullBlob
+	}
 	txTarget, blockHash, _, Index := rawdb.ReadTransaction(s.b.ChainDb(), hash)
 	if txTarget == nil {
 		return nil, nil
@@ -1045,7 +1053,7 @@ func (s *BlockChainAPI) GetBlobSidecarByTxHash(ctx context.Context, hash common.
 	}
 	for _, sidecar := range blobSidecars {
 		if sidecar.TxIndex == Index {
-			return marshalBlobSidecar(sidecar, fullBlob), nil
+			return marshalBlobSidecar(sidecar, showBlob), nil
 		}
 	}
 

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -2224,42 +2224,42 @@ func TestGetBlobSidecarByTxHash(t *testing.T) {
 		fullBlob bool
 		file     string
 	}{
-		//// 0. txHash is empty
-		//{
-		//	test:     common.Hash{},
-		//	fullBlob: true,
-		//	file:     "hash-empty",
-		//},
-		//// 1. txHash is not found
-		//{
-		//	test:     common.HexToHash("deadbeef"),
-		//	fullBlob: true,
-		//	file:     "hash-notfound",
-		//},
-		//// 2. txHash is not blob tx
-		//{
-		//	test:     common.HexToHash("deadbeef"),
-		//	fullBlob: true,
-		//	file:     "not-blob-tx",
-		//},
-		//// 3. block with blob tx without sidecar
-		//{
-		//	test:     txHashs[5],
-		//	fullBlob: true,
-		//	file:     "block-with-blob-tx",
-		//},
+		// 0. txHash is empty
+		{
+			test:     common.Hash{},
+			fullBlob: true,
+			file:     "hash-empty",
+		},
+		// 1. txHash is not found
+		{
+			test:     common.HexToHash("deadbeef"),
+			fullBlob: true,
+			file:     "hash-notfound",
+		},
+		// 2. txHash is not blob tx
+		{
+			test:     common.HexToHash("deadbeef"),
+			fullBlob: true,
+			file:     "not-blob-tx",
+		},
+		// 3. block with blob tx without sidecar
+		{
+			test:     txHashs[5],
+			fullBlob: true,
+			file:     "block-with-blob-tx",
+		},
 		// 4. block with sidecar
 		{
 			test:     txHashs[6],
 			fullBlob: true,
 			file:     "block-with-blobSidecars",
 		},
-		//// 5. block show part blobs
-		//{
-		//	test:     txHashs[6],
-		//	fullBlob: false,
-		//	file:     "block-with-blobSidecars-show-little",
-		//},
+		// 5. block show part blobs
+		{
+			test:     txHashs[6],
+			fullBlob: false,
+			file:     "block-with-blobSidecars-show-little",
+		},
 	}
 
 	for i, tt := range testSuite {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -2204,7 +2204,7 @@ func TestRPCGetBlobSidecars(t *testing.T) {
 			result interface{}
 			err    error
 		)
-		result, err = api.GetBlobSidecars(context.Background(), tt.test, tt.fullBlob)
+		result, err = api.GetBlobSidecars(context.Background(), tt.test, &tt.fullBlob)
 		if err != nil {
 			t.Errorf("test %d: want no error, have %v", i, err)
 			continue
@@ -2224,42 +2224,42 @@ func TestGetBlobSidecarByTxHash(t *testing.T) {
 		fullBlob bool
 		file     string
 	}{
-		// 0. txHash is empty
-		{
-			test:     common.Hash{},
-			fullBlob: true,
-			file:     "hash-empty",
-		},
-		// 1. txHash is not found
-		{
-			test:     common.HexToHash("deadbeef"),
-			fullBlob: true,
-			file:     "hash-notfound",
-		},
-		// 2. txHash is not blob tx
-		{
-			test:     common.HexToHash("deadbeef"),
-			fullBlob: true,
-			file:     "not-blob-tx",
-		},
-		// 3. block with blob tx without sidecar
-		{
-			test:     txHashs[5],
-			fullBlob: true,
-			file:     "block-with-blob-tx",
-		},
+		//// 0. txHash is empty
+		//{
+		//	test:     common.Hash{},
+		//	fullBlob: true,
+		//	file:     "hash-empty",
+		//},
+		//// 1. txHash is not found
+		//{
+		//	test:     common.HexToHash("deadbeef"),
+		//	fullBlob: true,
+		//	file:     "hash-notfound",
+		//},
+		//// 2. txHash is not blob tx
+		//{
+		//	test:     common.HexToHash("deadbeef"),
+		//	fullBlob: true,
+		//	file:     "not-blob-tx",
+		//},
+		//// 3. block with blob tx without sidecar
+		//{
+		//	test:     txHashs[5],
+		//	fullBlob: true,
+		//	file:     "block-with-blob-tx",
+		//},
 		// 4. block with sidecar
 		{
 			test:     txHashs[6],
 			fullBlob: true,
 			file:     "block-with-blobSidecars",
 		},
-		// 4. block show part blobs
-		{
-			test:     txHashs[6],
-			fullBlob: false,
-			file:     "block-with-blobSidecars-show-little",
-		},
+		//// 5. block show part blobs
+		//{
+		//	test:     txHashs[6],
+		//	fullBlob: false,
+		//	file:     "block-with-blobSidecars-show-little",
+		//},
 	}
 
 	for i, tt := range testSuite {
@@ -2267,7 +2267,7 @@ func TestGetBlobSidecarByTxHash(t *testing.T) {
 			result interface{}
 			err    error
 		)
-		result, err = api.GetBlobSidecarByTxHash(context.Background(), tt.test, tt.fullBlob)
+		result, err = api.GetBlobSidecarByTxHash(context.Background(), tt.test, &tt.fullBlob)
 		if err != nil {
 			t.Errorf("test %d: want no error, have %v", i, err)
 			continue

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -617,12 +617,12 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'getBlobSidecars',
 			call: 'eth_getBlobSidecars',
-			params: 2,
+			params: 1,
 		}),
 		new web3._extend.Method({
 			name: 'getBlobSidecarByTxHash',
 			call: 'eth_getBlobSidecarByTxHash',
-			params: 2,
+			params: 1,
 		}),
 	],
 	properties: [

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -612,12 +612,12 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'getBlockReceipts',
 			call: 'eth_getBlockReceipts',
-			params: 1,
+			params: 2,
 		}),
 		new web3._extend.Method({
 			name: 'getBlobSidecars',
 			call: 'eth_getBlobSidecars',
-			params: 1,
+			params: 2,
 		}),
 		new web3._extend.Method({
 			name: 'getBlobSidecarByTxHash',

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -612,7 +612,7 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'getBlockReceipts',
 			call: 'eth_getBlockReceipts',
-			params: 2,
+			params: 1,
 		}),
 		new web3._extend.Method({
 			name: 'getBlobSidecars',
@@ -622,7 +622,7 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'getBlobSidecarByTxHash',
 			call: 'eth_getBlobSidecarByTxHash',
-			params: 1,
+			params: 2,
 		}),
 	],
 	properties: [


### PR DESCRIPTION
### Description

Make the param showBlob optional, user don't need change the way to query blobs, even if they don't add the bool param it work as before.

### Rationale
The two way both works now.
```
{"jsonrpc":"2.0","method":"eth_getBlobSidecars","params":["latest", false],"id":1}]'
{"jsonrpc":"2.0","method":"eth_getBlobSidecars","params":["latest"],"id":1}]'
```

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
