### PR TITLE
fix: add mev method to console

### DIFF
--- a/eth/api_admin.go
+++ b/eth/api_admin.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -141,32 +140,4 @@ func (api *AdminAPI) ImportChain(file string) (bool, error) {
 		blocks = blocks[:0]
 	}
 	return true, nil
-}
-
-// MevRunning returns true if the validator accept bids from builder
-func (api *AdminAPI) MevRunning() bool {
-	return api.eth.APIBackend.MevRunning()
-}
-
-// StartMev starts mev. It notifies the miner to start to receive bids.
-func (api *AdminAPI) StartMev() {
-	api.eth.APIBackend.StartMev()
-}
-
-// StopMev stops mev. It notifies the miner to stop receiving bids from this moment,
-// but the bids before this moment would still been taken into consideration by mev.
-func (api *AdminAPI) StopMev() {
-	api.eth.APIBackend.StopMev()
-}
-
-// AddBuilder adds a builder to the bid simulator.
-// url is the endpoint of the builder, for example, "https://mev-builder.amazonaws.com",
-// if validator is equipped with sentry, ignore the url.
-func (api *AdminAPI) AddBuilder(builder common.Address, url string) error {
-	return api.eth.APIBackend.AddBuilder(builder, url)
-}
-
-// RemoveBuilder removes a builder from the bid simulator.
-func (api *AdminAPI) RemoveBuilder(builder common.Address) error {
-	return api.eth.APIBackend.RemoveBuilder(builder)
 }

--- a/eth/api_miner.go
+++ b/eth/api_miner.go
@@ -89,3 +89,31 @@ func (api *MinerAPI) SetEtherbase(etherbase common.Address) bool {
 func (api *MinerAPI) SetRecommitInterval(interval int) {
 	api.e.Miner().SetRecommitInterval(time.Duration(interval) * time.Millisecond)
 }
+
+// MevRunning returns true if the validator accept bids from builder
+func (api *MinerAPI) MevRunning() bool {
+	return api.e.APIBackend.MevRunning()
+}
+
+// StartMev starts mev. It notifies the miner to start to receive bids.
+func (api *MinerAPI) StartMev() {
+	api.e.APIBackend.StartMev()
+}
+
+// StopMev stops mev. It notifies the miner to stop receiving bids from this moment,
+// but the bids before this moment would still been taken into consideration by mev.
+func (api *MinerAPI) StopMev() {
+	api.e.APIBackend.StopMev()
+}
+
+// AddBuilder adds a builder to the bid simulator.
+// url is the endpoint of the builder, for example, "https://mev-builder.amazonaws.com",
+// if validator is equipped with sentry, ignore the url.
+func (api *MinerAPI) AddBuilder(builder common.Address, url string) error {
+	return api.e.APIBackend.AddBuilder(builder, url)
+}
+
+// RemoveBuilder removes a builder from the bid simulator.
+func (api *MinerAPI) RemoveBuilder(builder common.Address) error {
+	return api.e.APIBackend.RemoveBuilder(builder)
+}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -660,6 +660,30 @@ web3._extend({
 			call: 'miner_stop'
 		}),
 		new web3._extend.Method({
+			name: 'mevRunning',
+			call: 'miner_mevRunning'
+		}),
+		new web3._extend.Method({
+			name: 'startMev',
+			call: 'miner_startMev'
+		}),
+		new web3._extend.Method({
+			name: 'stopMev',
+			call: 'miner_stopMev'
+		}),
+		new web3._extend.Method({
+			name: 'addBuilder',
+			call: 'miner_addBuilder',
+			params: 2,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null]
+		}),
+		new web3._extend.Method({
+			name: 'removeBuilder',
+			call: 'miner_removeBuilder',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter]
+		}),
+		new web3._extend.Method({
 			name: 'setEtherbase',
 			call: 'miner_setEtherbase',
 			params: 1,


### PR DESCRIPTION
### Description

I think the mev commands are much more related to miner group, not admin group.
The command JS is missing so I made it up
`add mev operation to console`
```js
miner.mevRunning()
miner.startMev()
miner.stopMev()
miner.addBuilder("0xadd", "http://")
miner.removeBuilder("0xadd")
```

### Rationale

NA

### Example

NA

### Changes

NA