### PR TITLE
dev: ensure consistency in BPS bundle result

### DIFF
--- a/core/types/bid.go
+++ b/core/types/bid.go
@@ -42,11 +42,11 @@ func (b *BidArgs) ToBid(builder common.Address, signer Signer) (*Bid, error) {
 		return nil, err
 	}
 
-	if len(b.RawBid.NonRevertible) > len(txs) {
+	if len(b.RawBid.UnRevertible) > len(txs) {
 		return nil, fmt.Errorf("expect NonRevertible no more than %d", len(txs))
 	}
-	nonRevertibleHashes := mapset.NewThreadUnsafeSetWithSize[common.Hash](len(b.RawBid.NonRevertible))
-	nonRevertibleHashes.Append(b.RawBid.NonRevertible...)
+	unRevertibleHashes := mapset.NewThreadUnsafeSetWithSize[common.Hash](len(b.RawBid.UnRevertible))
+	unRevertibleHashes.Append(b.RawBid.UnRevertible...)
 
 	if len(b.PayBidTx) != 0 {
 		var payBidTx = new(Transaction)
@@ -59,15 +59,15 @@ func (b *BidArgs) ToBid(builder common.Address, signer Signer) (*Bid, error) {
 	}
 
 	bid := &Bid{
-		Builder:       builder,
-		BlockNumber:   b.RawBid.BlockNumber,
-		ParentHash:    b.RawBid.ParentHash,
-		Txs:           txs,
-		NonRevertible: nonRevertibleHashes,
-		GasUsed:       b.RawBid.GasUsed + b.PayBidTxGasUsed,
-		GasFee:        b.RawBid.GasFee,
-		BuilderFee:    b.RawBid.BuilderFee,
-		rawBid:        *b.RawBid,
+		Builder:      builder,
+		BlockNumber:  b.RawBid.BlockNumber,
+		ParentHash:   b.RawBid.ParentHash,
+		Txs:          txs,
+		UnRevertible: unRevertibleHashes,
+		GasUsed:      b.RawBid.GasUsed + b.PayBidTxGasUsed,
+		GasFee:       b.RawBid.GasFee,
+		BuilderFee:   b.RawBid.BuilderFee,
+		rawBid:       *b.RawBid,
 	}
 
 	if bid.BuilderFee == nil {
@@ -79,13 +79,13 @@ func (b *BidArgs) ToBid(builder common.Address, signer Signer) (*Bid, error) {
 
 // RawBid represents a raw bid from builder directly.
 type RawBid struct {
-	BlockNumber   uint64          `json:"blockNumber"`
-	ParentHash    common.Hash     `json:"parentHash"`
-	Txs           []hexutil.Bytes `json:"txs"`
-	NonRevertible []common.Hash   `json:"nonRevertible"`
-	GasUsed       uint64          `json:"gasUsed"`
-	GasFee        *big.Int        `json:"gasFee"`
-	BuilderFee    *big.Int        `json:"builderFee"`
+	BlockNumber  uint64          `json:"blockNumber"`
+	ParentHash   common.Hash     `json:"parentHash"`
+	Txs          []hexutil.Bytes `json:"txs"`
+	UnRevertible []common.Hash   `json:"unRevertible"`
+	GasUsed      uint64          `json:"gasUsed"`
+	GasFee       *big.Int        `json:"gasFee"`
+	BuilderFee   *big.Int        `json:"builderFee"`
 
 	hash atomic.Value
 }
@@ -164,14 +164,14 @@ func (b *RawBid) Hash() common.Hash {
 
 // Bid represents a bid.
 type Bid struct {
-	Builder       common.Address
-	BlockNumber   uint64
-	ParentHash    common.Hash
-	Txs           Transactions
-	NonRevertible mapset.Set[common.Hash]
-	GasUsed       uint64
-	GasFee        *big.Int
-	BuilderFee    *big.Int
+	Builder      common.Address
+	BlockNumber  uint64
+	ParentHash   common.Hash
+	Txs          Transactions
+	UnRevertible mapset.Set[common.Hash]
+	GasUsed      uint64
+	GasFee       *big.Int
+	BuilderFee   *big.Int
 
 	rawBid RawBid
 }

--- a/core/types/bid.go
+++ b/core/types/bid.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	mapset "github.com/deckarep/golang-set/v2"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -40,6 +42,12 @@ func (b *BidArgs) ToBid(builder common.Address, signer Signer) (*Bid, error) {
 		return nil, err
 	}
 
+	if len(b.RawBid.NonRevertible) > len(txs) {
+		return nil, fmt.Errorf("expect NonRevertible no more than %d", len(txs))
+	}
+	nonRevertibleHashes := mapset.NewThreadUnsafeSetWithSize[common.Hash](len(b.RawBid.NonRevertible))
+	nonRevertibleHashes.Append(b.RawBid.NonRevertible...)
+
 	if len(b.PayBidTx) != 0 {
 		var payBidTx = new(Transaction)
 		err = payBidTx.UnmarshalBinary(b.PayBidTx)
@@ -51,14 +59,15 @@ func (b *BidArgs) ToBid(builder common.Address, signer Signer) (*Bid, error) {
 	}
 
 	bid := &Bid{
-		Builder:     builder,
-		BlockNumber: b.RawBid.BlockNumber,
-		ParentHash:  b.RawBid.ParentHash,
-		Txs:         txs,
-		GasUsed:     b.RawBid.GasUsed + b.PayBidTxGasUsed,
-		GasFee:      b.RawBid.GasFee,
-		BuilderFee:  b.RawBid.BuilderFee,
-		rawBid:      *b.RawBid,
+		Builder:       builder,
+		BlockNumber:   b.RawBid.BlockNumber,
+		ParentHash:    b.RawBid.ParentHash,
+		Txs:           txs,
+		NonRevertible: nonRevertibleHashes,
+		GasUsed:       b.RawBid.GasUsed + b.PayBidTxGasUsed,
+		GasFee:        b.RawBid.GasFee,
+		BuilderFee:    b.RawBid.BuilderFee,
+		rawBid:        *b.RawBid,
 	}
 
 	if bid.BuilderFee == nil {
@@ -70,12 +79,13 @@ func (b *BidArgs) ToBid(builder common.Address, signer Signer) (*Bid, error) {
 
 // RawBid represents a raw bid from builder directly.
 type RawBid struct {
-	BlockNumber uint64          `json:"blockNumber"`
-	ParentHash  common.Hash     `json:"parentHash"`
-	Txs         []hexutil.Bytes `json:"txs"`
-	GasUsed     uint64          `json:"gasUsed"`
-	GasFee      *big.Int        `json:"gasFee"`
-	BuilderFee  *big.Int        `json:"builderFee"`
+	BlockNumber   uint64          `json:"blockNumber"`
+	ParentHash    common.Hash     `json:"parentHash"`
+	Txs           []hexutil.Bytes `json:"txs"`
+	NonRevertible []common.Hash   `json:"nonRevertible"`
+	GasUsed       uint64          `json:"gasUsed"`
+	GasFee        *big.Int        `json:"gasFee"`
+	BuilderFee    *big.Int        `json:"builderFee"`
 
 	hash atomic.Value
 }
@@ -154,13 +164,14 @@ func (b *RawBid) Hash() common.Hash {
 
 // Bid represents a bid.
 type Bid struct {
-	Builder     common.Address
-	BlockNumber uint64
-	ParentHash  common.Hash
-	Txs         Transactions
-	GasUsed     uint64
-	GasFee      *big.Int
-	BuilderFee  *big.Int
+	Builder       common.Address
+	BlockNumber   uint64
+	ParentHash    common.Hash
+	Txs           Transactions
+	NonRevertible mapset.Set[common.Hash]
+	GasUsed       uint64
+	GasFee        *big.Int
+	BuilderFee    *big.Int
 
 	rawBid RawBid
 }


### PR DESCRIPTION
### Description

This commit introduces a NonRevertible hash list within the RPC to address potential inconsistencies between the builder and validator during bundle operations. The builder sends a list of transaction hashes, which must be successfully executed, to the validator. If the validator cannot accurately execute the bundle, it refrains from packing that block. This mechanism ensures that both components maintain output consistency under the same input conditions, thereby preventing financial losses for searchers due to incorrect block inclusion.

### Rationale

This happened on BloxRoute builder before. The simulation runs fine on builder but one transaction in bundle somehow couldn't pass on validator, which costs searcher $$$$$

### Example

The builder sends the list of hashes from bundle txs that is no-revertible, to ensure the validator runs the MEV bundles right.

### Changes

Notable changes: 
* builder `SendBid` with `NonRevertible`
