### PR TITLE
fix: use warn level to print logs

### DIFF
--- a/triedb/pathdb/difflayer.go
+++ b/triedb/pathdb/difflayer.go
@@ -113,7 +113,7 @@ func (dl *diffLayer) node(owner common.Hash, path []byte, hash common.Hash, dept
 			// bubble up an error here. It shouldn't happen at all.
 			if n.Hash != hash {
 				dirtyFalseMeter.Mark(1)
-				log.Error("Unexpected trie node in diff layer", "owner", owner, "path", path, "expect", hash, "got", n.Hash)
+				log.Warn("Unexpected trie node in diff layer", "owner", owner, "path", path, "expect", hash, "got", n.Hash)
 				return nil, newUnexpectedNodeError("diff", hash, n.Hash, owner, path, n.Blob)
 			}
 			dirtyHitMeter.Mark(1)


### PR DESCRIPTION
### Description

Use warn level to print logs.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* N/A
