### PR TITLE
fix: fix inspect database error

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -769,7 +769,9 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		trieIter = db.StateStore().NewIterator(keyPrefix, nil)
 		defer trieIter.Release()
 	}
-	if db.BlockStore() != db {
+
+	blockStore := db.BlockStore()
+	if _, ok := blockStore.(*freezerdb); !ok {
 		blockIter = db.BlockStore().NewIterator(keyPrefix, nil)
 		defer blockIter.Release()
 	}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -138,6 +138,10 @@ func (frdb *freezerdb) SetBlockStore(block ethdb.Database) {
 	frdb.blockStore = block
 }
 
+func (frdb *freezerdb) HasSeparateBlockStore() bool {
+	return frdb.blockStore != nil
+}
+
 // Freeze is a helper method used for external testing to trigger and block until
 // a freeze cycle completes, without having to sleep for a minute to trigger the
 // automatic background run.
@@ -261,6 +265,10 @@ func (db *nofreezedb) BlockStore() ethdb.Database {
 
 func (db *nofreezedb) SetBlockStore(block ethdb.Database) {
 	db.blockStore = block
+}
+
+func (db *nofreezedb) HasSeparateBlockStore() bool {
+	return db.blockStore != nil
 }
 
 func (db *nofreezedb) BlockStoreReader() ethdb.Reader {
@@ -770,8 +778,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		defer trieIter.Release()
 	}
 
-	blockStore := db.BlockStore()
-	if _, ok := blockStore.(*freezerdb); !ok {
+	if db.HasSeparateBlockStore() {
 		blockIter = db.BlockStore().NewIterator(keyPrefix, nil)
 		defer blockIter.Release()
 	}

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -43,6 +43,10 @@ func (t *table) SetBlockStore(block ethdb.Database) {
 	panic("not implement")
 }
 
+func (t *table) HasSeparateBlockStore() bool {
+	panic("not implement")
+}
+
 // NewTable returns a database object that prefixes all keys with a given string.
 func NewTable(db ethdb.Database, prefix string) ethdb.Database {
 	return &table{

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -183,6 +183,7 @@ type StateStoreReader interface {
 type BlockStore interface {
 	BlockStore() Database
 	SetBlockStore(block Database)
+	HasSeparateBlockStore() bool
 }
 
 type BlockStoreReader interface {

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -44,6 +44,10 @@ func (db *Database) BlockStore() ethdb.Database {
 	return db
 }
 
+func (db *Database) HasSeparateBlockStore() bool {
+	return false
+}
+
 func (db *Database) SetBlockStore(block ethdb.Database) {
 	panic("not supported")
 }


### PR DESCRIPTION
### Description

When executing inspect, an error in judgment causes block data to be repeatedly traversed, resulting in a large amount of data being marked as unaccounted.


### Rationale

In Go, directly comparing two interface values for equality is generally unsafe, especially for complex types like the database interface ethdb.Database. This is because interface comparison checks not only their values but also whether their dynamic types match.

Add the `HasSeparateBlockStore` interface to indicate whether a separate block store is enabled.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
