### PR TITLE
release: prepare for release v1.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+## v1.4.8
+### FEATURE
+* [\#2483](https://github.com/bnb-chain/bsc/pull/2483) core/vm: add secp256r1 into PrecompiledContractsHaber
+* [\#2400](https://github.com/bnb-chain/bsc/pull/2400) RIP-7212: Precompile for secp256r1 Curve Support
+
+### IMPROVEMENT
+NA
+
+### BUGFIX
+NA
+
 ## v1.4.7
 ### FEATURE
 * [\#2439](https://github.com/bnb-chain/bsc/pull/2439) config: setup Mainnet Tycho(Cancun) hardfork date

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 4  // Minor version component of the current release
-	VersionPatch = 7  // Patch version component of the current release
+	VersionPatch = 8  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
Release v1.4.8 is a cut-in **hard fork release for BSC Testnet and Mainnet**, the HF name is: [Haber](https://forum.bnbchain.org/t/bnb-chain-roadmap-mainnet/936#h-4haber-wip-25), it only supports one BEP: [BEP-381: Precompile for secp256r1 Curve Support](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-381.md)

As there is strong demand for supporting of secp256r1 pre-compile contract, we decide to move it faster.
And BSC would use address 0x100, which is same as other major chains to make it easier for developers. 
Developers may refer this code on how to use this pre-compile contract: https://github.com/getclave/clave-contracts/blob/master/contracts/helpers/VerifierCaller.sol

The target Haber hard fork time will be:
- Testnet:  2024-05-29 06:07:00 AM UTC
- Mainnet:  2024-06-20 06:05:00 AM UTC

### Change Log
**FEATURE**
* [\#2483](https://github.com/bnb-chain/bsc/pull/2483) core/vm: add secp256r1 into PrecompiledContractsHaber
* [\#2400](https://github.com/bnb-chain/bsc/pull/2400) RIP-7212: Precompile for secp256r1 Curve Support

**IMPROVEMENT**
NA

**BUGFIX**
NA
### Example
NA

### Compatibility
NA