### PR TITLE
txpool: buffer so that we dont delete txs

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -361,7 +361,7 @@ func (pool *LegacyPool) loop() {
 		evict      = time.NewTicker(evictionInterval)
 		reannounce = time.NewTicker(reannounceInterval)
 		journal    = time.NewTicker(pool.config.Rejournal)
-		readd      = time.NewTicker(time.Minute) // Add a ticker to re-add buffered transactions periodically
+		readd      = time.NewTicker(time.Minute) // ticker to re-add buffered transactions periodically
 	)
 	defer report.Stop()
 	defer evict.Stop()


### PR DESCRIPTION
### Description

To ensure we don't have to let go of valid authentic transactions just because the txpool is full, here's a potential mechanism of keeping the transactions in memory which would have been otherwise deleted. Then time to time the txpool can be checked if it is truly full. If it is not then these buffered transactions can be included. 

### Rationale

This is to ensure we keep as many transactions as possible without significantly affecting networking. 

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
