### PR TITLE
fix: waiting for the last simulation before pick best bid

### DIFF
--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -29,11 +29,6 @@ import (
 const (
 	// maxBidPerBuilderPerBlock is the max bid number per builder
 	maxBidPerBuilderPerBlock = 3
-
-	// leftOverTimeRate is the rate of left over time to simulate a bid
-	leftOverTimeRate = 11
-	// leftOverTimeScale is the scale of left over time to simulate a bid
-	leftOverTimeScale = 10
 )
 
 var (

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -318,14 +318,6 @@ func (b *bidSimulator) newBidLoop() {
 
 	// commit aborts in-flight bid execution with given signal and resubmits a new one.
 	commit := func(reason int32, bidRuntime *BidRuntime) {
-		// if the left time is not enough to do simulation, return
-		delay := b.engine.Delay(b.chain, bidRuntime.env.header, &b.delayLeftOver)
-		if delay == nil || *delay <= 0 {
-			log.Info("BidSimulator: abort commit, not enough time to simulate",
-				"builder", bidRuntime.bid.Builder, "bidHash", bidRuntime.bid.Hash().Hex())
-			return
-		}
-
 		if interruptCh != nil {
 			// each commit work will have its own interruptCh to stop work with a reason
 			interruptCh <- reason
@@ -577,6 +569,14 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 		parentHash: bidRuntime.bid.ParentHash,
 		coinbase:   b.bidWorker.etherbase(),
 	}); err != nil {
+		return
+	}
+
+	// if the left time is not enough to do simulation, return
+	delay := b.engine.Delay(b.chain, bidRuntime.env.header, &b.delayLeftOver)
+	if delay == nil || *delay <= 0 {
+		log.Info("BidSimulator: abort commit, not enough time to simulate",
+			"builder", bidRuntime.bid.Builder, "bidHash", bidRuntime.bid.Hash().Hex())
 		return
 	}
 

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -394,11 +394,6 @@ func (b *bidSimulator) newBidLoop() {
 	}
 }
 
-func (b *bidSimulator) bidMustBefore(parentHash common.Hash) time.Time {
-	parentHeader := b.chain.GetHeaderByHash(parentHash)
-	return bidutil.BidMustBefore(parentHeader, b.chainConfig.Parlia.Period, b.delayLeftOver)
-}
-
 func (b *bidSimulator) bidBetterBefore(parentHash common.Hash) time.Time {
 	parentHeader := b.chain.GetHeaderByHash(parentHash)
 	return bidutil.BidBetterBefore(parentHeader, b.chainConfig.Parlia.Period, b.delayLeftOver, b.config.BidSimulationLeftOver)

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -647,14 +647,12 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 	if b.config.GreedyMergeTx {
 		delay := b.engine.Delay(b.chain, bidRuntime.env.header, &b.delayLeftOver)
 		if delay != nil && *delay > 0 {
-			stopTimer := time.NewTimer(*delay)
-
 			bidTxsSet := mapset.NewSet[common.Hash]()
 			for _, tx := range bidRuntime.bid.Txs {
 				bidTxsSet.Add(tx.Hash())
 			}
 
-			fillErr := b.bidWorker.fillTransactions(interruptCh, bidRuntime.env, stopTimer, bidTxsSet)
+			fillErr := b.bidWorker.fillTransactions(interruptCh, bidRuntime.env, nil, bidTxsSet)
 			log.Trace("BidSimulator: greedy merge stopped", "block", bidRuntime.env.header.Number,
 				"builder", bidRuntime.bid.Builder, "tx count", bidRuntime.env.tcount-bidTxLen+1, "err", fillErr)
 


### PR DESCRIPTION
### Description

fix: waiting for the last simulation before pick best bid

### Rationale

The final round of bid simulation is often interrupted by stopTimer and not fully packed, making it less competitive than local miner and degrading the mev experience.

So we take two steps to optimize it:
1. do not set a stop timer when the bid is packaged;
2. when the local miner fetches the best bid, wait a while for the bid that is being packaged at the time to finish job.

This is a short-term solution. It will be addressed in the long run with a more formal fix and be put into the next stable release.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
