### PR TITLE
perf: optimize chain commit performance for multi-database

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1783,7 +1783,6 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		if bc.chainConfig.IsCancun(block.Number(), block.Time()) {
 			rawdb.WriteBlobSidecars(blockBatch, block.Hash(), block.NumberU64(), block.Sidecars())
 		}
-		rawdb.WritePreimages(blockBatch, state.Preimages())
 		if err := blockBatch.Write(); err != nil {
 			log.Crit("Failed to write block into disk", "err", err)
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1300,6 +1300,7 @@ func (bc *BlockChain) ExportN(w io.Writer, first uint64, last uint64) error {
 // Note, this function assumes that the `mu` mutex is held!
 func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	bc.dbWg.Add(2)
+	defer bc.dbWg.Wait()
 	go func() {
 		defer bc.dbWg.Done()
 		// Add the block to the canonical chain number scheme and mark as the head
@@ -1336,8 +1337,6 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	headBlockGauge.Update(int64(block.NumberU64()))
 	justifiedBlockGauge.Update(int64(bc.GetJustifiedNumber(block.Header())))
 	finalizedBlockGauge.Update(int64(bc.getFinalizedNumber(block.Header())))
-
-	bc.dbWg.Wait()
 }
 
 // stopWithoutSaving stops the blockchain service. If any imports are currently in progress

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1138,7 +1138,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 	// If SetHead was only called as a chain reparation method, try to skip
 	// touching the header chain altogether, unless the freezer is broken
 	if repair {
-		if target, force := updateFn(bc.db, bc.CurrentBlock()); force {
+		if target, force := updateFn(bc.db.BlockStore(), bc.CurrentBlock()); force {
 			bc.hc.SetHead(target.Number.Uint64(), updateFn, delFn)
 		}
 	} else {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1305,14 +1305,13 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 		defer bc.dbWg.Done()
 		// Add the block to the canonical chain number scheme and mark as the head
 		blockBatch := bc.db.BlockStore().NewBatch()
-
 		rawdb.WriteCanonicalHash(blockBatch, block.Hash(), block.NumberU64())
 		rawdb.WriteHeadHeaderHash(blockBatch, block.Hash())
 		rawdb.WriteHeadBlockHash(blockBatch, block.Hash())
 		rawdb.WriteHeadFastBlockHash(blockBatch, block.Hash())
 		// Flush the whole batch into the disk, exit the node if failed
 		if err := blockBatch.Write(); err != nil {
-			log.Crit("Failed to update chain indexes and markers", "err", err)
+			log.Crit("Failed to update chain indexes and markers in block db", "err", err)
 		}
 	}()
 	go func() {
@@ -1323,7 +1322,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 
 		// Flush the whole batch into the disk, exit the node if failed
 		if err := batch.Write(); err != nil {
-			log.Crit("Failed to update chain indexes and markers", "err", err)
+			log.Crit("Failed to update chain indexes in chain db", "err", err)
 		}
 	}()
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -498,7 +498,7 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 	rawdb.WriteReceipts(db.BlockStore(), block.Hash(), block.NumberU64(), nil)
 	rawdb.WriteCanonicalHash(db.BlockStore(), block.Hash(), block.NumberU64())
 	rawdb.WriteHeadBlockHash(db.BlockStore(), block.Hash())
-	rawdb.WriteHeadFastBlockHash(db, block.Hash())
+	rawdb.WriteHeadFastBlockHash(db.BlockStore(), block.Hash())
 	rawdb.WriteHeadHeaderHash(db.BlockStore(), block.Hash())
 	rawdb.WriteChainConfig(db, block.Hash(), config)
 	return block, nil

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -668,7 +668,7 @@ func (hc *HeaderChain) setHead(headBlock uint64, headTime uint64, updateFn Updat
 		// first then remove the relative data from the database.
 		//
 		// Update head first(head fast block, head full block) before deleting the data.
-		markerBatch := hc.chainDb.NewBatch()
+		markerBatch := hc.chainDb.BlockStore().NewBatch()
 		if updateFn != nil {
 			newHead, force := updateFn(markerBatch, parent)
 			if force && ((headTime > 0 && newHead.Time < headTime) || (headTime == 0 && newHead.Number.Uint64() < headBlock)) {

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -677,7 +677,7 @@ func (hc *HeaderChain) setHead(headBlock uint64, headTime uint64, updateFn Updat
 			}
 		}
 		// Update head header then.
-		rawdb.WriteHeadHeaderHash(hc.chainDb.BlockStore(), parentHash)
+		rawdb.WriteHeadHeaderHash(markerBatch, parentHash)
 		if err := markerBatch.Write(); err != nil {
 			log.Crit("Failed to update chain markers", "error", err)
 		}

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -81,7 +81,7 @@ func InitDatabaseFromFreezer(db ethdb.Database) {
 	batch.Reset()
 
 	WriteHeadHeaderHash(db.BlockStore(), hash)
-	WriteHeadFastBlockHash(db, hash)
+	WriteHeadFastBlockHash(db.BlockStore(), hash)
 	log.Info("Initialized database from freezer", "blocks", frozen, "elapsed", common.PrettyDuration(time.Since(start)))
 }
 

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -1088,7 +1088,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 				hashNumPairings.Add(size)
 			default:
 				var accounted bool
-				for _, meta := range [][]byte{headHeaderKey, headFinalizedBlockKey} {
+				for _, meta := range [][]byte{headHeaderKey, headFinalizedBlockKey, headBlockKey, headFastBlockKey} {
 					if bytes.Equal(key, meta) {
 						metadata.Add(size)
 						accounted = true

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -1282,7 +1282,7 @@ func ReadChainMetadataFromMultiDatabase(db ethdb.Database) [][]string {
 	data := [][]string{
 		{"databaseVersion", pp(ReadDatabaseVersion(db))},
 		{"headBlockHash", fmt.Sprintf("%v", ReadHeadBlockHash(db.BlockStore()))},
-		{"headFastBlockHash", fmt.Sprintf("%v", ReadHeadFastBlockHash(db))},
+		{"headFastBlockHash", fmt.Sprintf("%v", ReadHeadFastBlockHash(db.BlockStore()))},
 		{"headHeaderHash", fmt.Sprintf("%v", ReadHeadHeaderHash(db.BlockStore()))},
 		{"lastPivotNumber", pp(ReadLastPivotNumber(db))},
 		{"len(snapshotSyncStatus)", fmt.Sprintf("%d bytes", len(ReadSnapshotSyncStatus(db)))},

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -873,7 +873,7 @@ func DataTypeByKey(key []byte) DataType {
 				return StateDataType
 			}
 		}
-		for _, meta := range [][]byte{headHeaderKey, headFinalizedBlockKey} {
+		for _, meta := range [][]byte{headHeaderKey, headFinalizedBlockKey, headBlockKey} {
 			if bytes.Equal(key, meta) {
 				return BlockDataType
 			}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -873,7 +873,7 @@ func DataTypeByKey(key []byte) DataType {
 				return StateDataType
 			}
 		}
-		for _, meta := range [][]byte{headHeaderKey, headFinalizedBlockKey, headBlockKey} {
+		for _, meta := range [][]byte{headHeaderKey, headFinalizedBlockKey, headBlockKey, headFastBlockKey} {
 			if bytes.Equal(key, meta) {
 				return BlockDataType
 			}


### PR DESCRIPTION
### Description

In a multi-database, the performance of the chain commit process degrades. The chain commit process mainly involves writing data; the performance drops when using multiple databases.

### Rationale

Optimization
* The BlockStore makes multiple calls to the rawdb interface, performing multiple batch writes. Encapsulating these into a single batch will improve performance.
* Currently, the process writes to BlockStore first and then to chaindb in a sequential manner. Parallelizing these two database writes using go routines will optimize the write process.

Impact
These optimizations result in a 10% performance improvement during the commit phase in a multi-database setup.
### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
