### PR TITLE
cmd/jsutils: add a tool to get performance between a range of blocks

### DIFF
--- a/cmd/jsutils/README.md
+++ b/cmd/jsutils/README.md
@@ -25,3 +25,14 @@ testnet validators version
 ```bash
 node gettxcount.js --rpc ${url} --startNum ${start} --endNum ${end} --miner ${miner} (optional)
 ```
+
+### 3. Get Performance
+```bash
+node get_perf.js --rpc ${url} --startNum ${start} --endNum ${end}
+```
+output as following
+```bash
+Get the performance between [ 19470 , 19670 )
+txCountPerBlock = 3142.81 txCountTotal = 628562 BlockCount = 200 avgBlockTime = 3.005 inturnBlocksRatio = 0.975
+txCountPerSecond = 1045.8602329450914 avgGasUsedPerBlock = 250.02062627 avgGasUsedPerSecond =  83.20153952412646
+```

--- a/cmd/jsutils/get_perf.js
+++ b/cmd/jsutils/get_perf.js
@@ -1,0 +1,58 @@
+import { ethers } from "ethers";
+import program from "commander";
+
+program.option("--rpc <rpc>", "Rpc");
+program.option("--startNum <startNum>", "start num")
+program.option("--endNum <endNum>", "end num")
+program.parse(process.argv);
+
+const provider = new ethers.JsonRpcProvider(program.rpc)
+
+const main = async () => {
+    let txCountTotal = 0;
+    let gasUsedTotal = 0;
+    let inturnBlocks = 0;
+    for (let i = program.startNum; i < program.endNum; i++) {
+        let txCount = await provider.send("eth_getBlockTransactionCountByNumber", [
+            ethers.toQuantity(i)]);
+        txCountTotal += ethers.toNumber(txCount)
+
+        let header = await provider.send("eth_getHeaderByNumber", [
+            ethers.toQuantity(i)]);
+        let gasUsed = eval(eval(header.gasUsed).toString(10))
+        gasUsedTotal += gasUsed
+        let difficulty = eval(eval(header.difficulty).toString(10))
+        if (difficulty == 2) {
+            inturnBlocks += 1
+        }
+        let timestamp = eval(eval(header.timestamp).toString(10))
+        console.log("BlockNumber =", i, "mod =", i%4, "miner =", header.miner , "difficulty =", difficulty, "txCount =", ethers.toNumber(txCount), "gasUsed", gasUsed, "timestamp", timestamp)
+    }
+
+    let blockCount = program.endNum - program.startNum
+    let txCountPerBlock = txCountTotal/blockCount
+
+    let startHeader = await provider.send("eth_getHeaderByNumber", [
+        ethers.toQuantity(program.startNum)]);
+    let startTime = eval(eval(startHeader.timestamp).toString(10))
+    let endHeader = await provider.send("eth_getHeaderByNumber", [
+        ethers.toQuantity(program.endNum)]);
+    let endTime = eval(eval(endHeader.timestamp).toString(10))
+    let timeCost = endTime - startTime
+    let avgBlockTime = timeCost/blockCount
+    let inturnBlocksRatio = inturnBlocks/blockCount
+    let tps = txCountTotal/timeCost
+    let M = 1000000
+    let avgGasUsedPerBlock = gasUsedTotal/blockCount/M
+    let avgGasUsedPerSecond = gasUsedTotal/timeCost/M
+
+    console.log("Get the performance between [", program.startNum, ",", program.endNum, ")");
+    console.log("txCountPerBlock =", txCountPerBlock, "txCountTotal =", txCountTotal, "BlockCount =", blockCount, "avgBlockTime =", avgBlockTime, "inturnBlocksRatio =", inturnBlocksRatio);
+    console.log("txCountPerSecond =", tps, "avgGasUsedPerBlock =", avgGasUsedPerBlock, "avgGasUsedPerSecond =", avgGasUsedPerSecond);
+};
+
+main().then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });


### PR DESCRIPTION
### Description

cmd/jsutils: add a tool to get performance between a range of blocks

### Rationale

tell us why we need these changes...

### Example

node get_perf.js --rpc http:/127.0.0.1:8545 --startNum 19470 --endNum 19670
```
Get the performance between [ 19470 , 19670 )
txCountPerBlock = 3142.81 txCountTotal = 628562 BlockCount = 200 avgBlockTime = 3.005 inturnBlocksRatio 0.975
txCountPerSecond = 1045.8602329450914 avgGasUsedPerBlock = 250.02062627 avgGasUsedPerSecond =  83.20153952412646
```

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
