### PR TITLE
fix: remove zero gasprice check for BSC

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -204,7 +204,8 @@ func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend) erro
 	// Sanity check the EIP-1559 fee parameters if present.
 	if args.GasPrice == nil && eip1559ParamsSet {
 		if args.MaxFeePerGas.ToInt().Sign() == 0 {
-			return errors.New("maxFeePerGas must be non-zero")
+			// return errors.New("maxFeePerGas must be non-zero")
+			log.Warn("EIP-1559 Tx with zero maxFeePerGas") // BSC accepts zero gas price.
 		}
 		if args.MaxFeePerGas.ToInt().Cmp(args.MaxPriorityFeePerGas.ToInt()) < 0 {
 			return fmt.Errorf("maxFeePerGas (%v) < maxPriorityFeePerGas (%v)", args.MaxFeePerGas, args.MaxPriorityFeePerGas)
@@ -217,7 +218,8 @@ func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend) erro
 	if args.GasPrice != nil && !eip1559ParamsSet {
 		// Zero gas-price is not allowed after London fork
 		if args.GasPrice.ToInt().Sign() == 0 && isLondon {
-			return errors.New("gasPrice must be non-zero after london fork")
+			// return errors.New("gasPrice must be non-zero after london fork")
+			log.Warn("non EIP-1559 Tx with zero gasPrice") // BSC accepts zero gas price.
 		}
 		return nil // No need to set anything, user already set GasPrice
 	}

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -85,8 +85,8 @@ func TestSetFeeDefaults(t *testing.T) {
 			"legacy tx post-London with zero price",
 			"london",
 			&TransactionArgs{GasPrice: zero},
-			nil,
-			errors.New("gasPrice must be non-zero after london fork"),
+			&TransactionArgs{GasPrice: zero},
+			nil, // errors.New("gasPrice must be non-zero after london fork"),
 		},
 
 		// Access list txs
@@ -180,8 +180,8 @@ func TestSetFeeDefaults(t *testing.T) {
 			"dynamic fee tx post-London, explicit gas price",
 			"london",
 			&TransactionArgs{MaxFeePerGas: zero, MaxPriorityFeePerGas: zero},
-			nil,
-			errors.New("maxFeePerGas must be non-zero"),
+			&TransactionArgs{MaxFeePerGas: zero, MaxPriorityFeePerGas: zero},
+			nil, // errors.New("maxFeePerGas must be non-zero"),
 		},
 
 		// Misc


### PR DESCRIPTION
### Description
This is subtle change to remove the zero gasprice check on BSC  to fix issue: https://github.com/bnb-chain/bsc/issues/2517

Before signing a transaction, there is gasPrice check. For Ethereum zeroGasPrice is unacceptable since London hard fork. But for BSC, zero gasprice is still acceptable.
note: blobGasFeePrice can not be zero right now.

### Rationale
NA

### Example
NA

### Changes
Before this PR, sign a zero gasprice BSC transaction will be failed, but after this PR it will be success.