### PR TITLE
UT: random failure of TestSnapSyncWithBlobs

### DIFF
--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -633,6 +633,9 @@ func testBroadcastBlock(t *testing.T, peers, bcasts int) {
 		go source.handler.runEthPeer(sourcePeer, func(peer *eth.Peer) error {
 			return eth.Handle((*ethHandler)(source.handler), peer)
 		})
+		// Wait a bit for the above handlers to start
+		time.Sleep(100 * time.Millisecond)
+
 		if err := sinkPeer.Handshake(1, td, genesis.Hash(), genesis.Hash(), forkid.NewIDWithChain(source.chain), forkid.NewFilter(source.chain), nil); err != nil {
 			t.Fatalf("failed to run protocol handshake")
 		}

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -151,6 +151,8 @@ func testChainSyncWithBlobs(t *testing.T, mode downloader.SyncMode, preCancunBlk
 	go full.handler.runEthPeer(fullPeerEth, func(peer *eth.Peer) error {
 		return eth.Handle((*ethHandler)(full.handler), peer)
 	})
+	// Wait a bit for the above handlers to start
+	time.Sleep(250 * time.Millisecond)
 
 	emptyPipeSnap, fullPipeSnap := p2p.MsgPipe()
 	defer emptyPipeSnap.Close()


### PR DESCRIPTION
### Description
To fix issue: https://github.com/bnb-chain/bsc/issues/2489
this case failed randomly in github CI, the ratio of around 20%.
but it can not be reproduced locally:
```
cd eth
go test -p 1 -v -run TestSnapSyncWithBlobs -count 100
```
There could be a potential risk between `runEthPeer` and `runSnapExtension`, as  they shared the `handler.peers`. Add extra wait time for `runEthPeer`

And also same for UT TestBroadcastBlock3Peers:
```
--- FAIL: TestBroadcastBlock3Peers (0.24s)
    handler_eth_test.go:672: broadcast count mismatch: have 0, want 1
```

### Rationale
NA

### Example
NA

### Changes
NA