### PR TITLE
enhance GreedyMergeTx performance && simplified bid comparison && details bid logs

### DIFF
--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -347,8 +347,6 @@ func (b *bidSimulator) newBidLoop() {
 				continue
 			}
 
-			bidRuntime := &BidRuntime{
-				bid:                     newBid,
 				expectedBlockReward:     expectedBlockReward,
 				expectedValidatorReward: expectedValidatorReward,
 				packedBlockReward:       big.NewInt(0),
@@ -637,7 +635,7 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 	if b.config.GreedyMergeTx {
 		delay := b.engine.Delay(b.chain, bidRuntime.env.header, &b.delayLeftOver)
 		if delay != nil && *delay > 0 {
-			bidTxsSet := mapset.NewSet[common.Hash]()
+			bidTxsSet := mapset.NewThreadUnsafeSetWithSize[common.Hash](len(bidRuntime.bid.Txs))
 			for _, tx := range bidRuntime.bid.Txs {
 				bidTxsSet.Add(tx.Hash())
 			}

--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -100,6 +100,14 @@ func (miner *Miner) SendBid(ctx context.Context, bidArgs *types.BidArgs) (common
 		return common.Hash{}, err
 	}
 
+	log.Info("bid received",
+		"block", bid.BlockNumber,
+		"from", bid.Builder,
+		"tx", len(bid.Txs),
+		"fee", bid.GasFee,
+		"hash", bid.Hash(),
+	)
+
 	return bid.Hash(), nil
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1371,7 +1371,19 @@ LOOP:
 				bestWork = bestBid.env
 				from = bestBid.bid.Builder
 
-				log.Debug("BidSimulator: bid win", "block", bestWork.header.Number.Uint64(), "bid", bestBid.bid.Hash())
+				log.Info("builder block",
+					"number", bestWork.header.Number.Uint64(),
+					"builder", bestBid.bid.Builder,
+					"blockReward", bestBid.blockReward(),
+					"builderContribute", bestBid.blockRewardFromBuilder(),
+					"builderPercentage", new(big.Int).Div(
+						new(big.Int).Mul(
+							bestBid.blockRewardFromBuilder(),
+							big.NewInt(100),
+						),
+						bestBid.blockReward(),
+					),
+				)
 			}
 		}
 	}


### PR DESCRIPTION
### Description

The thread safe transaction set is no need for GreedyMergeTx. The change will lift extensive locking mechanisms.
Add builder bid arriving and comparing log into standard log output. 
Simplified bid comparison.

### Rationale

The log helps validator records the builder bid operation, to better understand and get involve the BPS mechanisms

### Changes

Notable changes: 
* `bidTxsSet := mapset.NewSet[common.Hash]()` -> `mapset.NewThreadUnsafeSetWithSize[common.Hash](len(bidRuntime.bid.Txs))`
