### PR TITLE
fix: ensure empty withdrawals after cancun before broadcast

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -731,9 +731,6 @@ func (f *BlockFetcher) loop() {
 						matched = true
 						if f.getBlock(hash) == nil {
 							block := types.NewBlockWithHeader(announce.header).WithBody(task.transactions[i], task.uncles[i])
-							if block.Header().EmptyWithdrawalsHash() {
-								block = block.WithWithdrawals(make([]*types.Withdrawal, 0))
-							}
 							block = block.WithSidecars(task.sidecars[i])
 							block.ReceivedAt = task.time
 							blocks = append(blocks, block)
@@ -917,6 +914,10 @@ func (f *BlockFetcher) importBlocks(op *blockOrHeaderInject) {
 			f.done <- hash
 			f.requeue <- op
 			return
+		}
+
+		if block.Header().EmptyWithdrawalsHash() {
+			block = block.WithWithdrawals(make([]*types.Withdrawal, 0))
 		}
 
 		defer func() { f.done <- hash }()


### PR DESCRIPTION
### Description

fix: ensure empty withdrawals after cancun before broadcast

### Rationale

no matter get a new block directly or by fetching

both need to ensure empty withdrawals after cancun before broadcast

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
