### PR TITLE
p2p/discover: avoid adding node to table when ENR failed request

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	crand "crypto/rand"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	mrand "math/rand"
 	"net"
@@ -381,13 +380,12 @@ func (tab *Table) doRevalidate(done chan<- struct{}) {
 	if last.Seq() < remoteSeq {
 		n, err := tab.net.RequestENR(unwrapNode(last))
 		if err != nil {
+			// if ENR fails we just do not update the node record
 			tab.log.Debug("ENR request failed", "id", last.ID(), "addr", last.addr(), "err", err)
-			errHandle = err
 		} else {
 			if tab.enrFilter != nil {
 				if !tab.enrFilter(n.Record()) {
 					tab.log.Trace("ENR record filter out", "id", last.ID(), "addr", last.addr())
-					errHandle = errors.New("filtered node")
 				}
 			}
 			last = &node{Node: *n, addedAt: last.addedAt, livenessChecks: last.livenessChecks}


### PR DESCRIPTION
### Description

The change of https://github.com/bnb-chain/bsc/pull/1320 create  the other Error without handling which  make the node still is added into table without caring success or failed when calling to ENR Request.

The idea is to create a local errorHandle for easy control.
