### PR TITLE
feat: enhance bid comparison and reply bidding results && detail logs

### DIFF
--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -737,7 +737,6 @@ type BidRuntime struct {
 }
 
 func newBidRuntime(newBid *types.Bid, validatorCommission uint64) (*BidRuntime, error) {
-
 	// check the block reward and validator reward of the newBid
 	expectedBlockReward := newBid.GasFee
 	expectedValidatorReward := new(big.Int).Mul(expectedBlockReward, big.NewInt(int64(validatorCommission)))

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -334,8 +334,8 @@ func (b *bidSimulator) newBidLoop() {
 		}
 	}
 
-	genReplyReason := func(betterBid *BidRuntime) error {
-		return fmt.Errorf("bid discarded, current bestBid is [blockReward: %s, validatorReward: %s]", betterBid.expectedBlockReward, betterBid.expectedValidatorReward)
+	genDiscardedReply := func(betterBid *BidRuntime) error {
+		return fmt.Errorf("bid is discarded, current bestBid is [blockReward: %s, validatorReward: %s]", betterBid.expectedBlockReward, betterBid.expectedValidatorReward)
 	}
 
 	for {
@@ -360,7 +360,7 @@ func (b *bidSimulator) newBidLoop() {
 				if bidRuntime.isExpectedBetterThan(simulatingBid) {
 					commit(commitInterruptBetterBid, bidRuntime)
 				} else {
-					replyErr = genReplyReason(simulatingBid)
+					replyErr = genDiscardedReply(simulatingBid)
 				}
 			} else {
 				// bestBid is nil means the bid is the first bid, otherwise the bid should compare with the bestBid
@@ -368,7 +368,7 @@ func (b *bidSimulator) newBidLoop() {
 					bidRuntime.isExpectedBetterThan(bestBid) {
 					commit(commitInterruptBetterBid, bidRuntime)
 				} else {
-					replyErr = genReplyReason(bestBid)
+					replyErr = genDiscardedReply(bestBid)
 				}
 			}
 

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -347,6 +347,9 @@ func (b *bidSimulator) newBidLoop() {
 
 			bidRuntime, err := newBidRuntime(newBid.bid, b.config.ValidatorCommission)
 			if err != nil {
+				if newBid.feedback != nil {
+					newBid.feedback <- err
+				}
 				continue
 			}
 
@@ -747,7 +750,7 @@ func newBidRuntime(newBid *types.Bid, validatorCommission uint64) (*BidRuntime, 
 		// damage self profit, ignore
 		log.Debug("BidSimulator: invalid bid, validator reward is less than 0, ignore",
 			"builder", newBid.Builder, "bidHash", newBid.Hash().Hex())
-		return nil, errors.New("validator reward is less than 0")
+		return nil, fmt.Errorf("validator reward is less than 0, value: %s, commissionConfig: %d", expectedValidatorReward, validatorCommission)
 	}
 
 	bidRuntime := &BidRuntime{

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -633,7 +633,7 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 	if b.config.GreedyMergeTx {
 		delay := b.engine.Delay(b.chain, bidRuntime.env.header, &b.delayLeftOver)
 		if delay != nil && *delay > 0 {
-			bidTxsSet := mapset.NewSet[common.Hash]()
+			bidTxsSet := mapset.NewThreadUnsafeSetWithSize[common.Hash](len(bidRuntime.bid.Txs))
 			for _, tx := range bidRuntime.bid.Txs {
 				bidTxsSet.Add(tx.Hash())
 			}

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -441,7 +441,7 @@ func (b *bidSimulator) sendBid(_ context.Context, bid *types.Bid) error {
 	timer := time.NewTimer(1 * time.Second)
 	defer timer.Stop()
 
-	replyCh := make(chan error)
+	replyCh := make(chan error, 1)
 
 	select {
 	case b.newBidCh <- newBidPackage{bid: bid, feedback: replyCh}:

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -544,6 +544,7 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 		if success {
 			bidRuntime.duration = time.Since(simStart)
 			bidSimTimer.UpdateSince(simStart)
+			metrics.GetOrRegisterCounter(fmt.Sprintf("bid/sim/count/%d", bidRuntime.bid.BlockNumber), nil).Inc(1)
 
 			// only recommit self bid when newBidCh is empty
 			if len(b.newBidCh) > 0 {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1371,7 +1371,13 @@ LOOP:
 				bestWork = bestBid.env
 				from = bestBid.bid.Builder
 
-				log.Debug("BidSimulator: bid win", "block", bestWork.header.Number.Uint64(), "bid", bestBid.bid.Hash())
+				log.Info("[BUILDER BLOCK]",
+					"block", bestWork.header.Number.Uint64(),
+					"builder", from,
+					"blockReward", weiToEtherStringF6(bestBid.packedBlockReward),
+					"validatorReward", weiToEtherStringF6(bestBid.packedValidatorReward),
+					"bid", bestBid.bid.Hash().TerminalString(),
+				)
 			}
 		}
 	}


### PR DESCRIPTION
### Description

* mev_sendBid replies current bestBid reward if it's discard due to low reward (but it still cost 1 submit chance for builder).
* The thread safe transaction set is no need for GreedyMergeTx. The change will lift extensive locking mechanisms.
Add builder bid arriving and comparing log into standard log output.
* Simplified bidRuntime comparison by moving comparing function into bidRuntime.
* add bid arrive/comparsion detail logs,  helps validator records the builder bid operation, to better understand and get involve the BPS mechanisms.