### PR TITLE
fix: pruneancient freeze from the previous position when the first time

### DIFF
--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -127,6 +127,11 @@ func newFreezerTable(path, name string, disableSnappy, readonly bool) (*freezerT
 	return newTable(path, name, metrics.NilMeter{}, metrics.NilMeter{}, metrics.NilGauge{}, freezerTableSize, disableSnappy, readonly)
 }
 
+// newAdditionTable opens the given path as a addition table.
+func newAdditionTable(path, name string, disableSnappy, readonly bool) (*freezerTable, error) {
+	return openAdditionTable(path, name, metrics.NilMeter{}, metrics.NilMeter{}, metrics.NilGauge{}, freezerTableSize, disableSnappy, readonly)
+}
+
 // newTable opens a freezer table, creating the data and index files if they are
 // non-existent. Both files are truncated to the shortest common length to ensure
 // they don't go out of sync.

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -68,6 +68,7 @@ func newPrunedFreezer(datadir string, db ethdb.KeyValueStore, offset uint64) (*p
 
 // repair init frozen , compatible disk-ancientdb and pruner-block-tool.
 func (f *prunedfreezer) repair(datadir string) error {
+	offset := atomic.LoadUint64(&f.frozen)
 	// compatible freezer
 	minItems := uint64(math.MaxUint64)
 	for name, disableSnappy := range chainFreezerNoSnappy {
@@ -95,8 +96,15 @@ func (f *prunedfreezer) repair(datadir string) error {
 		}
 		table.Close()
 	}
-	log.Info("Read ancientdb item counts", "items", minItems)
-	offset := minItems
+
+	// If minItems is non-zero, it indicates that the chain freezer was previously enabled, and we should use minItems as the current frozen value.
+	// If minItems is zero, it indicates that the pruneAncient was previously enabled, and we should continue using frozen
+	//	(retrieved from CurrentAncientFreezer) as the current frozen value.
+	if minItems != 0 {
+		offset = minItems
+	}
+	log.Info("Read ancientdb item counts", "items", minItems, "offset", offset)
+
 	if frozen := ReadFrozenOfAncientFreezer(f.db); frozen > offset {
 		offset = frozen
 	}

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -99,10 +99,9 @@ func (f *prunedfreezer) repair(datadir string) error {
 	// If minItems is non-zero, it indicates that the chain freezer was previously enabled, and we should use minItems as the current frozen value.
 	// If minItems is zero, it indicates that the pruneAncient was previously enabled, and we should continue using frozen
 	//	(retrieved from CurrentAncientFreezer) as the current frozen value.
-	var offset uint64
-	if minItems != 0 {
-		offset = minItems
-	} else {
+	offset := minItems
+	if offset == 0 {
+		// no item in ancientDB, init `offset` to the `f.frozen`
 		offset = atomic.LoadUint64(&f.frozen)
 	}
 	log.Info("Read ancientdb item counts", "items", minItems, "offset", offset)

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -68,9 +68,8 @@ func newPrunedFreezer(datadir string, db ethdb.KeyValueStore, offset uint64) (*p
 
 // repair init frozen , compatible disk-ancientdb and pruner-block-tool.
 func (f *prunedfreezer) repair(datadir string) error {
-	offset := atomic.LoadUint64(&f.frozen)
 	// compatible freezer
-	min := uint64(math.MaxUint64)
+	minItems := uint64(math.MaxUint64)
 	for name, disableSnappy := range chainFreezerNoSnappy {
 		var (
 			table *freezerTable
@@ -91,14 +90,13 @@ func (f *prunedfreezer) repair(datadir string) error {
 			}
 		}
 		items := table.items.Load()
-		if min > items {
-			min = items
+		if minItems > items {
+			minItems = items
 		}
 		table.Close()
 	}
-	log.Info("Read ancientdb item counts", "items", min)
-	offset += min
-
+	log.Info("Read ancientdb item counts", "items", minItems)
+	offset := minItems
 	if frozen := ReadFrozenOfAncientFreezer(f.db); frozen > offset {
 		offset = frozen
 	}

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -108,7 +108,7 @@ func (f *prunedfreezer) repair(datadir string) error {
 		}
 		table.Close()
 	}
-	items := head - tail
+	items := head - tail + 1
 	log.Info("Read ancientdb item counts", "items", items)
 	offset += items
 

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -109,7 +109,7 @@ func (f *prunedfreezer) repair(datadir string) error {
 		table.Close()
 	}
 	items := head - tail
-	log.Info("Read ancientdb item counts", "items", items)
+	log.Info("Read ancientdb item counts", "head", head, "tail", tail, "items", items)
 	offset += items
 
 	if frozen := ReadFrozenOfAncientFreezer(f.db); frozen > offset {

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -74,6 +74,10 @@ func (f *prunedfreezer) repair(datadir string) error {
 		if err != nil {
 			return err
 		}
+		// blob sidecar can not be same as ancient-tables, it may smaller than others
+		if name == ChainFreezerBlobSidecarTable {
+			continue
+		}
 		items := table.items.Load()
 		if min > items {
 			min = items

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -108,7 +108,7 @@ func (f *prunedfreezer) repair(datadir string) error {
 		}
 		table.Close()
 	}
-	items := head - tail + 1
+	items := head - tail
 	log.Info("Read ancientdb item counts", "items", items)
 	offset += items
 


### PR DESCRIPTION
### Description

The first time online pruning is enabled, the freeze() process starts from 0, leading to a large number of log.Error("Canonical hash missing, can't freeze", "number", f.frozen) logs.

![image](https://github.com/bnb-chain/bsc/assets/11239387/188dd416-987c-4f79-a5a2-9910896a893c)


In the freezer's database, record FrozenOfAncientFreezer. When online pruning is enabled for the first time, it will continue to freeze from the previous position.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
