### PR TITLE
release: bump version to 1.4.11

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 4  // Minor version component of the current release
-	VersionPatch = 10 // Patch version component of the current release
+	VersionPatch = 11 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description

Bump the version from 1.4.10 to v1.4.11

### Rationale
None

### Example
None

### Changes

None
