### PR TITLE
fix: fix inspect after delete-trie-state 

### DIFF
--- a/core/rawdb/ancient_utils.go
+++ b/core/rawdb/ancient_utils.go
@@ -18,6 +18,8 @@ package rawdb
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -98,6 +100,18 @@ func inspectFreezers(db ethdb.Database) ([]freezerInfo, error) {
 			if err != nil {
 				return nil, err
 			}
+
+			file, err := os.Open(filepath.Join(datadir, StateFreezerName))
+			if err != nil {
+				return nil, err
+			}
+			defer file.Close()
+			// if state freezer folder has been pruned, there is no need for inspection
+			_, err = file.Readdirnames(1)
+			if err == io.EOF {
+				continue
+			}
+
 			f, err := NewStateFreezer(datadir, true, 0)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
### Description

The files of  freezer ancient state folder will be empty after running "db delete-trie-state" command in pbss mode and the inspectFreezers function need to judge this situation to avoid inspecting the empty state freezer. 

### Rationale

fix issue:[issue]( https://github.com/bnb-chain/bsc/issues/2543)

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
