### PR TITLE
nancy: ignore go-retryablehttp@v0.7.4

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,1 +1,2 @@
 CVE-2024-34478 # "CWE-754: Improper Check for Unusual or Exceptional Conditions." This vulnerability is BTC only, BSC does not have the issue.
+CVE-2024-6104 # "CWE-532: Information Exposure Through Log Files" This is caused by the vulnerabilities go-retryablehttp@v0.7.4, it is only used in cmd devp2p, impact is limited. will upgrade to v0.7.7 later


### PR DESCRIPTION
### Description
Detected Nancy failure:
```

pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.4
1 known vulnerabilities affecting installed version 
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ [CVE-2024-6104] CWE-532: Information Exposure Through Log Files                                                                                                                                                                 ┃
┣━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
┃ Description        ┃ go-retryablehttp prior to 0.7.7 did not sanitize urls when writing them to                                                                                                                                 ┃
┃                    ┃ its log file. This could lead to go-retryablehttp writing sensitive HTTP                                                                                                                                   ┃
┃                    ┃ basic auth credentials to its log file. This vulnerability, CVE-2024-6104,                                                                                                                                 ┃
┃                    ┃ was fixed in go-retryablehttp 0.7.7.                                                                                                                                                                       ┃
��━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
```
`go-retryablehttp` is imported indirectly by `cloudflare-go`, which is only used for cmd/devp2p, the vulnerability is limited. Update the go-retryablehttp to v0.7.7 will upgrade many other dependencies, so we can delay this upgrade right now.

```
go mod why -m github.com/hashicorp/go-retryablehttp
# github.com/hashicorp/go-retryablehttp
github.com/ethereum/go-ethereum/cmd/devp2p
github.com/cloudflare/cloudflare-go
github.com/hashicorp/go-retryablehttp
```
### Rationale
NA

### Example
NA