### PR TITLE
fix: online prune of ancient delete unexpected blocks

### DIFF
--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -299,9 +299,8 @@ func (f *prunedfreezer) freeze() {
 				log.Error("Append ancient err", "number", f.frozen, "hash", hash, "err", err)
 				break
 			}
-			if hash != (common.Hash{}) {
-				ancients = append(ancients, hash)
-			}
+			// may include common.Hash{}, will be delete in gcKvStore
+			ancients = append(ancients, hash)
 		}
 		// Batch of blocks have been frozen, flush them before wiping from leveldb
 		if err := f.Sync(); err != nil {


### PR DESCRIPTION
### Description

The first time you run with the --pruneancient option, a BAD BLOCK error may occur.

![image](https://github.com/bnb-chain/bsc/assets/11239387/7f2f3097-6a3d-40e1-840d-109f4b26965d)


### Rationale

When pruneancient is enabled, it deletes the CanonicalHash previously stored in the ancient database. This results in the loss of some CanonicalHash entries in the range [first, frozen) during the subsequent loop.
![image](https://github.com/bnb-chain/bsc/assets/11239387/a650ba63-5caa-4a75-832b-8de06c246d39)

 In gcKvStore, when attempting to delete CanonicalHash and Header, the ancients and numbers do not match, preventing the proper deletion.
> For example, if first in the loop is 60002, the range being traversed is [60002, 90003). Due to the deletion of CanonicalHash in the range [60002, 61298], the data in ancients is actually [61299, 90003).
In gcKvStore, the number range [60002, 88706) is being deleted, while the corresponding hash range is [61299, 90003), causing the construction of incorrect block keys and failing to delete the actual blocks.
number[60002] + hash[61299]
number[60003] + hash[61300]

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
