### PR TITLE
core: avoid to cache block before wroten into db

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -657,13 +657,6 @@ func (bc *BlockChain) cacheDiffLayer(diffLayer *types.DiffLayer, diffLayerCh cha
 	}
 }
 
-func (bc *BlockChain) cacheBlock(hash common.Hash, block *types.Block) {
-	bc.blockCache.Add(hash, block)
-	if bc.chainConfig.IsCancun(block.Number(), block.Time()) {
-		bc.sidecarsCache.Add(hash, block.Sidecars())
-	}
-}
-
 // empty returns an indicator whether the blockchain is empty.
 // Note, it's a special case that we connect a non-empty ancient
 // database with an empty node, so that we can plugin the ancient
@@ -2281,8 +2274,6 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		}
 		vtime := time.Since(vstart)
 		proctime := time.Since(start) // processing + validation
-
-		bc.cacheBlock(block.Hash(), block)
 
 		// Update the metrics touched during block processing and validation
 		accountReadTimer.Update(statedb.AccountReads)                   // Account reads are complete(in processing)


### PR DESCRIPTION
### Description

core: avoid to cache block before wroten into db

### Rationale

let's see the `GetBlock` interface, it's used to get block from db
after add func `cacheBlock`, block not wroten into db also will be add into bc.blockCache.
so this destroy the semitics of `GetBlock`, and will lead to potential issue
```
// GetBlock retrieves a block from the database by hash and number,
// caching it if found.
func (bc *BlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {
	// Short circuit if the block's already in the cache, retrieve otherwise
	if block, ok := bc.blockCache.Get(hash); ok {
		return block
	}
	block := rawdb.ReadBlock(bc.db, hash, number)
	if block == nil {
		return nil
	}
	// Cache the found block for next time and return
	bc.blockCache.Add(block.Hash(), block)
	return block
}
```

for example, if a block can be retrieved by calling `GetBlock`, then the Td can be retrieved by GetTd,
<img width="1154" alt="image" src="https://github.com/bnb-chain/bsc/assets/7995985/fe4320f7-e16e-4d07-afff-460f58495183">
in the above code, no need to check GetTd will return nil if no exist of `cacheBlock`
but now, it lead to crash.

so this PR suggest to remove cacheBlock to recover the semitics of `GetBlock`


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
