### PR TITLE
fix: fix statedb copy

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -933,8 +933,8 @@ func (s *StateDB) copyInternal(doPrefetch bool) *StateDB {
 	// along with their original values.
 	state.accounts = copySet(s.accounts)
 	state.storages = copy2DSet(s.storages)
-	state.accountsOrigin = copySet(state.accountsOrigin)
-	state.storagesOrigin = copy2DSet(state.storagesOrigin)
+	state.accountsOrigin = copySet(s.accountsOrigin)
+	state.storagesOrigin = copy2DSet(s.storagesOrigin)
 
 	// Deep copy the logs occurred in the scope of block
 	for hash, logs := range s.logs {


### PR DESCRIPTION
### Description

In the force-kill test scenario, it was found that rewind failed. The specific reason was that the data format of the state's undolog was incorrect. Failed to rollback state, error like this:
`
invalid account index, len: 0
`

### Rationale

https://github.com/bnb-chain/bsc/blob/a5810fefc90de206459cca4c24e5946670f532da/miner/worker.go#L1434-L1437

Miner inner workflow uses statedb copy function, but the copy function loses the state's origin fields, so the written undo log is wrong and fails to rollback.

### Example

N/A.

### Changes

Notable changes: 
* Statedb: copy function
