### PR TITLE
core/vote: not vote if too late for next in turn validator

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -307,6 +307,10 @@ func New(
 	return c
 }
 
+func (p *Parlia) Period() uint64 {
+	return p.config.Period
+}
+
 func (p *Parlia) IsSystemTransaction(tx *types.Transaction, header *types.Header) (bool, error) {
 	// deploy a contract
 	if tx.To() == nil {

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -143,7 +143,7 @@ func (voteManager *VoteManager) loop() {
 			curHead := cHead.Block.Header()
 			if p, ok := voteManager.engine.(*parlia.Parlia); ok {
 				nextBlockMinedTime := time.Unix(int64((curHead.Time + p.Period())), 0)
-				timeForBroadcast := 100 * time.Millisecond
+				timeForBroadcast := 50 * time.Millisecond // enough to broadcast a vote
 				if time.Now().Add(timeForBroadcast).After(nextBlockMinedTime) {
 					log.Warn("too late to vote", "Head.Time(Second)", curHead.Time, "Now(Millisecond)", time.Now().UnixMilli())
 					continue

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -145,7 +145,7 @@ func (voteManager *VoteManager) loop() {
 				nextBlockMinedTime := time.Unix(int64((curHead.Time + p.Period())), 0)
 				timeForBroadcast := 100 * time.Millisecond
 				if time.Now().Add(timeForBroadcast).After(nextBlockMinedTime) {
-					log.Debug("too late to vote", "Head.Time(Second)", curHead.Time, "Now(Millisecond)", time.Now().UnixMilli())
+					log.Warn("too late to vote", "Head.Time(Second)", curHead.Time, "Now(Millisecond)", time.Now().UnixMilli())
 					continue
 				}
 			}

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/parlia"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/downloader"
@@ -139,6 +141,15 @@ func (voteManager *VoteManager) loop() {
 			}
 
 			curHead := cHead.Block.Header()
+			if p, ok := voteManager.engine.(*parlia.Parlia); ok {
+				nextBlockMinedTime := time.Unix(int64((curHead.Time + p.Period())), 0)
+				timeForBroadcast := 100 * time.Millisecond
+				if time.Now().Add(timeForBroadcast).After(nextBlockMinedTime) {
+					log.Debug("too late to vote", "Head.Time(Second)", curHead.Time, "Now(Millisecond)", time.Now().UnixMilli())
+					continue
+				}
+			}
+
 			// Check if cur validator is within the validatorSet at curHead
 			if !voteManager.engine.IsActiveValidatorAt(voteManager.chain, curHead,
 				func(bLSPublicKey *types.BLSPublicKey) bool {


### PR DESCRIPTION
### Description

core/vote: not vote if too late for next in turn validator

### Rationale
![image](https://github.com/bnb-chain/bsc/assets/122502194/b0d76dc3-4322-424a-aa7f-b5ecde521fb2)

Assume that at block height N, validator Va mines a large block BN, broadcasts it, and votes immediately. Due to the block's large size, other validators (such as Vb, Vc, and Vd) take a longer time to import BN, resulting in Vc and Vd voting for BN later. As a result, at block height N+1, Vb fails to collect enough votes for BN and mines and broadcasts a block BN1 without vote proof. Subsequently, backup validator Vc collects enough votes for BN, mines, and broadcasts a block BN1' with vote proof, causing other validators to experience a block reorganization (reorg).

this PR suggest not to vote if too late for next in turn validator

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
