### PR TITLE
fix: only take non-mempool tx to calculate bid price

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -102,7 +102,7 @@ func New(eth Backend, config *Config, chainConfig *params.ChainConfig, mux *even
 		worker:  newWorker(config, chainConfig, engine, eth, mux, isLocalBlock, false),
 	}
 
-	miner.bidSimulator = newBidSimulator(&config.Mev, config.DelayLeftOver, config.GasPrice, eth.BlockChain(), chainConfig, engine, miner.worker)
+	miner.bidSimulator = newBidSimulator(&config.Mev, config.DelayLeftOver, config.GasPrice, eth, chainConfig, engine, miner.worker)
 	miner.worker.setBestBidFetcher(miner.bidSimulator)
 
 	miner.wg.Add(1)


### PR DESCRIPTION
### Description

define bidGasPrice as sum of (gas used * gas price ) for every non-mempool tx / by the sum of gas used for non-mempool tx.

### Rationale

In current implementation, when a builder receive a bundle, it will simulate all txs within the bundle. Bundle price = sum( gas price * gas used ) /sum(gas used ) , ensure bundle price > = 1 gwei. It seems not a good solution. Consider the following example:
There is a public mempool tx with 100 gwei, gas usage 21,000 and its a simple transfer tx. A malicious actor can submit a 0 gas price tx to bundle it up with the public mempool tx, this tx has 0 gwei gas price, it can involve very complex smart contract calls and it has a gas usage of 1,000,000. 
In that case, it will be (100\*21000+0\*1000000)/(21000+1000000)=2.05 gwei. This means this bundle can be included by builders and land on chain.
However, the malicious actor is essentially a "free rider" in this scenario, and this actor is able to "exploit" the bundle scoring algorithm and make high-gas-usage tx land on chain for free.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
