### PR TITLE
freezer: Opt freezer env checking

### DIFF
--- a/cmd/geth/pruneblock_test.go
+++ b/cmd/geth/pruneblock_test.go
@@ -155,6 +155,12 @@ func BlockchainCreator(t *testing.T, chaindbPath, AncientPath string, blockRemai
 	triedb := triedb.NewDatabase(db, nil)
 	defer triedb.Close()
 
+	if err = db.SetupFreezerEnv(&ethdb.FreezerEnv{
+		ChainCfg:         gspec.Config,
+		BlobExtraReserve: params.DefaultExtraReserveForBlobRequests,
+	}); err != nil {
+		t.Fatalf("Failed to create chain: %v", err)
+	}
 	genesis := gspec.MustCommit(db, triedb)
 	// Initialize a fresh chain with only a genesis block
 	blockchain, err := core.NewBlockChain(db, config, gspec, nil, engine, vm.Config{}, nil, nil)

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/ethdb"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -1795,6 +1797,13 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 		config.SnapshotWait = true
 	}
 	config.TriesInMemory = 128
+
+	if err = db.SetupFreezerEnv(&ethdb.FreezerEnv{
+		ChainCfg:         gspec.Config,
+		BlobExtraReserve: params.DefaultExtraReserveForBlobRequests,
+	}); err != nil {
+		t.Fatalf("Failed to create chain: %v", err)
+	}
 	chain, err := NewBlockChain(db, config, gspec, nil, engine, vm.Config{}, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create chain: %v", err)

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/ethdb"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -1998,6 +2000,13 @@ func testSetHeadWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme 
 		config.SnapshotWait = true
 	}
 	config.TriesInMemory = 128
+
+	if err = db.SetupFreezerEnv(&ethdb.FreezerEnv{
+		ChainCfg:         gspec.Config,
+		BlobExtraReserve: params.DefaultExtraReserveForBlobRequests,
+	}); err != nil {
+		t.Fatalf("Failed to create chain: %v", err)
+	}
 	chain, err := NewBlockChain(db, config, gspec, nil, engine, vm.Config{}, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create chain: %v", err)

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -280,7 +280,7 @@ func (f *chainFreezer) freeze(db ethdb.KeyValueStore) {
 		// check env first before chain freeze, it must wait when the env is necessary
 		if err := f.checkFreezerEnv(); err != nil {
 			f.waitEnvTimes++
-			if f.waitEnvTimes > maxWaitFreezerEnvTimes {
+			if f.waitEnvTimes >= maxWaitFreezerEnvTimes {
 				log.Warn("Wait freezer env too many times, skip the chain freezing.")
 				return
 			}

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -44,7 +44,7 @@ const (
 
 	// maxWaitFreezerEnvTimes is not critical for most scenarios,
 	// the most cases won't insert block and trigger chain freezing.
-	// But the core.BlockChain instance must init the freezer env for chain freeze.
+	// But the eth.Backend instance must init the freezer env for chain freeze.
 	maxWaitFreezerEnvTimes = 3
 )
 


### PR DESCRIPTION
### Description

This PR adds a silent logic. For scenarios that require Freezer Env, `SetupFreezerEnv` should be called to initialize. For other scenarios, Freezer will silently wait 3 times and return, and will no longer execute freeze.

Using silent logic effectively avoids large-scale API modifications and unnecessary DB initialization operations.

It fixed this issue, https://github.com/bnb-chain/bsc/issues/2570

### Changes

Notable changes: 
* freezer: opt freezer env check logic;
* ...
