### PR TITLE
fix: remove delete and dangling side chains in prunefreezer

### DIFF
--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -541,41 +541,6 @@ func gcKvStore(db ethdb.KeyValueStore, ancients []common.Hash, first uint64, fro
 	}
 	batch.Reset()
 
-	// Step into the future and delete and dangling side chains
-	if frozen > 0 {
-		tip := frozen
-		nfdb := &nofreezedb{KeyValueStore: db}
-		for len(dangling) > 0 {
-			drop := make(map[common.Hash]struct{})
-			for _, hash := range dangling {
-				log.Debug("Dangling parent from freezer", "number", tip-1, "hash", hash)
-				drop[hash] = struct{}{}
-			}
-			children := ReadAllHashes(db, tip)
-			for i := 0; i < len(children); i++ {
-				// Dig up the child and ensure it's dangling
-				child := ReadHeader(nfdb, children[i], tip)
-				if child == nil {
-					log.Error("Missing dangling header", "number", tip, "hash", children[i])
-					continue
-				}
-				if _, ok := drop[child.ParentHash]; !ok {
-					children = append(children[:i], children[i+1:]...)
-					i--
-					continue
-				}
-				// Delete all block data associated with the child
-				log.Debug("Deleting dangling block", "number", tip, "hash", children[i], "parent", child.ParentHash)
-				DeleteBlock(batch, children[i], tip)
-			}
-			dangling = children
-			tip++
-		}
-		if err := batch.Write(); err != nil {
-			log.Crit("Failed to delete dangling side blocks", "err", err)
-		}
-	}
-
 	// Log something friendly for the user
 	context := []interface{}{
 		"blocks", frozen - first, "elapsed", common.PrettyDuration(time.Since(start)), "number", frozen - 1,


### PR DESCRIPTION
### Description

When using the freezer deletion strategy, some side chain blocks are not yet finalized and might still be subject to reorganization (reorg). Therefore, they cannot be deleted at this time.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
