### PR TITLE
core: improve the network stability when double sign happens

### DIFF
--- a/core/forkchoice.go
+++ b/core/forkchoice.go
@@ -121,9 +121,12 @@ func (f *ForkChoice) ReorgNeeded(current *types.Header, extern *types.Header) (b
 		if f.preserve != nil {
 			currentPreserve, externPreserve = f.preserve(current), f.preserve(extern)
 		}
+		doubleSign := (extern.Coinbase == current.Coinbase)
 		reorg = !currentPreserve && (externPreserve ||
 			extern.Time < current.Time ||
-			extern.Time == current.Time && f.rand.Float64() < 0.5)
+			extern.Time == current.Time &&
+				(doubleSign && extern.Hash().Cmp(current.Hash()) < 0 ||
+					!doubleSign && f.rand.Float64() < 0.5))
 	}
 	return reorg, nil
 }

--- a/core/forkchoice.go
+++ b/core/forkchoice.go
@@ -125,8 +125,8 @@ func (f *ForkChoice) ReorgNeeded(current *types.Header, extern *types.Header) (b
 		reorg = !currentPreserve && (externPreserve ||
 			extern.Time < current.Time ||
 			extern.Time == current.Time &&
-				(doubleSign && extern.Hash().Cmp(current.Hash()) < 0 ||
-					!doubleSign && f.rand.Float64() < 0.5))
+				((doubleSign && extern.Hash().Cmp(current.Hash()) < 0) ||
+					(!doubleSign && f.rand.Float64() < 0.5)))
 	}
 	return reorg, nil
 }


### PR DESCRIPTION
### Description

core: improve the network stability when double sign happens

### Rationale

for example, 3 validator(vb, vc, vd) do an double sign attack together,
they can easily spilt the network into 8 subnets, then the whole chain stops

<img width="816" alt="image" src="https://github.com/user-attachments/assets/cc6bdf46-acd7-4ebc-9d62-ad7e580557cc">

to solve this issue, we should give a definited rule to select forks.

in additon, this change is back compatible

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
