### PR TITLE
core: cache block after wroten into db

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1801,6 +1801,12 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		if err := blockBatch.Write(); err != nil {
 			log.Crit("Failed to write block into disk", "err", err)
 		}
+		bc.hc.tdCache.Add(block.Hash(), externTd)
+		bc.blockCache.Add(block.Hash(), block)
+		bc.receiptsCache.Add(block.Hash(), receipts)
+		if bc.chainConfig.IsCancun(block.Number(), block.Time()) {
+			bc.sidecarsCache.Add(block.Hash(), block.Sidecars())
+		}
 		wg.Done()
 	}()
 


### PR DESCRIPTION
### Description

core: cache block after wroten into db

### Rationale

[PR 2566](https://github.com/bnb-chain/bsc/pull/2566) fix a potential bug, but may downgrade the performance,
this PR is to recovery the performance

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
