### PR TITLE
fix: prune-state when specify `--triesInMemory 32`

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1390,7 +1390,7 @@ func (bc *BlockChain) Stop() {
 		if !bc.cacheConfig.TrieDirtyDisabled {
 			triedb := bc.triedb
 			var once sync.Once
-			for _, offset := range []uint64{0, 1, TriesInMemory - 1} {
+			for _, offset := range []uint64{0, 1, bc.TriesInMemory() - 1} {
 				if number := bc.CurrentBlock().Number.Uint64(); number > offset {
 					recent := bc.GetBlockByNumber(number - offset)
 					log.Info("Writing cached state to disk", "block", recent.Number(), "hash", recent.Hash(), "root", recent.Root())
@@ -1822,7 +1822,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 
 		// Flush limits are not considered for the first TriesInMemory blocks.
 		current := block.NumberU64()
-		if current <= TriesInMemory {
+		if current <= bc.TriesInMemory() {
 			return nil
 		}
 		// If we exceeded our memory allowance, flush matured singleton nodes to disk

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -409,7 +409,7 @@ func (b *bidSimulator) clearLoop() {
 		}
 		delete(b.bestBid, parentHash)
 		for k, v := range b.bestBid {
-			if v.bid.BlockNumber <= blockNumber-core.TriesInMemory {
+			if v.bid.BlockNumber <= blockNumber-b.chain.TriesInMemory() {
 				v.env.discard()
 				delete(b.bestBid, k)
 			}
@@ -418,7 +418,7 @@ func (b *bidSimulator) clearLoop() {
 
 		b.simBidMu.Lock()
 		for k, v := range b.simulatingBid {
-			if v.bid.BlockNumber <= blockNumber-core.TriesInMemory {
+			if v.bid.BlockNumber <= blockNumber-b.chain.TriesInMemory() {
 				v.env.discard()
 				delete(b.simulatingBid, k)
 			}


### PR DESCRIPTION
### Description

To address and fix the issue described in [hash schema: prune state failed #2588](https://github.com/bnb-chain/bsc/issues/2588)

### Rationale

The prune-state command, when specifying --triesInMemory 32, results in a "no snapshot paired state" error, while the command runs successfully with the default value.
Previously, the fixed value of TriesInMemory was set to 128 and then changed to a configurable value. However, there are still some references in the code that have not been updated. For example, during persistence in (bc *BlockChain) Stop(), the constant value 128 is still being used instead of the configurable bc.TriesInMemory().

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
