### PR TITLE
consensus/parlia: modify mining time for last block in one turn

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1510,14 +1510,8 @@ func (p *Parlia) Delay(chain consensus.ChainReader, header *types.Header, leftOv
 
 	// The blocking time should be no more than half of period when snap.TurnLength == 1
 	timeForMining := time.Duration(p.config.Period) * time.Second / 2
-	if snap.TurnLength > 1 {
-		if snap.lastBlockInOneTurn(header.Number.Uint64()) {
-			// To ensure that the next validator produces and broadcasts blocks in a timely manner,
-			// set the value of timeForMining to a small amount
-			timeForMining = 500 * time.Millisecond
-		} else {
-			timeForMining = time.Duration(p.config.Period) * time.Second * 2 / 3
-		}
+	if !snap.lastBlockInOneTurn(header.Number.Uint64()) {
+		timeForMining = time.Duration(p.config.Period) * time.Second * 2 / 3
 	}
 	if delay > timeForMining {
 		delay = timeForMining


### PR DESCRIPTION
### Description

consensus/parlia: modify mining time for last block in one turn

### Rationale

the last block in one turn is too small, so revert it
compared to logic before BEP-341, just modify the delay for front blocks in one turn

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
