### PR TITLE
cmd/utils: add new flag OverridePassedForkTime

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -62,6 +62,7 @@ var (
 		ArgsUsage: "<genesisPath>",
 		Flags: flags.Merge([]cli.Flag{
 			utils.CachePreimagesFlag,
+			utils.OverridePassedForkTime,
 			utils.OverrideBohr,
 			utils.OverrideVerkle,
 			utils.MultiDataBaseFlag,
@@ -253,6 +254,10 @@ func initGenesis(ctx *cli.Context) error {
 	defer stack.Close()
 
 	var overrides core.ChainOverrides
+	if ctx.IsSet(utils.OverridePassedForkTime.Name) {
+		v := ctx.Uint64(utils.OverridePassedForkTime.Name)
+		overrides.OverridePassedForkTime = &v
+	}
 	if ctx.IsSet(utils.OverrideBohr.Name) {
 		v := ctx.Uint64(utils.OverrideBohr.Name)
 		overrides.OverrideBohr = &v

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -185,6 +185,10 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		params.RialtoGenesisHash = common.HexToHash(v)
 	}
 
+	if ctx.IsSet(utils.OverridePassedForkTime.Name) {
+		v := ctx.Uint64(utils.OverridePassedForkTime.Name)
+		cfg.Eth.OverridePassedForkTime = &v
+	}
 	if ctx.IsSet(utils.OverrideBohr.Name) {
 		v := ctx.Uint64(utils.OverrideBohr.Name)
 		cfg.Eth.OverrideBohr = &v

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -72,6 +72,7 @@ var (
 		utils.USBFlag,
 		utils.SmartCardDaemonPathFlag,
 		utils.RialtoHash,
+		utils.OverridePassedForkTime,
 		utils.OverrideBohr,
 		utils.OverrideVerkle,
 		utils.OverrideFullImmutabilityThreshold,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -305,6 +305,11 @@ var (
 		Usage:    "Manually specify the Rialto Genesis Hash, to trigger builtin network logic",
 		Category: flags.EthCategory,
 	}
+	OverridePassedForkTime = &cli.Uint64Flag{
+		Name:     "override.passedforktime",
+		Usage:    "Manually specify the hard fork timestamp except the last one, overriding the bundled setting",
+		Category: flags.EthCategory,
+	}
 	OverrideBohr = &cli.Uint64Flag{
 		Name:     "override.bohr",
 		Usage:    "Manually specify the Bohr fork timestamp, overriding the bundled setting",

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -216,8 +216,9 @@ func (e *GenesisMismatchError) Error() string {
 // ChainOverrides contains the changes to chain config
 // Typically, these modifications involve hardforks that are not enabled on the BSC mainnet, intended for testing purposes.
 type ChainOverrides struct {
-	OverrideBohr   *uint64
-	OverrideVerkle *uint64
+	OverridePassedForkTime *uint64
+	OverrideBohr           *uint64
+	OverrideVerkle         *uint64
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.
@@ -243,6 +244,15 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	}
 	applyOverrides := func(config *params.ChainConfig) {
 		if config != nil {
+			if overrides != nil && overrides.OverridePassedForkTime != nil {
+				config.ShanghaiTime = overrides.OverridePassedForkTime
+				config.KeplerTime = overrides.OverridePassedForkTime
+				config.FeynmanTime = overrides.OverridePassedForkTime
+				config.FeynmanFixTime = overrides.OverridePassedForkTime
+				config.CancunTime = overrides.OverridePassedForkTime
+				config.HaberTime = overrides.OverridePassedForkTime
+				config.HaberFixTime = overrides.OverridePassedForkTime
+			}
 			if overrides != nil && overrides.OverrideBohr != nil {
 				config.BohrTime = overrides.OverrideBohr
 			}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -185,6 +185,16 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	// Override the chain config with provided settings.
 	var overrides core.ChainOverrides
+	if config.OverridePassedForkTime != nil {
+		chainConfig.ShanghaiTime = config.OverridePassedForkTime
+		chainConfig.KeplerTime = config.OverridePassedForkTime
+		chainConfig.FeynmanTime = config.OverridePassedForkTime
+		chainConfig.FeynmanFixTime = config.OverridePassedForkTime
+		chainConfig.CancunTime = config.OverridePassedForkTime
+		chainConfig.HaberTime = config.OverridePassedForkTime
+		chainConfig.HaberFixTime = config.OverridePassedForkTime
+		overrides.OverridePassedForkTime = config.OverridePassedForkTime
+	}
 	if config.OverrideBohr != nil {
 		chainConfig.BohrTime = config.OverrideBohr
 		overrides.OverrideBohr = config.OverrideBohr

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -188,6 +188,9 @@ type Config struct {
 	// send-transaction variants. The unit is ether.
 	RPCTxFeeCap float64
 
+	// OverridePassedForkTime
+	OverridePassedForkTime *uint64 `toml:",omitempty"`
+
 	// OverrideBohr (TODO: remove after the fork)
 	OverrideBohr *uint64 `toml:",omitempty"`
 

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -70,6 +70,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCGasCap               uint64
 		RPCEVMTimeout           time.Duration
 		RPCTxFeeCap             float64
+		OverridePassedForkTime      *uint64 `toml:",omitempty"`
 		OverrideBohr            *uint64 `toml:",omitempty"`
 		OverrideVerkle          *uint64 `toml:",omitempty"`
 		BlobExtraReserve        uint64
@@ -128,6 +129,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RPCGasCap = c.RPCGasCap
 	enc.RPCEVMTimeout = c.RPCEVMTimeout
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
+	enc.OverridePassedForkTime = c.OverridePassedForkTime
 	enc.OverrideBohr = c.OverrideBohr
 	enc.OverrideVerkle = c.OverrideVerkle
 	enc.BlobExtraReserve = c.BlobExtraReserve
@@ -190,6 +192,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCGasCap               *uint64
 		RPCEVMTimeout           *time.Duration
 		RPCTxFeeCap             *float64
+		OverridePassedForkTime      *uint64 `toml:",omitempty"`
 		OverrideBohr            *uint64 `toml:",omitempty"`
 		OverrideVerkle          *uint64 `toml:",omitempty"`
 		BlobExtraReserve        *uint64
@@ -356,6 +359,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.RPCTxFeeCap != nil {
 		c.RPCTxFeeCap = *dec.RPCTxFeeCap
+	}
+	if dec.OverridePassedForkTime != nil {
+		c.OverridePassedForkTime = dec.OverridePassedForkTime
 	}
 	if dec.OverrideBohr != nil {
 		c.OverrideBohr = dec.OverrideBohr


### PR DESCRIPTION
### Description

cmd/utils: add new flag OverridePassedForkTime

### Rationale

reth client not accept hardfork time equal to `0`

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
