### PR TITLE
concensus/parlia.go: reverse iteration order

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1152,8 +1152,8 @@ func (p *Parlia) distributeFinalityReward(chain consensus.ChainHeaderReader, sta
 
 	head := header
 	accumulatedWeights := make(map[common.Address]uint64)
-	for height := currentHeight - 1; height+epoch >= currentHeight && height >= 1; height-- {
-		head = chain.GetHeaderByHash(head.ParentHash)
+	for height := uint64(math.Max(float64(currentHeight-epoch), 1)); height < currentHeight; height++ {
+		head = chain.GetHeaderByNumber(height - 1)
 		if head == nil {
 			return fmt.Errorf("header is nil at height %d", height)
 		}


### PR DESCRIPTION
### Description

When import a lots of block, the recentSnaps cache will not be used when distributeFinalityReward.  BTW the ecrecover is take long time. Affect more in erigon stage_sync. So add more snaps to cache when apply snapshots. 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* consensus/parlia.go
