### PR TITLE
Makefile: use docker compose v2 instead of v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ truffle-test:
 	docker build . -f ./docker/Dockerfile --target bsc-genesis -t bsc-genesis
 	docker build . -f ./docker/Dockerfile --target bsc -t bsc
 	docker build . -f ./docker/Dockerfile.truffle -t truffle-test
-	docker-compose -f ./tests/truffle/docker-compose.yml up genesis
-	docker-compose -f ./tests/truffle/docker-compose.yml up -d bsc-rpc bsc-validator1
+	docker compose -f ./tests/truffle/docker-compose.yml up genesis
+	docker compose -f ./tests/truffle/docker-compose.yml up -d bsc-rpc bsc-validator1
 	sleep 30
-	docker-compose -f ./tests/truffle/docker-compose.yml up --exit-code-from truffle-test truffle-test
-	docker-compose -f ./tests/truffle/docker-compose.yml down
+	docker compose -f ./tests/truffle/docker-compose.yml up --exit-code-from truffle-test truffle-test
+	docker compose -f ./tests/truffle/docker-compose.yml down
 
 #? lint: Run certain pre-selected linters
 lint: ## Run linters.


### PR DESCRIPTION
### Description

Makefile: use docker compose v2 instead of v1

### Rationale

truffle-test CI failed
https://github.com/bnb-chain/bsc/actions/runs/10242044173/job/28331648481?pr=2627
![image](https://github.com/user-attachments/assets/e036dbf0-dfac-4337-a3d2-f10900fa4c41)

because the latest ubuntu has dropped supporting `docker compose v1`
[[Ubuntu, Windows] Docker Compose v1 will be removed from images on July, 29](https://github.com/actions/runner-images/blob/ubuntu22/20240730.2/images/ubuntu/Ubuntu2204-Readme.md)

so we switch to use `docker compose v2`

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
