### PR TITLE
faucet: bump and resend faucet transaction if it has been pending for a while

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ geth:
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
+#? faucet: Build faucet
+faucet:
+	$(GORUN) build/ci.go install ./cmd/faucet
+	@echo "Done building faucet"
+
 #? all: Build all packages and executables
 all:
 	$(GORUN) build/ci.go install


### PR DESCRIPTION
### Description
The faucet service is not stable, sometimes it got stuck for quite a long time and can only be recovered by restarting the process.
After some investigation, found it could be caused by transaction lost, there are various cases that a transaction can be dropped, such as network issue or discarded when TxPool is full. One lost transaction could cause the stuck of faucet service, due to the nonce gap issue.
This PR will check for each new imported block, if the faucet transaction got stuck for a certain time, trigger a resend operation, so it will not block the faucet service.

### Rationale
NA

### Example
NA

### Changes
NA