### PR TITLE
eth: Add sidecars when available to broadcasted current block

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -248,6 +248,9 @@ func (h *handler) doSync(op *chainSyncOp) error {
 		// degenerate connectivity, but it should be healthy for the mainnet too to
 		// more reliably update peers or the local TD state.
 		if block := h.chain.GetBlock(head.Hash(), head.Number.Uint64()); block != nil {
+			if h.chain.Config().IsCancun(block.Number(), block.Time()) {
+				block = block.WithSidecars(h.chain.GetSidecarsByHash(block.Hash()))
+			}
 			h.BroadcastBlock(block, false)
 		}
 	}


### PR DESCRIPTION
### Description

Add to the broadcasted "Current" block the Sidecars, when available.

### Rationale

The Sidecars were missing in this case, leading to invalid `NewBlockPacket` being propagated
