### PR TITLE
eth/handler: remove duplicate check for lists in body

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -320,22 +320,26 @@ func newHandler(config *handlerConfig) (*handler, error) {
 	}
 
 	broadcastBlockWithCheck := func(block *types.Block, propagate bool) {
+		// All the block fetcher activities should be disabled
+		// after the transition. Print the warning log.
+		if h.merger.PoSFinalized() {
+			log.Warn("Unexpected validation activity", "hash", block.Hash(), "number", block.Number())
+			return
+		}
+		// Reject all the PoS style headers in the first place. No matter
+		// the chain has finished the transition or not, the PoS headers
+		// should only come from the trusted consensus layer instead of
+		// p2p network.
+		if beacon, ok := h.chain.Engine().(*beacon.Beacon); ok {
+			if beacon.IsPoSHeader(block.Header()) {
+				log.Warn("unexpected post-merge header")
+				return
+			}
+		}
 		if propagate {
-			checkErrs := make(chan error, 2)
-
-			go func() {
-				checkErrs <- core.ValidateListsInBody(block)
-			}()
-			go func() {
-				checkErrs <- core.IsDataAvailable(h.chain, block)
-			}()
-
-			for i := 0; i < cap(checkErrs); i++ {
-				err := <-checkErrs
-				if err != nil {
-					log.Error("Propagating invalid block", "number", block.Number(), "hash", block.Hash(), "err", err)
-					return
-				}
+			if err := core.IsDataAvailable(h.chain, block); err != nil {
+				log.Error("Propagating block with invalid sidecars", "number", block.Number(), "hash", block.Hash(), "err", err)
+				return
 			}
 		}
 		h.BroadcastBlock(block, propagate)


### PR DESCRIPTION
### Description

eth/handler: remove duplicate check for lists in body

### Rationale

in this PR(https://github.com/bnb-chain/bsc/pull/2461),
check for 3 lists `Uncles`, `Transactions`, `Withdrawals` is added.

but indeed, most of them are useless, because 
if block recieved by `handleBlockBodies`, 
`Uncles` and `Transactions` have been checked  at https://github.com/bnb-chain/bsc/blob/master/eth/fetcher/block_fetcher.go#L718
if block recieved by `handleNewBlock`
`Uncles` and `Transactions` have been checked at https://github.com/bnb-chain/bsc/blob/master/eth/protocols/eth/handlers.go#L316
so only add check for Withdrawals` is ok.

the check for `Transactions` cost not a little time when block is huge,
by removing the dupicate check, a better performance can be acheived

so this PR have 2 commits,
the first one is to revert the above PR,
the second one add the check for Withdrawals`

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
