### PR TITLE
config: fix default value for PascalTime and add OverridePascal

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -64,6 +64,7 @@ var (
 			utils.CachePreimagesFlag,
 			utils.OverridePassedForkTime,
 			utils.OverrideBohr,
+			utils.OverridePascal,
 			utils.OverrideVerkle,
 			utils.MultiDataBaseFlag,
 		}, utils.DatabaseFlags),
@@ -261,6 +262,10 @@ func initGenesis(ctx *cli.Context) error {
 	if ctx.IsSet(utils.OverrideBohr.Name) {
 		v := ctx.Uint64(utils.OverrideBohr.Name)
 		overrides.OverrideBohr = &v
+	}
+	if ctx.IsSet(utils.OverridePascal.Name) {
+		v := ctx.Uint64(utils.OverridePascal.Name)
+		overrides.OverridePascal = &v
 	}
 	if ctx.IsSet(utils.OverrideVerkle.Name) {
 		v := ctx.Uint64(utils.OverrideVerkle.Name)

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -195,6 +195,10 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		v := ctx.Uint64(utils.OverrideBohr.Name)
 		cfg.Eth.OverrideBohr = &v
 	}
+	if ctx.IsSet(utils.OverridePascal.Name) {
+		v := ctx.Uint64(utils.OverridePascal.Name)
+		cfg.Eth.OverridePascal = &v
+	}
 	if ctx.IsSet(utils.OverrideVerkle.Name) {
 		v := ctx.Uint64(utils.OverrideVerkle.Name)
 		cfg.Eth.OverrideVerkle = &v

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -74,6 +74,7 @@ var (
 		utils.RialtoHash,
 		utils.OverridePassedForkTime,
 		utils.OverrideBohr,
+		utils.OverridePascal,
 		utils.OverrideVerkle,
 		utils.OverrideFullImmutabilityThreshold,
 		utils.OverrideMinBlocksForBlobRequests,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -310,12 +310,17 @@ var (
 	}
 	OverridePassedForkTime = &cli.Uint64Flag{
 		Name:     "override.passedforktime",
-		Usage:    "Manually specify the hard fork timestamp except the last one, overriding the bundled setting",
+		Usage:    "Manually specify the hard fork timestamps which have passed on the mainnet, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
 	OverrideBohr = &cli.Uint64Flag{
 		Name:     "override.bohr",
 		Usage:    "Manually specify the Bohr fork timestamp, overriding the bundled setting",
+		Category: flags.EthCategory,
+	}
+	OverridePascal = &cli.Uint64Flag{
+		Name:     "override.pascal",
+		Usage:    "Manually specify the Pascal fork timestamp, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
 	OverrideVerkle = &cli.Uint64Flag{

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -218,6 +218,7 @@ func (e *GenesisMismatchError) Error() string {
 type ChainOverrides struct {
 	OverridePassedForkTime *uint64
 	OverrideBohr           *uint64
+	OverridePascal         *uint64
 	OverrideVerkle         *uint64
 }
 
@@ -252,10 +253,12 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 				config.CancunTime = overrides.OverridePassedForkTime
 				config.HaberTime = overrides.OverridePassedForkTime
 				config.HaberFixTime = overrides.OverridePassedForkTime
-				config.PascalTime = overrides.OverridePassedForkTime
 			}
 			if overrides != nil && overrides.OverrideBohr != nil {
 				config.BohrTime = overrides.OverrideBohr
+			}
+			if overrides != nil && overrides.OverridePascal != nil {
+				config.PascalTime = overrides.OverridePascal
 			}
 			if overrides != nil && overrides.OverrideVerkle != nil {
 				config.VerkleTime = overrides.OverrideVerkle

--- a/core/systemcontracts/upgrade.go
+++ b/core/systemcontracts/upgrade.go
@@ -1064,7 +1064,6 @@ func init() {
 			},
 		},
 	}
-
 }
 
 func UpgradeBuildInSystemContract(config *params.ChainConfig, blockNumber *big.Int, lastBlockTime uint64, blockTime uint64, statedb vm.StateDB) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -193,12 +193,15 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		chainConfig.CancunTime = config.OverridePassedForkTime
 		chainConfig.HaberTime = config.OverridePassedForkTime
 		chainConfig.HaberFixTime = config.OverridePassedForkTime
-		chainConfig.PascalTime = config.OverridePassedForkTime
 		overrides.OverridePassedForkTime = config.OverridePassedForkTime
 	}
 	if config.OverrideBohr != nil {
 		chainConfig.BohrTime = config.OverrideBohr
 		overrides.OverrideBohr = config.OverrideBohr
+	}
+	if config.OverridePascal != nil {
+		chainConfig.PascalTime = config.OverridePascal
+		overrides.OverridePascal = config.OverridePascal
 	}
 	if config.OverrideVerkle != nil {
 		chainConfig.VerkleTime = config.OverrideVerkle

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -194,6 +194,9 @@ type Config struct {
 	// OverrideBohr (TODO: remove after the fork)
 	OverrideBohr *uint64 `toml:",omitempty"`
 
+	// OverridePascal (TODO: remove after the fork)
+	OverridePascal *uint64 `toml:",omitempty"`
+
 	// OverrideVerkle (TODO: remove after the fork)
 	OverrideVerkle *uint64 `toml:",omitempty"`
 

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -70,8 +70,9 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCGasCap               uint64
 		RPCEVMTimeout           time.Duration
 		RPCTxFeeCap             float64
-		OverridePassedForkTime      *uint64 `toml:",omitempty"`
+		OverridePassedForkTime  *uint64 `toml:",omitempty"`
 		OverrideBohr            *uint64 `toml:",omitempty"`
+		OverridePascal          *uint64 `toml:",omitempty"`
 		OverrideVerkle          *uint64 `toml:",omitempty"`
 		BlobExtraReserve        uint64
 	}
@@ -131,6 +132,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
 	enc.OverridePassedForkTime = c.OverridePassedForkTime
 	enc.OverrideBohr = c.OverrideBohr
+	enc.OverridePascal = c.OverridePascal
 	enc.OverrideVerkle = c.OverrideVerkle
 	enc.BlobExtraReserve = c.BlobExtraReserve
 	return &enc, nil
@@ -192,8 +194,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCGasCap               *uint64
 		RPCEVMTimeout           *time.Duration
 		RPCTxFeeCap             *float64
-		OverridePassedForkTime      *uint64 `toml:",omitempty"`
+		OverridePassedForkTime  *uint64 `toml:",omitempty"`
 		OverrideBohr            *uint64 `toml:",omitempty"`
+		OverridePascal          *uint64 `toml:",omitempty"`
 		OverrideVerkle          *uint64 `toml:",omitempty"`
 		BlobExtraReserve        *uint64
 	}
@@ -365,6 +368,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.OverrideBohr != nil {
 		c.OverrideBohr = dec.OverrideBohr
+	}
+	if dec.OverridePascal != nil {
+		c.OverridePascal = dec.OverridePascal
 	}
 	if dec.OverrideVerkle != nil {
 		c.OverrideVerkle = dec.OverrideVerkle

--- a/params/config.go
+++ b/params/config.go
@@ -156,7 +156,7 @@ var (
 		HaberFixTime:        newUint64(1727316120), // 2024-09-26 02:02:00 AM UTC
 		BohrTime:            newUint64(1727317200), // 2024-09-26 02:20:00 AM UTC
 		// TODO
-		PascalTime: newUint64(0),
+		PascalTime: nil,
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -199,7 +199,7 @@ var (
 		HaberFixTime:        newUint64(1719986788), // 2024-07-03 06:06:28 AM UTC
 		BohrTime:            newUint64(1724116996), // 2024-08-20 01:23:16 AM UTC
 		// TODO
-		PascalTime: newUint64(0),
+		PascalTime: nil,
 
 		Parlia: &ParliaConfig{
 			Period: 3,


### PR DESCRIPTION
### Description

config: fix default value for PascalTime and add OverridePascal

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
