### PR TITLE
chore: add missing symbols in comment

### DIFF
--- a/crypto/bn256/cloudflare/gfp12.go
+++ b/crypto/bn256/cloudflare/gfp12.go
@@ -1,7 +1,7 @@
 package bn256
 
 // For details of the algorithms used, see "Multiplication and Squaring on
-// Pairing-Friendly Fields, Devegili et al.
+// Pairing-Friendly Fields", Devegili et al.
 // http://eprint.iacr.org/2006/471.pdf.
 
 import (

--- a/crypto/bn256/cloudflare/gfp2.go
+++ b/crypto/bn256/cloudflare/gfp2.go
@@ -1,7 +1,7 @@
 package bn256
 
 // For details of the algorithms used, see "Multiplication and Squaring on
-// Pairing-Friendly Fields, Devegili et al.
+// Pairing-Friendly Fields", Devegili et al.
 // http://eprint.iacr.org/2006/471.pdf.
 
 // gfP2 implements a field of size p² as a quadratic extension of the base field

--- a/crypto/bn256/cloudflare/gfp6.go
+++ b/crypto/bn256/cloudflare/gfp6.go
@@ -1,7 +1,7 @@
 package bn256
 
 // For details of the algorithms used, see "Multiplication and Squaring on
-// Pairing-Friendly Fields, Devegili et al.
+// Pairing-Friendly Fields", Devegili et al.
 // http://eprint.iacr.org/2006/471.pdf.
 
 // gfP6 implements the field of size p⁶ as a cubic extension of gfP2 where τ³=ξ

--- a/crypto/bn256/google/gfp12.go
+++ b/crypto/bn256/google/gfp12.go
@@ -5,7 +5,7 @@
 package bn256
 
 // For details of the algorithms used, see "Multiplication and Squaring on
-// Pairing-Friendly Fields, Devegili et al.
+// Pairing-Friendly Fields", Devegili et al.
 // http://eprint.iacr.org/2006/471.pdf.
 
 import (

--- a/crypto/bn256/google/gfp2.go
+++ b/crypto/bn256/google/gfp2.go
@@ -5,7 +5,7 @@
 package bn256
 
 // For details of the algorithms used, see "Multiplication and Squaring on
-// Pairing-Friendly Fields, Devegili et al.
+// Pairing-Friendly Fields", Devegili et al.
 // http://eprint.iacr.org/2006/471.pdf.
 
 import (

--- a/crypto/bn256/google/gfp6.go
+++ b/crypto/bn256/google/gfp6.go
@@ -5,7 +5,7 @@
 package bn256
 
 // For details of the algorithms used, see "Multiplication and Squaring on
-// Pairing-Friendly Fields, Devegili et al.
+// Pairing-Friendly Fields", Devegili et al.
 // http://eprint.iacr.org/2006/471.pdf.
 
 import (


### PR DESCRIPTION
### Description

These codes appear to come from Go's crypto library, and upstream has fixed these comments

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
