### PR TITLE
github: upgrade artifact from v3 to v4.1.7

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -82,28 +82,28 @@ jobs:
       # ==============================
 
       - name: Upload Linux Build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.7
         if: matrix.os == 'ubuntu-latest'
         with:
           name: linux
           path: ./build/bin/geth
 
       - name: Upload MacOS Build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.7
         if: matrix.os == 'macos-latest'
         with:
           name: macos
           path: ./build/bin/geth
       
       - name: Upload Windows Build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.7
         if: matrix.os == 'windows-latest'
         with:
           name: windows
           path: ./build/bin/geth.exe
 
       - name: Upload ARM-64 Build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.7
         if: matrix.os == 'ubuntu-latest'
         with:
           name: arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,28 +81,28 @@ jobs:
       # ==============================
 
       - name: Upload Linux Build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.7
         if: matrix.os == 'ubuntu-latest'
         with:
           name: linux
           path: ./build/bin/geth
 
       - name: Upload MacOS Build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.7
         if: matrix.os == 'macos-latest'
         with:
           name: macos
           path: ./build/bin/geth
       
       - name: Upload Windows Build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.7
         if: matrix.os == 'windows-latest'
         with:
           name: windows
           path: ./build/bin/geth.exe
 
       - name: Upload ARM-64 Build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.7
         if: matrix.os == 'ubuntu-latest'
         with:
           name: arm64


### PR DESCRIPTION
### Description
upload-artifact and download-artifact must use same version, otherwise release workflow will fail.
https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md


### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
