### PR TITLE
BEP-440: Implement EIP-2935: Serve historical block hashes from state

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -651,11 +651,11 @@ func (p *Parlia) verifyHeader(chain consensus.ChainHeaderReader, header *types.H
 		if header.RequestsHash != nil {
 			return fmt.Errorf("invalid RequestsHash, have %#x, expected nil", header.ParentBeaconRoot)
 		}
-	} else {
-		// TODO(Nathan): need a BEP to define this and `Requests` in struct Body
-		if !header.EmptyRequestsHash() {
-			return errors.New("header has wrong RequestsHash")
-		}
+		// } else {
+		// 	// TODO(Nathan): need a BEP to define this and `Requests` in struct Body
+		// 	if !header.EmptyRequestsHash() {
+		// 		return errors.New("header has wrong RequestsHash")
+		// 	}
 	}
 
 	// All basic checks passed, verify cascading fields
@@ -1287,9 +1287,7 @@ func (p *Parlia) Finalize(chain consensus.ChainHeaderReader, header *types.Heade
 		return errors.New("parent not found")
 	}
 
-	if p.chainConfig.IsFeynman(header.Number, header.Time) {
-		systemcontracts.UpgradeBuildInSystemContract(p.chainConfig, header.Number, parent.Time, header.Time, state)
-	}
+	systemcontracts.ModifyBuildInSystemContract(p.chainConfig, header.Number, parent.Time, header.Time, state, false)
 
 	if p.chainConfig.IsOnFeynman(header.Number, parent.Time, header.Time) {
 		err := p.initializeFeynmanContract(state, header, cx, txs, receipts, systemTxs, usedGas, false)
@@ -1374,9 +1372,7 @@ func (p *Parlia) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *
 		return nil, nil, errors.New("parent not found")
 	}
 
-	if p.chainConfig.IsFeynman(header.Number, header.Time) {
-		systemcontracts.UpgradeBuildInSystemContract(p.chainConfig, header.Number, parent.Time, header.Time, state)
-	}
+	systemcontracts.ModifyBuildInSystemContract(p.chainConfig, header.Number, parent.Time, header.Time, state, false)
 
 	if p.chainConfig.IsOnFeynman(header.Number, parent.Time, header.Time) {
 		err := p.initializeFeynmanContract(state, header, cx, &body.Transactions, &receipts, nil, &header.GasUsed, true)

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1287,7 +1287,7 @@ func (p *Parlia) Finalize(chain consensus.ChainHeaderReader, header *types.Heade
 		return errors.New("parent not found")
 	}
 
-	systemcontracts.ModifyBuildInSystemContract(p.chainConfig, header.Number, parent.Time, header.Time, state, false)
+	systemcontracts.TryUpdateBuildInSystemContract(p.chainConfig, header.Number, parent.Time, header.Time, state, false)
 
 	if p.chainConfig.IsOnFeynman(header.Number, parent.Time, header.Time) {
 		err := p.initializeFeynmanContract(state, header, cx, txs, receipts, systemTxs, usedGas, false)
@@ -1372,7 +1372,7 @@ func (p *Parlia) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *
 		return nil, nil, errors.New("parent not found")
 	}
 
-	systemcontracts.ModifyBuildInSystemContract(p.chainConfig, header.Number, parent.Time, header.Time, state, false)
+	systemcontracts.TryUpdateBuildInSystemContract(p.chainConfig, header.Number, parent.Time, header.Time, state, false)
 
 	if p.chainConfig.IsOnFeynman(header.Number, parent.Time, header.Time) {
 		err := p.initializeFeynmanContract(state, header, cx, &body.Transactions, &receipts, nil, &header.GasUsed, true)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -363,9 +363,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			misc.ApplyDAOHardFork(statedb)
 		}
 
-		if !config.IsFeynman(b.header.Number, b.header.Time) {
-			systemcontracts.UpgradeBuildInSystemContract(config, b.header.Number, parent.Time(), b.header.Time, statedb)
-		}
+		systemcontracts.ModifyBuildInSystemContract(config, b.header.Number, parent.Time(), b.header.Time, statedb, true)
 
 		// Execute any user modifications to the block
 		if gen != nil {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -363,7 +363,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			misc.ApplyDAOHardFork(statedb)
 		}
 
-		systemcontracts.ModifyBuildInSystemContract(config, b.header.Number, parent.Time(), b.header.Time, statedb, true)
+		systemcontracts.TryUpdateBuildInSystemContract(config, b.header.Number, parent.Time(), b.header.Time, statedb, true)
 
 		// Execute any user modifications to the block
 		if gen != nil {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -76,10 +76,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	if lastBlock == nil {
 		return nil, errors.New("could not get parent block")
 	}
-	if !p.config.IsFeynman(block.Number(), block.Time()) {
-		// Handle upgrade build-in system contract code
-		systemcontracts.UpgradeBuildInSystemContract(p.config, blockNumber, lastBlock.Time, block.Time(), statedb)
-	}
+	// Handle upgrade build-in system contract code
+	systemcontracts.ModifyBuildInSystemContract(p.config, blockNumber, lastBlock.Time, block.Time(), statedb, true)
 
 	var (
 		context vm.BlockContext

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -77,7 +77,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		return nil, errors.New("could not get parent block")
 	}
 	// Handle upgrade build-in system contract code
-	systemcontracts.ModifyBuildInSystemContract(p.config, blockNumber, lastBlock.Time, block.Time(), statedb, true)
+	systemcontracts.TryUpdateBuildInSystemContract(p.config, blockNumber, lastBlock.Time, block.Time(), statedb, true)
 
 	var (
 		context vm.BlockContext

--- a/core/systemcontracts/upgrade.go
+++ b/core/systemcontracts/upgrade.go
@@ -1050,7 +1050,7 @@ func init() {
 	}
 }
 
-func ModifyBuildInSystemContract(config *params.ChainConfig, blockNumber *big.Int, lastBlockTime uint64, blockTime uint64, statedb vm.StateDB, atBlockBegin bool) {
+func TryUpdateBuildInSystemContract(config *params.ChainConfig, blockNumber *big.Int, lastBlockTime uint64, blockTime uint64, statedb vm.StateDB, atBlockBegin bool) {
 	if atBlockBegin {
 		if !config.IsFeynman(blockNumber, lastBlockTime) {
 			upgradeBuildInSystemContract(config, blockNumber, lastBlockTime, blockTime, statedb)

--- a/core/systemcontracts/upgrade_test.go
+++ b/core/systemcontracts/upgrade_test.go
@@ -55,7 +55,7 @@ func TestUpgradeBuildInSystemContractNilInterface(t *testing.T) {
 
 	GenesisHash = params.BSCGenesisHash
 
-	UpgradeBuildInSystemContract(config, blockNumber, lastBlockTime, blockTime, statedb)
+	upgradeBuildInSystemContract(config, blockNumber, lastBlockTime, blockTime, statedb)
 }
 
 func TestUpgradeBuildInSystemContractNilValue(t *testing.T) {
@@ -69,5 +69,5 @@ func TestUpgradeBuildInSystemContractNilValue(t *testing.T) {
 
 	GenesisHash = params.BSCGenesisHash
 
-	UpgradeBuildInSystemContract(config, blockNumber, lastBlockTime, blockTime, statedb)
+	upgradeBuildInSystemContract(config, blockNumber, lastBlockTime, blockTime, statedb)
 }

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -249,7 +249,6 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, eth.blockchain.Config(), vm.Config{})
 		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
 	}
-
 	// If prague hardfork, insert parent block hash in the state as per EIP-2935.
 	if eth.blockchain.Config().IsPrague(block.Number(), block.Time()) {
 		context := core.NewEVMBlockContext(block.Header(), eth.blockchain, nil)

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -242,7 +242,7 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		return nil, vm.BlockContext{}, nil, nil, err
 	}
 	// upgrade build-in system contract before normal txs if Feynman is not enabled
-	systemcontracts.ModifyBuildInSystemContract(eth.blockchain.Config(), block.Number(), parent.Time(), block.Time(), statedb, true)
+	systemcontracts.TryUpdateBuildInSystemContract(eth.blockchain.Config(), block.Number(), parent.Time(), block.Time(), statedb, true)
 	// Insert parent beacon block root in the state as per EIP-4788.
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		context := core.NewEVMBlockContext(block.Header(), eth.blockchain, nil)
@@ -275,7 +275,7 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 						statedb.AddBalance(block.Header().Coinbase, balance, tracing.BalanceChangeUnspecified)
 					}
 
-					systemcontracts.ModifyBuildInSystemContract(eth.blockchain.Config(), block.Number(), parent.Time(), block.Time(), statedb, false)
+					systemcontracts.TryUpdateBuildInSystemContract(eth.blockchain.Config(), block.Number(), parent.Time(), block.Time(), statedb, false)
 					beforeSystemTx = false
 				}
 			}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -288,7 +288,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 									task.statedb.AddBalance(blockCtx.Coinbase, balance, tracing.BalanceChangeUnspecified)
 								}
 
-								systemcontracts.ModifyBuildInSystemContract(api.backend.ChainConfig(), task.block.Number(), task.parent.Time(), task.block.Time(), task.statedb, false)
+								systemcontracts.TryUpdateBuildInSystemContract(api.backend.ChainConfig(), task.block.Number(), task.parent.Time(), task.block.Time(), task.statedb, false)
 								beforeSystemTx = false
 							}
 						}
@@ -402,7 +402,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 			}
 
 			// upgrade build-in system contract before normal txs if Feynman is not enabled
-			systemcontracts.ModifyBuildInSystemContract(api.backend.ChainConfig(), next.Number(), block.Time(), next.Time(), statedb, true)
+			systemcontracts.TryUpdateBuildInSystemContract(api.backend.ChainConfig(), next.Number(), block.Time(), next.Time(), statedb, true)
 
 			// Insert block's parent beacon block root in the state
 			// as per EIP-4788.
@@ -560,7 +560,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 	defer release()
 
 	// upgrade build-in system contract before normal txs if Feynman is not enabled
-	systemcontracts.ModifyBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, true)
+	systemcontracts.TryUpdateBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, true)
 
 	var (
 		roots              []common.Hash
@@ -596,7 +596,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 				}
 
 				if beforeSystemTx {
-					systemcontracts.ModifyBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, false)
+					systemcontracts.TryUpdateBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, false)
 					beforeSystemTx = false
 				}
 			}
@@ -656,7 +656,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	defer release()
 
 	// upgrade build-in system contract before normal txs if Feynman is not enabled
-	systemcontracts.ModifyBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, true)
+	systemcontracts.TryUpdateBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, true)
 
 	// JS tracers have high overhead. In this case run a parallel
 	// process that generates states in one thread and traces txes
@@ -695,7 +695,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 						statedb.AddBalance(blockCtx.Coinbase, balance, tracing.BalanceChangeUnspecified)
 					}
 
-					systemcontracts.ModifyBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, false)
+					systemcontracts.TryUpdateBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, false)
 					beforeSystemTx = false
 				}
 			}
@@ -786,7 +786,7 @@ txloop:
 						statedb.AddBalance(block.Header().Coinbase, balance, tracing.BalanceChangeUnspecified)
 					}
 
-					systemcontracts.ModifyBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, false)
+					systemcontracts.TryUpdateBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, false)
 					beforeSystemTx = false
 				}
 			}
@@ -852,7 +852,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	defer release()
 
 	// upgrade build-in system contract before normal txs if Feynman is not enabled
-	systemcontracts.ModifyBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, true)
+	systemcontracts.TryUpdateBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, true)
 
 	// Retrieve the tracing configurations, or use default values
 	var (
@@ -902,7 +902,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 						statedb.AddBalance(vmctx.Coinbase, balance, tracing.BalanceChangeUnspecified)
 					}
 
-					systemcontracts.ModifyBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, false)
+					systemcontracts.TryUpdateBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, false)
 					beforeSystemTx = false
 				}
 			}
@@ -1084,7 +1084,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 		if err != nil {
 			return nil, err
 		}
-		systemcontracts.ModifyBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, true)
+		systemcontracts.TryUpdateBuildInSystemContract(api.backend.ChainConfig(), block.Number(), parent.Time(), block.Time(), statedb, true)
 	}
 
 	vmctx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1042,10 +1042,8 @@ func (w *worker) prepareWork(genParams *generateParams, witness bool) (*environm
 		return nil, err
 	}
 
-	if !w.chainConfig.IsFeynman(header.Number, header.Time) {
-		// Handle upgrade build-in system contract code
-		systemcontracts.UpgradeBuildInSystemContract(w.chainConfig, header.Number, parent.Time, header.Time, env.state)
-	}
+	// Handle upgrade build-in system contract code
+	systemcontracts.ModifyBuildInSystemContract(w.chainConfig, header.Number, parent.Time, header.Time, env.state, true)
 
 	if header.ParentBeaconRoot != nil {
 		context := core.NewEVMBlockContext(header, w.chain, nil)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1043,7 +1043,7 @@ func (w *worker) prepareWork(genParams *generateParams, witness bool) (*environm
 	}
 
 	// Handle upgrade build-in system contract code
-	systemcontracts.ModifyBuildInSystemContract(w.chainConfig, header.Number, parent.Time, header.Time, env.state, true)
+	systemcontracts.TryUpdateBuildInSystemContract(w.chainConfig, header.Number, parent.Time, header.Time, env.state, true)
 
 	if header.ParentBeaconRoot != nil {
 		context := core.NewEVMBlockContext(header, w.chain, nil)

--- a/params/config.go
+++ b/params/config.go
@@ -1024,6 +1024,15 @@ func (c *ChainConfig) IsPrague(num *big.Int, time uint64) bool {
 	return c.IsLondon(num) && isTimestampForked(c.PragueTime, time)
 }
 
+// IsOnPrague returns whether currentBlockTime is either equal to the Prague fork time or greater firstly.
+func (c *ChainConfig) IsOnPrague(currentBlockNumber *big.Int, lastBlockTime uint64, currentBlockTime uint64) bool {
+	lastBlockNumber := new(big.Int)
+	if currentBlockNumber.Cmp(big.NewInt(1)) >= 0 {
+		lastBlockNumber.Sub(currentBlockNumber, big.NewInt(1))
+	}
+	return !c.IsPrague(lastBlockNumber, lastBlockTime) && c.IsPrague(currentBlockNumber, currentBlockTime)
+}
+
 // IsVerkle returns whether time is either equal to the Verkle fork time or greater.
 func (c *ChainConfig) IsVerkle(num *big.Int, time uint64) bool {
 	return c.IsLondon(num) && isTimestampForked(c.VerkleTime, time)


### PR DESCRIPTION
### Description

[BEP-440: Implement EIP-2935: Serve historical block hashes from state](https://github.com/bnb-chain/BEPs/pull/440)

### Rationale

tell us why we need these changes...

### Example
use node-deploy(bfc5db87b54db995ac06dd3b38d40a2a77bd89a8) to test
1. modify `bsc_cluster.sh`, then set up the cluster
<img width="1162" alt="image" src="https://github.com/user-attachments/assets/70b7c0c4-f44f-4c99-ad42-83b7b4d3fcf2">
2. cat log, if prague is enabled at `blockNumber=13`

get blockhash of `blockNumber=11`

```
curl http://127.0.0.1:8545/ --data '{
      "jsonrpc": "2.0",
      "id": 0,
      "method": "eth_call",
      "params": [ {
            "to": "0x0aae40965e6800cd9b1f4b05ff21581047e3f91e",
            "data": "0x000000000000000000000000000000000000000000000000000000000000000B"
        }, "latest"]
    }'  -H "Content-Type: application/json"  -X POST
```

get zero hash

```
{"jsonrpc":"2.0","id":0,"result":"0x0000000000000000000000000000000000000000000000000000000000000000"}
```

get blockhash of `blockNumber=12`

```
curl http://127.0.0.1:8545/ --data '{
      "jsonrpc": "2.0",
      "id": 0,
      "method": "eth_call",
      "params": [ {
            "to": "0x0aae40965e6800cd9b1f4b05ff21581047e3f91e",
            "data": "0x000000000000000000000000000000000000000000000000000000000000000C"
        }, "latest"]
    }'  -H "Content-Type: application/json"  -X POST
```

get expected hash

```
{"jsonrpc":"2.0","id":0,"result":"0x1a4552035ba93e7a463e13f458e9d71b798c4393a79a6c08e157cb81cb11c0bb"}
```
<img width="665" alt="image" src="https://github.com/user-attachments/assets/cc5c8c9b-c2a6-4814-adcb-e11e00744787">

### Changes

code implement following https://github.com/ethereum/go-ethereum/pull/29465

but the logic for deployment is different from the raw eip-2935

Notable changes: 
* add each change in a bullet point here
* ...
