### PR TITLE
fix: fix multi-db env

### DIFF
--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -71,10 +71,12 @@ func newChainFreezer(datadir string, namespace string, readonly bool, offset uin
 		return nil, err
 	}
 	cf := chainFreezer{
-		Freezer:       freezer,
-		quit:          make(chan struct{}),
-		trigger:       make(chan chan struct{}),
-		multiDatabase: multiDatabase,
+		Freezer: freezer,
+		quit:    make(chan struct{}),
+		trigger: make(chan chan struct{}),
+		// After enabling pruneAncient, the ancient data is not retained. In some specific scenarios where it is
+		// necessary to roll back to blocks prior to the finalized block, it is mandatory to keep the most recent 90,000 blocks in the database to ensure proper functionality and rollback capability.
+		multiDatabase: false,
 	}
 	cf.threshold.Store(params.FullImmutabilityThreshold)
 	return &cf, nil

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -71,9 +71,10 @@ func newChainFreezer(datadir string, namespace string, readonly bool, offset uin
 		return nil, err
 	}
 	cf := chainFreezer{
-		Freezer: freezer,
-		quit:    make(chan struct{}),
-		trigger: make(chan chan struct{}),
+		Freezer:       freezer,
+		quit:          make(chan struct{}),
+		trigger:       make(chan chan struct{}),
+		multiDatabase: multiDatabase,
 	}
 	cf.threshold.Store(params.FullImmutabilityThreshold)
 	return &cf, nil

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -210,7 +210,11 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 
 	// startup ancient freeze
-	if err = chainDb.SetupFreezerEnv(&ethdb.FreezerEnv{
+	freezeDb := chainDb
+	if stack.CheckIfMultiDataBase() {
+		freezeDb = chainDb.BlockStore()
+	}
+	if err = freezeDb.SetupFreezerEnv(&ethdb.FreezerEnv{
 		ChainCfg:         chainConfig,
 		BlobExtraReserve: config.BlobExtraReserve,
 	}); err != nil {


### PR DESCRIPTION
### Description

When multi-database (multi-db) mode is enabled, the freezer's environment (env) is not properly set for the multi-db configuration. This prevents the multi-db chain_freezer from moving block data from the database (db) to the ancient storage (ancient).

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
