### PR TITLE
nancy: ignore github.com/golang-jwt/jwt/v4 4.5.0 in .nancy-ignore

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,3 +1,4 @@
 CVE-2024-34478 # "CWE-754: Improper Check for Unusual or Exceptional Conditions." This vulnerability is BTC only, BSC does not have the issue.
 CVE-2024-6104 # "CWE-532: Information Exposure Through Log Files" This is caused by the vulnerabilities go-retryablehttp@v0.7.4, it is only used in cmd devp2p, impact is limited. will upgrade to v0.7.7 later
 CVE-2024-8421 # "CWE-400: Uncontrolled Resource Consumption (Resource Exhaustion)" This vulnerability is caused by issues in the golang.org/x/net package. Even the latest version(v0.29.0) has not yet addressed it, but we will continue to monitor updates closely.
+CVE-2024-51744 # "CWE-347: Improper Verification of Cryptographic Signature" & "CWE-755: Improper Handling of Exceptional Conditions" This vulnerability is caused mishandling of JWT error code, BSC does not have the issue as it does not check the detail error code.


### PR DESCRIPTION
### Description

This security issue is caused by mishandling the error code when paring JWT token. It is not an issue for BSC as BSC does not check the detail error code. Right now, would prefer to ignore this nancy warning against upgrade the JWT version as BSC would likely to upgrade it in the future.

### Rationale
NA

### Example
NA

### Changes
NA