### PR TITLE
fix: add blobSidecars in db inspect

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -930,6 +930,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		receipts        stat
 		tds             stat
 		numHashPairings stat
+		blobSidecars    stat
 		hashNumPairings stat
 		legacyTries     stat
 		stateLookups    stat
@@ -973,6 +974,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			legacyTries.Add(size)
 		case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerTDSuffix):
 			tds.Add(size)
+		case bytes.HasPrefix(key, BlockBlobSidecarsPrefix) && bytes.HasSuffix(key, BlockBlobSidecarsPrefix):
+			blobSidecars.Add(size)
 		case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerHashSuffix):
 			numHashPairings.Add(size)
 		case bytes.HasPrefix(key, headerNumberPrefix) && len(key) == (len(headerNumberPrefix)+common.HashLength):
@@ -1103,6 +1106,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 				receipts.Add(size)
 			case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerTDSuffix):
 				tds.Add(size)
+			case bytes.HasPrefix(key, BlockBlobSidecarsPrefix) && bytes.HasSuffix(key, BlockBlobSidecarsPrefix):
+				blobSidecars.Add(size)
 			case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerHashSuffix):
 				numHashPairings.Add(size)
 			case bytes.HasPrefix(key, headerNumberPrefix) && len(key) == (len(headerNumberPrefix)+common.HashLength):
@@ -1134,6 +1139,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Bodies", bodies.Size(), bodies.Count()},
 		{"Key-Value store", "Receipt lists", receipts.Size(), receipts.Count()},
 		{"Key-Value store", "Difficulties", tds.Size(), tds.Count()},
+		{"Key-Value store", "BlobSidecars", blobSidecars.Size(), blobSidecars.Count()},
 		{"Key-Value store", "Block number->hash", numHashPairings.Size(), numHashPairings.Count()},
 		{"Key-Value store", "Block hash->number", hashNumPairings.Size(), hashNumPairings.Count()},
 		{"Key-Value store", "Transaction index", txLookups.Size(), txLookups.Count()},


### PR DESCRIPTION
### Description
Currently, in db inspect, blockBlobSidecars are treated as unaccounted data and not recognized properly.
Example error log:
`t=2024-11-21T08:48:10+0000 lvl=error msg="Database contains unaccounted data" size="3.16 GiB" count=90065`
This issue leads to incomplete or incorrect accounting for BlobSidecars during database inspection.

### Rationale

This PR updates the db inspect tool to include BlobSidecars in its statistical output, ensuring all database data is correctly accounted for.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
