### PR TITLE
fix: add blobsidecar

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -974,7 +974,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			legacyTries.Add(size)
 		case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerTDSuffix):
 			tds.Add(size)
-		case bytes.HasPrefix(key, BlockBlobSidecarsPrefix) && bytes.HasSuffix(key, BlockBlobSidecarsPrefix):
+		case bytes.HasPrefix(key, BlockBlobSidecarsPrefix):
 			blobSidecars.Add(size)
 		case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerHashSuffix):
 			numHashPairings.Add(size)
@@ -1106,7 +1106,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 				receipts.Add(size)
 			case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerTDSuffix):
 				tds.Add(size)
-			case bytes.HasPrefix(key, BlockBlobSidecarsPrefix) && bytes.HasSuffix(key, BlockBlobSidecarsPrefix):
+			case bytes.HasPrefix(key, BlockBlobSidecarsPrefix):
 				blobSidecars.Add(size)
 			case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerHashSuffix):
 				numHashPairings.Add(size)


### PR DESCRIPTION
### Description

fix a issue in inspect blobsidecars

### Rationale

* After the modification, the inspect command now displays the count of BlobSidecars.
<img width="935" alt="image" src="https://github.com/user-attachments/assets/01bad791-bd51-4f1d-b993-59ac976423a5">

* The updated unaccounted data size is shown as follows:
`lvl=error msg="Database contains unaccounted data" size="922.00 B" count=18  `

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
