### PR TITLE
release: prepare for release v1.4.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,32 @@
 # Changelog
+
+## v1.4.16
+### BUGFIX
+* [\#2736](https://github.com/bnb-chain/bsc/pull/2736) ethclient: move TransactionOpts to avoid import internal package;
+* [\#2755](https://github.com/bnb-chain/bsc/pull/2755) fix: fix multi-db env
+* [\#2759](https://github.com/bnb-chain/bsc/pull/2759) fix: add blobSidecars in db inspect
+* [\#2764](https://github.com/bnb-chain/bsc/pull/2764) fix: add blobSidecars in db inspect
+
+### FEATURE
+* [\#2692](https://github.com/bnb-chain/bsc/pull/2692) feat: add pascal hardfork
+* [\#2718](https://github.com/bnb-chain/bsc/pull/2718) feat: add Prague hardfork
+* [\#2734](https://github.com/bnb-chain/bsc/pull/2734) feat: update system contract bytecodes of pascal hardfork
+* [\#2737](https://github.com/bnb-chain/bsc/pull/2737) feat: modify LOCK_PERIOD_FOR_TOKEN_RECOVER to 300 seconds on BSC Testnet in pascal hardfork
+* [\#2660](https://github.com/bnb-chain/bsc/pull/2660) core/txpool/legacypool: add overflowpool for txs
+* [\#2754](https://github.com/bnb-chain/bsc/pull/2754) core/txpool: improve Add() logic, handle edge case
+
+### IMPROVEMENT
+* [\#2727](https://github.com/bnb-chain/bsc/pull/2727) core: clearup testflag for Bohr
+* [\#2716](https://github.com/bnb-chain/bsc/pull/2716) minor Update group_prover.sage
+* [\#2735](https://github.com/bnb-chain/bsc/pull/2735) concensus/parlia.go: make distribute incoming tx more independence
+* [\#2742](https://github.com/bnb-chain/bsc/pull/2742) feat: remove pipecommit
+* [\#2748](https://github.com/bnb-chain/bsc/pull/2748) jsutil: put all js utils in one file
+* [\#2749](https://github.com/bnb-chain/bsc/pull/2749) jsutils: add tool GetKeyParameters
+* [\#2756](https://github.com/bnb-chain/bsc/pull/2756) nancy: ignore github.com/golang-jwt/jwt/v4 4.5.0 in .nancy-ignore
+* [\#2757](https://github.com/bnb-chain/bsc/pull/2757) util: python script to get stats of reorg
+* [\#2758](https://github.com/bnb-chain/bsc/pull/2758) utils: print monikey for reorg script
+* [\#2714](https://github.com/bnb-chain/bsc/pull/2714) refactor: Directly swap two variables to optimize code
+
 ## v1.4.15
 ### BUGFIX
 * [\#2680](https://github.com/bnb-chain/bsc/pull/2680) txpool: apply miner's gasceil to txpool

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 4  // Minor version component of the current release
-	VersionPatch = 15 // Patch version component of the current release
+	VersionPatch = 16 // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description

v1.4.16 is a maintenance release, which mainly include:
- Fix a multi-DB bug, which failed to prune historical data from main db after BSC support 4844
- Add the framework of BSC next hardfork: Pascal
- Systemcontract code cleanup, which will be enabled after Pascal hard fork
- Implement new feature: [overflowpool](https://github.com/bnb-chain/bsc/pull/2660), it tries to enhance the current TxPool to support large traffic.
-  Add some tool for trouble shoot, JSTool and PythonTool

### Rationale
NA

### Example
NA

### Changes
NA