### PR TITLE
eth/tracers: add onSystemTxEnd hook for system tx gasused.

### DIFF
--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -150,6 +150,8 @@ type (
 	// beacon block root.
 	OnSystemCallEndHook = func()
 
+	// OnSystemTxEndHook is called when tracing a system transaction, which does not calculate intrinsic gas during execution.
+	// This hook will subtract intrinsic gas from the total gas used.
 	OnSystemTxEndHook = func(uint64)
 
 	/*

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -150,8 +150,7 @@ type (
 	// beacon block root.
 	OnSystemCallEndHook = func()
 
-	// TODO(Nathan,Eric): refine this func
-	OnCaptureSystemTxEndHook = func(uint64)
+	OnSystemTxEndHook = func(uint64)
 
 	/*
 		- State events -
@@ -192,7 +191,7 @@ type Hooks struct {
 	OnSystemCallStart OnSystemCallStartHook
 	OnSystemCallEnd   OnSystemCallEndHook
 
-	CaptureSystemTxEnd OnCaptureSystemTxEndHook
+	OnSystemTxEnd OnSystemTxEndHook
 
 	// State events
 	OnBalanceChange BalanceChangeHook

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -151,7 +151,7 @@ type (
 	OnSystemCallEndHook = func()
 
 	// OnSystemTxEndHook is called when tracing a system transaction, which does not calculate intrinsic gas during execution.
-	// This hook will subtract intrinsic gas from the total gas used.
+	// this hook will subtract intrinsic gas from the total gas used.
 	OnSystemTxEndHook = func(uint64)
 
 	/*

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -1198,8 +1198,8 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %w", err)
 	}
-	if tracer.CaptureSystemTxEnd != nil {
-		tracer.CaptureSystemTxEnd(intrinsicGas)
+	if tracer.OnSystemTxEnd != nil {
+		tracer.OnSystemTxEnd(intrinsicGas)
 	}
 	return tracer.GetResult()
 }

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -236,8 +236,6 @@ func newJsTracer(code string, ctx *tracers.Context, cfg json.RawMessage) (*trace
 	}, nil
 }
 
-func (t *jsTracer) CaptureSystemTxEnd(intrinsicGas uint64) {}
-
 // OnTxStart implements the Tracer interface and is invoked at the beginning of
 // transaction processing.
 func (t *jsTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -154,8 +154,6 @@ func (a *AccessListTracer) OnOpcode(pc uint64, opcode byte, gas, cost uint64, sc
 	}
 }
 
-func (*AccessListTracer) CaptureSystemTxEnd(intrinsicGas uint64) {}
-
 // AccessList returns the current accesslist maintained by the tracer.
 func (a *AccessListTracer) AccessList() types.AccessList {
 	return a.list.accessList()

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -134,10 +134,11 @@ func NewStructLogger(cfg *Config) *StructLogger {
 
 func (l *StructLogger) Hooks() *tracing.Hooks {
 	return &tracing.Hooks{
-		OnTxStart: l.OnTxStart,
-		OnTxEnd:   l.OnTxEnd,
-		OnExit:    l.OnExit,
-		OnOpcode:  l.OnOpcode,
+		OnTxStart:     l.OnTxStart,
+		OnTxEnd:       l.OnTxEnd,
+		OnExit:        l.OnExit,
+		OnOpcode:      l.OnOpcode,
+		OnSystemTxEnd: l.OnSystemTxEnd,
 	}
 }
 
@@ -273,7 +274,7 @@ func (l *StructLogger) OnTxEnd(receipt *types.Receipt, err error) {
 	}
 }
 
-func (l *StructLogger) CaptureSystemTxEnd(intrinsicGas uint64) {
+func (l *StructLogger) OnSystemTxEnd(intrinsicGas uint64) {
 	l.usedGas -= intrinsicGas
 }
 
@@ -415,8 +416,6 @@ func (t *mdLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.
 func (t *mdLogger) OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error) {
 	fmt.Fprintf(t.out, "\nError: at pc=%d, op=%v: %v\n", pc, op, err)
 }
-
-func (*mdLogger) CaptureSystemTxEnd(intrinsicGas uint64) {}
 
 // ExecutionResult groups all structured logs emitted by the EVM
 // while replaying a transaction in debug mode as well as transaction

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -175,5 +175,3 @@ func (l *jsonLogger) OnExit(depth int, output []byte, gasUsed uint64, err error,
 func (l *jsonLogger) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
 	l.env = env
 }
-
-func (l *jsonLogger) CaptureSystemTxEnd(intrinsicGas uint64) {}

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -114,8 +114,6 @@ func (t *fourByteTracer) OnEnter(depth int, opcode byte, from common.Address, to
 	t.store(input[0:4], len(input)-4)
 }
 
-func (*fourByteTracer) CaptureSystemTxEnd(intrinsicGas uint64) {}
-
 // GetResult returns the json-encoded nested list of call traces, and any
 // error arising from the encoding or forceful termination (via `Stop`).
 func (t *fourByteTracer) GetResult() (json.RawMessage, error) {

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -132,11 +132,12 @@ func newCallTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, 
 	}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
-			OnTxStart: t.OnTxStart,
-			OnTxEnd:   t.OnTxEnd,
-			OnEnter:   t.OnEnter,
-			OnExit:    t.OnExit,
-			OnLog:     t.OnLog,
+			OnTxStart:     t.OnTxStart,
+			OnTxEnd:       t.OnTxEnd,
+			OnEnter:       t.OnEnter,
+			OnExit:        t.OnExit,
+			OnLog:         t.OnLog,
+			OnSystemTxEnd: t.OnSystemTxEnd,
 		},
 		GetResult: t.GetResult,
 		Stop:      t.Stop,
@@ -234,7 +235,7 @@ func (t *callTracer) OnTxEnd(receipt *types.Receipt, err error) {
 	}
 }
 
-func (t *callTracer) CaptureSystemTxEnd(intrinsicGas uint64) {
+func (t *callTracer) OnSystemTxEnd(intrinsicGas uint64) {
 	t.callstack[0].GasUsed -= intrinsicGas
 }
 

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -217,8 +217,8 @@ func (t *flatCallTracer) OnTxEnd(receipt *types.Receipt, err error) {
 	t.tracer.OnTxEnd(receipt, err)
 }
 
-func (t *flatCallTracer) CaptureSystemTxEnd(intrinsicGas uint64) {
-	t.tracer.CaptureSystemTxEnd(intrinsicGas)
+func (t *flatCallTracer) OnSystemTxEnd(intrinsicGas uint64) {
+	t.tracer.OnSystemTxEnd(intrinsicGas)
 }
 
 // GetResult returns an empty json object.

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -71,6 +71,7 @@ func newMuxTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, e
 			OnCodeChange:    t.OnCodeChange,
 			OnStorageChange: t.OnStorageChange,
 			OnLog:           t.OnLog,
+			OnSystemTxEnd:   t.OnSystemTxEnd,
 		},
 		GetResult: t.GetResult,
 		Stop:      t.Stop,
@@ -173,9 +174,9 @@ func (t *muxTracer) OnLog(log *types.Log) {
 	}
 }
 
-func (t *muxTracer) CaptureSystemTxEnd(intrinsicGas uint64) {
+func (t *muxTracer) OnSystemTxEnd(intrinsicGas uint64) {
 	for _, t := range t.tracers {
-		t.CaptureSystemTxEnd(intrinsicGas)
+		t.OnSystemTxEnd(intrinsicGas)
 	}
 }
 

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -51,6 +51,7 @@ func newNoopTracer(ctx *tracers.Context, _ json.RawMessage) (*tracers.Tracer, er
 			OnCodeChange:    t.OnCodeChange,
 			OnStorageChange: t.OnStorageChange,
 			OnLog:           t.OnLog,
+			OnSystemTxEnd:   t.OnSystemTxEnd,
 		},
 		GetResult: t.GetResult,
 		Stop:      t.Stop,
@@ -88,7 +89,7 @@ func (*noopTracer) OnStorageChange(a common.Address, k, prev, new common.Hash) {
 
 func (*noopTracer) OnLog(log *types.Log) {}
 
-func (*noopTracer) CaptureSystemTxEnd(intrinsicGas uint64) {}
+func (*noopTracer) OnSystemTxEnd(intrinsicGas uint64) {}
 
 // GetResult returns an empty json object.
 func (t *noopTracer) GetResult() (json.RawMessage, error) {

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -253,8 +253,6 @@ func (t *prestateTracer) processDiffState() {
 	}
 }
 
-func (t *prestateTracer) CaptureSystemTxEnd(intrinsicGas uint64) {}
-
 // lookupAccount fetches details of an account and adds it to the prestate
 // if it doesn't exist there.
 func (t *prestateTracer) lookupAccount(addr common.Address) {


### PR DESCRIPTION
### Description

eth/tracers: add onSystemTxEnd hook for system transaction gas used.

### Rationale

system transaction don't include intrinsic gas

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* eth/tracers