### PR TITLE
p2p/discover: fix ENR filtering

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -974,7 +974,7 @@ var (
 		Aliases:  []string{"discv5"},
 		Usage:    "Enables the V5 discovery mechanism",
 		Category: flags.NetworkingCategory,
-		Value:    true,
+		Value:    false,
 	}
 	NetrestrictFlag = &cli.StringFlag{
 		Name:     "netrestrict",

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -17,7 +17,6 @@
 package discover
 
 import (
-	"net"
 	"slices"
 	"sort"
 	"time"
@@ -49,11 +48,6 @@ func unwrapNodes(ns []*tableNode) []*enode.Node {
 		result[i] = n.Node
 	}
 	return result
-}
-
-//nolint:unused
-func (n *tableNode) addr() *net.UDPAddr {
-	return &net.UDPAddr{IP: n.IP(), Port: n.UDP()}
 }
 
 func (n *tableNode) String() string {

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -17,7 +17,6 @@
 package discover
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -176,7 +175,7 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 	var endpointChanged bool
 	if resp.newRecord != nil {
 		if tab.enrFilter != nil && !tab.enrFilter(resp.newRecord.Record()) {
-			tab.log.Trace("ENR record filter out", "id", n.ID(), "err", errors.New("filtered node"))
+			tab.log.Trace("ENR record filter out", "id", n.ID())
 			tab.deleteInBucket(b, n.ID())
 			return
 		}

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -121,13 +121,7 @@ func (tab *Table) doRevalidate(resp revalidationResponse, node *enode.Node) {
 		if err != nil {
 			tab.log.Debug("ENR request failed", "id", node.ID(), "err", err)
 		} else {
-			if tab.enrFilter != nil && !tab.enrFilter(newrec.Record()) {
-				tab.log.Trace("ENR record filter out", "id", node.ID(), "err", errors.New("filtered node"))
-				// TODO: use didRespond to express failure temporarily
-				resp.didRespond = false
-			} else {
-				resp.newRecord = newrec
-			}
+			resp.newRecord = newrec
 		}
 	}
 
@@ -181,6 +175,11 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 	tab.log.Debug("Node revalidated", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
 	var endpointChanged bool
 	if resp.newRecord != nil {
+		if tab.enrFilter != nil && !tab.enrFilter(resp.newRecord.Record()) {
+			tab.log.Trace("ENR record filter out", "id", n.ID(), "err", errors.New("filtered node"))
+			tab.deleteInBucket(b, n.ID())
+			return
+		}
 		_, endpointChanged = tab.bumpInBucket(b, resp.newRecord, false)
 	}
 

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -296,7 +296,7 @@ func TestTable_addInboundNode(t *testing.T) {
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
 	n2v2 := enode.SignNull(newrec, n2.ID())
-	tab.addInboundNode(n2v2)
+	tab.addInboundNodeSync(n2v2)
 	checkBucketContent(t, tab, []*enode.Node{n1, n2v2})
 
 	// Try updating n2 without sequence number change. The update is accepted
@@ -305,7 +305,7 @@ func TestTable_addInboundNode(t *testing.T) {
 	newrec.Set(enr.IP{100, 100, 100, 100})
 	newrec.SetSeq(n2.Seq())
 	n2v3 := enode.SignNull(newrec, n2.ID())
-	tab.addInboundNode(n2v3)
+	tab.addInboundNodeSync(n2v3)
 	checkBucketContent(t, tab, []*enode.Node{n1, n2v3})
 }
 
@@ -349,13 +349,13 @@ func TestTable_addInboundNodeUpdateV4Accept(t *testing.T) {
 	// Add a v4 node.
 	key, _ := crypto.HexToECDSA("dd3757a8075e88d0f2b1431e7d3c5b1562e1c0aab9643707e8cbfcc8dae5cfe3")
 	n1 := enode.NewV4(&key.PublicKey, net.IP{88, 77, 66, 1}, 9000, 9000)
-	tab.addInboundNode(n1)
+	tab.addInboundNodeSync(n1)
 	checkBucketContent(t, tab, []*enode.Node{n1})
 
 	// Add an updated version with changed IP.
 	// The update will be accepted because it is inbound.
 	n1v2 := enode.NewV4(&key.PublicKey, net.IP{99, 99, 99, 99}, 9000, 9000)
-	tab.addInboundNode(n1v2)
+	tab.addInboundNodeSync(n1v2)
 	checkBucketContent(t, tab, []*enode.Node{n1v2})
 }
 

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -437,6 +437,9 @@ func (t *UDPv5) verifyResponseNode(c *callV5, r *enr.Record, distances []uint, s
 	if node.UDP() <= 1024 {
 		return nil, errLowPort
 	}
+	if t.tab.enrFilter != nil && !t.tab.enrFilter(r) {
+		return nil, errors.New("filtered by ENR filter")
+	}
 	if distances != nil {
 		nd := enode.LogDist(c.id, node.ID())
 		if !slices.Contains(distances, uint(nd)) {


### PR DESCRIPTION
### Description

Reintroducing ENR filtering back. This allows discv4 ENR filtering and add small support for discv5 that could be enabled later on based on testing.
