### PR TITLE
core: fix the transfer test and make deterministic

### DIFF
--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -2274,10 +2274,11 @@ func TestTransferTransactions(t *testing.T) {
 	pool.addToOverflowPool([]*types.Transaction{tx2}, true)
 	assert.Equal(t, uint64(1), pool.statsOverflowPool(), "OverflowPool size unexpected")
 	<-pool.requestPromoteExecutables(newAccountSet(pool.signer, from))
+	time.Sleep(1 * time.Second)
 	pending, queue = pool.Stats()
 
-	assert.Equal(t, 0, pending, "pending transactions mismatched")
-	assert.Equal(t, 1, queue, "queued transactions mismatched")
+	assert.Equal(t, 1, pending, "pending transactions mismatched")
+	assert.Equal(t, 0, queue, "queued transactions mismatched")
 	assert.Equal(t, uint64(0), pool.statsOverflowPool(), "OverflowPool size unexpected")
 
 	tx3 := dynamicFeeTx(0, 100000, big.NewInt(3), big.NewInt(2), keys[2])


### PR DESCRIPTION
### Description

The TestTransferTransactions test expects the `TransferTransactions()` function to run in the background. But there isn't enough time for it to go through and the transaction to end up in the pending list. So a small waiting will ensure the async process finishes and the test becomes deterministic. 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
