### PR TITLE
ci: check generate and tidy in 'Build Test' ci

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -45,5 +45,7 @@ jobs:
 
     - name: Test Build
       run: |
-        go mod download
-        make geth
+        go run build/ci.go check_tidy
+        go run build/ci.go check_generate
+        go run build/ci.go check_baddeps
+        go mod download && make geth

--- a/core/types/gen_tx_opts_json.go
+++ b/core/types/gen_tx_opts_json.go
@@ -4,6 +4,7 @@ package types
 
 import (
 	"encoding/json"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 


### PR DESCRIPTION
### Description

ci: do more test in build ci

### Rationale

do the following test in the build ci
```
check_tidy
check_generate
check_baddeps
```
if any one fails , the `Build Test` will fail
### Example

if some one forget to modify `gen_config.go` after modifying `eth/ethconfig/config.go`,
`Build Test` will fail now

if some one forget to do `go mod tidy` after change `go.mod`,
`Build Test` will also fail

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
