### PR TITLE
ethdb/pebble: roll back sync mode when write

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -190,7 +190,7 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 		fn:           file,
 		log:          logger,
 		quitChan:     make(chan chan error),
-		writeOptions: &pebble.WriteOptions{Sync: false},
+		writeOptions: pebble.Sync,
 	}
 	opt := &pebble.Options{
 		// Pebble has a single combined cache area and the write


### PR DESCRIPTION
### Description

ethdb/pebble: roll back sync mode when write

### Rationale

introduced by ‘[core, ethdb/pebble: run pebble in non-sync mode](https://github.com/ethereum/go-ethereum/pull/30573)’
roll back it for now, it may be enabled after more tests by storage team in the future.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
