### PR TITLE
pbss: support to load legacy async buffer format

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -434,12 +434,14 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 			var diskRoot common.Hash
 			if bc.cacheConfig.SnapshotLimit > 0 {
 				diskRoot = rawdb.ReadSnapshotRoot(bc.db)
+				log.Debug("Head state missing, ReadSnapshotRoot", "snap root", diskRoot)
 			}
 			if bc.triedb.Scheme() == rawdb.PathScheme && !bc.NoTries() {
 				recoverable, _ := bc.triedb.Recoverable(diskRoot)
 				if !bc.HasState(diskRoot) && !recoverable {
 					diskRoot = bc.triedb.Head()
 				}
+				log.Debug("Head state missing, check recoverable", "disk root", diskRoot, "recoverable", recoverable)
 			}
 			if diskRoot != (common.Hash{}) {
 				log.Warn("Head state missing, repairing", "number", head.Number, "hash", head.Hash(), "diskRoot", diskRoot)

--- a/triedb/pathdb/buffer.go
+++ b/triedb/pathdb/buffer.go
@@ -95,9 +95,9 @@ func (b *buffer) revertTo(db ethdb.KeyValueReader, nodes map[common.Hash]map[str
 		return nil
 	}
 	b.nodes.revertTo(db, nodes)
-	// TODO(galaio): In order to be compatible with the legacy version,
-	// a temporary empty check is added, which may affect the reading
-	// result of pbss as flatReader, see: flatReader.Account()
+	// TODO(galaio): In order to be compatible with the legacy version, a temporary empty check is added,
+	// which may affect the reading result of pbss as flatReader, see: flatReader.Account()
+	// it could be removed in the future
 	if len(b.states.accountData) != 0 || len(b.states.storageData) != 0 {
 		b.states.revertTo(accounts, storages)
 	}

--- a/triedb/pathdb/buffer.go
+++ b/triedb/pathdb/buffer.go
@@ -95,7 +95,12 @@ func (b *buffer) revertTo(db ethdb.KeyValueReader, nodes map[common.Hash]map[str
 		return nil
 	}
 	b.nodes.revertTo(db, nodes)
-	b.states.revertTo(accounts, storages)
+	// TODO(galaio): In order to be compatible with the legacy version,
+	// a temporary empty check is added, which may affect the reading
+	// result of pbss as flatReader, see: flatReader.Account()
+	if len(b.states.accountData) != 0 || len(b.states.storageData) != 0 {
+		b.states.revertTo(accounts, storages)
+	}
 	return nil
 }
 

--- a/triedb/pathdb/buffer.go
+++ b/triedb/pathdb/buffer.go
@@ -98,6 +98,7 @@ func (b *buffer) revertTo(db ethdb.KeyValueReader, nodes map[common.Hash]map[str
 	// TODO(galaio): In order to be compatible with the legacy version, a temporary empty check is added,
 	// which may affect the reading result of pbss as flatReader, see: flatReader.Account()
 	// it could be removed in the future
+	// Caution: there is also a panic issue with non-empty states when rewinding the chain again, but it is a very low possibility with finality.
 	if len(b.states.accountData) != 0 || len(b.states.storageData) != 0 {
 		b.states.revertTo(accounts, storages)
 	}

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -207,7 +207,7 @@ func (db *Database) loadJournal(diskRoot common.Hash) (layer, error) {
 		return nil, fmt.Errorf("%w want %x got %x", errUnmatchedJournal, root, diskRoot)
 	}
 	// Load the disk layer from the journal
-	base, err := db.loadDiskLayer(r, journalTypeForReader)
+	base, err := db.loadDiskLayer(r, journalTypeForReader, version)
 	if err != nil {
 		return nil, err
 	}
@@ -238,13 +238,58 @@ func (db *Database) loadLayers() layer {
 	if !(root == types.EmptyRootHash && errors.Is(err, errMissJournal)) {
 		log.Info("Failed to load journal, discard it", "err", err)
 	}
+	// try to load async buffer only, it can be compatible with old journal ver
+	base, err := db.loadDiskLayerWithAsyncBuffer(root)
+	if err == nil {
+		return base
+	}
 	// Return single layer with persistent state.
 	return newDiskLayer(root, rawdb.ReadPersistentStateID(db.diskdb), db, nil, NewTrieNodeBuffer(db.config.SyncFlush, db.config.WriteBufferSize, nil, nil, 0))
 }
 
+// loadDiskLayerWithAsyncBuffer try to load legacy async buffer data from journal
+func (db *Database) loadDiskLayerWithAsyncBuffer(diskRoot common.Hash) (layer, error) {
+	start := time.Now()
+	journalTypeForReader := db.DetermineJournalTypeForReader()
+	reader, err := newJournalReader(db.config.JournalFilePath, db.diskdb, journalTypeForReader)
+
+	if err != nil {
+		return nil, err
+	}
+	if reader != nil {
+		defer reader.Close()
+	}
+	r := rlp.NewStream(reader, 0)
+
+	// Firstly, resolve the first element as the journal version
+	version, err := r.Uint64()
+	if err != nil {
+		return nil, errMissVersion
+	}
+	if version == journalVersion {
+		return nil, fmt.Errorf("%w, only handle legacy journal version, got %v", errUnexpectedVersion, version)
+	}
+	// Secondly, resolve the disk layer root, ensure it's continuous
+	// with disk layer. Note now we can ensure it's the layer journal
+	// correct version, so we expect everything can be resolved properly.
+	var root common.Hash
+	if err := r.Decode(&root); err != nil {
+		return nil, errMissDiskRoot
+	}
+	// The journal is not matched with persistent state, discard them.
+	// It can happen that geth crashes without persisting the journal.
+	if !bytes.Equal(root.Bytes(), diskRoot.Bytes()) {
+		return nil, fmt.Errorf("%w want %x got %x", errUnmatchedJournal, root, diskRoot)
+	}
+	// Load the disk layer from the journal
+	base, err := db.loadDiskLayer(r, journalTypeForReader, version)
+	log.Info("Loaded disk layer with async buffer", "diskroot", diskRoot, "elapsed", common.PrettyDuration(time.Since(start)))
+	return base, nil
+}
+
 // loadDiskLayer reads the binary blob from the layer journal, reconstructing
 // a new disk layer on it.
-func (db *Database) loadDiskLayer(r *rlp.Stream, journalTypeForReader JournalType) (layer, error) {
+func (db *Database) loadDiskLayer(r *rlp.Stream, journalTypeForReader JournalType, version uint64) (layer, error) {
 	// Resolve disk layer root
 	var (
 		root               common.Hash
@@ -279,10 +324,14 @@ func (db *Database) loadDiskLayer(r *rlp.Stream, journalTypeForReader JournalTyp
 	if err := nodes.decode(journalBuf); err != nil {
 		return nil, err
 	}
-	// Resolve flat state sets in aggregated buffer
+
+	// handle new states in new journal version
 	var states stateSet
-	if err := states.decode(journalBuf); err != nil {
-		return nil, err
+	if version == journalVersion {
+		// Resolve flat state sets in aggregated buffer
+		if err := states.decode(journalBuf); err != nil {
+			return nil, err
+		}
 	}
 
 	if journalTypeForReader == JournalFileType {

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -238,18 +238,19 @@ func (db *Database) loadLayers() layer {
 	if !(root == types.EmptyRootHash && errors.Is(err, errMissJournal)) {
 		log.Info("Failed to load journal, discard it", "err", err)
 	}
-	// try to load async buffer only, it can be compatible with old journal ver
-	base, err := db.loadAsyncBufferAsJournalV0V1(root)
+	// try to load node buffer only, it can be compatible with old journal ver
+	base, err := db.loadNodeBufferAsJournalV0V1(root)
 	if err == nil {
+		log.Info("load legacy node buffer successful", "new root", base.rootHash(), "disk root", root)
 		return base
 	}
-	log.Warn("Failed to load disk journal with async buffer, discard it", "err", err)
+	log.Warn("Failed to load disk journal with node buffer, discard it", "err", err)
 	// Return single layer with persistent state.
 	return newDiskLayer(root, rawdb.ReadPersistentStateID(db.diskdb), db, nil, NewTrieNodeBuffer(db.config.SyncFlush, db.config.WriteBufferSize, nil, nil, 0))
 }
 
-// loadAsyncBufferAsJournalV0V1 try to load legacy async buffer data from journal
-func (db *Database) loadAsyncBufferAsJournalV0V1(diskRoot common.Hash) (layer, error) {
+// loadNodeBufferAsJournalV0V1 try to load legacy node buffer data from journal
+func (db *Database) loadNodeBufferAsJournalV0V1(diskRoot common.Hash) (layer, error) {
 	journalTypeForReader := db.DetermineJournalTypeForReader()
 	reader, err := newJournalReader(db.config.JournalFilePath, db.diskdb, journalTypeForReader)
 

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -243,6 +243,7 @@ func (db *Database) loadLayers() layer {
 	if err == nil {
 		return base
 	}
+	log.Warn("Failed to load disk journal with async buffer, discard it", "err", err)
 	// Return single layer with persistent state.
 	return newDiskLayer(root, rawdb.ReadPersistentStateID(db.diskdb), db, nil, NewTrieNodeBuffer(db.config.SyncFlush, db.config.WriteBufferSize, nil, nil, 0))
 }

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -250,7 +250,6 @@ func (db *Database) loadLayers() layer {
 
 // loadDiskLayerWithAsyncBuffer try to load legacy async buffer data from journal
 func (db *Database) loadDiskLayerWithAsyncBuffer(diskRoot common.Hash) (layer, error) {
-	start := time.Now()
 	journalTypeForReader := db.DetermineJournalTypeForReader()
 	reader, err := newJournalReader(db.config.JournalFilePath, db.diskdb, journalTypeForReader)
 
@@ -283,9 +282,7 @@ func (db *Database) loadDiskLayerWithAsyncBuffer(diskRoot common.Hash) (layer, e
 		return nil, fmt.Errorf("%w want %x got %x", errUnmatchedJournal, root, diskRoot)
 	}
 	// Load the disk layer from the journal
-	base, err := db.loadDiskLayer(r, journalTypeForReader, version)
-	log.Info("Loaded disk layer with async buffer", "diskroot", diskRoot, "elapsed", common.PrettyDuration(time.Since(start)))
-	return base, nil
+	return db.loadDiskLayer(r, journalTypeForReader, version)
 }
 
 // loadDiskLayer reads the binary blob from the layer journal, reconstructing

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -250,6 +250,7 @@ func (db *Database) loadLayers() layer {
 }
 
 // loadNodeBufferAsJournalV0V1 try to load legacy node buffer data from journal
+// TODO(galaio): the method is a temporary solution for legacy journal, it could be removed in the future
 func (db *Database) loadNodeBufferAsJournalV0V1(diskRoot common.Hash) (layer, error) {
 	journalTypeForReader := db.DetermineJournalTypeForReader()
 	reader, err := newJournalReader(db.config.JournalFilePath, db.diskdb, journalTypeForReader)


### PR DESCRIPTION
### Description

This PR fixes a legacy journal format issue, it tries to load an async buffer in a legacy journal file.

When the PR is enabled, the node can read the async buffer correctly.

```bash
logs/bsc.log.2024-12-20_11:t=2024-12-20T11:15:10+0000 lvl=info msg="New async node buffer" limit="256.00 MiB" layers=44221
logs/bsc.log.2024-12-20_12:t=2024-12-20T12:15:37+0000 lvl=info msg="Failed to load journal, discard it" err="unexpected journal version want 2 got 0"
```

It will fix the issue https://github.com/bnb-chain/bsc/issues/2796.

### Changes

Notable changes: 
* pbss: support to load legacy async buffer format;
* ...
