### PR TITLE
core/txpool: accept SetCodeTxType transactions for test purpose

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -299,7 +299,8 @@ func New(config Config, chain BlockChain) *LegacyPool {
 // pool, specifically, whether it is a Legacy, AccessList or Dynamic transaction.
 func (pool *LegacyPool) Filter(tx *types.Transaction) bool {
 	switch tx.Type() {
-	case types.LegacyTxType, types.AccessListTxType, types.DynamicFeeTxType:
+	//TODO(Nathan): add SetCodeTxType into LegacyPool for test, finally will rollback and be consistent with upstream
+	case types.LegacyTxType, types.AccessListTxType, types.DynamicFeeTxType, types.SetCodeTxType:
 		return true
 	default:
 		return false
@@ -687,7 +688,8 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 		Accept: 0 |
 			1<<types.LegacyTxType |
 			1<<types.AccessListTxType |
-			1<<types.DynamicFeeTxType,
+			1<<types.DynamicFeeTxType |
+			1<<types.SetCodeTxType,
 		MaxSize: txMaxSize,
 		MinTip:  pool.gasTip.Load().ToBig(),
 		MaxGas:  pool.GetMaxGas(),


### PR DESCRIPTION
### Description

core/txpool: accept SetCodeTxType transactions for test purpose

### Rationale

support SetCodeTxType txs in pool is [not done ](https://github.com/ethereum/go-ethereum/pull/30949)

for testing, we follow [prague-devnet-4](https://github.com/ethereum/go-ethereum/compare/master...lightclient:go-ethereum:prague-devnet-4#diff-3b03ebf997a1699ce8e84a53a4b3981e403e74e2f90128eb188ad4226703970c): add it into legacypool for simplicity.


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
