### PR TITLE
eth: enhance stability of small networks

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -64,6 +64,10 @@ const (
 	// All transactions with a higher size will be announced and need to be fetched
 	// by the peer.
 	txMaxBroadcastSize = 4096
+
+	// minPeers2DirectBroadcast defines the minimum number of peers required
+	// to directly broadcast blocks in order to enhance stability on a small network.
+	minPeers2DirectBroadcast = 3
 )
 
 var (
@@ -760,10 +764,10 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		}
 		// Send the block to a subset of our peers
 		var transfer []*ethPeer
-		if h.directBroadcast {
+		if h.directBroadcast || len(peers) <= minPeers2DirectBroadcast {
 			transfer = peers[:]
 		} else {
-			transfer = peers[:int(math.Sqrt(float64(len(peers))))]
+			transfer = peers[:max(int(math.Sqrt(float64(len(peers)))), minPeers2DirectBroadcast)]
 		}
 
 		for _, peer := range transfer {

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -586,10 +586,10 @@ func TestTransactionPendingReannounce(t *testing.T) {
 
 // Tests that blocks are broadcast to a sqrt number of peers only.
 func TestBroadcastBlock1Peer(t *testing.T)    { testBroadcastBlock(t, 1, 1) }
-func TestBroadcastBlock2Peers(t *testing.T)   { testBroadcastBlock(t, 2, 1) }
-func TestBroadcastBlock3Peers(t *testing.T)   { testBroadcastBlock(t, 3, 1) }
-func TestBroadcastBlock4Peers(t *testing.T)   { testBroadcastBlock(t, 4, 2) }
-func TestBroadcastBlock5Peers(t *testing.T)   { testBroadcastBlock(t, 5, 2) }
+func TestBroadcastBlock2Peers(t *testing.T)   { testBroadcastBlock(t, 2, 2) }
+func TestBroadcastBlock3Peers(t *testing.T)   { testBroadcastBlock(t, 3, 3) }
+func TestBroadcastBlock4Peers(t *testing.T)   { testBroadcastBlock(t, 4, 3) }
+func TestBroadcastBlock5Peers(t *testing.T)   { testBroadcastBlock(t, 5, 3) }
 func TestBroadcastBlock8Peers(t *testing.T)   { testBroadcastBlock(t, 9, 3) }
 func TestBroadcastBlock12Peers(t *testing.T)  { testBroadcastBlock(t, 12, 3) }
 func TestBroadcastBlock16Peers(t *testing.T)  { testBroadcastBlock(t, 16, 4) }


### PR DESCRIPTION
### Description

eth: enhance stability of small networks

### Rationale

Small networks are more prone to instability when broadcasting blocks.
For example, in a 3-node network, the miner will only broadcast directly to one validator and send the block hash to the other nodes. When transaction volume spikes, fetching blocks via the block hash may occasionally fail.
This PR introduces a minimum number of peers required to directly broadcast blocks, improving stability in small networks.

This PR will also have a big improvemnet in performance for small networks.

this PR will fix https://github.com/bnb-chain/bsc/issues/2838, https://github.com/bnb-chain/bsc/issues/2782
### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
