### PR TITLE
feat: wait miner finish the later multi-proposals when restarting the node;

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -161,4 +161,6 @@ type PoSA interface {
 	GetFinalizedHeader(chain ChainHeaderReader, header *types.Header) *types.Header
 	VerifyVote(chain ChainHeaderReader, vote *types.VoteEnvelope) error
 	IsActiveValidatorAt(chain ChainHeaderReader, header *types.Header, checkVoteKeyFn func(bLSPublicKey *types.BLSPublicKey) bool) bool
+	BlockInterval() uint64
+	NextProposalBlock(chain ChainHeaderReader, header *types.Header, proposer common.Address) (uint64, uint64, error)
 }

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -2123,6 +2123,19 @@ func (p *Parlia) backOffTime(snap *Snapshot, header *types.Header, val common.Ad
 	}
 }
 
+func (p *Parlia) BlockInterval() uint64 {
+	return p.config.Period
+}
+
+func (p *Parlia) NextProposalBlock(chain consensus.ChainHeaderReader, header *types.Header, proposer common.Address) (uint64, uint64, error) {
+	snap, err := p.snapshot(chain, header.Number.Uint64(), header.Hash(), nil)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return snap.nextProposalBlock(proposer)
+}
+
 // chain context
 type chainContext struct {
 	Chain  consensus.ChainHeaderReader

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -423,12 +423,8 @@ func (s *Snapshot) nexValidatorsChangeBlock() uint64 {
 // nextProposalBlock returns the validator next proposal block.
 func (s *Snapshot) nextProposalBlock(proposer common.Address) (uint64, uint64, error) {
 	validators := s.validators()
-	currentProposer := validators[s.Number/uint64(s.TurnLength)%uint64(len(validators))]
-	currentIndex := s.indexOfVal(currentProposer)
+	currentIndex := int(s.Number / uint64(s.TurnLength) % uint64(len(validators)))
 	expectIndex := s.indexOfVal(proposer)
-	if currentIndex < 0 {
-		return 0, 0, errors.New("currentProposer not in validator set")
-	}
 	if expectIndex < 0 {
 		return 0, 0, errors.New("proposer not in validator set")
 	}

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -411,6 +411,38 @@ func (s *Snapshot) inturnValidator() common.Address {
 	return validators[offset]
 }
 
+func (s *Snapshot) nexValidatorsChangeBlock() uint64 {
+	currentEpoch := s.Number - s.Number%s.config.Epoch
+	checkLen := s.minerHistoryCheckLen()
+	if s.Number%s.config.Epoch < checkLen {
+		return currentEpoch + checkLen
+	}
+	return currentEpoch + s.config.Epoch + checkLen
+}
+
+// nextProposalBlock returns the validator next proposal block.
+func (s *Snapshot) nextProposalBlock(proposer common.Address) (uint64, uint64, error) {
+	validators := s.validators()
+	currentProposer := validators[s.Number/uint64(s.TurnLength)%uint64(len(validators))]
+	currentIndex := s.indexOfVal(currentProposer)
+	expectIndex := s.indexOfVal(proposer)
+	if expectIndex < 0 {
+		return 0, 0, errors.New("proposer not in validator set")
+	}
+	startBlock := uint64((expectIndex+len(validators)-currentIndex)%len(validators)*int(s.TurnLength)) + s.Number
+	startBlock = startBlock - startBlock%uint64(s.TurnLength)
+	endBlock := startBlock + uint64(s.TurnLength) - 1
+
+	changeValidatorsBlock := s.nexValidatorsChangeBlock()
+	if startBlock >= changeValidatorsBlock {
+		return 0, 0, errors.New("next proposal block is out of current epoch")
+	}
+	if endBlock >= changeValidatorsBlock {
+		endBlock = changeValidatorsBlock - 1
+	}
+	return startBlock, endBlock, nil
+}
+
 func (s *Snapshot) enoughDistance(validator common.Address, header *types.Header) bool {
 	idx := s.indexOfVal(validator)
 	if idx < 0 {

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -441,7 +441,7 @@ func (s *Snapshot) nextProposalBlock(proposer common.Address) (uint64, uint64, e
 		return 0, 0, errors.New("next proposal block is out of current epoch")
 	}
 	if endBlock >= changeValidatorsBlock {
-		endBlock = changeValidatorsBlock - 1
+		endBlock = changeValidatorsBlock
 	}
 	return startBlock, endBlock, nil
 }

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -426,10 +426,13 @@ func (s *Snapshot) nextProposalBlock(proposer common.Address) (uint64, uint64, e
 	currentProposer := validators[s.Number/uint64(s.TurnLength)%uint64(len(validators))]
 	currentIndex := s.indexOfVal(currentProposer)
 	expectIndex := s.indexOfVal(proposer)
+	if currentIndex < 0 {
+		return 0, 0, errors.New("currentProposer not in validator set")
+	}
 	if expectIndex < 0 {
 		return 0, 0, errors.New("proposer not in validator set")
 	}
-	startBlock := uint64((expectIndex+len(validators)-currentIndex)%len(validators)*int(s.TurnLength)) + s.Number
+	startBlock := s.Number + uint64(((expectIndex+len(validators)-currentIndex)%len(validators))*int(s.TurnLength))
 	startBlock = startBlock - startBlock%uint64(s.TurnLength)
 	endBlock := startBlock + uint64(s.TurnLength) - 1
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -637,6 +637,9 @@ func (s *Ethereum) setupDiscovery() error {
 // Stop implements node.Lifecycle, terminating all internal goroutines used by the
 // Ethereum protocol.
 func (s *Ethereum) Stop() error {
+	if s.miner.Mining() {
+		s.miner.TryWaitProposalDoneWhenStopping()
+	}
 	// Stop all the peer-related stuff first.
 	s.discmix.Close()
 	s.handler.Stop()

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -174,6 +174,10 @@ func (miner *Miner) InTurn() bool {
 	return miner.worker.inTurn()
 }
 
+func (miner *Miner) TryWaitProposalDoneWhenStopping() {
+	miner.worker.tryWaitProposalDoneWhenStopping()
+}
+
 // Pending returns the currently pending block and associated receipts, logs
 // and statedb. The returned values can be nil in case the pending block is
 // not initialized.

--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	GasPrice              *big.Int       // Minimum gas price for mining a transaction
 	Recommit              time.Duration  // The time interval for miner to re-create mining work.
 	VoteEnable            bool           // Whether to vote when mining
-	MaxWaitProposalInSecs uint64         // The maximum time to wait for the proposal to be done, it's aimed to prevent validator slashed when restarting
+	MaxWaitProposalInSecs uint64         // The maximum time to wait for the proposal to be done, it's aimed to prevent validator being slashed when restarting
 
 	DisableVoteAttestation bool // Whether to skip assembling vote attestation
 
@@ -56,7 +56,7 @@ var DefaultConfig = Config{
 	DelayLeftOver: 50 * time.Millisecond,
 
 	// The default value is set to 30 seconds.
-	// Because the avg restart time in mainnet is around 30s, so the node try to wait for next proposal done.
+	// Because the avg restart time in mainnet is around 30s, so the node try to wait for the next multi-proposals to be done.
 	MaxWaitProposalInSecs: 30,
 
 	Mev: DefaultMevConfig,

--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -28,14 +28,15 @@ import (
 
 // Config is the configuration parameters of mining.
 type Config struct {
-	Etherbase     common.Address `toml:",omitempty"` // Public address for block mining rewards
-	ExtraData     hexutil.Bytes  `toml:",omitempty"` // Block extra data set by the miner
-	DelayLeftOver time.Duration  // Time reserved to finalize a block(calculate root, distribute income...)
-	GasFloor      uint64         // Target gas floor for mined blocks.
-	GasCeil       uint64         // Target gas ceiling for mined blocks.
-	GasPrice      *big.Int       // Minimum gas price for mining a transaction
-	Recommit      time.Duration  // The time interval for miner to re-create mining work.
-	VoteEnable    bool           // Whether to vote when mining
+	Etherbase             common.Address `toml:",omitempty"` // Public address for block mining rewards
+	ExtraData             hexutil.Bytes  `toml:",omitempty"` // Block extra data set by the miner
+	DelayLeftOver         time.Duration  // Time reserved to finalize a block(calculate root, distribute income...)
+	GasFloor              uint64         // Target gas floor for mined blocks.
+	GasCeil               uint64         // Target gas ceiling for mined blocks.
+	GasPrice              *big.Int       // Minimum gas price for mining a transaction
+	Recommit              time.Duration  // The time interval for miner to re-create mining work.
+	VoteEnable            bool           // Whether to vote when mining
+	MaxWaitProposalInSecs uint64         // The maximum time to wait for the proposal to be done, it's aimed to prevent validator slashed when restarting
 
 	DisableVoteAttestation bool // Whether to skip assembling vote attestation
 
@@ -53,6 +54,10 @@ var DefaultConfig = Config{
 	// run 3 rounds.
 	Recommit:      3 * time.Second,
 	DelayLeftOver: 50 * time.Millisecond,
+
+	// The default value is set to 30 seconds.
+	// Because the avg restart time in mainnet is around 30s, so the node try to wait for next proposal done.
+	MaxWaitProposalInSecs: 30,
 
 	Mev: DefaultMevConfig,
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1516,21 +1516,22 @@ func (w *worker) tryWaitProposalDoneWhenStopping() {
 	}
 
 	currentHeader := w.chain.CurrentBlock()
-	startBlock, endBlock, err := posa.NextProposalBlock(w.chain, w.chain.CurrentBlock(), w.coinbase)
+	currentBlock := currentHeader.Number.Uint64()
+	startBlock, endBlock, err := posa.NextProposalBlock(w.chain, currentHeader, w.coinbase)
 	if err != nil {
 		log.Warn("Failed to get next proposal block", "err", err)
 		return
 	}
+	log.Info("Checking miner's next proposal block", "current", currentBlock,
+		"proposalStart", startBlock, "proposalEnd", endBlock, "maxWait", w.config.MaxWaitProposalInSecs)
 
-	currentBlock := currentHeader.Number.Uint64()
+	if endBlock < currentBlock {
+		log.Warn("next proposal end block has passed, ignore")
+		return
+	}
 	waitSecs := (endBlock - currentBlock) * posa.BlockInterval()
 	if waitSecs > 0 && waitSecs <= w.config.MaxWaitProposalInSecs {
 		log.Info("The miner will propose in later, waiting for the proposal to be done",
-			"currentBlock", currentBlock, "nextProposalStart", startBlock, "nextProposalEnd", endBlock, "waitTime", waitSecs)
-		time.Sleep(time.Duration(waitSecs) * time.Second)
-	}
-	if startBlock <= currentBlock && currentBlock < endBlock {
-		log.Info("The miner is proposing, waiting for the proposal to be done",
 			"currentBlock", currentBlock, "nextProposalStart", startBlock, "nextProposalEnd", endBlock, "waitTime", waitSecs)
 		time.Sleep(time.Duration(waitSecs) * time.Second)
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1519,7 +1519,7 @@ func (w *worker) tryWaitProposalDoneWhenStopping() {
 	currentBlock := currentHeader.Number.Uint64()
 	startBlock, endBlock, err := posa.NextProposalBlock(w.chain, currentHeader, w.coinbase)
 	if err != nil {
-		log.Warn("Failed to get next proposal block", "err", err)
+		log.Warn("Failed to get next proposal block, skip waiting", "err", err)
 		return
 	}
 
@@ -1534,7 +1534,7 @@ func (w *worker) tryWaitProposalDoneWhenStopping() {
 		return
 	}
 
-	// wait a more block for safety
+	// wait one more block for safety
 	waitSecs := (endBlock - currentBlock + 1) * posa.BlockInterval()
 	log.Info("The miner will propose in later, waiting for the proposal to be done",
 		"currentBlock", currentBlock, "nextProposalStart", startBlock, "nextProposalEnd", endBlock, "waitTime", waitSecs)
@@ -1571,5 +1571,3 @@ func signalToErr(signal int32) error {
 		panic(fmt.Errorf("undefined signal %d", signal))
 	}
 }
-
-// signalToErr converts the interruption signal to a concrete error type for return.


### PR DESCRIPTION
### Description

The PR aims to avoid validator being slashed when restarting the node, the node will propose multi blocks after enabling the https://github.com/bnb-chain/bsc/pull/2482.

So the PR will wait for the multi-block proposals to be done to avoid the slashing when restarting, and the node will wait `MaxWaitProposalInSecs`.

The default value of `MaxWaitProposalInSecs` is set to 30 seconds.   Because the average restart time in mainnet is around 30s, so the node try to wait for the next multi-proposals to be done.

> Attention: if you maintain the node with `systemd`, pls set `TimeoutStopSpec` >= 60s, it will allow the node shutdown safely when enabling the `MaxWaitProposalInSecs` > 0.

### Changes

Notable changes: 
* feat: wait miner finish the later multi-proposals when restarting the node;
* ...
