### PR TITLE
faucet: enable one way to skip captcha verification

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -423,7 +423,7 @@ func (f *faucet) apiHandler(w http.ResponseWriter, r *http.Request) {
 		log.Info("Faucet funds requested", "url", msg.URL, "tier", msg.Tier, "ip", ip)
 
 		// check #1: captcha verifications to exclude robot
-		if *captchaToken != "" {
+		if *captchaToken != "" && msg.Captcha != "noCaptchaToken" {
 			form := url.Values{}
 			form.Add("secret", *captchaSecret)
 			form.Add("response", msg.Captcha)


### PR DESCRIPTION
### Description

Enable a method to bypass captcha verification when requesting faucet tokens.

### Rationale

Captcha verification can be quite cumbersome when making API calls to request Faucet access. Additionally, the Faucet currently has robust anti-bot measures in place. Therefore, we are considering the possibility of exempting captcha verification in certain scenarios to enhance user experience.

### Example

NA

### Changes

Notable changes: 
* NA
