### PR TITLE
eth/tracers: fix call nil OnSystemTxFixIntrinsicGas

### DIFF
--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -144,10 +144,11 @@ func newFlatCallTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *p
 	ft := &flatCallTracer{tracer: t, ctx: ctx, config: config, chainConfig: chainConfig}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
-			OnTxStart: ft.OnTxStart,
-			OnTxEnd:   ft.OnTxEnd,
-			OnEnter:   ft.OnEnter,
-			OnExit:    ft.OnExit,
+			OnTxStart:                 ft.OnTxStart,
+			OnTxEnd:                   ft.OnTxEnd,
+			OnEnter:                   ft.OnEnter,
+			OnExit:                    ft.OnExit,
+			OnSystemTxFixIntrinsicGas: ft.OnSystemTxFixIntrinsicGas,
 		},
 		Stop:      ft.Stop,
 		GetResult: ft.GetResult,

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -175,7 +175,9 @@ func (t *muxTracer) OnLog(log *types.Log) {
 
 func (t *muxTracer) OnSystemTxFixIntrinsicGas(intrinsicGas uint64) {
 	for _, t := range t.tracers {
-		t.OnSystemTxFixIntrinsicGas(intrinsicGas)
+		if t.OnSystemTxFixIntrinsicGas != nil {
+			t.OnSystemTxFixIntrinsicGas(intrinsicGas)
+		}
 	}
 }
 

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -40,19 +40,18 @@ func newNoopTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *param
 	t := &noopTracer{}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
-			OnTxStart:                 t.OnTxStart,
-			OnTxEnd:                   t.OnTxEnd,
-			OnEnter:                   t.OnEnter,
-			OnExit:                    t.OnExit,
-			OnOpcode:                  t.OnOpcode,
-			OnFault:                   t.OnFault,
-			OnGasChange:               t.OnGasChange,
-			OnBalanceChange:           t.OnBalanceChange,
-			OnNonceChange:             t.OnNonceChange,
-			OnCodeChange:              t.OnCodeChange,
-			OnStorageChange:           t.OnStorageChange,
-			OnLog:                     t.OnLog,
-			OnSystemTxFixIntrinsicGas: t.OnSystemTxFixIntrinsicGas,
+			OnTxStart:       t.OnTxStart,
+			OnTxEnd:         t.OnTxEnd,
+			OnEnter:         t.OnEnter,
+			OnExit:          t.OnExit,
+			OnOpcode:        t.OnOpcode,
+			OnFault:         t.OnFault,
+			OnGasChange:     t.OnGasChange,
+			OnBalanceChange: t.OnBalanceChange,
+			OnNonceChange:   t.OnNonceChange,
+			OnCodeChange:    t.OnCodeChange,
+			OnStorageChange: t.OnStorageChange,
+			OnLog:           t.OnLog,
 		},
 		GetResult: t.GetResult,
 		Stop:      t.Stop,
@@ -89,8 +88,6 @@ func (*noopTracer) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev
 func (*noopTracer) OnStorageChange(a common.Address, k, prev, new common.Hash) {}
 
 func (*noopTracer) OnLog(log *types.Log) {}
-
-func (*noopTracer) OnSystemTxFixIntrinsicGas(intrinsicGas uint64) {}
 
 // GetResult returns an empty json object.
 func (t *noopTracer) GetResult() (json.RawMessage, error) {


### PR DESCRIPTION
### Description

eth/tracers: fix call nil OnSystemTxFixIntrinsicGas

### Rationale

1. FlatCallTracer.OnSystemTxFixIntrinsicGas=CallTracer.OnSystemTxFixIntrinsicGas
2. ensure OnSystemTxFixIntrinsicGas not equal to nil before call it
3. remove useless empty func `OnSystemTxFixIntrinsicGas` in noopTracer

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
