### PR TITLE
build: add flag noexecstack for ld on linux

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -262,7 +262,7 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 		// regarding the options --build-id=none and --strip-all. It is needed for
 		// reproducible builds; removing references to temporary files in C-land, and
 		// making build-id reproducibly absent.
-		extld := []string{"-Wl,-z,stack-size=0x800000,--build-id=none,--strip-all"}
+		extld := []string{"-Wl,-z,noexecstack,--build-id=none,--strip-all"}
 		if staticLinking {
 			extld = append(extld, "-static")
 			// Under static linking, use of certain glibc features must be


### PR DESCRIPTION
### Description

build: add flag noexecstack for ld on linux

### Rationale

lots of warnings in Unit Test
![image](https://github.com/user-attachments/assets/f191d152-f1c4-40fc-a25d-84b658162893)
https://github.com/bnb-chain/bsc/actions/runs/12652682067/job/35255843010

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
