### PR TITLE
Add IsOnCurve check when Unmarshaling

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -212,6 +212,9 @@ func UnmarshalPubkey(pub []byte) (*ecdsa.PublicKey, error) {
 	if x == nil {
 		return nil, errInvalidPubkey
 	}
+	if !S256().IsOnCurve(x, y) {
+		return nil, errInvalidPubkey
+	}
 	return &ecdsa.PublicKey{Curve: S256(), X: x, Y: y}, nil
 }
 


### PR DESCRIPTION
### Description

This fixes an issue reported in go-ethereum [see this PR](https://github.com/ethereum/go-ethereum/pull/31100)

