### PR TITLE
release: prepare for release v1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
+## v1.5.5
+v1.5.5 mainly did a upstream code sync, it catches up to Geth of date around 5th-Feb-2025 to sync the latest Praque hard fork changes, see: https://github.com/bnb-chain/bsc/pull/2856
+
+Besides the code sync, there are a few improvement PRs of BSC:
+### IMPROVEMENT
+* [\#2846](https://github.com/bnb-chain/bsc/pull/2846) tracing: pass *tracing.Hooks around instead of vm.Config
+* [\#2850](https://github.com/bnb-chain/bsc/pull/2850) metric: revert default expensive metrics in blockchain
+* [\#2851](https://github.com/bnb-chain/bsc/pull/2851) eth/tracers: fix call nil OnSystemTxFixIntrinsicGas
+* [\#2862](https://github.com/bnb-chain/bsc/pull/2862) cmd/jsutils/getchainstatus.js: add GetEip7623
+* [\#2867](https://github.com/bnb-chain/bsc/pull/2867) p2p: lowered log lvl for failed enr request
+
 ## v1.5.4
-NA
+### BUGFIX
+* [\#2874](https://github.com/bnb-chain/bsc/pull/2874) crypto: add IsOnCurve check
+
 
 ## v1.5.3
 ### BUGFIX

--- a/cmd/jsutils/getchainstatus.js
+++ b/cmd/jsutils/getchainstatus.js
@@ -497,7 +497,7 @@ async function getKeyParameters()  {
 }
 
 // 9.cmd: "getEip7623", usage:
-// node getEip7623.js GetEip7736 \
+// node getEip7623.js GetEip7623 \
 //      --rpc https://bsc-testnet-dataseed.bnbchain.org \
 //      --startNum 40000001  --endNum 40000005
 async function getEip7623()  {

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1  // Major version component of the current release
 	Minor = 5  // Minor version component of the current release
-	Patch = 4  // Patch version component of the current release
+	Patch = 5  // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
## Description
It is a hard fork release to support BSC Pascal on BSC testnet, which includes 5 BEPs:
- [BEP-439: Implement EIP-2537: Precompile for BLS12-381 curve operations](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-439.md)
- [BEP-440: Implement EIP-2935: Serve historical block hashes from state](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-440.md)
- [BEP-441: Implement EIP-7702: Set EOA account code](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-441.md)
- [BEP-466: Make the block format compatible with EIP-7685](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-466.md)
- [ BEP-496: Implement EIP-7623: Increase calldata cost](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-496.md)

Most of these BEPs are compatible with Ethereum Praque hard fork. The behavior of EIP-2537, EIP-2935, EIP-7702, EIP-7623 on BSC would be same as Ethereum. And for EIP-7685, as BSC does not have the consensus layer, it reserves the new element in block header.

It is only for BSC testnet, so mainnet node can skip this version. And it is quite easy to upgrade to v1.5.5 from v1.4.x or v1.5.x, simply do binary replacement would be enough.

## Changes
v1.5.5 mainly did a upstream code sync, it catches up to Geth of date around 5th-Feb-2025 to sync the latest Praque hard fork changes, see: https://github.com/bnb-chain/bsc/pull/2856

Besides the code sync, there are a few improvement PRs of BSC:
### IMPROVEMENT
* [\#2846](https://github.com/bnb-chain/bsc/pull/2846) tracing: pass *tracing.Hooks around instead of vm.Config
* [\#2850](https://github.com/bnb-chain/bsc/pull/2850) metric: revert default expensive metrics in blockchain
* [\#2851](https://github.com/bnb-chain/bsc/pull/2851) eth/tracers: fix call nil OnSystemTxFixIntrinsicGas
* [\#2862](https://github.com/bnb-chain/bsc/pull/2862) cmd/jsutils/getchainstatus.js: add GetEip7623
* [\#2867](https://github.com/bnb-chain/bsc/pull/2867) p2p: lowered log lvl for failed enr request
