### PR TITLE
release: prepare for release v1.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## v1.5.6
+v1.5.6 performed another small code sync with Geth upstream, mainly sync the 7702 tx type txpool update, refer: https://github.com/bnb-chain/bsc/pull/2888/
+
+And it also setup the Testnet Pascal hard fork date.
+
 ## v1.5.5
 v1.5.5 mainly did a upstream code sync, it catches up to Geth of date around 5th-Feb-2025 to sync the latest Praque hard fork changes, see: https://github.com/bnb-chain/bsc/pull/2856
 

--- a/cmd/jsutils/getchainstatus.js
+++ b/cmd/jsutils/getchainstatus.js
@@ -302,7 +302,7 @@ async function getSlashCount()  {
                 let isMaintaining = validatorExtra[1]
                 // let voteAddress = validatorExtra[2]
                 if (isMaintaining) {
-                    let jailHeight = (felonyThreshold - slashCount) * slashScale * maxElected + BigInt(enterMaintenanceHeight)
+                    let jailHeight = (felonyThreshold - BigInt(slashCount)) * slashScale * maxElected + BigInt(enterMaintenanceHeight)
                     console.log("          in maintenance mode since", enterMaintenanceHeight, "will jail after", ethers.toNumber(jailHeight))    
                 } else {
                     console.log("          exited maintenance mode")

--- a/params/config.go
+++ b/params/config.go
@@ -235,9 +235,8 @@ var (
 		HaberTime:           newUint64(1716962820), // 2024-05-29 06:07:00 AM UTC
 		HaberFixTime:        newUint64(1719986788), // 2024-07-03 06:06:28 AM UTC
 		BohrTime:            newUint64(1724116996), // 2024-08-20 01:23:16 AM UTC
-		// TODO
-		PascalTime: nil,
-		PragueTime: nil,
+		PascalTime:          newUint64(1740021480), // 2025-02-20 03:18:00 AM UTC
+		PragueTime:          newUint64(1740021480), // 2025-02-20 03:18:00 AM UTC
 
 		Parlia: &ParliaConfig{
 			Period: 3,

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1  // Major version component of the current release
 	Minor = 5  // Minor version component of the current release
-	Patch = 5  // Patch version component of the current release
+	Patch = 6  // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
## Description
It is a hard fork release to support BSC Pascal on BSC testnet, hard fork date will be: `2025-02-20 03:18:00 AM UTC`, pls upgrade your testnet node to v1.5.6 before the hard fork time.

Pascal hard fork includes 5 BEPs:
- [BEP-439: Implement EIP-2537: Precompile for BLS12-381 curve operations](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-439.md)
- [BEP-440: Implement EIP-2935: Serve historical block hashes from state](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-440.md)
- [BEP-441: Implement EIP-7702: Set EOA account code](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-441.md)
- [BEP-466: Make the block format compatible with EIP-7685](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-466.md)
- [ BEP-496: Implement EIP-7623: Increase calldata cost](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-496.md)

Most of these BEPs are compatible with Ethereum Praque hard fork. The behavior of EIP-2537, EIP-2935, EIP-7702, EIP-7623 on BSC would be same as Ethereum. And for EIP-7685, as BSC does not have the consensus layer, it reserves the new element in block header.

It is only for BSC testnet, so mainnet node can skip this version. And it is quite easy to upgrade to v1.5.5 from v1.4.x or v1.5.x, simply do binary replacement would be enough.

## Changes
v1.5.6 performed another small code sync with Geth upstream, mainly sync the 7702 tx type txpool update, refer: https://github.com/bnb-chain/bsc/pull/2888/