### PR TITLE
config: update BSC Testnet hardfork date: Pascal & Praque

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -235,8 +235,8 @@ var (
 		HaberTime:           newUint64(1716962820), // 2024-05-29 06:07:00 AM UTC
 		HaberFixTime:        newUint64(1719986788), // 2024-07-03 06:06:28 AM UTC
 		BohrTime:            newUint64(1724116996), // 2024-08-20 01:23:16 AM UTC
-		PascalTime:          newUint64(1740021480), // 2025-02-20 03:18:00 AM UTC
-		PragueTime:          newUint64(1740021480), // 2025-02-20 03:18:00 AM UTC
+		PascalTime:          newUint64(1740452880), // 2025-02-25 03:08:00 AM UTC
+		PragueTime:          newUint64(1740452880), // 2025-02-25 03:08:00 AM UTC
 
 		Parlia: &ParliaConfig{
 			Period: 3,


### PR DESCRIPTION

### Description
  update Testet Pascal&Praque hard fork date to 2025-02-25 03:08:00 AM UTC

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
