### PR TITLE
consensus/parlia: improve performance of func IsSystemTransaction

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -321,18 +321,17 @@ func (p *Parlia) Period() uint64 {
 }
 
 func (p *Parlia) IsSystemTransaction(tx *types.Transaction, header *types.Header) (bool, error) {
-	// deploy a contract
-	if tx.To() == nil {
+	if tx.To() == nil || !isToSystemContract(*tx.To()) {
+		return false, nil
+	}
+	if tx.GasPrice().Sign() != 0 {
 		return false, nil
 	}
 	sender, err := types.Sender(p.signer, tx)
 	if err != nil {
 		return false, errors.New("UnAuthorized transaction")
 	}
-	if sender == header.Coinbase && isToSystemContract(*tx.To()) && tx.GasPrice().Cmp(big.NewInt(0)) == 0 {
-		return true, nil
-	}
-	return false, nil
+	return sender == header.Coinbase, nil
 }
 
 func (p *Parlia) IsSystemContract(to *common.Address) bool {


### PR DESCRIPTION
### Description

consensus/parlia: improve performance of func IsSystemTransaction

### Rationale

when use v1.5.x to do benchmark before prague hardfork, strange things happen: the performance downgrades a lot.

Reason is that, when importing a block, for every txs, need to apply func `IsSystemTransaction`.

In func `IsSystemTransaction`, use `p.signer` which is a `pragueSigner`,

but when getting `Sender` for txs, use signer `cancunSigner`,

different type of signers lead to cache missing.

so in this PR, avoid to get sender in `IsSystemTransaction` when possible.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
