### PR TITLE
core/vm: add basic test cases for blsSignatureVerify

### DIFF
--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -325,6 +325,8 @@ func TestPrecompiledBLS12381Pairing(t *testing.T)    { testJson("blsPairing", "f
 func TestPrecompiledBLS12381MapG1(t *testing.T)      { testJson("blsMapG1", "f0f", t) }
 func TestPrecompiledBLS12381MapG2(t *testing.T)      { testJson("blsMapG2", "f10", t) }
 
+func TestPrecompiledBlsSignatureVerify(t *testing.T) { testJson("blsSignatureVerify", "66", t) }
+
 func TestPrecompiledPointEvaluation(t *testing.T) { testJson("pointEvaluation", "0a", t) }
 
 func BenchmarkPrecompiledPointEvaluation(b *testing.B) { benchJson("pointEvaluation", "0a", b) }
@@ -347,6 +349,8 @@ func TestPrecompiledBLS12381G2MultiExpFail(t *testing.T) { testJsonFail("blsG2Mu
 func TestPrecompiledBLS12381PairingFail(t *testing.T)    { testJsonFail("blsPairing", "f0e", t) }
 func TestPrecompiledBLS12381MapG1Fail(t *testing.T)      { testJsonFail("blsMapG1", "f0f", t) }
 func TestPrecompiledBLS12381MapG2Fail(t *testing.T)      { testJsonFail("blsMapG2", "f10", t) }
+
+func TestPrecompiledBlsSignatureVerifyFail(t *testing.T) { testJson("blsSignatureVerify", "66", t) }
 
 func loadJson(name string) ([]precompiledTest, error) {
 	data, err := os.ReadFile(fmt.Sprintf("testdata/precompiles/%v.json", name))

--- a/core/vm/testdata/precompiles/blsSignatureVerify.json
+++ b/core/vm/testdata/precompiles/blsSignatureVerify.json
@@ -1,0 +1,9 @@
+[
+    {
+      "Input": "f2d8e8e5bf354429e3ce8b97c4e88f7a0bf7bc917e856de762ed6d70dd8ec2d289a04d63285e4b45309e7c180ea82565e375dd62c7b80d957aea4c9b7e16bdb28a0f910036bd3220fe3d7614fb137a8f0a68b3c564ddd214b5041d8f7a124e6e7285ac42635e75eeb9051a052fb500b1c2bc23bd4290db59fc02be11f2b80896b6e22d5b8dd31ba2e49b13cd6be19fcd01c1e23af3e5165d88d8b9deaf38baa77770fa6a358e2eebdffd1bd8a1eb7386",
+      "Expected": "01",
+      "Name": "vector 0",
+      "Gas": 4500,
+      "NoBenchmark": false
+    }
+]

--- a/core/vm/testdata/precompiles/fail-blsSignatureVerify.json
+++ b/core/vm/testdata/precompiles/fail-blsSignatureVerify.json
@@ -1,0 +1,12 @@
+[
+    {
+      "Input": "",
+      "ExpectedError": "execution reverted",
+      "Name": "bls_signatureVerify_empty_input"
+    },
+    {
+      "Input": "f2d8e8e5bf354429e3ce8b97c4e88f7a0bf7bc917e856de762ed6d70dd8ec2d289a04d63285e4b45309e7c180ea82565e375dd62c7b80d957aea4c9b7e16bdb28a0f910036bd3220fe3d7614fb137a8f0a68b3c564ddd214b5041d8f7a124e6e7285ac42635e75eeb9051a052fb500b1c2bc23bd4290db59fc02be11f2b80896b6e22d5b8dd31ba2e49b13cd6be19fcd01c1e23af3e5165d88d8b9deaf38baa77770fa6a358e2eebdffd1bd8a1eb7387",
+      "ExpectedError": "execution reverted",
+      "Name": "bls_signatureVerify_wrong_signature"
+    }
+  ]


### PR DESCRIPTION
### Description

core/vm: add basic test cases for blsSignatureVerify

### Rationale

add basic test cases for blsSignatureVerify, to find issue early when update bls libs

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
