### PR TITLE
miner: avoid to collect requests when getting pending blocks

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1191,7 +1191,7 @@ func (w *worker) generateWork(params *generateParams, witness bool) *newPayloadR
 	}
 	// Collect consensus-layer requests if Prague is enabled.
 	var requests [][]byte
-	if w.chainConfig.IsPrague(work.header.Number, work.header.Time) {
+	if w.chainConfig.IsPrague(work.header.Number, work.header.Time) && w.chainConfig.Parlia == nil {
 		requests = [][]byte{}
 		// EIP-6110 deposits
 		if err := core.ParseDepositLogs(&requests, allLogs, w.chainConfig); err != nil {


### PR DESCRIPTION
### Description

miner: avoid to collect requests when getting pending blocks

### Rationale

<img width="802" alt="image" src="https://github.com/user-attachments/assets/711e6df7-8809-4655-b3bf-3cc8958a48dd" />
now `requestsHash` is the `EmptyRequestsHash`

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
