### PR TITLE
core/txpool/legacypool/legacypool.go: add gasTip check when reset

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1423,8 +1423,9 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 					}
 				}
 				lost := make([]*types.Transaction, 0, len(discarded))
+				gasTip := pool.gasTip.Load().ToBig()
 				for _, tx := range types.TxDifference(discarded, included) {
-					if pool.Filter(tx) {
+					if pool.Filter(tx) && tx.GasTipCapIntCmp(gasTip) >= 0 {
 						lost = append(lost, tx)
 					}
 				}


### PR DESCRIPTION
### Description
If we're reorging an old state, reinject all dropped transactions, there are MEV transaction have zero gas price. They should not add to the txpool.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
