### PR TITLE
miner: fix commitWork not interrupted properly

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -450,6 +450,11 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 			if !w.isRunning() {
 				continue
 			}
+			if interruptCh != nil {
+				interruptCh <- commitInterruptNewHead
+				close(interruptCh)
+				interruptCh = nil
+			}
 			clearPending(head.Header.Number.Uint64())
 			timestamp = time.Now().Unix()
 			if p, ok := w.engine.(*parlia.Parlia); ok {


### PR DESCRIPTION
### Description

miner: fix commitWork not interrupted properly

### Rationale

a validator is mining block `N`, but not in turn.

an in turn block with Number `N` arrived, so a chainHeadCh event trigged.

but this validator is not allowed to mine block `N+1`,

in this senario, the `commitwork` for Number `N` will not be interrupted properly!

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
