### PR TITLE
metrics: add more peer, block/vote metrics

### DIFF
--- a/common/format.go
+++ b/common/format.go
@@ -80,3 +80,13 @@ func (t PrettyAge) String() string {
 	}
 	return result
 }
+
+func FormatMilliTime(n int64) string {
+	if n < 0 {
+		return "invalid"
+	}
+	if n == 0 {
+		return ""
+	}
+	return time.UnixMilli(n).Format("2006-01-02 15:04:05.000")
+}

--- a/common/format.go
+++ b/common/format.go
@@ -90,3 +90,13 @@ func FormatMilliTime(n int64) string {
 	}
 	return time.UnixMilli(n).Format("2006-01-02 15:04:05.000")
 }
+
+func FormatUnixTime(n int64) string {
+	if n < 0 {
+		return "invalid"
+	}
+	if n == 0 {
+		return ""
+	}
+	return time.Unix(n, 0).Format("2006-01-02 15:04:05.000")
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1781,6 +1781,9 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	defer wg.Wait()
 	wg.Add(1)
 	go func() {
+		if _, ok := bc.recvTimeCache.Get(block.Hash()); !ok {
+			bc.recvTimeCache.Add(block.Hash(), time.Now().UnixMilli())
+		}
 		blockBatch := bc.db.BlockStore().NewBatch()
 		rawdb.WriteTd(blockBatch, block.Hash(), block.NumberU64(), externTd)
 		rawdb.WriteBlock(blockBatch, block)

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -199,6 +199,14 @@ func (bc *BlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {
 	return block
 }
 
+func (bc *BlockChain) GetRecvTime(hash common.Hash) int64 {
+	t, ok := bc.recvTimeCache.Get(hash)
+	if !ok {
+		return 0
+	}
+	return t
+}
+
 // GetBlockByHash retrieves a block from the database by hash, caching it if found.
 func (bc *BlockChain) GetBlockByHash(hash common.Hash) *types.Block {
 	number := bc.hc.GetBlockNumber(hash)

--- a/core/vote/vote_pool.go
+++ b/core/vote/vote_pool.go
@@ -3,6 +3,7 @@ package vote
 import (
 	"container/heap"
 	"sync"
+	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 
@@ -25,6 +26,8 @@ const (
 	upperLimitOfVoteBlockNumber = 11 // refer to fetcher.maxUncleDist
 
 	highestVerifiedBlockChanSize = 10 // highestVerifiedBlockChanSize is the size of channel listening to HighestVerifiedBlockEvent.
+
+	defaultMajorityThreshold = 14 // this is an inaccurate value, mainly used for metric acquisition
 )
 
 var (
@@ -38,8 +41,25 @@ var (
 )
 
 type VoteBox struct {
-	blockNumber  uint64
-	voteMessages []*types.VoteEnvelope
+	blockNumber      uint64
+	voteMessages     []*types.VoteEnvelope
+	majorityVoteTime int64
+}
+
+func (v *VoteBox) trySetMajorityVoteTime(oldTime int64) {
+	if v.majorityVoteTime > 0 {
+		if oldTime > 0 && v.majorityVoteTime > oldTime {
+			v.majorityVoteTime = oldTime
+		}
+		return
+	}
+	if oldTime > 0 {
+		v.majorityVoteTime = oldTime
+		return
+	}
+	if len(v.voteMessages) >= defaultMajorityThreshold {
+		v.majorityVoteTime = time.Now().UnixMilli()
+	}
 }
 
 type VotePool struct {
@@ -197,6 +217,7 @@ func (pool *VotePool) putVote(m map[common.Hash]*VoteBox, votesPq *votesPriority
 
 	// Put into corresponding votes map.
 	m[targetHash].voteMessages = append(m[targetHash].voteMessages, vote)
+	m[targetHash].trySetMajorityVoteTime(0)
 	// Add into received vote to avoid future duplicated vote comes.
 	pool.receivedVotes.Add(voteHash)
 	log.Debug("VoteHash put into votepool is:", "voteHash", voteHash)
@@ -269,10 +290,15 @@ func (pool *VotePool) transfer(blockHash common.Hash) {
 	// may len(curVotes[blockHash].voteMessages) extra maxCurVoteAmountPerBlock, but it doesn't matter
 	if _, ok := curVotes[blockHash]; !ok {
 		heap.Push(curPq, voteData)
-		curVotes[blockHash] = &VoteBox{voteBox.blockNumber, validVotes}
+		curVotes[blockHash] = &VoteBox{
+			blockNumber:      voteBox.blockNumber,
+			voteMessages:     validVotes,
+			majorityVoteTime: voteBox.majorityVoteTime,
+		}
 		localCurVotesPqGauge.Update(int64(curPq.Len()))
 	} else {
 		curVotes[blockHash].voteMessages = append(curVotes[blockHash].voteMessages, validVotes...)
+		curVotes[blockHash].trySetMajorityVoteTime(voteBox.majorityVoteTime)
 	}
 
 	delete(futureVotes, blockHash)
@@ -320,6 +346,17 @@ func (pool *VotePool) GetVotes() []*types.VoteEnvelope {
 		votesRes = append(votesRes, voteBox.voteMessages...)
 	}
 	return votesRes
+}
+
+func (pool *VotePool) GetMajorityVoteTime(hash common.Hash) int64 {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	vb := pool.curVotes[hash]
+	if vb == nil {
+		return 0
+	}
+	return vb.majorityVoteTime
 }
 
 func (pool *VotePool) FetchVoteByBlockHash(blockHash common.Hash) []*types.VoteEnvelope {

--- a/core/vote/vote_pool.go
+++ b/core/vote/vote_pool.go
@@ -348,15 +348,15 @@ func (pool *VotePool) GetVotes() []*types.VoteEnvelope {
 	return votesRes
 }
 
-func (pool *VotePool) GetMajorityVoteTime(hash common.Hash) int64 {
+func (pool *VotePool) GetMajorityVote(hash common.Hash) (int64, int) {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
 
 	vb := pool.curVotes[hash]
 	if vb == nil {
-		return 0
+		return 0, 0
 	}
-	return vb.majorityVoteTime
+	return vb.majorityVoteTime, len(vb.voteMessages)
 }
 
 func (pool *VotePool) FetchVoteByBlockHash(blockHash common.Hash) []*types.VoteEnvelope {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -701,15 +701,15 @@ func (s *Ethereum) reportRecentBlocksLoop() {
 			hash := cur.Hash()
 			records := make(map[string]interface{})
 			records["Current"] = num
-			records["Current_recvBlock"] = s.blockchain.GetRecvTime(hash)
-			records["Current_majorityVote"] = s.votePool.GetMajorityVoteTime(hash)
+			records["Current_recvBlock"] = common.FormatMilliTime(s.blockchain.GetRecvTime(hash))
+			records["Current_majorityVote"] = common.FormatMilliTime(s.votePool.GetMajorityVoteTime(hash))
 
 			prv := s.blockchain.GetBlockByNumber(num - 1)
 			num = prv.NumberU64()
 			hash = prv.Hash()
 			records["Prev"] = num
-			records["Prev_recvBlock"] = s.blockchain.GetRecvTime(hash)
-			records["Prev_majorityVote"] = s.votePool.GetMajorityVoteTime(hash)
+			records["Prev_recvBlock"] = common.FormatMilliTime(s.blockchain.GetRecvTime(hash))
+			records["Prev_majorityVote"] = common.FormatMilliTime(s.votePool.GetMajorityVoteTime(hash))
 			metrics.GetOrRegisterLabel("report-blocks", nil).Mark(records)
 		case <-s.stopCh:
 			return

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/metrics"
 	"math/big"
 	"runtime"
 	"sync"
@@ -702,6 +703,7 @@ func (s *Ethereum) reportRecentBlocksLoop() {
 				records[fmt.Sprintf("block-%d", num-i)] = s.blockchain.GetRecvTime(hash)
 				records[fmt.Sprintf("vote-%d", num-i)] = s.votePool.GetMajorityVoteTime(hash)
 			}
+			metrics.GetOrRegisterLabel("recent-blocks", nil).Mark(records)
 		case <-s.stopCh:
 			return
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -700,10 +700,13 @@ func (s *Ethereum) reportRecentBlocksLoop() {
 			num := cur.Number.Uint64()
 			hash := cur.Hash()
 			records := make(map[string]interface{})
-			records["Current"] = num
-			records["RecvBlock"] = common.FormatMilliTime(s.blockchain.GetRecvTime(hash))
-			records["MajorityVote"] = common.FormatMilliTime(s.votePool.GetMajorityVoteTime(hash))
+			records["BlockNum"] = num
+			records["RecvBlockAt"] = common.FormatMilliTime(s.blockchain.GetRecvTime(hash))
+			t, cnt := s.votePool.GetMajorityVote(hash)
+			records["MajorityVotesAt"] = common.FormatMilliTime(t)
+			records["TotalVotes"] = cnt
 			records["Coinbase"] = cur.Coinbase.String()
+			records["BlockTime"] = common.FormatUnixTime(int64(cur.Time))
 			metrics.GetOrRegisterLabel("report-blocks", nil).Mark(records)
 		case <-s.stopCh:
 			return

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -701,15 +701,9 @@ func (s *Ethereum) reportRecentBlocksLoop() {
 			hash := cur.Hash()
 			records := make(map[string]interface{})
 			records["Current"] = num
-			records["Current_recvBlock"] = common.FormatMilliTime(s.blockchain.GetRecvTime(hash))
-			records["Current_majorityVote"] = common.FormatMilliTime(s.votePool.GetMajorityVoteTime(hash))
-
-			prv := s.blockchain.GetBlockByNumber(num - 1)
-			num = prv.NumberU64()
-			hash = prv.Hash()
-			records["Prev"] = num
-			records["Prev_recvBlock"] = common.FormatMilliTime(s.blockchain.GetRecvTime(hash))
-			records["Prev_majorityVote"] = common.FormatMilliTime(s.votePool.GetMajorityVoteTime(hash))
+			records["RecvBlock"] = common.FormatMilliTime(s.blockchain.GetRecvTime(hash))
+			records["MajorityVote"] = common.FormatMilliTime(s.votePool.GetMajorityVoteTime(hash))
+			records["Coinbase"] = cur.Coinbase.String()
 			metrics.GetOrRegisterLabel("report-blocks", nil).Mark(records)
 		case <-s.stopCh:
 			return

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -34,6 +34,9 @@ const (
 
 	// egressMeterName is the prefix of the per-packet outbound metrics.
 	egressMeterName = "p2p/egress"
+
+	// peerLatencyName is the prefix of peer the latency metrics.
+	peerLatencyName = "p2p/peers/latency"
 )
 
 var (

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -34,9 +34,6 @@ const (
 
 	// egressMeterName is the prefix of the per-packet outbound metrics.
 	egressMeterName = "p2p/egress"
-
-	// peerLatencyName is the prefix of peer the latency metrics.
-	peerLatencyName = "p2p/peers/latency"
 )
 
 var (
@@ -71,6 +68,8 @@ var (
 	serveUnexpectedIdentity  = metrics.NewRegisteredMeter("p2p/serves/error/id/unexpected", nil)
 	serveEncHandshakeError   = metrics.NewRegisteredMeter("p2p/serves/error/rlpx/enc", nil)
 	serveProtoHandshakeError = metrics.NewRegisteredMeter("p2p/serves/error/rlpx/proto", nil)
+
+	peerLatencyStat = metrics.NewRegisteredTimer("p2p/peers/latency", nil)
 )
 
 // markDialError matches errors that occur while setting up a dial connection

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"net"
 	"slices"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -358,10 +357,7 @@ func (p *Peer) pingLoop() {
 			latency := (time.Now().UnixMilli() - startPing.Load()) / 2
 			if latency > 0 {
 				p.latency.Store(latency)
-				ip := strings.ReplaceAll(p.Node().IPAddr().String(), ".", "-")
-				m := fmt.Sprintf("%s/%s", peerLatencyName, ip)
-				metrics.GetOrRegisterGauge(m, nil).Update(latency)
-				metrics.GetOrRegisterTimer(peerLatencyName, nil).Update(time.Duration(latency))
+				peerLatencyStat.Update(time.Duration(latency))
 			}
 		case <-p.closed:
 			return

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -357,8 +358,10 @@ func (p *Peer) pingLoop() {
 			latency := (time.Now().UnixMilli() - startPing.Load()) / 2
 			if latency > 0 {
 				p.latency.Store(latency)
-				m := fmt.Sprintf("%s/%s", peerLatencyName, p.Node().IPAddr().String())
+				ip := strings.ReplaceAll(p.Node().IPAddr().String(), ".", "-")
+				m := fmt.Sprintf("%s/%s", peerLatencyName, ip)
 				metrics.GetOrRegisterGauge(m, nil).Update(latency)
+				metrics.GetOrRegisterTimer(peerLatencyName, nil).Update(time.Duration(latency))
 			}
 		case <-p.closed:
 			return

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
@@ -113,12 +114,15 @@ type Peer struct {
 	protoErr chan error
 	closed   chan struct{}
 	pingRecv chan struct{}
+	pongRecv chan struct{}
 	disc     chan DiscReason
 
 	// events receives message send / receive events if set
 	events         *event.Feed
 	testPipe       *MsgPipeRW // for testing
 	testRemoteAddr string     // for testing
+
+	latency atomic.Int64 // mill second latency, estimated by ping msg
 }
 
 // NewPeer returns a peer for testing purposes.
@@ -268,6 +272,7 @@ func newPeer(log log.Logger, conn *conn, protocols []Protocol) *Peer {
 		protoErr: make(chan error, len(protomap)+1), // protocols + pingLoop
 		closed:   make(chan struct{}),
 		pingRecv: make(chan struct{}, 16),
+		pongRecv: make(chan struct{}, 16),
 		log:      log.New("id", conn.node.ID(), "conn", conn.flags),
 	}
 	return p
@@ -333,9 +338,11 @@ func (p *Peer) pingLoop() {
 	ping := time.NewTimer(pingInterval)
 	defer ping.Stop()
 
+	var startPing atomic.Int64
 	for {
 		select {
 		case <-ping.C:
+			startPing.Store(time.Now().UnixMilli())
 			if err := SendItems(p.rw, pingMsg); err != nil {
 				p.protoErr <- err
 				return
@@ -345,6 +352,14 @@ func (p *Peer) pingLoop() {
 		case <-p.pingRecv:
 			SendItems(p.rw, pongMsg)
 
+		case <-p.pongRecv:
+			// estimate latency here, it also includes tiny msg encode/decode, io wait time
+			latency := (time.Now().UnixMilli() - startPing.Load()) / 2
+			if latency > 0 {
+				p.latency.Store(latency)
+				m := fmt.Sprintf("%s/%s", peerLatencyName, p.Node().IPAddr().String())
+				metrics.GetOrRegisterGauge(m, nil).Update(latency)
+			}
 		case <-p.closed:
 			return
 		}
@@ -373,6 +388,12 @@ func (p *Peer) handle(msg Msg) error {
 		msg.Discard()
 		select {
 		case p.pingRecv <- struct{}{}:
+		case <-p.closed:
+		}
+	case msg.Code == pongMsg:
+		msg.Discard()
+		select {
+		case p.pongRecv <- struct{}{}:
 		case <-p.closed:
 		}
 	case msg.Code == discMsg:
@@ -557,6 +578,7 @@ type PeerInfo struct {
 		Static        bool   `json:"static"`
 	} `json:"network"`
 	Protocols map[string]interface{} `json:"protocols"` // Sub-protocol specific metadata fields
+	Latency   int64                  `json:"latency"`   // the estimate latency from ping msg
 }
 
 // Info gathers and returns a collection of metadata known about a peer.
@@ -573,6 +595,7 @@ func (p *Peer) Info() *PeerInfo {
 		Name:      p.Fullname(),
 		Caps:      caps,
 		Protocols: make(map[string]interface{}, len(p.running)),
+		Latency:   p.latency.Load(),
 	}
 	if p.Node().Seq() > 0 {
 		info.ENR = p.Node().String()


### PR DESCRIPTION
### Description

Currently, BSC lacks monitoring on node delay, block/vote and other message delays, especially the future implementation of BEP-520, which is more sensitive to delays.

This PR mainly adds two types of monitoring:

1. Monitor the network delay of connected nodes through ping messages, observe the network environment, and then optimize;
2. By printing the reception time of block/vote, determine the delay of core messages and optimize the message mechanism;

### Example

Here are some grafana examples:
1. peer latency
<img width="1645" alt="image" src="https://github.com/user-attachments/assets/ba437b10-2e26-4916-b8f6-aa49f22f4250" />

```bash
# query expression
p2p_peers_latency{quantile="0.95", job=~"$jobs"}
```

2. block/vote receive record
<img width="1250" alt="image" src="https://github.com/user-attachments/assets/fa73e1e2-c168-462a-8cb7-68eb85997797" />


```bash
# query expression
report_blocks{job=~"$jobs"}
```

You can also query peer latency data from admin API:
```bash
$ ./bsc attach --exec "admin.peers" ./geth.ipc | grep -E "enode|latency"
    enode: "enode://2e5a6c5d1760f1a6d07e117e3660468deb4ecd9aa62a9c371def3da1582b24da1d8cd0b3b013bdaaf35935a56566c68f9a08d742cc9e93d15dbfcd861b78ebcd@3.255.93.82:45076",
    latency: 101,
    enode: "enode://ca5890670f5148c80c2dea271c94a2b417668c3a1cf45c6027b2c42e4320a276887b803a3787d3a046435b924bd6671c1e95d14b5f99e1c24251fd7022179a1b@116.202.84.207:42272",
    latency: 129,
    enode: "enode://50ea9764dfc84e91c179e2e4e64fb6650f40dfbfd03e43ae185983ad240f626b746db99c8e4f00f7eba97da2870b524cc49346028b90c088b26fca8c630f7a42@115.79.195.171:34654",
    latency: 49,
...
```

### Changes

Notable changes: 
* p2p: estimate peer latency by ping;
* metrics: add metrics about recent blocks recv time;
