### PR TITLE
metrics: add more block/vote stats;

### DIFF
--- a/common/format.go
+++ b/common/format.go
@@ -90,13 +90,3 @@ func FormatMilliTime(n int64) string {
 	}
 	return time.UnixMilli(n).Format("2006-01-02 15:04:05.000")
 }
-
-func FormatUnixTime(n int64) string {
-	if n < 0 {
-		return "invalid"
-	}
-	if n == 0 {
-		return ""
-	}
-	return time.Unix(n, 0).Format("2006-01-02 15:04:05.000")
-}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -237,6 +237,8 @@ type txLookup struct {
 }
 
 type BlockRecorder struct {
+	BlockMiningTime atomic.Int64
+
 	SendBlockTime   atomic.Int64
 	InsertBlockTime atomic.Int64
 	RecvBlockTime   atomic.Int64

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1796,9 +1796,6 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	defer wg.Wait()
 	wg.Add(1)
 	go func() {
-		if r := bc.GetBlockStats(block.Hash()); r.StartImportBlockTime.Load() == 0 {
-			r.StartImportBlockTime.Store(time.Now().UnixMilli())
-		}
 		blockBatch := bc.db.BlockStore().NewBatch()
 		rawdb.WriteTd(blockBatch, block.Hash(), block.NumberU64(), externTd)
 		rawdb.WriteBlock(blockBatch, block)

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -199,14 +199,6 @@ func (bc *BlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {
 	return block
 }
 
-func (bc *BlockChain) GetRecvTime(hash common.Hash) int64 {
-	t, ok := bc.recvTimeCache.Get(hash)
-	if !ok {
-		return 0
-	}
-	return t
-}
-
 // GetBlockByHash retrieves a block from the database by hash, caching it if found.
 func (bc *BlockChain) GetBlockByHash(hash common.Hash) *types.Block {
 	number := bc.hc.GetBlockNumber(hash)

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -198,7 +198,7 @@ func (voteManager *VoteManager) loop() {
 
 				log.Debug("vote manager produced vote", "votedBlockNumber", voteMessage.Data.TargetNumber, "votedBlockHash", voteMessage.Data.TargetHash, "voteMessageHash", voteMessage.Hash())
 				voteManager.pool.PutVote(voteMessage)
-				voteManager.chain.GetBlockRecorder(curHead.Hash()).SendVoteTime.Store(time.Now().UnixMilli())
+				voteManager.chain.GetBlockStats(curHead.Hash()).SendVoteTime.Store(time.Now().UnixMilli())
 				votesManagerCounter.Inc(1)
 			}
 

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -198,6 +198,7 @@ func (voteManager *VoteManager) loop() {
 
 				log.Debug("vote manager produced vote", "votedBlockNumber", voteMessage.Data.TargetNumber, "votedBlockHash", voteMessage.Data.TargetHash, "voteMessageHash", voteMessage.Hash())
 				voteManager.pool.PutVote(voteMessage)
+				voteManager.chain.GetBlockRecorder(curHead.Hash()).SendVoteTime.Store(time.Now().UnixMilli())
 				votesManagerCounter.Inc(1)
 			}
 

--- a/core/vote/vote_pool.go
+++ b/core/vote/vote_pool.go
@@ -2,6 +2,7 @@ package vote
 
 import (
 	"container/heap"
+	"encoding/hex"
 	"sync"
 	"time"
 
@@ -55,10 +56,20 @@ func (v *VoteBox) trySetMajorityVoteTime(oldTime int64) {
 	}
 	if oldTime > 0 {
 		v.majorityVoteTime = oldTime
+		var addrs []string
+		for _, msg := range v.voteMessages {
+			addrs = append(addrs, hex.EncodeToString(msg.VoteAddress.Bytes()))
+		}
+		log.Info("receive MajorityVote from old", "block", v.blockNumber, "votes", addrs)
 		return
 	}
 	if len(v.voteMessages) >= defaultMajorityThreshold {
 		v.majorityVoteTime = time.Now().UnixMilli()
+		var addrs []string
+		for _, msg := range v.voteMessages {
+			addrs = append(addrs, hex.EncodeToString(msg.VoteAddress.Bytes()))
+		}
+		log.Info("receive MajorityVote", "block", v.blockNumber, "votes", addrs)
 	}
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -710,7 +710,8 @@ func (s *Ethereum) reportRecentBlocksLoop() {
 			recorder := s.blockchain.GetBlockRecorder(cur.Hash())
 			sendBlockTime := recorder.SendBlockTime.Load()
 			insertBlockTIme := recorder.InsertBlockTime.Load()
-			recvBlockTime := recorder.RecvBlockTime.Load()
+			recvNewBlockTime := recorder.RecvNewBlockTime.Load()
+			recvNewBlockHashTime := recorder.RecvNewBlockHashTime.Load()
 			sendVoteTime := recorder.SendVoteTime.Load()
 			firstVoteTime := recorder.FirstRecvVoteTime.Load()
 			recvMajorityTime := recorder.RecvMajorityVoteTime.Load()
@@ -719,13 +720,17 @@ func (s *Ethereum) reportRecentBlocksLoop() {
 			records["BlockNum"] = num
 			records["SendBlockTime"] = common.FormatMilliTime(sendBlockTime)
 			records["InsertBlockTime"] = common.FormatMilliTime(insertBlockTIme)
-			records["RecvBlockTime"] = common.FormatMilliTime(recvBlockTime)
-			records["RecvBlockSource"] = recorder.RecvBlockSource.Load()
-			records["RecvBlockFrom"] = recorder.RecvBlockFrom.Load()
+			records["RecvNewBlockTime"] = common.FormatMilliTime(recvNewBlockTime)
+			records["RecvNewBlockHashTime"] = common.FormatMilliTime(recvNewBlockHashTime)
+			records["RecvNewBlockFrom"] = recorder.RecvNewBlockFrom.Load()
+			records["RecvNewBlockHashFrom"] = recorder.RecvNewBlockHashFrom.Load()
 
 			records["SendVoteTime"] = common.FormatMilliTime(sendVoteTime)
 			records["FirstRecvVoteTime"] = common.FormatMilliTime(firstVoteTime)
 			records["RecvMajorityVoteTime"] = common.FormatMilliTime(recvMajorityTime)
+
+			records["BlockMiningTime"] = common.FormatMilliTime(recorder.BlockMiningTime.Load())
+			records["BlockProcessTime"] = common.FormatMilliTime(recorder.BlockProcessTime.Load())
 
 			records["Coinbase"] = cur.Coinbase.String()
 			blockMsTime := int64(cur.Time * 1000)
@@ -735,8 +740,8 @@ func (s *Ethereum) reportRecentBlocksLoop() {
 			if sendBlockTime > blockMsTime {
 				sendBlockTimer.Update(time.Duration(sendBlockTime - blockMsTime))
 			}
-			if recvBlockTime > blockMsTime {
-				recvBlockTimer.Update(time.Duration(recvBlockTime - blockMsTime))
+			if recvNewBlockTime > blockMsTime {
+				recvBlockTimer.Update(time.Duration(recvNewBlockTime - blockMsTime))
 			}
 			if insertBlockTIme > blockMsTime {
 				insertBlockTimer.Update(time.Duration(insertBlockTIme - blockMsTime))

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -729,8 +729,8 @@ func (s *Ethereum) reportRecentBlocksLoop() {
 			records["FirstRecvVoteTime"] = common.FormatMilliTime(firstVoteTime)
 			records["RecvMajorityVoteTime"] = common.FormatMilliTime(recvMajorityTime)
 
-			records["BlockMiningTime"] = common.FormatMilliTime(recorder.BlockMiningTime.Load())
-			records["BlockProcessTime"] = common.FormatMilliTime(recorder.BlockProcessTime.Load())
+			records["BlockMiningTime"] = recorder.BlockMiningTime.Load()
+			records["BlockProcessTime"] = recorder.BlockProcessTime.Load()
 
 			records["Coinbase"] = cur.Coinbase.String()
 			blockMsTime := int64(cur.Time * 1000)

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -105,12 +105,12 @@ func (h *ethHandler) handleBlockAnnounces(peer *eth.Peer, hashes []common.Hash, 
 		h.blockFetcher.Notify(peer.ID(), unknownHashes[i], unknownNumbers[i], time.Now(), peer.RequestOneHeader, peer.RequestBodies)
 	}
 	for _, hash := range hashes {
-		recorder := h.chain.GetBlockRecorder(hash)
-		if recorder.RecvNewBlockHashTime.Load() == 0 {
-			recorder.RecvNewBlockHashTime.Store(time.Now().UnixMilli())
+		stats := h.chain.GetBlockStats(hash)
+		if stats.RecvNewBlockHashTime.Load() == 0 {
+			stats.RecvNewBlockHashTime.Store(time.Now().UnixMilli())
 			addr := peer.RemoteAddr()
 			if addr != nil {
-				recorder.RecvNewBlockHashFrom.Store(addr.String())
+				stats.RecvNewBlockHashFrom.Store(addr.String())
 			}
 		}
 	}
@@ -129,12 +129,12 @@ func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, packet *eth.NewBlockPa
 
 	// Schedule the block for import
 	h.blockFetcher.Enqueue(peer.ID(), block)
-	recorder := h.chain.GetBlockRecorder(block.Hash())
-	if recorder.RecvNewBlockTime.Load() == 0 {
-		recorder.RecvNewBlockTime.Store(time.Now().UnixMilli())
+	stats := h.chain.GetBlockStats(block.Hash())
+	if stats.RecvNewBlockTime.Load() == 0 {
+		stats.RecvNewBlockTime.Store(time.Now().UnixMilli())
 		addr := peer.RemoteAddr()
 		if addr != nil {
-			recorder.RecvNewBlockFrom.Store(addr.String())
+			stats.RecvNewBlockFrom.Store(addr.String())
 		}
 	}
 

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -106,12 +106,11 @@ func (h *ethHandler) handleBlockAnnounces(peer *eth.Peer, hashes []common.Hash, 
 	}
 	for _, hash := range hashes {
 		recorder := h.chain.GetBlockRecorder(hash)
-		if recorder.RecvBlockTime.Load() == 0 {
-			recorder.RecvBlockTime.Store(time.Now().UnixMilli())
-			recorder.RecvBlockSource.Store("NewBlockHash")
+		if recorder.RecvNewBlockHashTime.Load() == 0 {
+			recorder.RecvNewBlockHashTime.Store(time.Now().UnixMilli())
 			addr := peer.RemoteAddr()
 			if addr != nil {
-				recorder.RecvBlockFrom.Store(addr.String())
+				recorder.RecvNewBlockHashFrom.Store(addr.String())
 			}
 		}
 	}
@@ -131,12 +130,11 @@ func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, packet *eth.NewBlockPa
 	// Schedule the block for import
 	h.blockFetcher.Enqueue(peer.ID(), block)
 	recorder := h.chain.GetBlockRecorder(block.Hash())
-	if recorder.RecvBlockTime.Load() == 0 {
-		recorder.RecvBlockTime.Store(time.Now().UnixMilli())
-		recorder.RecvBlockSource.Store("NewBlock")
+	if recorder.RecvNewBlockTime.Load() == 0 {
+		recorder.RecvNewBlockTime.Store(time.Now().UnixMilli())
 		addr := peer.RemoteAddr()
 		if addr != nil {
-			recorder.RecvBlockFrom.Store(addr.String())
+			recorder.RecvNewBlockFrom.Store(addr.String())
 		}
 	}
 

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -106,11 +106,13 @@ func (h *ethHandler) handleBlockAnnounces(peer *eth.Peer, hashes []common.Hash, 
 	}
 	for _, hash := range hashes {
 		recorder := h.chain.GetBlockRecorder(hash)
-		recorder.RecvBlockTime.Store(time.Now().UnixMilli())
-		recorder.RecvBlockSource.Store("NewBlockHash")
-		addr := peer.RemoteAddr()
-		if addr != nil {
-			recorder.RecvBlockFrom.Store(addr.String())
+		if recorder.RecvBlockTime.Load() == 0 {
+			recorder.RecvBlockTime.Store(time.Now().UnixMilli())
+			recorder.RecvBlockSource.Store("NewBlockHash")
+			addr := peer.RemoteAddr()
+			if addr != nil {
+				recorder.RecvBlockFrom.Store(addr.String())
+			}
 		}
 	}
 	return nil
@@ -129,11 +131,13 @@ func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, packet *eth.NewBlockPa
 	// Schedule the block for import
 	h.blockFetcher.Enqueue(peer.ID(), block)
 	recorder := h.chain.GetBlockRecorder(block.Hash())
-	recorder.RecvBlockTime.Store(time.Now().UnixMilli())
-	recorder.RecvBlockSource.Store("NewBlock")
-	addr := peer.RemoteAddr()
-	if addr != nil {
-		recorder.RecvBlockFrom.Store(addr.String())
+	if recorder.RecvBlockTime.Load() == 0 {
+		recorder.RecvBlockTime.Store(time.Now().UnixMilli())
+		recorder.RecvBlockSource.Store("NewBlock")
+		addr := peer.RemoteAddr()
+		if addr != nil {
+			recorder.RecvBlockFrom.Store(addr.String())
+		}
 	}
 
 	// Assuming the block is importable by the peer, but possibly not yet done so,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -669,10 +669,9 @@ func (w *worker) resultLoop() {
 				continue
 			}
 			writeBlockTimer.UpdateSince(start)
-			recorder := w.chain.GetBlockRecorder(block.Hash())
-			mineTime := time.Now().UnixMilli()
-			recorder.SendBlockTime.Store(mineTime)
-			recorder.BlockMiningTime.Store(time.Since(task.miningStartAt).Milliseconds())
+			stats := w.chain.GetBlockStats(block.Hash())
+			stats.SendBlockTime.Store(time.Now().UnixMilli())
+			stats.StartMiningTime.Store(task.miningStartAt.UnixMilli())
 			log.Info("Successfully sealed new block", "number", block.Number(), "sealhash", sealhash, "hash", hash,
 				"elapsed", common.PrettyDuration(time.Since(task.createdAt)))
 			w.mux.Post(core.NewMinedBlockEvent{Block: block})

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -668,6 +668,10 @@ func (w *worker) resultLoop() {
 				continue
 			}
 			writeBlockTimer.UpdateSince(start)
+			recorder := w.chain.GetBlockRecorder(block.Hash())
+			mineTime := time.Now().UnixMilli()
+			recorder.SendBlockTime.Store(mineTime)
+			recorder.RecvBlockTime.Store(mineTime)
 			log.Info("Successfully sealed new block", "number", block.Number(), "sealhash", sealhash, "hash", hash,
 				"elapsed", common.PrettyDuration(time.Since(task.createdAt)))
 			w.mux.Post(core.NewMinedBlockEvent{Block: block})

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -150,10 +150,11 @@ func (env *environment) discard() {
 
 // task contains all information for consensus engine sealing and result submitting.
 type task struct {
-	receipts      []*types.Receipt
-	state         *state.StateDB
-	block         *types.Block
-	createdAt     time.Time
+	receipts  []*types.Receipt
+	state     *state.StateDB
+	block     *types.Block
+	createdAt time.Time
+
 	miningStartAt time.Time
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -672,7 +672,6 @@ func (w *worker) resultLoop() {
 			recorder := w.chain.GetBlockRecorder(block.Hash())
 			mineTime := time.Now().UnixMilli()
 			recorder.SendBlockTime.Store(mineTime)
-			recorder.RecvBlockTime.Store(mineTime)
 			recorder.BlockMiningTime.Store(time.Since(task.miningStartAt).Milliseconds())
 			log.Info("Successfully sealed new block", "number", block.Number(), "sealhash", sealhash, "hash", hash,
 				"elapsed", common.PrettyDuration(time.Since(task.createdAt)))

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -358,6 +358,9 @@ func (p *Peer) pingLoop() {
 			if latency > 0 {
 				p.latency.Store(latency)
 				peerLatencyStat.Update(time.Duration(latency))
+				if latency > 1000 {
+					log.Warn("find a too slow peer", "id", p.ID(), "peer", p.RemoteAddr(), "latency", latency)
+				}
 			}
 		case <-p.closed:
 			return

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -47,6 +47,8 @@ const (
 	snappyProtocolVersion = 5
 
 	pingInterval = 15 * time.Second
+
+	slowPeerLatencyThreshold = 500
 )
 
 const (
@@ -358,7 +360,7 @@ func (p *Peer) pingLoop() {
 			if latency > 0 {
 				p.latency.Store(latency)
 				peerLatencyStat.Update(time.Duration(latency))
-				if latency > 1000 {
+				if latency > slowPeerLatencyThreshold {
 					log.Warn("find a too slow peer", "id", p.ID(), "peer", p.RemoteAddr(), "latency", latency)
 				}
 			}


### PR DESCRIPTION
### Description

This PR will add more metrics for later shorter block interval. It can monitor the block/vote delay between validators, it help to monitor the validator network, and optimizes the p2p msg forward efficient.

### Example

Here are some metrics examples, it can help to optimize the network and find msg broadcast issues.

<img width="1665" alt="image" src="https://github.com/user-attachments/assets/05226470-1af3-410f-ab25-04c7d31ea175" />
<img width="834" alt="image" src="https://github.com/user-attachments/assets/ca76a708-255d-4b5b-b8a3-f63dc22e3027" />

### Changes

Notable changes: 
* metrics: add some block/vote metrics;
* ...
