### PR TITLE
pbs: enable GreedyMergeTx by default

### DIFF
--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -79,6 +79,7 @@ type MevConfig struct {
 
 var DefaultMevConfig = MevConfig{
 	Enabled:               false,
+	GreedyMergeTx:         true,
 	SentryURL:             "",
 	Builders:              nil,
 	ValidatorCommission:   100,

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -481,9 +481,6 @@ func (h *handler) handleCallMsg(ctx *callProc, reqCtx context.Context, msg *json
 		var logctx []any
 		logctx = append(logctx, "reqid", idForLog{msg.ID}, "duration", time.Since(start))
 		if resp.Error != nil {
-			xForward := reqCtx.Value("X-Forwarded-For")
-			h.log.Warn("Served "+msg.Method, "reqid", idForLog{msg.ID}, "t", time.Since(start), "err", resp.Error.Message, "X-Forwarded-For", xForward)
-
 			monitoredError := "sender or to in black list" // using legacypool.ErrInBlackList.Error() will cause `import cycle`
 			if strings.Contains(resp.Error.Message, monitoredError) {
 				accountBlacklistRpcCounter.Inc(1)
@@ -493,6 +490,9 @@ func (h *handler) handleCallMsg(ctx *callProc, reqCtx context.Context, msg *json
 			if resp.Error.Data != nil {
 				logctx = append(logctx, "errdata", formatErrorData(resp.Error.Data))
 			}
+
+			xForward := reqCtx.Value("X-Forwarded-For")
+			logctx = append(logctx, "X-Forwarded-For", xForward)
 			h.log.Warn("Served "+msg.Method, logctx...)
 		} else {
 			h.log.Debug("Served "+msg.Method, logctx...)


### PR DESCRIPTION
### Description
"GreedyMergeTx" was introduced previously by https://github.com/bnb-chain/bsc/pull/2363/ to maximum the validator's reward and also increase the block space utilization rate.
It should be enabled by default, as it is a desired feature for validators.
And also clear up a duplicated log message.

> Notice: pls ignore the nancy check failure, as it will be fixed in https://github.com/bnb-chain/bsc/pull/2951
### Rationale
NA

### Changes
NA