### PR TITLE
miner: refuse to simulate new bid if time not enough

### DIFF
--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -206,7 +206,7 @@ func newBidSimulator(
 }
 
 func (b *bidSimulator) isTimeEnoughForSimulating(newBid *BidRuntime) (bool, error) {
-	if !b.config.EstimateTimeBeforeSimulation {
+	if !b.config.EstimateTimeForBid {
 		return true, nil
 	}
 

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -39,7 +39,8 @@ const (
 )
 
 var (
-	bidSimTimer = metrics.NewRegisteredTimer("bid/sim/duration", nil)
+	bidSimTimer        = metrics.NewRegisteredTimer("bid/sim/duration", nil)
+	simulateSpeedGauge = metrics.NewRegisteredGauge("bid/sim/simulateSpeed", nil) // Mps
 )
 
 var (
@@ -96,6 +97,7 @@ func updateSimulateSpeed(gasSimulated uint64, timeCost time.Duration) {
 	}
 
 	simulateSpeed.Store(newSpeed)
+	simulateSpeedGauge.Update(int64(newSpeed / 1000))
 	log.Debug("updateSimulateSpeed", "old", oldSpeed, "desired", desiredSpeed, "new", newSpeed)
 }
 

--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -68,23 +68,22 @@ type BuilderConfig struct {
 }
 
 type MevConfig struct {
-	Enabled                      bool            // Whether to enable Mev or not
-	EstimateTimeBeforeSimulation bool            // Whether to enable time estimation before bid simulation
-	GreedyMergeTx                bool            // Whether to merge local transactions to the bid
-	BuilderFeeCeil               string          // The maximum builder fee of a bid
-	SentryURL                    string          // The url of Mev sentry
-	Builders                     []BuilderConfig // The list of builders
-	ValidatorCommission          uint64          // 100 means the validator claims 1% from block reward
-	BidSimulationLeftOver        time.Duration   // Time left for bid simulation
-
+	Enabled               bool            // Whether to enable Mev or not
+	EstimateTimeForBid    bool            // Whether to enable time estimation before bid simulation
+	GreedyMergeTx         bool            // Whether to merge local transactions to the bid
+	BuilderFeeCeil        string          // The maximum builder fee of a bid
+	SentryURL             string          // The url of Mev sentry
+	Builders              []BuilderConfig // The list of builders
+	ValidatorCommission   uint64          // 100 means the validator claims 1% from block reward
+	BidSimulationLeftOver time.Duration
 }
 
 var DefaultMevConfig = MevConfig{
-	Enabled:                      false,
-	EstimateTimeBeforeSimulation: true,
-	GreedyMergeTx:                true,
-	SentryURL:                    "",
-	Builders:                     nil,
-	ValidatorCommission:          100,
-	BidSimulationLeftOver:        50 * time.Millisecond,
+	Enabled:               false,
+	EstimateTimeForBid:    true,
+	GreedyMergeTx:         true,
+	SentryURL:             "",
+	Builders:              nil,
+	ValidatorCommission:   100,
+	BidSimulationLeftOver: 50 * time.Millisecond,
 }

--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -68,20 +68,23 @@ type BuilderConfig struct {
 }
 
 type MevConfig struct {
-	Enabled               bool            // Whether to enable Mev or not
-	GreedyMergeTx         bool            // Whether to merge local transactions to the bid
-	BuilderFeeCeil        string          // The maximum builder fee of a bid
-	SentryURL             string          // The url of Mev sentry
-	Builders              []BuilderConfig // The list of builders
-	ValidatorCommission   uint64          // 100 means the validator claims 1% from block reward
-	BidSimulationLeftOver time.Duration
+	Enabled                      bool            // Whether to enable Mev or not
+	EstimateTimeBeforeSimulation bool            // Whether to enable time estimation before bid simulation
+	GreedyMergeTx                bool            // Whether to merge local transactions to the bid
+	BuilderFeeCeil               string          // The maximum builder fee of a bid
+	SentryURL                    string          // The url of Mev sentry
+	Builders                     []BuilderConfig // The list of builders
+	ValidatorCommission          uint64          // 100 means the validator claims 1% from block reward
+	BidSimulationLeftOver        time.Duration   // Time left for bid simulation
+
 }
 
 var DefaultMevConfig = MevConfig{
-	Enabled:               false,
-	GreedyMergeTx:         true,
-	SentryURL:             "",
-	Builders:              nil,
-	ValidatorCommission:   100,
-	BidSimulationLeftOver: 50 * time.Millisecond,
+	Enabled:                      false,
+	EstimateTimeBeforeSimulation: true,
+	GreedyMergeTx:                true,
+	SentryURL:                    "",
+	Builders:                     nil,
+	ValidatorCommission:          100,
+	BidSimulationLeftOver:        50 * time.Millisecond,
 }


### PR DESCRIPTION
### Description

refuse to simulate new bids immediately if time left:
a. not enough after estimation
b. less than 400ms before sealing
the best of these bids will be stored and try to simulate once the current bid done

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
