### PR TITLE
pbs: fix an inaccurate bid result log

### DIFF
--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -519,6 +519,7 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 
 	// ensure simulation exited then start next simulation
 	b.SetSimulatingBid(parentHash, bidRuntime)
+	bestBidOnStart := b.GetBestBid(parentHash)
 
 	defer func(simStart time.Time) {
 		logCtx := []any{
@@ -706,7 +707,12 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 
 	bestBid := b.GetBestBid(parentHash)
 	if bestBid == nil {
-		log.Info("[BID RESULT]", "win", "true[first]", "builder", bidRuntime.bid.Builder, "hash", bidRuntime.bid.Hash().TerminalString())
+		winResult := "true[first]"
+		if bestBidOnStart != nil {
+			// new block was imported, so the bestBidOnStart was cleared, the bid will be stale and useless.
+			winResult = "false[stale]"
+		}
+		log.Info("[BID RESULT]", "win", winResult, "builder", bidRuntime.bid.Builder, "hash", bidRuntime.bid.Hash().TerminalString())
 		b.SetBestBid(bidRuntime.bid.ParentHash, bidRuntime)
 		success = true
 		return


### PR DESCRIPTION
### Description
This PR only change the misleading log, like:
```
t=2025-03-11T11:17:47+0000 lvl=info msg="[BID ARRIVED]" ...
...
t=2025-03-11T11:17:48+0000 lvl=info msg="Successfully sealed new block"...
t=2025-03-11T11:17:48+0000 lvl=info msg="[BID RESULT]" win=true[first]...
```
Sometimes "bestBid == nil" does not mean it is the first bid, if new block was just imported during the bid simulation, the bestBid will be cleared as well. In this case, the bid is stale and useless.

Keep the SetBestBid right now, as it will be cleared later anyway. Once we have more confidence, it can be removed


### Rationale
NA

### Example
NA

### Changes
NA