### PR TITLE
pool: debug log instead of warn

### DIFF
--- a/core/txpool/legacypool/tx_overflowpool.go
+++ b/core/txpool/legacypool/tx_overflowpool.go
@@ -91,7 +91,7 @@ func (tp *TxOverflowPool) Add(tx *types.Transaction) bool {
 
 	// If the transaction is too big to ever fit (and the pool isn't empty right now), reject it
 	if (txSlots > tp.maxSize) || (txSlots == tp.maxSize && tp.totalSize != 0) {
-		log.Warn("Transaction too large to fit in OverflowPool", "transaction", tx.Hash().String(), "requiredSlots", txSlots, "maxSlots", tp.maxSize)
+		log.Debug("Transaction too large to fit in OverflowPool", "transaction", tx.Hash().String(), "requiredSlots", txSlots, "maxSlots", tp.maxSize)
 		return false
 	}
 


### PR DESCRIPTION
### Description

Addresses https://github.com/bnb-chain/bsc/issues/2945 

### Rationale

No need to warn when overflowpool is full. It can be a debug log only. 

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
