### PR TITLE
metric: add more block monitor metrics;

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -72,7 +72,9 @@ var (
 	justifiedBlockGauge = metrics.NewRegisteredGauge("chain/head/justified", nil)
 	finalizedBlockGauge = metrics.NewRegisteredGauge("chain/head/finalized", nil)
 
-	blockInsertMgaspsGauge = metrics.NewRegisteredGauge("chain/insert/mgasps", nil)
+	blockInsertMgaspsGauge  = metrics.NewRegisteredGauge("chain/insert/mgasps", nil)
+	blockInsertTxSizeGauge  = metrics.NewRegisteredGauge("chain/insert/txsize", nil)
+	blockInsertGasUsedGauge = metrics.NewRegisteredGauge("chain/insert/gasused", nil)
 
 	chainInfoGauge = metrics.NewRegisteredGaugeInfo("chain/info", nil)
 
@@ -2498,6 +2500,8 @@ func (bc *BlockChain) processBlock(block *types.Block, statedb *state.StateDB, s
 	}
 	blockWriteTimer.Update(time.Since(wstart) - max(statedb.AccountCommits, statedb.StorageCommits) /* concurrent */ - statedb.SnapshotCommits - statedb.TrieDBCommits)
 	blockInsertTimer.UpdateSince(start)
+	blockInsertTxSizeGauge.Update(int64(len(block.Transactions())))
+	blockInsertGasUsedGauge.Update(int64(block.GasUsed()))
 
 	return &blockProcessingResult{usedGas: res.GasUsed, procTime: proctime, status: status}, nil
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -737,7 +737,7 @@ func (s *Ethereum) reportRecentBlocksLoop() {
 			records["ImportedBlockTime"] = common.FormatMilliTime(importedBlockTime)
 
 			records["Coinbase"] = cur.Coinbase.String()
-			blockMsTime := int64(cur.Time * 1000)
+			blockMsTime := int64(cur.MilliTimestamp())
 			records["BlockTime"] = common.FormatMilliTime(blockMsTime)
 			metrics.GetOrRegisterLabel("report-blocks", nil).Mark(records)
 


### PR DESCRIPTION
### Description

This PR will add new metrics about block txsize, gasused. It can help to monitor the traffic of the chain.

### Example

Add new metrics:
```bash
chain_insert_txsize{job=~"$jobs"}
chain_insert_gasused{job=~"$jobs"}
```

### Changes

Notable changes: 
* metric: add more block monitor metrics;
* ...
