### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -1067,7 +1067,7 @@ func TestChangingSlotterSize(t *testing.T) {
 
 	// Write the two safely sized txs to store. note: although the store is
 	// configured for a blob count of 6, it can also support around ~1mb of call
-	// data - all this to say that we aren't using the the absolute largest shelf
+	// data - all this to say that we aren't using the absolute largest shelf
 	// available.
 	store.Put(blob1)
 	store.Put(blob2)

--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -113,7 +113,7 @@ func (a *SetCodeAuthorization) sigHash() common.Hash {
 	})
 }
 
-// Authority recovers the the authorizing account of an authorization.
+// Authority recovers the authorizing account of an authorization.
 func (a *SetCodeAuthorization) Authority() (common.Address, error) {
 	sighash := a.sigHash()
 	if !crypto.ValidateSignatureValues(a.V, a.R.ToBig(), a.S.ToBig(), true) {


### PR DESCRIPTION
### Description

remove redundant words in comment

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
