### PR TITLE
mev: no interrupt if it is too later

### DIFF
--- a/core/types/bid.go
+++ b/core/types/bid.go
@@ -172,6 +172,7 @@ type Bid struct {
 	GasUsed      uint64
 	GasFee       *big.Int
 	BuilderFee   *big.Int
+	Committed    bool // whether the bid has been committed to simulate or not
 
 	rawBid RawBid
 }

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -437,7 +437,8 @@ func (b *bidSimulator) newBidLoop() {
 					} else {
 						if newBid.bid.Hash() == bidRuntime.bid.Hash() {
 							left := time.Until(time.Unix(int64(blockTime), 0))
-							replyErr = fmt.Errorf("bid is pending as no enough time to interrupt, left:%s, NoInterruptTimeLeft:%s", left, NoInterruptTimeLeft)
+							replyErr = fmt.Errorf("bid is pending as no enough time to interrupt, left:%d, NoInterruptTimeLeft:%d",
+								left.Milliseconds(), NoInterruptTimeLeft.Milliseconds())
 						}
 					}
 				} else {

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -292,6 +292,9 @@ func (b *bidSimulator) DelBestBidToRun(prevBlockHash common.Hash, delBid *types.
 	b.bestBidMu.Lock()
 	defer b.bestBidMu.Unlock()
 	cur := b.bestBidToRun[prevBlockHash]
+	if cur == nil || delBid == nil {
+		return
+	}
 	if cur.Hash() == delBid.Hash() {
 		delete(b.bestBidToRun, prevBlockHash)
 	}
@@ -604,11 +607,11 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 			go b.reportIssue(bidRuntime, err)
 		}
 
-		b.RemoveSimulatingBid(parentHash)
-		close(bidRuntime.finished)
 		if !isValidBid {
 			b.DelBestBidToRun(parentHash, bidRuntime.bid)
 		}
+		b.RemoveSimulatingBid(parentHash)
+		close(bidRuntime.finished)
 
 		if success {
 			bidRuntime.duration = time.Since(simStart)


### PR DESCRIPTION
### Description
This is an improvement to the current MEV logic, especially on large traffic to avoid too frequent bid interrupt that could lead to no bid can be simulated.

with 3s block interval, if there is a simulating bid and with a short time left for simulate, then don't interrupt the current simulating bid. The new bid will be pending and can still run once the current simulating bid completes

### Rationale
NA

### Example
NA

### Changes
NA