### PR TITLE
mev: some code improvements

### DIFF
--- a/core/types/bid.go
+++ b/core/types/bid.go
@@ -172,9 +172,17 @@ type Bid struct {
 	GasUsed      uint64
 	GasFee       *big.Int
 	BuilderFee   *big.Int
-	Committed    bool // whether the bid has been committed to simulate or not
+	committed    bool // whether the bid has been committed to simulate or not
 
 	rawBid RawBid
+}
+
+func (b *Bid) Commit() {
+	b.committed = true
+}
+
+func (b *Bid) IsCommitted() bool {
+	return b.committed
 }
 
 // Hash returns the bid hash.
@@ -193,6 +201,7 @@ type BidIssue struct {
 type MevParams struct {
 	ValidatorCommission   uint64 // 100 means 1%
 	BidSimulationLeftOver time.Duration
+	NoInterruptLeftOver   time.Duration
 	GasCeil               uint64
 	GasPrice              *big.Int // Minimum avg gas price for bid block
 	BuilderFeeCeil        *big.Int

--- a/core/vote/vote_pool.go
+++ b/core/vote/vote_pool.go
@@ -338,7 +338,7 @@ func (pool *VotePool) basicVerify(vote *types.VoteEnvelope, headNumber uint64, m
 
 	// Check duplicate voteMessage firstly.
 	if pool.receivedVotes.Contains(voteHash) {
-		log.Debug("Vote pool already contained the same vote", "voteHash", voteHash)
+		log.Trace("Vote pool already contained the same vote", "voteHash", voteHash)
 		return false
 	}
 

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -643,7 +643,8 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 
 			select {
 			case b.newBidCh <- newBidPackage{bid: bidRuntime.bid}:
-				log.Debug("BidSimulator: recommit", "builder", bidRuntime.bid.Builder, "bidHash", bidRuntime.bid.Hash().Hex())
+				log.Debug("BidSimulator: recommit", "builder", bidRuntime.bid.Builder,
+					"bidHash", bidRuntime.bid.Hash().Hex(), "simElapsed", bidRuntime.duration)
 			default:
 			}
 		} else {

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -33,7 +33,6 @@ import (
 const (
 	// maxBidPerBuilderPerBlock is the max bid number per builder
 	maxBidPerBuilderPerBlock = 3
-	NoInterruptTimeLeft      = 400 * time.Millisecond
 )
 
 var (
@@ -356,7 +355,7 @@ func (b *bidSimulator) canBeInterrupted(targetTime uint64) bool {
 		return true
 	}
 	left := time.Until(time.Unix(int64(targetTime), 0))
-	return left >= NoInterruptTimeLeft
+	return left >= b.config.NoInterruptLeftOver
 }
 
 func (b *bidSimulator) newBidLoop() {
@@ -372,7 +371,7 @@ func (b *bidSimulator) newBidLoop() {
 			close(interruptCh)
 		}
 		interruptCh = make(chan int32, 1)
-		bidRuntime.bid.Committed = true
+		bidRuntime.bid.Commit()
 		select {
 		case b.simBidCh <- &simBidReq{interruptCh: interruptCh, bid: bidRuntime}:
 			log.Debug("BidSimulator: commit", "builder", bidRuntime.bid.Builder, "bidHash", bidRuntime.bid.Hash().Hex())
@@ -409,7 +408,7 @@ func (b *bidSimulator) newBidLoop() {
 					// new bid has better expectedBlockReward, use bidRuntime
 					log.Debug("new bid has better expectedBlockReward",
 						"builder", bidRuntime.bid.Builder, "bidHash", bidRuntime.bid.Hash().TerminalString())
-				} else if !bestBidToRun.Committed {
+				} else if !bestBidToRun.IsCommitted() {
 					// bestBidToRun is not committed yet, this newBid will trigger bestBidToRun to commit
 					bidRuntime = bestBidRuntime
 					replyErr = genDiscardedReply(bidRuntime)
@@ -418,7 +417,7 @@ func (b *bidSimulator) newBidLoop() {
 				} else {
 					// new bid will be discarded, as it is useless now.
 					toCommit = false
-					replyErr = genDiscardedReply(bidRuntime)
+					replyErr = genDiscardedReply(bestBidRuntime)
 					log.Debug("new bid will be discarded", "builder", bestBidToRun.Builder,
 						"bidHash", bestBidToRun.Hash().TerminalString())
 				}
@@ -442,8 +441,8 @@ func (b *bidSimulator) newBidLoop() {
 						commit(commitInterruptBetterBid, bidRuntime)
 					} else {
 						if newBid.bid.Hash() == bidRuntime.bid.Hash() {
-							replyErr = fmt.Errorf("bid is pending as no enough time to interrupt, left:%d, NoInterruptTimeLeft:%d",
-								left.Milliseconds(), NoInterruptTimeLeft.Milliseconds())
+							replyErr = fmt.Errorf("bid is pending as no enough time to interrupt, left:%d, NoInterruptLeftOver:%d",
+								left.Milliseconds(), b.config.NoInterruptLeftOver.Milliseconds())
 						}
 					}
 				} else {

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -435,11 +435,17 @@ func (b *bidSimulator) newBidLoop() {
 						blockTime = parentHeader.Time + blockInterval
 					}
 					left := time.Until(time.Unix(int64(blockTime), 0))
-					log.Debug("simulate in progress", "left", left.Milliseconds(), "blockTime", blockTime,
-						"builder", bidRuntime.bid.Builder, "bidHash", bidRuntime.bid.Hash().TerminalString())
 					if b.canBeInterrupted(blockTime) {
+						log.Debug("simulate in progress, interrupt",
+							"blockTime", blockTime, "left", left.Milliseconds(),
+							"NoInterruptLeftOver", b.config.NoInterruptLeftOver.Milliseconds(),
+							"builder", bidRuntime.bid.Builder, "bidHash", bidRuntime.bid.Hash().TerminalString())
 						commit(commitInterruptBetterBid, bidRuntime)
 					} else {
+						log.Debug("simulate in progress, no interrupt",
+							"blockTime", blockTime, "left", left.Milliseconds(),
+							"NoInterruptLeftOver", b.config.NoInterruptLeftOver.Milliseconds(),
+							"builder", bidRuntime.bid.Builder, "bidHash", bidRuntime.bid.Hash().TerminalString())
 						if newBid.bid.Hash() == bidRuntime.bid.Hash() {
 							replyErr = fmt.Errorf("bid is pending as no enough time to interrupt, left:%d, NoInterruptLeftOver:%d",
 								left.Milliseconds(), b.config.NoInterruptLeftOver.Milliseconds())
@@ -605,6 +611,7 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 			"parentHash", parentHash,
 			"builder", builder,
 			"gasUsed", bidRuntime.bid.GasUsed,
+			"simElapsed", time.Since(simStart),
 		}
 
 		if bidRuntime.env != nil {

--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -99,6 +99,7 @@ func (miner *Miner) MevParams() *types.MevParams {
 	return &types.MevParams{
 		ValidatorCommission:   miner.worker.config.Mev.ValidatorCommission,
 		BidSimulationLeftOver: miner.worker.config.Mev.BidSimulationLeftOver,
+		NoInterruptLeftOver:   miner.worker.config.Mev.NoInterruptLeftOver,
 		GasCeil:               miner.worker.config.GasCeil,
 		GasPrice:              miner.worker.config.GasPrice,
 		BuilderFeeCeil:        builderFeeCeil,

--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -75,6 +75,7 @@ type MevConfig struct {
 	Builders              []BuilderConfig // The list of builders
 	ValidatorCommission   uint64          // 100 means the validator claims 1% from block reward
 	BidSimulationLeftOver time.Duration
+	NoInterruptLeftOver   time.Duration
 }
 
 var DefaultMevConfig = MevConfig{
@@ -84,4 +85,5 @@ var DefaultMevConfig = MevConfig{
 	Builders:              nil,
 	ValidatorCommission:   100,
 	BidSimulationLeftOver: 50 * time.Millisecond,
+	NoInterruptLeftOver:   400 * time.Millisecond,
 }


### PR DESCRIPTION
### Description
1.update some log
2.to address latest comments from: https://github.com/bnb-chain/bsc/pull/2971/files
there will be a new option in config.toml:
```

[Eth.Miner.Mev]
NoInterruptLeftOver = 400000000
```
by default it will be 400ms

### Rationale
NA

### Example
NA

### Changes
NA