### PR TITLE
config: apply default value if it is not set in config.toml

### DIFF
--- a/cmd/devp2p/internal/ethtest/suite_test.go
+++ b/cmd/devp2p/internal/ethtest/suite_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/catalyst"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/internal/utesting"
+	"github.com/ethereum/go-ethereum/miner/minerconfig"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 )
@@ -143,6 +144,7 @@ func setupGeth(stack *node.Node, dir string) error {
 		TrieTimeout:    60 * time.Minute,
 		SnapshotCache:  10,
 		TriesInMemory:  128,
+		Miner:          &minerconfig.Config{},
 	})
 	if err != nil {
 		return err

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -155,6 +155,9 @@ func loadBaseConfig(ctx *cli.Context) gethConfig {
 		if err := loadConfig(file, &cfg); err != nil {
 			utils.Fatalf("%v", err)
 		}
+		// some default options could be overwritten after `loadConfig()`
+		// apply the default value if the options are not specified in config.toml file.
+		ethconfig.ApplyDefaultEthConfig(&cfg.Eth)
 	}
 
 	scheme := cfg.Eth.StateScheme
@@ -276,7 +279,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	git, _ := version.VCS()
 	utils.SetupMetrics(&cfg.Metrics,
 		utils.EnableBuildInfo(git.Commit, git.Date),
-		utils.EnableMinerInfo(ctx, &cfg.Eth.Miner),
+		utils.EnableMinerInfo(ctx, cfg.Eth.Miner),
 		utils.EnableNodeInfo(&cfg.Eth.TxPool, stack.Server().NodeInfo()),
 		utils.EnableNodeTrack(ctx, &cfg.Eth, stack),
 	)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -641,13 +641,13 @@ var (
 	MinerRecommitIntervalFlag = &cli.DurationFlag{
 		Name:     "miner.recommit",
 		Usage:    "Time interval to recreate the block being mined",
-		Value:    ethconfig.Defaults.Miner.Recommit,
+		Value:    *ethconfig.Defaults.Miner.Recommit,
 		Category: flags.MinerCategory,
 	}
 	MinerDelayLeftoverFlag = &cli.DurationFlag{
 		Name:     "miner.delayleftover",
 		Usage:    "Time reserved to finalize a block",
-		Value:    ethconfig.Defaults.Miner.DelayLeftOver,
+		Value:    *ethconfig.Defaults.Miner.DelayLeftOver,
 		Category: flags.MinerCategory,
 	}
 
@@ -1862,17 +1862,20 @@ func setMiner(ctx *cli.Context, cfg *minerconfig.Config) {
 		cfg.GasPrice = flags.GlobalBig(ctx, MinerGasPriceFlag.Name)
 	}
 	if ctx.IsSet(MinerRecommitIntervalFlag.Name) {
-		cfg.Recommit = ctx.Duration(MinerRecommitIntervalFlag.Name)
+		recommit := ctx.Duration(MinerRecommitIntervalFlag.Name)
+		cfg.Recommit = &recommit
 	}
 	if ctx.IsSet(MinerDelayLeftoverFlag.Name) {
-		cfg.DelayLeftOver = ctx.Duration(MinerDelayLeftoverFlag.Name)
+		delayLeftOver := ctx.Duration(MinerDelayLeftoverFlag.Name)
+		cfg.DelayLeftOver = &delayLeftOver
 	}
 	if ctx.Bool(VotingEnabledFlag.Name) {
 		cfg.VoteEnable = true
 	}
 	if ctx.IsSet(MinerNewPayloadTimeoutFlag.Name) {
 		log.Warn("The flag --miner.newpayload-timeout is deprecated and will be removed, please use --miner.recommit")
-		cfg.Recommit = ctx.Duration(MinerNewPayloadTimeoutFlag.Name)
+		recommit := ctx.Duration(MinerNewPayloadTimeoutFlag.Name)
+		cfg.Recommit = &recommit
 	}
 	if ctx.Bool(DisableVoteAttestationFlag.Name) {
 		cfg.DisableVoteAttestation = true
@@ -1959,7 +1962,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	setGPO(ctx, &cfg.GPO)
 	setTxPool(ctx, &cfg.TxPool)
 	setBlobPool(ctx, &cfg.BlobPool)
-	setMiner(ctx, &cfg.Miner)
+	setMiner(ctx, cfg.Miner)
 	setRequiredBlocks(ctx, cfg)
 	setLes(ctx, cfg)
 

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -133,7 +133,7 @@ var (
 	MinerNewPayloadTimeoutFlag = &cli.DurationFlag{
 		Name:     "miner.newpayload-timeout",
 		Usage:    "Specify the maximum time allowance for creating a new payload (deprecated)",
-		Value:    ethconfig.Defaults.Miner.Recommit,
+		Value:    *ethconfig.Defaults.Miner.Recommit,
 		Category: flags.DeprecatedCategory,
 	}
 	MetricsEnabledExpensiveFlag = &cli.BoolFlag{

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -95,7 +95,7 @@ func newTester(t *testing.T, confOverride func(*ethconfig.Config)) *tester {
 	}
 	ethConf := &ethconfig.Config{
 		Genesis: core.DeveloperGenesisBlock(11_500_000, nil),
-		Miner: minerconfig.Config{
+		Miner: &minerconfig.Config{
 			Etherbase: common.HexToAddress(testAddress),
 		},
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -388,7 +388,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		return nil, err
 	}
 
-	eth.miner = miner.New(eth, &config.Miner, eth.EventMux(), eth.engine)
+	eth.miner = miner.New(eth, config.Miner, eth.EventMux(), eth.engine)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 	eth.miner.SetPrioAddresses(config.TxPool.Locals)
 

--- a/eth/catalyst/simulated_beacon_test.go
+++ b/eth/catalyst/simulated_beacon_test.go
@@ -49,7 +49,7 @@ func startSimulatedBeaconEthService(t *testing.T, genesis *core.Genesis, period 
 		t.Fatal("can't create node:", err)
 	}
 
-	ethcfg := &ethconfig.Config{Genesis: genesis, SyncMode: ethconfig.FullSync, TrieTimeout: time.Minute, TrieDirtyCache: 256, TrieCleanCache: 256, Miner: minerconfig.DefaultConfig}
+	ethcfg := &ethconfig.Config{Genesis: genesis, SyncMode: ethconfig.FullSync, TrieTimeout: time.Minute, TrieDirtyCache: 256, TrieCleanCache: 256, Miner: &minerconfig.DefaultConfig}
 	ethservice, err := eth.New(n, ethcfg)
 	if err != nil {
 		t.Fatal("can't create eth service:", err)

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -63,7 +63,7 @@ var Defaults = Config{
 	SnapshotCache:      102,
 	DiffBlock:          uint64(86400),
 	FilterLogCacheSize: 32,
-	Miner:              minerconfig.DefaultConfig,
+	Miner:              &minerconfig.DefaultConfig,
 	TxPool:             legacypool.DefaultConfig,
 	BlobPool:           blobpool.DefaultConfig,
 	RPCGasCap:          50000000,
@@ -156,7 +156,7 @@ type Config struct {
 	FilterLogCacheSize int
 
 	// Mining options
-	Miner minerconfig.Config
+	Miner *minerconfig.Config
 
 	// Transaction pool options
 	TxPool   legacypool.Config
@@ -214,4 +214,14 @@ func CreateConsensusEngine(config *params.ChainConfig, db ethdb.Database, ee *et
 		return clique.New(config.Clique, db), nil
 	}
 	return beacon.New(ethash.NewFaker()), nil
+}
+
+func ApplyDefaultEthConfig(cfg *Config) {
+	if cfg == nil {
+		// [Eth] is a mandatory option in config.toml, it should never be nil
+		log.Error("ApplyDefaultEthConfig cfg should not be nil")
+		return
+	}
+
+	cfg.Miner = cfg.Miner.ApplyDefaultMinerConfig()
 }

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -53,7 +53,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		TriesVerifyMode         core.VerifyMode
 		Preimages               bool
 		FilterLogCacheSize      int
-		Miner                   minerconfig.Config
+		Miner                   *minerconfig.Config
 		TxPool                  legacypool.Config
 		BlobPool                blobpool.Config
 		GPO                     gasprice.Config
@@ -297,7 +297,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		c.FilterLogCacheSize = *dec.FilterLogCacheSize
 	}
 	if dec.Miner != nil {
-		c.Miner = *dec.Miner
+		c.Miner = dec.Miner
 	}
 	if dec.TxPool != nil {
 		c.TxPool = *dec.TxPool

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/miner/minerconfig"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -195,7 +196,7 @@ func newTestBackend(config *node.Config) (*node.Node, []*types.Block, error) {
 		return nil, nil, fmt.Errorf("can't create new node: %v", err)
 	}
 	// Create Ethereum Service
-	ecfg := &ethconfig.Config{Genesis: genesis, RPCGasCap: 1000000}
+	ecfg := &ethconfig.Config{Genesis: genesis, RPCGasCap: 1000000, Miner: &minerconfig.Config{}}
 	ecfg.SnapshotCache = 256
 	ecfg.TriesInMemory = 128
 	ethservice, err := eth.New(n, ecfg)

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/miner/minerconfig"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -58,7 +59,7 @@ func newTestBackend(t *testing.T) (*node.Node, []*types.Block) {
 		t.Fatalf("can't create new node: %v", err)
 	}
 	// Create Ethereum Service
-	config := &ethconfig.Config{Genesis: genesis, RPCGasCap: 1000000}
+	config := &ethconfig.Config{Genesis: genesis, RPCGasCap: 1000000, Miner: &minerconfig.Config{}}
 	ethservice, err := eth.New(n, config)
 	if err != nil {
 		t.Fatalf("can't create new ethereum service: %v", err)

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/eth/filters"
+	"github.com/ethereum/go-ethereum/miner/minerconfig"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 
@@ -455,6 +456,7 @@ func newGQLService(t *testing.T, stack *node.Node, shanghai bool, gspec *core.Ge
 		SnapshotCache:  5,
 		RPCGasCap:      1000000,
 		StateScheme:    rawdb.HashScheme,
+		Miner:          &minerconfig.Config{},
 	}
 	var engine consensus.Engine = ethash.NewFaker()
 	if shanghai {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -69,8 +69,24 @@ func New(eth Backend, config *minerconfig.Config, mux *event.TypeMux, engine con
 		stopCh:  make(chan struct{}),
 		worker:  newWorker(config, engine, eth, mux, false),
 	}
+	mev := config.Mev
+	if mev == nil {
+		// for unit test, it could be nil, as it is not initialized
+		mev = &minerconfig.MevConfig{}
+	}
 
-	miner.bidSimulator = newBidSimulator(&config.Mev, config.DelayLeftOver, config.GasPrice, eth, eth.BlockChain().Config(), engine, miner.worker)
+	delayLeftOver := config.DelayLeftOver
+	if delayLeftOver == nil {
+		// for unit test, it could be nil, as it is not initialized
+		delayLeftOver = new(time.Duration)
+	}
+	gasPrice := config.GasPrice
+	if gasPrice == nil {
+		// for unit test, it could be nil, as it is not initialized
+		gasPrice = new(big.Int)
+	}
+
+	miner.bidSimulator = newBidSimulator(mev, *delayLeftOver, gasPrice, eth, eth.BlockChain().Config(), engine, miner.worker)
 	miner.worker.setBestBidFetcher(miner.bidSimulator)
 
 	miner.wg.Add(1)

--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -97,9 +97,9 @@ func (miner *Miner) MevParams() *types.MevParams {
 	}
 
 	return &types.MevParams{
-		ValidatorCommission:   miner.worker.config.Mev.ValidatorCommission,
-		BidSimulationLeftOver: miner.worker.config.Mev.BidSimulationLeftOver,
-		NoInterruptLeftOver:   miner.worker.config.Mev.NoInterruptLeftOver,
+		ValidatorCommission:   *miner.worker.config.Mev.ValidatorCommission,
+		BidSimulationLeftOver: *miner.worker.config.Mev.BidSimulationLeftOver,
+		NoInterruptLeftOver:   *miner.worker.config.Mev.NoInterruptLeftOver,
 		GasCeil:               miner.worker.config.GasCeil,
 		GasPrice:              miner.worker.config.GasPrice,
 		BuilderFeeCeil:        builderFeeCeil,

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -299,6 +299,7 @@ func createMiner(t *testing.T) (*Miner, *event.TypeMux, func(skipMiner bool)) {
 	// Create Ethash config
 	config := minerconfig.Config{
 		Etherbase: common.HexToAddress("123456789"),
+		Recommit:  new(time.Duration),
 	}
 	// Create chainConfig
 	chainDB := rawdb.NewMemoryDatabase()

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -64,11 +64,11 @@ var (
 	testUserAddress = crypto.PubkeyToAddress(testUserKey.PublicKey)
 
 	// Test transactions
-	pendingTxs []*types.Transaction
-	newTxs     []*types.Transaction
-
-	testConfig = &minerconfig.Config{
-		Recommit: time.Second,
+	pendingTxs   []*types.Transaction
+	newTxs       []*types.Transaction
+	reCommitTime time.Duration = time.Second
+	testConfig                 = &minerconfig.Config{
+		Recommit: &reCommitTime,
 		GasCeil:  params.GenesisGasLimit,
 	}
 )


### PR DESCRIPTION
### Description
To simplify the configuration of config.toml file, node operators can just leave some options empty if they just want the default behavior.
For more background, pls refer: https://github.com/bnb-chain/bsc/issues/2986

### Rationale
R1: Why use pointer instead of zero value check
Generally, pointer value is preferable to avoid initialising unset variable. It will be nil pointer, instead of a zero-value.
Sometime we just can't tell if the zero-value decoded from the TOML file was set by user specifically or not.
For example, Alice sets the "maxPoolSize" to "0" in config.toml to disable the pool, it's better not to be taken as Alice want the default value.

### Example
NA

### Changes
NA