### PR TITLE
release: prepare for release v1.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 # Changelog
+## v1.5.9
+### FEATURE
+[\#2932](https://github.com/bnb-chain/bsc/pull/2932) BEP-520: Short Block Interval Phase One: 1.5 seconds
+
+### BUGFIX
+NA
+
+### IMPROVEMENT
+[\#2933](https://github.com/bnb-chain/bsc/pull/2933) metrics: add more peer, block/vote metrics
+[\#2938](https://github.com/bnb-chain/bsc/pull/2938) cmd/geth: add example for geth bls account generate-proof
+[\#2949](https://github.com/bnb-chain/bsc/pull/2949) metrics: add more block/vote stats;
+[\#2948](https://github.com/bnb-chain/bsc/pull/2948) go.mod: update crypto to solve CVE-2025-22869
+[\#2960](https://github.com/bnb-chain/bsc/pull/2960) pool: debug log instead of warn
+[\#2961](https://github.com/bnb-chain/bsc/pull/2961) metric: add more block monitor metrics;
+
 ## v1.5.8
 ### FEATURE
 * [\#2955](https://github.com/bnb-chain/bsc/pull/2955) pbs: enable GreedyMergeTx by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 ## v1.5.9
 ### FEATURE
 [\#2932](https://github.com/bnb-chain/bsc/pull/2932) BEP-520: Short Block Interval Phase One: 1.5 seconds
+[\#2991](https://github.com/bnb-chain/bsc/pull/2991) config: update BSC Testnet hardfork time: Lorentz
 
 ### BUGFIX
-NA
+[\#2990](https://github.com/bnb-chain/bsc/pull/2990) core/state: fix concurrent map read and write for stateUpdate.accounts
 
 ### IMPROVEMENT
 [\#2933](https://github.com/bnb-chain/bsc/pull/2933) metrics: add more peer, block/vote metrics
@@ -13,6 +14,8 @@ NA
 [\#2948](https://github.com/bnb-chain/bsc/pull/2948) go.mod: update crypto to solve CVE-2025-22869
 [\#2960](https://github.com/bnb-chain/bsc/pull/2960) pool: debug log instead of warn
 [\#2961](https://github.com/bnb-chain/bsc/pull/2961) metric: add more block monitor metrics;
+[\#2992](https://github.com/bnb-chain/bsc/pull/2992) core/systemcontracts: update url for lorentz hardfork
+[\#2993](https://github.com/bnb-chain/bsc/pull/2993) cmd/jsutils: add tool GetMevStatus
 
 ## v1.5.8
 ### FEATURE

--- a/build/ci.go
+++ b/build/ci.go
@@ -253,7 +253,7 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 	// Strip DWARF on darwin. This used to be required for certain things,
 	// and there is no downside to this, so we just keep doing it.
 	if runtime.GOOS == "darwin" {
-		// ld = append(ld, "-s")
+		ld = append(ld, "-s")
 	}
 	if runtime.GOOS == "linux" {
 		// Enforce the stacksize to 8M, which is the case on most platforms apart from

--- a/build/ci.go
+++ b/build/ci.go
@@ -253,7 +253,7 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 	// Strip DWARF on darwin. This used to be required for certain things,
 	// and there is no downside to this, so we just keep doing it.
 	if runtime.GOOS == "darwin" {
-		ld = append(ld, "-s")
+		// ld = append(ld, "-s")
 	}
 	if runtime.GOOS == "linux" {
 		// Enforce the stacksize to 8M, which is the case on most platforms apart from

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -27,7 +27,6 @@ import (
 	"sync/atomic"
 	"time"
 
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1  // Major version component of the current release
 	Minor = 5  // Minor version component of the current release
-	Patch = 8  // Patch version component of the current release
+	Patch = 9  // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
## Description
v1.5.9 is for BSC Testnet [Lorentz hard fork](https://forum.bnbchain.org/t/bnb-chain-upgrades-testnet/934#p-1416-h-2lorentz-wip-3), which is expected to be enabled at: `2025-04-08 07:33:00 AM UTC`, all BSC testnet nodes need to upgrade to v1.5.9 before the hard fork time. For this upgrade, simply binary replacement should be enough.

Besides hard fork setup, v1.5.9 also include one bugfix and some improvements, pls check the change log for detail.
## ChangeLog
### FEATURE
[\#2932](https://github.com/bnb-chain/bsc/pull/2932) BEP-520: Short Block Interval Phase One: 1.5 seconds
[\#2991](https://github.com/bnb-chain/bsc/pull/2991) config: update BSC Testnet hardfork time: Lorentz

### BUGFIX
[\#2990](https://github.com/bnb-chain/bsc/pull/2990) core/state: fix concurrent map read and write for stateUpdate.accounts

### IMPROVEMENT
[\#2933](https://github.com/bnb-chain/bsc/pull/2933) metrics: add more peer, block/vote metrics
[\#2938](https://github.com/bnb-chain/bsc/pull/2938) cmd/geth: add example for geth bls account generate-proof
[\#2949](https://github.com/bnb-chain/bsc/pull/2949) metrics: add more block/vote stats;
[\#2948](https://github.com/bnb-chain/bsc/pull/2948) go.mod: update crypto to solve CVE-2025-22869
[\#2960](https://github.com/bnb-chain/bsc/pull/2960) pool: debug log instead of warn
[\#2961](https://github.com/bnb-chain/bsc/pull/2961) metric: add more block monitor metrics;
[\#2992](https://github.com/bnb-chain/bsc/pull/2992) core/systemcontracts: update url for lorentz hardfork
[\#2993](https://github.com/bnb-chain/bsc/pull/2993) cmd/jsutils: add tool GetMevStatus
