### PR TITLE
core/state: fix concurrent map read and write for stateUpdate.accounts

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1488,11 +1488,9 @@ func (s *StateDB) commitAndFlush(block uint64, deleteEmptyObjects bool, noStorag
 			// - head layer is paired with HEAD state
 			// - head-1 layer is paired with HEAD-1 state
 			// - head-127 layer(bottom-most diff layer) is paired with HEAD-127 state
-			go func() {
-				if err := snap.Cap(ret.root, snap.CapLimit()); err != nil {
-					log.Warn("Failed to cap snapshot tree", "root", ret.root, "layers", TriesInMemory, "err", err)
-				}
-			}()
+			if err := snap.Cap(ret.root, snap.CapLimit()); err != nil {
+				log.Warn("Failed to cap snapshot tree", "root", ret.root, "layers", TriesInMemory, "err", err)
+			}
 			if metrics.EnabledExpensive() {
 				s.SnapshotCommits += time.Since(start)
 			}


### PR DESCRIPTION
### Description

core/state: fix concurrent map read and write for stateUpdate.accounts

### Rationale

[v1.5.7 crashed via log](https://github.com/bnb-chain/bsc/issues/2981)
![Image](https://github.com/user-attachments/assets/a385e8e5-4c16-4745-97ce-fbb2509b17bc)


### Example

read path is as shown in the above picture
write path:
```
  commitAndFlush
  	-->err := snap.Cap(ret.root, snap.CapLimit())
  		-->persisted := t.cap(diff, layers)
  			-->flattened := parent.flatten().(*diffLayer)
  				-->	for hash, data := range dl.accountData {
  					parent.accountData[hash] = data
  					}
```

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
