### PR TITLE
p2p/nat: remove test with default servers (#31225)

### DIFF
--- a/p2p/nat/stun_test.go
+++ b/p2p/nat/stun_test.go
@@ -18,16 +18,7 @@ package nat
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
-
-func TestNatStun(t *testing.T) {
-	nat, err := newSTUN("")
-	assert.NoError(t, err)
-	_, err = nat.ExternalIP()
-	assert.NoError(t, err)
-}
 
 func TestUnreachedNatServer(t *testing.T) {
 	stun := &stun{


### PR DESCRIPTION
### Description

p2p/nat: remove test with default servers (#31225)

### Rationale

pick from go-etherreum https://github.com/ethereum/go-ethereum/pull/31225

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
