### PR TITLE
mev: make max bids per builder per block configurable

### DIFF
--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -76,6 +76,7 @@ type MevConfig struct {
 	ValidatorCommission   uint64          // 100 means the validator claims 1% from block reward
 	BidSimulationLeftOver time.Duration
 	NoInterruptLeftOver   time.Duration
+	MaxBidsPerBuilder     uint32          // Maximum number of bids allowed per builder per block
 }
 
 var DefaultMevConfig = MevConfig{
@@ -86,4 +87,5 @@ var DefaultMevConfig = MevConfig{
 	ValidatorCommission:   100,
 	BidSimulationLeftOver: 50 * time.Millisecond,
 	NoInterruptLeftOver:   400 * time.Millisecond,
+	MaxBidsPerBuilder:     3,
 }

--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -76,7 +76,7 @@ type MevConfig struct {
 	ValidatorCommission   uint64          // 100 means the validator claims 1% from block reward
 	BidSimulationLeftOver time.Duration
 	NoInterruptLeftOver   time.Duration
-	MaxBidsPerBuilder     uint32          // Maximum number of bids allowed per builder per block
+	MaxBidsPerBuilder     uint32 // Maximum number of bids allowed per builder per block
 }
 
 var DefaultMevConfig = MevConfig{


### PR DESCRIPTION
### Description

mev: make max bids per builder per block configurable

### Rationale

when block interval reduced to 1.5s, 
may limit  max bids per builder to 2 from 3,

before do that, make it configurable is better.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
