### PR TITLE
nancy: update nancy ignore

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,4 +1,3 @@
 CVE-2024-34478 # "CWE-754: Improper Check for Unusual or Exceptional Conditions." This vulnerability is BTC only, BSC does not have the issue.
-CVE-2024-6104 # "CWE-532: Information Exposure Through Log Files" This is caused by the vulnerabilities go-retryablehttp@v0.7.4, it is only used in cmd devp2p, impact is limited. will upgrade to v0.7.7 later
-CVE-2024-8421 # "CWE-400: Uncontrolled Resource Consumption (Resource Exhaustion)" This vulnerability is caused by issues in the golang.org/x/net package. Even the latest version(v0.29.0) has not yet addressed it, but we will continue to monitor updates closely.
 CVE-2024-51744 # "CWE-347: Improper Verification of Cryptographic Signature" & "CWE-755: Improper Handling of Exceptional Conditions" This vulnerability is caused mishandling of JWT error code, BSC does not have the issue as it does not check the detail error code.
+CVE-2025-22872 # "CWE-1286: github.com/golang/net - Improper Validation of Syntactic Correctness of Input", golang/golang.org/x/net@v0.36.0 was indirectly dependency by devp2p, can be will upgraded in the future

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,3 +1,1 @@
-CVE-2024-34478 # "CWE-754: Improper Check for Unusual or Exceptional Conditions." This vulnerability is BTC only, BSC does not have the issue.
-CVE-2024-51744 # "CWE-347: Improper Verification of Cryptographic Signature" & "CWE-755: Improper Handling of Exceptional Conditions" This vulnerability is caused mishandling of JWT error code, BSC does not have the issue as it does not check the detail error code.
 CVE-2025-22872 # "CWE-1286: github.com/golang/net - Improper Validation of Syntactic Correctness of Input", golang/golang.org/x/net@v0.36.0 was indirectly dependency by devp2p, can be will upgraded in the future

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,1 +1,2 @@
+CVE-2024-34478 # "CWE-754: Improper Check for Unusual or Exceptional Conditions." This vulnerability is BTC only, BSC does not have the issue.
 CVE-2025-22872 # "CWE-1286: github.com/golang/net - Improper Validation of Syntactic Correctness of Input", golang/golang.org/x/net@v0.36.0 was indirectly dependency by devp2p, can be will upgraded in the future


### PR DESCRIPTION
### Description
- add nancy ignore: golang/golang.org/x/net@v0.36.0, it is indirectly included by devp2p can bd upgraded in the future with devp2p
- remove several fixed nancy vulnerabilities: jwt, go-retryablehttp, golang.org/x/net v0.29

### Rationale
NA

### Example
NA

### Changes
NA