### PR TITLE
mev: include MaxBidsPerBuilder in MevParams

### DIFF
--- a/core/types/bid.go
+++ b/core/types/bid.go
@@ -202,6 +202,7 @@ type MevParams struct {
 	ValidatorCommission   uint64 // 100 means 1%
 	BidSimulationLeftOver time.Duration
 	NoInterruptLeftOver   time.Duration
+	MaxBidsPerBuilder     uint32 // Maximum number of bids allowed per builder per block
 	GasCeil               uint64
 	GasPrice              *big.Int // Minimum avg gas price for bid block
 	BuilderFeeCeil        *big.Int

--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -100,6 +100,7 @@ func (miner *Miner) MevParams() *types.MevParams {
 		ValidatorCommission:   *miner.worker.config.Mev.ValidatorCommission,
 		BidSimulationLeftOver: *miner.worker.config.Mev.BidSimulationLeftOver,
 		NoInterruptLeftOver:   *miner.worker.config.Mev.NoInterruptLeftOver,
+		MaxBidsPerBuilder:     *miner.worker.config.Mev.MaxBidsPerBuilder,
 		GasCeil:               miner.worker.config.GasCeil,
 		GasPrice:              miner.worker.config.GasPrice,
 		BuilderFeeCeil:        builderFeeCeil,


### PR DESCRIPTION
### Description
Notice: this will change the return value of miner API: miner.MevParams()

### Rationale
NA

### Example
NA

### Changes
NA