### PR TITLE
mev: update two default mev paramater for 1.5s block interval

### DIFF
--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -29,12 +29,12 @@ import (
 
 var (
 	defaultDelayLeftOver = 50 * time.Millisecond
-	// default confogurations for MEV
+	// default configurations for MEV
 	defaultGreedyMergeTx         bool   = true
 	defaultValidatorCommission   uint64 = 100
 	defaultBidSimulationLeftOver        = 50 * time.Millisecond
-	defaultNoInterruptLeftOver          = 400 * time.Millisecond
-	defaultMaxBidsPerBuilder     uint32 = 3
+	defaultNoInterruptLeftOver          = 250 * time.Millisecond
+	defaultMaxBidsPerBuilder     uint32 = 2
 )
 
 // Config is the configuration parameters of mining.


### PR DESCRIPTION
### Description
With shorter block interval, will have less resource to simulate bid for each block.

defaultMaxBidsPerBuilder from 3 to 2
defaultNoInterruptLeftOver  from 400ms to 250

### Rationale
NA

### Example
NA

### Changes
NA