### PR TITLE
miner: optimize clear up logic for envs

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -715,7 +715,7 @@ func (bc *BlockChain) GetJustifiedNumber(header *types.Header) uint64 {
 }
 
 // getFinalizedNumber returns the highest finalized number before the specific block.
-func (bc *BlockChain) getFinalizedNumber(header *types.Header) uint64 {
+func (bc *BlockChain) GetFinalizedNumber(header *types.Header) uint64 {
 	if p, ok := bc.engine.(consensus.PoSA); ok {
 		if finalizedHeader := p.GetFinalizedHeader(bc, header); finalizedHeader != nil {
 			return finalizedHeader.Number.Uint64()
@@ -747,7 +747,7 @@ func (bc *BlockChain) loadLastState() error {
 	bc.currentBlock.Store(headBlock.Header())
 	headBlockGauge.Update(int64(headBlock.NumberU64()))
 	justifiedBlockGauge.Update(int64(bc.GetJustifiedNumber(headBlock.Header())))
-	finalizedBlockGauge.Update(int64(bc.getFinalizedNumber(headBlock.Header())))
+	finalizedBlockGauge.Update(int64(bc.GetFinalizedNumber(headBlock.Header())))
 
 	// Restore the last known head header
 	headHeader := headBlock.Header()
@@ -1196,7 +1196,7 @@ func (bc *BlockChain) SnapSyncCommitHead(hash common.Hash) error {
 	bc.currentBlock.Store(block.Header())
 	headBlockGauge.Update(int64(block.NumberU64()))
 	justifiedBlockGauge.Update(int64(bc.GetJustifiedNumber(block.Header())))
-	finalizedBlockGauge.Update(int64(bc.getFinalizedNumber(block.Header())))
+	finalizedBlockGauge.Update(int64(bc.GetFinalizedNumber(block.Header())))
 	bc.chainmu.Unlock()
 
 	// Destroy any existing state snapshot and regenerate it in the background,
@@ -1337,7 +1337,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	bc.currentBlock.Store(block.Header())
 	headBlockGauge.Update(int64(block.NumberU64()))
 	justifiedBlockGauge.Update(int64(bc.GetJustifiedNumber(block.Header())))
-	finalizedBlockGauge.Update(int64(bc.getFinalizedNumber(block.Header())))
+	finalizedBlockGauge.Update(int64(bc.GetFinalizedNumber(block.Header())))
 }
 
 // stopWithoutSaving stops the blockchain service. If any imports are currently in progress

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -97,7 +97,7 @@ func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine c
 	hc.currentHeaderHash = hc.CurrentHeader().Hash()
 	headHeaderGauge.Update(hc.CurrentHeader().Number.Int64())
 	justifiedBlockGauge.Update(int64(hc.GetJustifiedNumber(hc.CurrentHeader())))
-	finalizedBlockGauge.Update(int64(hc.getFinalizedNumber(hc.CurrentHeader())))
+	finalizedBlockGauge.Update(int64(hc.GetFinalizedNumber(hc.CurrentHeader())))
 
 	return hc, nil
 }
@@ -116,7 +116,7 @@ func (hc *HeaderChain) GetJustifiedNumber(header *types.Header) uint64 {
 }
 
 // getFinalizedNumber returns the highest finalized number before the specific block.
-func (hc *HeaderChain) getFinalizedNumber(header *types.Header) uint64 {
+func (hc *HeaderChain) GetFinalizedNumber(header *types.Header) uint64 {
 	if p, ok := hc.engine.(consensus.PoSA); ok {
 		if finalizedHeader := p.GetFinalizedHeader(hc, header); finalizedHeader != nil {
 			return finalizedHeader.Number.Uint64()
@@ -585,7 +585,7 @@ func (hc *HeaderChain) SetCurrentHeader(head *types.Header) {
 	hc.currentHeaderHash = head.Hash()
 	headHeaderGauge.Update(head.Number.Int64())
 	justifiedBlockGauge.Update(int64(hc.GetJustifiedNumber(head)))
-	finalizedBlockGauge.Update(int64(hc.getFinalizedNumber(head)))
+	finalizedBlockGauge.Update(int64(hc.GetFinalizedNumber(head)))
 }
 
 type (
@@ -673,7 +673,7 @@ func (hc *HeaderChain) setHead(headBlock uint64, headTime uint64, updateFn Updat
 		hc.currentHeaderHash = parentHash
 		headHeaderGauge.Update(parent.Number.Int64())
 		justifiedBlockGauge.Update(int64(hc.GetJustifiedNumber(parent)))
-		finalizedBlockGauge.Update(int64(hc.getFinalizedNumber(parent)))
+		finalizedBlockGauge.Update(int64(hc.GetFinalizedNumber(parent)))
 
 		// If this is the first iteration, wipe any leftover data upwards too so
 		// we don't end up with dangling daps in the database


### PR DESCRIPTION
### Description

miner: optimize clear up logic for envs

### Rationale

#### 1. Fix for `bid.discard` Conflict with `worker.commit()` Causing [Panic](https://github.com/bnb-chain/bsc/issues/3031)
![image](https://github.com/user-attachments/assets/5aefeed2-e917-4c50-8cf6-858c0d2c54be)
In `bid_simulator.go`, the `bid.discard` function conflicts with `worker.commit()`, resulting in a panic.  
Specifically:
- At line 304, `s.db.prefetcher` is not `nil`.
- But at line 305, it suddenly becomes `nil`, causing a panic.

This happens due to concurrent modification of `s.db.prefetcher`.

Based on code analysis, this issue only occurs when a miner selects a bid as the final work to commit. There are two scenarios where this can happen *after* the worker calls `GetBestBid`:
- (a) `bidSimulator.SetBestBid` is invoked, or  
- (b) a new `chainHead` event is received, triggering `clearFn` in `bidSimulator.clearLoop`.

This PR resolves the issue by **delaying the discard action** to avoid the race condition.

---

#### 2. Centralized Discard Logic in `bidSimulator`

Previously, environment discards (`envs`) were scattered across multiple locations within `bidSimulator`.

In this PR, we consolidate the logic so that **environment discards happen in only one place**, improving maintainability and reducing complexity.

---

#### 3. Optimizing `clearLoop` Iteration

In `clearLoop`, both `bestBidToRun` and `simulatingBid` retain up to `b.chain.TriesInMemory()` items.  
Iterating over all of them is inefficient.

This PR introduces the use of `GetFinalizedNumber` to **limit the retained items to just 2**, significantly improving performance.

---


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
