### PR TITLE
Revert "miner: limit block size to eth protocol msg size (#2696)"

### DIFF
--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -47,7 +46,7 @@ var ProtocolVersions = []uint{ETH68}
 var protocolLengths = map[uint]uint64{ETH68: 17}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
-var maxMessageSize = params.MaxMessageSize
+const maxMessageSize = 10 * 1024 * 1024
 
 const (
 	StatusMsg                     = 0x00

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -832,14 +832,6 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 		return
 	}
 
-	// check bid size
-	if bidRuntime.env.size+blockReserveSize > params.MaxMessageSize {
-		log.Error("BidSimulator: failed to check bid size", "builder", bidRuntime.bid.Builder,
-			"bidHash", bidRuntime.bid.Hash(), "env.size", bidRuntime.env.size)
-		err = errors.New("invalid bid size")
-		return
-	}
-
 	bestBid := b.GetBestBid(parentHash)
 	if bestBid == nil {
 		winResult := "true[first]"
@@ -1011,7 +1003,6 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 	}
 
 	r.env.tcount++
-	r.env.size += uint32(tx.Size())
 
 	return nil
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -69,12 +69,6 @@ const (
 	// the current 4 mining loops could have asynchronous risk of mining block with
 	// save height, keep recently mined blocks to avoid double sign for safety,
 	recentMinedCacheLimit = 20
-
-	// Reserve block size for the following 3 components:
-	// a. System transactions at the end of the block
-	// b. Seal in the block header
-	// c. Overhead from RLP encoding
-	blockReserveSize = 100 * 1024
 )
 
 var (
@@ -100,7 +94,6 @@ type environment struct {
 	signer   types.Signer
 	state    *state.StateDB // apply state changes here
 	tcount   int            // tx count in cycle
-	size     uint32         // almost accurate block size,
 	gasPool  *core.GasPool  // available gas used to pack transactions
 	coinbase common.Address
 	evm      *vm.EVM
@@ -120,7 +113,6 @@ func (env *environment) copy() *environment {
 		signer:   env.signer,
 		state:    env.state.Copy(),
 		tcount:   env.tcount,
-		size:     env.size,
 		coinbase: env.coinbase,
 		header:   types.CopyHeader(env.header),
 		receipts: copyReceipts(env.receipts),
@@ -922,13 +914,6 @@ LOOP:
 			txs.Pop()
 			continue
 		}
-		// If we don't have enough size left for the next transaction, skip it.
-		if env.size+uint32(tx.Size())+blockReserveSize > params.MaxMessageSize {
-			log.Trace("Not enough size left for transaction", "hash", ltx.Hash,
-				"env.size", env.size, "needed", uint32(tx.Size()))
-			txs.Pop()
-			continue
-		}
 		// Error may be ignored here. The error has already been checked
 		// during transaction acceptance in the transaction pool.
 		from, _ := types.Sender(env.signer, tx)
@@ -954,7 +939,6 @@ LOOP:
 			// Everything ok, collect the logs and shift in the next transaction from the same account
 			coalescedLogs = append(coalescedLogs, logs...)
 			env.tcount++
-			env.size += uint32(tx.Size()) // size of BlobTxSidecar included
 			txs.Shift()
 
 		default:
@@ -1090,9 +1074,6 @@ func (w *worker) prepareWork(genParams *generateParams, witness bool) (*environm
 	if w.chainConfig.IsPrague(header.Number, header.Time) {
 		core.ProcessParentBlockHash(header.ParentHash, env.evm)
 	}
-
-	env.size = uint32(env.header.Size())
-
 	return env, nil
 }
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -29,8 +29,6 @@ const (
 	GenesisGasLimit      uint64 = 4712388            // Gas limit of the Genesis block.
 	PayBidTxGasLimit     uint64 = 25000              // Gas limit of the PayBidTx in the types.BidArgs.
 
-	MaxMessageSize uint32 = 10 * 1024 * 1024 // MaxMessageSize is the maximum cap on the size of a eth protocol message.
-
 	MaximumExtraDataSize  uint64 = 32       // Maximum size extra data may be after Genesis.
 	ForkIDSize            uint64 = 4        // The length of fork id
 	ExpByteGas            uint64 = 10       // Times ceil(log256(exponent)) for the EXP instruction.


### PR DESCRIPTION
This reverts commit a28262b3ecefd12909538795cf8f5b0a5dd476a2.

### Description

Revert "miner: limit block size to eth protocol msg size (#2696)"

### Rationale

#### Two Changes Recently:

1. **EIP-7623 Implementation**
   Increased the gas cost of zero bytes from 4 to 10 gas, following [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623).

2. **Gas Limit Reduction**:  
   The BSC gas limit is reduced from 140M to **35M**.

#### Estimating the Maximum BSC Block Size

With the increased zero byte cost and reduced block gas limit, the **maximum block size** is significantly reduced, even without enforcing an explicit size cap.

- A simple transfer transaction (21,000 gas base) with payload fully filled with zero bytes (~128KB) now costs:  
  `21000 + (128*1024 - 110)*10 = 1,330,620 gas ≈ 1.33M`
- Therefore, a 35M gas block can include at most:  
  `35M / 1.33M ≈ 26.3 ≈ 27 transactions`
- Additionally, up to **6 blobs** can be included in a block.
- So the **maximum theoretical block size** is:  
  `(27 + 6) * 128KB = 4.125MB`

#### Conclusion

With this configuration, the maximum block size is now ~4.1MB, **well below** the previous soft cap of 10MB.  
As a result, we no longer need to enforce the 10MB block size limit.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
