### PR TITLE
bsc: add new block fetching mechanism;

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -373,18 +373,19 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	// Permit the downloader to use the trie cache allowance during fast sync
 	cacheLimit := cacheConfig.TrieCleanLimit + cacheConfig.TrieDirtyLimit + cacheConfig.SnapshotLimit
 	if eth.handler, err = newHandler(&handlerConfig{
-		NodeID:                 eth.p2pServer.Self().ID(),
-		Database:               chainDb,
-		Chain:                  eth.blockchain,
-		TxPool:                 eth.txPool,
-		Network:                networkID,
-		Sync:                   config.SyncMode,
-		BloomCache:             uint64(cacheLimit),
-		EventMux:               eth.eventMux,
-		RequiredBlocks:         config.RequiredBlocks,
-		DirectBroadcast:        config.DirectBroadcast,
-		DisablePeerTxBroadcast: config.DisablePeerTxBroadcast,
-		PeerSet:                peers,
+		NodeID:                   eth.p2pServer.Self().ID(),
+		Database:                 chainDb,
+		Chain:                    eth.blockchain,
+		TxPool:                   eth.txPool,
+		Network:                  networkID,
+		Sync:                     config.SyncMode,
+		BloomCache:               uint64(cacheLimit),
+		EventMux:                 eth.eventMux,
+		RequiredBlocks:           config.RequiredBlocks,
+		DirectBroadcast:          config.DirectBroadcast,
+		EnableQuickBlockFetching: stack.Config().EnableQuickBlockFetching,
+		DisablePeerTxBroadcast:   config.DisablePeerTxBroadcast,
+		PeerSet:                  peers,
 	}); err != nil {
 		return nil, err
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -383,9 +383,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		EventMux:                 eth.eventMux,
 		RequiredBlocks:           config.RequiredBlocks,
 		DirectBroadcast:          config.DirectBroadcast,
-		EnableQuickBlockFetching: stack.Config().EnableQuickBlockFetching,
 		DisablePeerTxBroadcast:   config.DisablePeerTxBroadcast,
 		PeerSet:                  peers,
+		EnableQuickBlockFetching: stack.Config().EnableQuickBlockFetching,
 	}); err != nil {
 		return nil, err
 	}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -506,6 +506,8 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 			return errLaggingPeer
 		}
 	}
+
+	log.Debug("try sync chain from peer", "remote", p.id, "local", localHeight, "remote", remoteHeight)
 	d.syncStatsLock.Lock()
 	if d.syncStatsChainHeight <= origin || d.syncStatsChainOrigin > origin {
 		d.syncStatsChainOrigin = origin

--- a/eth/fetcher/block_fetcher_test.go
+++ b/eth/fetcher/block_fetcher_test.go
@@ -1290,9 +1290,6 @@ func TestQuickBlockFetching(t *testing.T) {
 		},
 	)
 
-	// Enable quick block fetching
-	fetcher.EnableQuickBlockFetching()
-
 	// Start fetcher
 	fetcher.Start()
 	defer fetcher.Stop()

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -301,7 +301,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 			return nil, errors.New("peer not found")
 		}
 		if p.bscExt.Version() != bsc.Bsc2 {
-			return nil, errors.New("the remote peer is not bsc2")
+			return nil, errors.New("Remote peer does not support the required Bsc2 protocol version")
 		}
 		res, err := p.bscExt.RequestBlocksByRange(startHeight, startHash, count)
 		if err != nil {
@@ -328,11 +328,12 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		return blocks, err
 	}
 
+	if !config.EnableQuickBlockFetching {
+		fetchRangeBlocks = nil
+	}
+
 	h.blockFetcher = fetcher.NewBlockFetcher(h.chain.GetBlockByHash, validator, broadcastBlockWithCheck,
 		heighter, finalizeHeighter, inserter, h.removePeer, fetchRangeBlocks)
-	if config.EnableQuickBlockFetching {
-		h.blockFetcher.EnableQuickBlockFetching()
-	}
 
 	fetchTx := func(peer string, hashes []common.Hash) error {
 		p := h.peers.peer(peer)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -113,19 +113,20 @@ type votePool interface {
 // handlerConfig is the collection of initialization parameters to create a full
 // node network handler.
 type handlerConfig struct {
-	NodeID                 enode.ID         // P2P node ID used for tx propagation topology
-	Database               ethdb.Database   // Database for direct sync insertions
-	Chain                  *core.BlockChain // Blockchain to serve data from
-	TxPool                 txPool           // Transaction pool to propagate from
-	VotePool               votePool
-	Network                uint64                 // Network identifier to adfvertise
-	Sync                   ethconfig.SyncMode     // Whether to snap or full sync
-	BloomCache             uint64                 // Megabytes to alloc for snap sync bloom
-	EventMux               *event.TypeMux         // Legacy event mux, deprecate for `feed`
-	RequiredBlocks         map[uint64]common.Hash // Hard coded map of required block hashes for sync challenges
-	DirectBroadcast        bool
-	DisablePeerTxBroadcast bool
-	PeerSet                *peerSet
+	NodeID                   enode.ID         // P2P node ID used for tx propagation topology
+	Database                 ethdb.Database   // Database for direct sync insertions
+	Chain                    *core.BlockChain // Blockchain to serve data from
+	TxPool                   txPool           // Transaction pool to propagate from
+	VotePool                 votePool
+	Network                  uint64                 // Network identifier to adfvertise
+	Sync                     ethconfig.SyncMode     // Whether to snap or full sync
+	BloomCache               uint64                 // Megabytes to alloc for snap sync bloom
+	EventMux                 *event.TypeMux         // Legacy event mux, deprecate for `feed`
+	RequiredBlocks           map[uint64]common.Hash // Hard coded map of required block hashes for sync challenges
+	DirectBroadcast          bool
+	DisablePeerTxBroadcast   bool
+	PeerSet                  *peerSet
+	EnableQuickBlockFetching bool
 }
 
 type handler struct {
@@ -294,8 +295,31 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		h.BroadcastBlock(block, propagate)
 	}
 
+	fetchRangeBlocks := func(peer string, startHeight uint64, startHash common.Hash, count uint64) ([]*types.Block, error) {
+		p := h.peers.peer(peer)
+		if p == nil {
+			return nil, errors.New("peer not found")
+		}
+		res, err := p.bscExt.RequestBlocksByRange(startHeight, startHash, count)
+		if err != nil {
+			return nil, err
+		}
+
+		blocks := make([]*types.Block, len(res))
+		for i, item := range res {
+			block := types.NewBlockWithHeader(item.Header).WithBody(types.Body{Transactions: item.Txs, Uncles: item.Uncles})
+			block = block.WithSidecars(item.Sidecars)
+			block.ReceivedAt = time.Now()
+			blocks[i] = block
+		}
+		return blocks, err
+	}
+
 	h.blockFetcher = fetcher.NewBlockFetcher(h.chain.GetBlockByHash, validator, broadcastBlockWithCheck,
-		heighter, finalizeHeighter, inserter, h.removePeer)
+		heighter, finalizeHeighter, inserter, h.removePeer, fetchRangeBlocks)
+	if config.EnableQuickBlockFetching {
+		h.blockFetcher.EnableQuickBlockFetching()
+	}
 
 	fetchTx := func(peer string, hashes []common.Hash) error {
 		p := h.peers.peer(peer)

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
@@ -101,6 +102,7 @@ func (h *ethHandler) handleBlockAnnounces(peer *eth.Peer, hashes []common.Hash, 
 		}
 	}
 
+	log.Debug("handleBlockAnnounces", "peer", peer.ID(), "numbers", numbers, "hashes", hashes)
 	for i := 0; i < len(unknownHashes); i++ {
 		h.blockFetcher.Notify(peer.ID(), unknownHashes[i], unknownNumbers[i], time.Now(), peer.RequestOneHeader, peer.RequestBodies)
 	}
@@ -128,6 +130,7 @@ func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, packet *eth.NewBlockPa
 	}
 
 	// Schedule the block for import
+	log.Debug("handleBlockBroadcast", "peer", peer.ID(), "block", block.Number(), "hash", block.Hash())
 	h.blockFetcher.Enqueue(peer.ID(), block)
 	stats := h.chain.GetBlockStats(block.Hash())
 	if stats.RecvNewBlockTime.Load() == 0 {

--- a/eth/protocols/bsc/dispatcher.go
+++ b/eth/protocols/bsc/dispatcher.go
@@ -1,0 +1,89 @@
+package bsc
+
+import (
+	"errors"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p"
+)
+
+type Request struct {
+	code      uint64
+	want      uint64
+	requestID uint64
+	data      interface{}
+	resCh     chan interface{}
+	timeout   time.Duration
+}
+
+type Response struct {
+	code      uint64
+	requestID uint64
+	data      interface{}
+}
+
+// Dispatcher handles message requests and responses
+type Dispatcher struct {
+	peer     *Peer
+	requests map[uint64]*Request
+	mu       sync.Mutex
+}
+
+// NewDispatcher creates a new message dispatcher
+func NewDispatcher(peer *Peer) *Dispatcher {
+	d := &Dispatcher{
+		peer:     peer,
+		requests: make(map[uint64]*Request),
+	}
+
+	return d
+}
+
+// GenRequestID get requestID for packet
+func (d *Dispatcher) GenRequestID() uint64 {
+	return rand.Uint64()
+}
+
+// DispatchRequest send the request, and track the later response
+func (d *Dispatcher) DispatchRequest(req *Request) (interface{}, error) {
+	err := p2p.Send(d.peer.rw, req.code, req.data)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.resCh == nil {
+		req.resCh = make(chan interface{}, 1)
+	}
+	d.mu.Lock()
+	d.requests[req.requestID] = req
+	d.mu.Unlock()
+
+	timeout := time.NewTimer(req.timeout)
+	select {
+	case res := <-req.resCh:
+		return res, nil
+	case <-timeout.C:
+		return nil, errors.New("request timeout")
+	case <-d.peer.term:
+		return nil, errors.New("peer disconnected")
+	}
+}
+
+func (d *Dispatcher) DispatchResponse(res *Response) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	req := d.requests[res.requestID]
+	if req == nil {
+		d.peer.Log().Debug("handleResponse missing the request", "requestID", res.requestID)
+		return
+	}
+
+	if req.want != res.code {
+		d.peer.Log().Debug("handleResponse mismatch", "request", req, "response", res.code, "want", req.want)
+	}
+
+	req.resCh <- res.data
+	delete(d.requests, res.requestID)
+}

--- a/eth/protocols/bsc/handler.go
+++ b/eth/protocols/bsc/handler.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 )
 
-const MaxRequestRangeBlocksCount = 128
+const MaxRequestRangeBlocksCount = 64
 
 // Handler is a callback to invoke from an outside runner after the boilerplate
 // exchanges have passed.

--- a/eth/protocols/bsc/handler.go
+++ b/eth/protocols/bsc/handler.go
@@ -188,11 +188,11 @@ func handleBlocksByRange(backend Backend, msg Decoder, peer *Peer) error {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 
-	log.Debug("receive BlocksByRange response", "from", peer.id, "blocks", len(res.Blocks))
-	peer.dispatcher.DispatchResponse(&Response{
+	err := peer.dispatcher.DispatchResponse(&Response{
 		requestID: res.RequestId,
 		data:      res,
 	})
+	log.Debug("receive BlocksByRange response", "from", peer.id, "blocks", len(res.Blocks), "err", err)
 	return nil
 }
 

--- a/eth/protocols/bsc/handler.go
+++ b/eth/protocols/bsc/handler.go
@@ -147,7 +147,7 @@ func handleGetBlocksByRange(backend Backend, msg Decoder, peer *Peer) error {
 		return fmt.Errorf("msg %v, decode err: %v", GetBlocksByRangeMsg, err)
 	}
 
-	log.Trace("receive GetBlocksByRange request", "from", peer.id, "req", req)
+	log.Debug("receive GetBlocksByRange request", "from", peer.id, "req", req)
 	// Validate request parameters
 	if req.Count == 0 || req.Count > MaxRequestRangeBlocksCount { // Limit maximum request count
 		return fmt.Errorf("msg %v, invalid count: %v", GetBlocksByRangeMsg, req.Count)
@@ -188,7 +188,7 @@ func handleBlocksByRange(backend Backend, msg Decoder, peer *Peer) error {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 
-	log.Trace("receive BlocksByRange response", "from", peer.id, "blocks", len(res.Blocks))
+	log.Debug("receive BlocksByRange response", "from", peer.id, "blocks", len(res.Blocks))
 	peer.dispatcher.DispatchResponse(&Response{
 		requestID: res.RequestId,
 		data:      res,

--- a/eth/protocols/bsc/handler_test.go
+++ b/eth/protocols/bsc/handler_test.go
@@ -1,0 +1,209 @@
+package bsc
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+// mockBackend implements the Backend interface for testing
+type mockBackend struct {
+	chain *core.BlockChain
+}
+
+func (b *mockBackend) Chain() *core.BlockChain {
+	return b.chain
+}
+
+func (b *mockBackend) RunPeer(peer *Peer, handler Handler) error {
+	return nil
+}
+
+func (b *mockBackend) PeerInfo(id enode.ID) interface{} {
+	return nil
+}
+
+func (b *mockBackend) Handle(peer *Peer, packet Packet) error {
+	return nil
+}
+
+// mockMsg implements the Decoder interface for testing
+type mockMsg struct {
+	code uint64
+	data interface{}
+}
+
+func (m *mockMsg) Decode(val interface{}) error {
+	// Simple implementation for testing
+	switch v := val.(type) {
+	case *GetBlocksByRangePacket:
+		*v = *m.data.(*GetBlocksByRangePacket)
+	case *BlocksByRangePacket:
+		*v = *m.data.(*BlocksByRangePacket)
+	}
+	return nil
+}
+
+func TestHandleGetBlocksByRange(t *testing.T) {
+	// Setup test environment
+	backend := &mockBackend{
+		chain: &core.BlockChain{}, // You might want to use a more sophisticated mock
+	}
+	peer := &Peer{}
+
+	// Test cases
+	tests := []struct {
+		name    string
+		msg     *mockMsg
+		wantErr bool
+	}{
+		{
+			name: "Valid request with block hash",
+			msg: &mockMsg{
+				code: GetBlocksByRangeMsg,
+				data: &GetBlocksByRangePacket{
+					RequestId:        1,
+					StartBlockHash:   common.HexToHash("0x123"),
+					StartBlockHeight: 100,
+					Count:            5,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid request with block height",
+			msg: &mockMsg{
+				code: GetBlocksByRangeMsg,
+				data: &GetBlocksByRangePacket{
+					RequestId:        2,
+					StartBlockHeight: 100,
+					Count:            5,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid count",
+			msg: &mockMsg{
+				code: GetBlocksByRangeMsg,
+				data: &GetBlocksByRangePacket{
+					RequestId:        3,
+					StartBlockHeight: 100,
+					Count:            0,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid request ID",
+			msg: &mockMsg{
+				code: GetBlocksByRangeMsg,
+				data: &GetBlocksByRangePacket{
+					RequestId:        0,
+					StartBlockHeight: 100,
+					Count:            5,
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handleGetBlocksByRange(backend, tt.msg, peer)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleGetBlocksByRange() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandleBlocksByRange(t *testing.T) {
+	// Setup test environment
+	backend := &mockBackend{
+		chain: &core.BlockChain{}, // You might want to use a more sophisticated mock
+	}
+	peer := &Peer{}
+
+	// Create test blocks
+	blocks := make([]*types.Block, 3)
+	for i := 0; i < 3; i++ {
+		header := &types.Header{
+			Number:     big.NewInt(int64(100 - i)),
+			ParentHash: common.HexToHash("0x123"),
+		}
+		body := &types.Body{
+			Transactions: []*types.Transaction{},
+			Uncles:       []*types.Header{},
+		}
+		blocks[i] = types.NewBlock(header, body, []*types.Receipt{}, nil)
+	}
+
+	// Test cases
+	tests := []struct {
+		name    string
+		msg     *mockMsg
+		wantErr bool
+	}{
+		{
+			name: "Valid blocks response",
+			msg: &mockMsg{
+				code: BlocksByRangeMsg,
+				data: &BlocksByRangePacket{
+					RequestId: 1,
+					Blocks:    blocks,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Empty blocks response",
+			msg: &mockMsg{
+				code: BlocksByRangeMsg,
+				data: &BlocksByRangePacket{
+					RequestId: 2,
+					Blocks:    []*types.Block{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid request ID",
+			msg: &mockMsg{
+				code: BlocksByRangeMsg,
+				data: &BlocksByRangePacket{
+					RequestId: 0,
+					Blocks:    blocks,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Non-continuous blocks",
+			msg: &mockMsg{
+				code: BlocksByRangeMsg,
+				data: &BlocksByRangePacket{
+					RequestId: 3,
+					Blocks: []*types.Block{
+						blocks[0],
+						blocks[2], // Skip block 1 to create discontinuity
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handleBlocksByRange(backend, tt.msg, peer)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleBlocksByRange() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/eth/protocols/bsc/protocol.go
+++ b/eth/protocols/bsc/protocol.go
@@ -32,7 +32,7 @@ const maxMessageSize = 10 * 1024 * 1024
 const (
 	BscCapMsg           = 0x00 // bsc capability msg used upon handshake
 	VotesMsg            = 0x01
-	GetBlocksByRangeMsg = 0x02 // it can request (Head-n, Head] range blocks from remote peer
+	GetBlocksByRangeMsg = 0x02 // it can request (StartBlockHeight-Count, StartBlockHeight] range blocks from remote peer
 	BlocksByRangeMsg    = 0x03 // the replied blocks from remote peer
 )
 
@@ -79,9 +79,28 @@ type GetBlocksByRangePacket struct {
 func (*GetBlocksByRangePacket) Name() string { return "GetBlocksByRange" }
 func (*GetBlocksByRangePacket) Kind() byte   { return GetBlocksByRangeMsg }
 
+// BlockData contains types.extblock + sidecars
+type BlockData struct {
+	Header      *types.Header
+	Txs         []*types.Transaction
+	Uncles      []*types.Header
+	Withdrawals []*types.Withdrawal `rlp:"optional"`
+	Sidecars    types.BlobSidecars  `rlp:"optional"`
+}
+
+func NewBlockData(block *types.Block) *BlockData {
+	return &BlockData{
+		Header:      block.Header(),
+		Txs:         block.Transactions(),
+		Uncles:      block.Uncles(),
+		Withdrawals: block.Withdrawals(),
+		Sidecars:    block.Sidecars(),
+	}
+}
+
 type BlocksByRangePacket struct {
 	RequestId uint64
-	Blocks    []*types.Block
+	Blocks    []*BlockData
 }
 
 func (*BlocksByRangePacket) Name() string { return "BlocksByRange" }

--- a/eth/protocols/bsc/protocol.go
+++ b/eth/protocols/bsc/protocol.go
@@ -3,6 +3,7 @@ package bsc
 import (
 	"errors"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -10,6 +11,7 @@ import (
 // Constants to match up protocol versions and messages
 const (
 	Bsc1 = 1
+	Bsc2 = 2
 )
 
 // ProtocolName is the official short name of the `bsc` protocol used during
@@ -18,18 +20,20 @@ const ProtocolName = "bsc"
 
 // ProtocolVersions are the supported versions of the `bsc` protocol (first
 // is primary).
-var ProtocolVersions = []uint{Bsc1}
+var ProtocolVersions = []uint{Bsc1, Bsc2}
 
 // protocolLengths are the number of implemented message corresponding to
 // different protocol versions.
-var protocolLengths = map[uint]uint64{Bsc1: 2}
+var protocolLengths = map[uint]uint64{Bsc1: 2, Bsc2: 4}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
 const maxMessageSize = 10 * 1024 * 1024
 
 const (
-	BscCapMsg = 0x00 // bsc capability msg used upon handshake
-	VotesMsg  = 0x01
+	BscCapMsg           = 0x00 // bsc capability msg used upon handshake
+	VotesMsg            = 0x01
+	GetBlocksByRangeMsg = 0x02 // it can request (Head-n, Head] range blocks from remote peer
+	BlocksByRangeMsg    = 0x03 // the replied blocks from remote peer
 )
 
 var defaultExtra = []byte{0x00}
@@ -64,3 +68,21 @@ func (*BscCapPacket) Kind() byte   { return BscCapMsg }
 
 func (*VotesPacket) Name() string { return "Votes" }
 func (*VotesPacket) Kind() byte   { return VotesMsg }
+
+type GetBlocksByRangePacket struct {
+	RequestId        uint64
+	StartBlockHeight uint64      // The start block height expected to be obtained from
+	StartBlockHash   common.Hash // The start block hash expected to be obtained from
+	Count            uint64      // Get the number of blocks from the start
+}
+
+func (*GetBlocksByRangePacket) Name() string { return "GetBlocksByRange" }
+func (*GetBlocksByRangePacket) Kind() byte   { return GetBlocksByRangeMsg }
+
+type BlocksByRangePacket struct {
+	RequestId uint64
+	Blocks    []*types.Block
+}
+
+func (*BlocksByRangePacket) Name() string { return "BlocksByRange" }
+func (*BlocksByRangePacket) Kind() byte   { return BlocksByRangeMsg }

--- a/node/config.go
+++ b/node/config.go
@@ -93,11 +93,11 @@ type Config struct {
 	// DirectBroadcast enable directly broadcast mined block to all peers
 	DirectBroadcast bool `toml:",omitempty"`
 
-	// EnableQuickBlockFetching Whether enable fetch new block by new messages
-	EnableQuickBlockFetching bool `toml:",omitempty"`
-
 	// DisableSnapProtocol disable the snap protocol
 	DisableSnapProtocol bool `toml:",omitempty"`
+
+	// EnableQuickBlockFetching Whether enable fetch new block by new messages
+	EnableQuickBlockFetching bool `toml:",omitempty"`
 
 	// RangeLimit enable 5000 blocks limit when handle range query
 	RangeLimit bool `toml:",omitempty"`

--- a/node/config.go
+++ b/node/config.go
@@ -93,6 +93,9 @@ type Config struct {
 	// DirectBroadcast enable directly broadcast mined block to all peers
 	DirectBroadcast bool `toml:",omitempty"`
 
+	// EnableQuickBlockFetching Whether enable fetch new block by new messages
+	EnableQuickBlockFetching bool `toml:",omitempty"`
+
 	// DisableSnapProtocol disable the snap protocol
 	DisableSnapProtocol bool `toml:",omitempty"`
 

--- a/node/config.go
+++ b/node/config.go
@@ -96,7 +96,7 @@ type Config struct {
 	// DisableSnapProtocol disable the snap protocol
 	DisableSnapProtocol bool `toml:",omitempty"`
 
-	// EnableQuickBlockFetching Whether enable fetch new block by new messages
+	// EnableQuickBlockFetching indicates whether to fetch new blocks using new messages.
 	EnableQuickBlockFetching bool `toml:",omitempty"`
 
 	// RangeLimit enable 5000 blocks limit when handle range query


### PR DESCRIPTION
### Description

This PR will implement https://github.com/bnb-chain/BEPs/pull/564.

It supports fast fetching of newly generated blocks, avoids validators and full nodes from lagging behind in the subsecond block interval, and especially improves the validator consensus efficiency, which can produce the next block or send vote faster.
![image](https://github.com/user-attachments/assets/7ac25d0e-8c1d-4c41-84d3-6be982796b47)

### Example

If you want to use new block fetching mechanism, you need modify the config:

```toml
[Node]
EnableQuickBlockFetching = true
```

### Changes

Notable changes: 
* bsc: add BlocksByRange msgs;
* block_fetcher: support quick block fetching;
