### PR TITLE
params: double FullImmutabilityThreshold for BEP-520 & BEP-524

### DIFF
--- a/params/network_params.go
+++ b/params/network_params.go
@@ -37,5 +37,5 @@ var (
 	// considered immutable (i.e. soft finality). It is used by the downloader as a
 	// hard limit against deep ancestors, by the blockchain against deep reorgs, by
 	// the freezer as the cutoff threshold and by clique as the snapshot trust limit.
-	FullImmutabilityThreshold uint64 = 90000
+	FullImmutabilityThreshold uint64 = 180_000
 )

--- a/params/network_params.go
+++ b/params/network_params.go
@@ -37,5 +37,5 @@ var (
 	// considered immutable (i.e. soft finality). It is used by the downloader as a
 	// hard limit against deep ancestors, by the blockchain against deep reorgs, by
 	// the freezer as the cutoff threshold and by clique as the snapshot trust limit.
-	FullImmutabilityThreshold uint64 = 180_000
+	FullImmutabilityThreshold uint64 = 360_000
 )


### PR DESCRIPTION
### Description

params: double FullImmutabilityThreshold for BEP-520 & BEP-524

### Rationale

`FullImmutabilityThreshold` is now applied to block freezing, block pruning, and state history.

When the block interval is reduced, the default value of `FullImmutabilityThreshold` is increased accordingly to ensure consistent behavior.

this PR will solve issue https://github.com/bnb-chain/bsc/issues/3042

**Note:**  
The `TransactionHistory` threshold remains unchanged. Its original default value is `2,350,000`, which is sufficiently large even with a shorter block interval.  
If a node requires transaction indexing over a larger number of blocks, please use the `history.transactions` flag to configure it explicitly.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
