### PR TITLE
release: prepare for release v1.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v1.5.12
+### BUGFIX
+[\#3057](https://github.com/bnb-chain/bsc/pull/3057) eth/protocols/bsc: adjust vote reception limit
+
 ## v1.5.11
 ### FEATURE
 [\#3008](https://github.com/bnb-chain/bsc/pull/3008) params: add MaxwellTime

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1  // Major version component of the current release
 	Minor = 5  // Minor version component of the current release
-	Patch = 11 // Patch version component of the current release
+	Patch = 12 // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
### Description
v1.5.12 was a hotfix release on a separate branch, based on v1.5.11, see: https://github.com/bnb-chain/bsc/pull/3058
merge the v1.5.12 change log to develop branch.


### Rationale
NA

### Example
NA

### Changes
NA