### PR TITLE
chore: support more evn configuration in tool;

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -84,11 +84,9 @@ It expects the genesis file as argument.`,
 			utils.InitNetworkPort,
 			utils.InitNetworkSize,
 			utils.InitNetworkIps,
-			utils.InitSentryNode,
 			utils.InitSentryNodeSize,
 			utils.InitSentryNodeIPs,
 			utils.InitSentryNodePorts,
-			utils.InitFullNode,
 			utils.InitFullNodeSize,
 			utils.InitFullNodeIPs,
 			utils.InitFullNodePorts,
@@ -244,7 +242,8 @@ Therefore, you must specify the blockNumber or blockHash that locates in diffLay
 )
 
 const (
-	DefaultP2PPort = 30311
+	DefaultSentryP2PPort   = 30312
+	DefaultFullNodeP2PPort = 30313
 )
 
 // initGenesis will initialise the given JSON format genesis file and writes it as
@@ -345,7 +344,7 @@ func parseIps(ipStr string, size int) ([]string, error) {
 
 func parsePorts(portStr string, defaultPort int, size int) ([]int, error) {
 	var ports []int
-	if len(portStr) != 0 && strings.Contains(portStr, ",") {
+	if strings.Contains(portStr, ",") {
 		portParts := strings.Split(portStr, ",")
 		if len(portParts) != size {
 			return nil, errors.New("mismatch of size and length of ports")
@@ -459,7 +458,7 @@ func initNetwork(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	enableSentryNode := ctx.Bool(utils.InitSentryNode.Name)
+	enableSentryNode := ctx.Int(utils.InitSentryNodeSize.Name) > 0
 	var (
 		sentryConfigs         []gethConfig
 		sentryEnodes          []*enode.Node
@@ -525,7 +524,7 @@ func initNetwork(ctx *cli.Context) error {
 		}
 	}
 
-	if ctx.Bool(utils.InitFullNode.Name) {
+	if ctx.Int(utils.InitFullNodeSize.Name) > 0 {
 		var extraEnodes []*enode.Node
 		if enableSentryNode {
 			extraEnodes = sentryEnodes
@@ -552,7 +551,7 @@ func createSentryNodeConfigs(ctx *cli.Context, baseConfig gethConfig, initDir st
 	if err != nil {
 		utils.Fatalf("Failed to parse ips: %v", err)
 	}
-	ports, err := parsePorts(portStr, DefaultP2PPort, size)
+	ports, err := parsePorts(portStr, DefaultSentryP2PPort, size)
 	if err != nil {
 		utils.Fatalf("Failed to parse ports: %v", err)
 	}
@@ -571,7 +570,7 @@ func createAndSaveFullNodeConfigs(ctx *cli.Context, inGenesisFile *os.File, base
 	if err != nil {
 		utils.Fatalf("Failed to parse ips: %v", err)
 	}
-	ports, err := parsePorts(portStr, DefaultP2PPort, size)
+	ports, err := parsePorts(portStr, DefaultFullNodeP2PPort, size)
 	if err != nil {
 		utils.Fatalf("Failed to parse ports: %v", err)
 	}

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -242,8 +242,8 @@ Therefore, you must specify the blockNumber or blockHash that locates in diffLay
 )
 
 const (
-	DefaultSentryP2PPort   = 30312
-	DefaultFullNodeP2PPort = 30313
+	DefaultSentryP2PPort   = 30411
+	DefaultFullNodeP2PPort = 30511
 )
 
 // initGenesis will initialise the given JSON format genesis file and writes it as

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -85,6 +85,17 @@ It expects the genesis file as argument.`,
 			utils.InitNetworkSize,
 			utils.InitNetworkIps,
 			utils.InitSentryNode,
+			utils.InitSentryNodeSize,
+			utils.InitSentryNodeIPs,
+			utils.InitSentryNodePorts,
+			utils.InitFullNode,
+			utils.InitFullNodeSize,
+			utils.InitFullNodeIPs,
+			utils.InitFullNodePorts,
+			utils.InitEVNSentryWhitelist,
+			utils.InitEVNValidatorWhitelist,
+			utils.InitEVNSentryRegister,
+			utils.InitEVNValidatorRegister,
 			configFileFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
@@ -232,6 +243,10 @@ Therefore, you must specify the blockNumber or blockHash that locates in diffLay
 	}
 )
 
+const (
+	DefaultP2PPort = 30311
+)
+
 // initGenesis will initialise the given JSON format genesis file and writes it as
 // the zero'd block (i.e. genesis) or will fail hard if it can't succeed.
 func initGenesis(ctx *cli.Context) error {
@@ -328,6 +343,38 @@ func parseIps(ipStr string, size int) ([]string, error) {
 	return ips, nil
 }
 
+func parsePorts(portStr string, defaultPort int, size int) ([]int, error) {
+	var ports []int
+	if len(portStr) != 0 && strings.Contains(portStr, ",") {
+		portParts := strings.Split(portStr, ",")
+		if len(portParts) != size {
+			return nil, errors.New("mismatch of size and length of ports")
+		}
+		for i := 0; i < size; i++ {
+			port, err := strconv.Atoi(portParts[i])
+			if err != nil {
+				return nil, errors.New("invalid format of port")
+			}
+			ports[i] = port
+		}
+	} else if len(portStr) != 0 {
+		startPort, err := strconv.Atoi(portStr)
+		if err != nil {
+			return nil, errors.New("invalid format of port")
+		}
+		ports = make([]int, size)
+		for i := 0; i < size; i++ {
+			ports[i] = startPort + i
+		}
+	} else {
+		ports = make([]int, size)
+		for i := 0; i < size; i++ {
+			ports[i] = defaultPort
+		}
+	}
+	return ports, nil
+}
+
 func createPorts(ipStr string, port int, size int) []int {
 	ports := make([]int, size)
 	if len(ipStr) == 0 { // localhost , so different ports
@@ -343,82 +390,23 @@ func createPorts(ipStr string, port int, size int) []int {
 }
 
 // Create config for node i in the cluster
-func createNodeConfig(baseConfig gethConfig, enodes []*enode.Node, ip string, port int, size int, i int) gethConfig {
+func createNodeConfig(baseConfig gethConfig, ip string, port int, enodes []*enode.Node, index int, staticConnect bool) gethConfig {
 	baseConfig.Node.HTTPHost = ip
 	baseConfig.Node.P2P.ListenAddr = fmt.Sprintf(":%d", port)
-	baseConfig.Node.P2P.BootstrapNodes = make([]*enode.Node, size-1)
-	// Set the P2P connections between this node and the other nodes
-	for j := 0; j < i; j++ {
-		baseConfig.Node.P2P.BootstrapNodes[j] = enodes[j]
+	connectEnodes := make([]*enode.Node, 0, len(enodes)-1)
+	for j := 0; j < index; j++ {
+		connectEnodes = append(connectEnodes, enodes[j])
 	}
-	for j := i + 1; j < size; j++ {
-		baseConfig.Node.P2P.BootstrapNodes[j-1] = enodes[j]
+	for j := index + 1; j < len(enodes); j++ {
+		connectEnodes = append(connectEnodes, enodes[j])
+	}
+	// Set the P2P connections between this node and the other nodes
+	if staticConnect {
+		baseConfig.Node.P2P.StaticNodes = connectEnodes
+	} else {
+		baseConfig.Node.P2P.BootstrapNodes = connectEnodes
 	}
 	return baseConfig
-}
-
-func createStaticNodeConfig(baseConfig gethConfig, enodes []*enode.Node, ip string, port int, size int, i int) gethConfig {
-	baseConfig.Node.HTTPHost = ip
-	baseConfig.Node.P2P.ListenAddr = fmt.Sprintf(":%d", port)
-	baseConfig.Node.P2P.StaticNodes = make([]*enode.Node, size-1)
-	// Set the P2P connections between this node and the other nodes
-	for j := 0; j < i; j++ {
-		baseConfig.Node.P2P.StaticNodes[j] = enodes[j]
-	}
-	for j := i + 1; j < size; j++ {
-		baseConfig.Node.P2P.StaticNodes[j-1] = enodes[j]
-	}
-	return baseConfig
-}
-
-// Create configs for nodes in the cluster
-func createNodeConfigs(baseConfig gethConfig, initDir string, ips []string, ports []int, size int, enableSentryNode bool) ([]gethConfig, error) {
-	// Create the nodes
-	totalSize := size
-	if enableSentryNode {
-		totalSize = size * 2
-	}
-	enodes := make([]*enode.Node, size)
-	sentryEnodes := make([]*enode.Node, size)
-	for i, j := 0, 0; i < size && j < totalSize; i++ {
-		nodeConfig := baseConfig.Node
-		nodeConfig.DataDir = path.Join(initDir, fmt.Sprintf("node%d", i))
-		stack, err := node.New(&nodeConfig)
-		if err != nil {
-			return nil, err
-		}
-		pk := stack.Config().NodeKey()
-		enodes[i] = enode.NewV4(&pk.PublicKey, net.ParseIP(ips[j]), ports[j], ports[j])
-		j++
-		if enableSentryNode {
-			nodeConfig := baseConfig.Node
-			nodeConfig.DataDir = path.Join(initDir, fmt.Sprintf("sentry%d", i))
-			stack, err := node.New(&nodeConfig)
-			if err != nil {
-				return nil, err
-			}
-			pk := stack.Config().NodeKey()
-			sentryEnodes[i] = enode.NewV4(&pk.PublicKey, net.ParseIP(ips[j]), ports[j], ports[j])
-			j++
-		}
-	}
-
-	// Create the configs
-	configs := make([]gethConfig, 0, totalSize)
-	for i, j := 0, 0; i < size && j < totalSize; i++ {
-		if !enableSentryNode {
-			configs = append(configs, createNodeConfig(baseConfig, enodes, ips[j], ports[j], size, i))
-			j++
-			continue
-		}
-		// if enableSentryNode, sentry will connect each other, and vlaidator only connect sentry
-		configs = append(configs, createStaticNodeConfig(baseConfig, []*enode.Node{enodes[i], sentryEnodes[i]}, ips[j], ports[j], 2, 0))
-		sentry := createStaticNodeConfig(baseConfig, sentryEnodes, ips[j+1], ports[j+1], size, i)
-		sentry.Node.P2P.ProxyedValidatorNodeIDs = append(sentry.Node.P2P.ProxyedValidatorNodeIDs, enodes[i].ID())
-		configs = append(configs, sentry)
-		j += 2
-	}
-	return configs, nil
 }
 
 // initNetwork will bootstrap and initialize a new genesis block, and nodekey, config files for network nodes
@@ -435,7 +423,6 @@ func initNetwork(ctx *cli.Context) error {
 	if port <= 0 {
 		utils.Fatalf("port should be greater than 0")
 	}
-	enableSentryNode := ctx.Bool(utils.InitSentryNode.Name)
 	ipStr := ctx.String(utils.InitNetworkIps.Name)
 	cfgFile := ctx.String(configFileFlag.Name)
 
@@ -443,16 +430,12 @@ func initNetwork(ctx *cli.Context) error {
 		utils.Fatalf("config file is required")
 	}
 
-	totalSize := size
-	if enableSentryNode {
-		totalSize = size * 2
-	}
-	ips, err := parseIps(ipStr, totalSize)
+	ips, err := parseIps(ipStr, size)
 	if err != nil {
 		utils.Fatalf("Failed to pase ips string: %v", err)
 	}
 
-	ports := createPorts(ipStr, port, totalSize)
+	ports := createPorts(ipStr, port, size)
 
 	// Make sure we have a valid genesis JSON
 	genesisPath := ctx.Args().First()
@@ -476,28 +459,167 @@ func initNetwork(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	enableSentryNode := ctx.Bool(utils.InitSentryNode.Name)
+	var (
+		sentryConfigs         []gethConfig
+		sentryEnodes          []*enode.Node
+		sentryNodeIDs         []enode.ID
+		connectOneExtraEnodes bool
+		staticConnect         bool
+	)
+	if enableSentryNode {
+		sentryConfigs, sentryEnodes, err = createSentryNodeConfigs(ctx, config, initDir)
+		if err != nil {
+			utils.Fatalf("Failed to create sentry node configs: %v", err)
+		}
+		sentryNodeIDs = make([]enode.ID, len(sentryEnodes))
+		for i := 0; i < len(sentryEnodes); i++ {
+			sentryNodeIDs[i] = sentryEnodes[i].ID()
+		}
+		connectOneExtraEnodes = true
+		staticConnect = true
+	}
 
-	configs, err := createNodeConfigs(config, initDir, ips, ports, size, enableSentryNode)
+	configs, enodes, err := createConfigs(config, initDir, "node", ips, ports, sentryEnodes, connectOneExtraEnodes, staticConnect)
 	if err != nil {
 		utils.Fatalf("Failed to create node configs: %v", err)
 	}
 
-	for i, j := 0, 0; i < size && j < totalSize; i++ {
-		// Write config.toml
-		err = writeConfig(inGenesisFile, configs[j], path.Join(initDir, fmt.Sprintf("node%d", i)))
+	nodeIDs := make([]enode.ID, len(enodes))
+	for i := 0; i < len(enodes); i++ {
+		nodeIDs[i] = enodes[i].ID()
+	}
+	// add more feature configs
+	if ctx.Bool(utils.InitEVNValidatorWhitelist.Name) {
+		for i := 0; i < size; i++ {
+			configs[i].Node.P2P.EVNNodeIdsWhitelist = nodeIDs
+		}
+	}
+	if ctx.Bool(utils.InitEVNValidatorRegister.Name) {
+		for i := 0; i < size; i++ {
+			configs[i].Eth.ValidatorNodeIDsToAdd = []enode.ID{nodeIDs[i]}
+		}
+	}
+	if enableSentryNode && ctx.Bool(utils.InitEVNSentryWhitelist.Name) {
+		for i := 0; i < len(sentryConfigs); i++ {
+			sentryConfigs[i].Node.P2P.EVNNodeIdsWhitelist = sentryNodeIDs
+		}
+	}
+	if enableSentryNode && ctx.Bool(utils.InitEVNSentryRegister.Name) {
+		for i := 0; i < size; i++ {
+			configs[i].Eth.ValidatorNodeIDsToAdd = append(configs[i].Eth.ValidatorNodeIDsToAdd, sentryNodeIDs[i])
+		}
+	}
+
+	// write node & sentry configs
+	for i, config := range configs {
+		err = writeConfig(inGenesisFile, config, path.Join(initDir, fmt.Sprintf("node%d", i)))
 		if err != nil {
 			return err
 		}
-		j++
-		if enableSentryNode {
-			err = writeConfig(inGenesisFile, configs[j], path.Join(initDir, fmt.Sprintf("sentry%d", i)))
-			if err != nil {
-				return err
-			}
-			j++
+	}
+	for i, config := range sentryConfigs {
+		err = writeConfig(inGenesisFile, config, path.Join(initDir, fmt.Sprintf("sentry%d", i)))
+		if err != nil {
+			return err
 		}
 	}
+
+	if ctx.Bool(utils.InitFullNode.Name) {
+		var extraEnodes []*enode.Node
+		if enableSentryNode {
+			extraEnodes = sentryEnodes
+		} else {
+			extraEnodes = enodes
+		}
+		_, _, err := createAndSaveFullNodeConfigs(ctx, inGenesisFile, config, initDir, extraEnodes)
+		if err != nil {
+			utils.Fatalf("Failed to create full node configs: %v", err)
+		}
+	}
+
 	return nil
+}
+
+func createSentryNodeConfigs(ctx *cli.Context, baseConfig gethConfig, initDir string) ([]gethConfig, []*enode.Node, error) {
+	size := ctx.Int(utils.InitSentryNodeSize.Name)
+	if size <= 0 {
+		utils.Fatalf("size should be greater than 0")
+	}
+	ipStr := ctx.String(utils.InitSentryNodeIPs.Name)
+	portStr := ctx.String(utils.InitSentryNodePorts.Name)
+	ips, err := parseIps(ipStr, size)
+	if err != nil {
+		utils.Fatalf("Failed to parse ips: %v", err)
+	}
+	ports, err := parsePorts(portStr, DefaultP2PPort, size)
+	if err != nil {
+		utils.Fatalf("Failed to parse ports: %v", err)
+	}
+
+	return createConfigs(baseConfig, initDir, "sentry", ips, ports, nil, false, true)
+}
+
+func createAndSaveFullNodeConfigs(ctx *cli.Context, inGenesisFile *os.File, baseConfig gethConfig, initDir string, extraEnodes []*enode.Node) ([]gethConfig, []*enode.Node, error) {
+	size := ctx.Int(utils.InitFullNodeSize.Name)
+	if size <= 0 {
+		utils.Fatalf("size should be greater than 0")
+	}
+	ipStr := ctx.String(utils.InitFullNodeIPs.Name)
+	portStr := ctx.String(utils.InitFullNodePorts.Name)
+	ips, err := parseIps(ipStr, size)
+	if err != nil {
+		utils.Fatalf("Failed to parse ips: %v", err)
+	}
+	ports, err := parsePorts(portStr, DefaultP2PPort, size)
+	if err != nil {
+		utils.Fatalf("Failed to parse ports: %v", err)
+	}
+
+	configs, enodes, err := createConfigs(baseConfig, initDir, "fullnode", ips, ports, extraEnodes, false, false)
+	if err != nil {
+		utils.Fatalf("Failed to create config: %v", err)
+	}
+
+	// write configs
+	for i := 0; i < len(configs); i++ {
+		err := writeConfig(inGenesisFile, configs[i], path.Join(initDir, fmt.Sprintf("fullnode%d", i)))
+		if err != nil {
+			utils.Fatalf("Failed to write config: %v", err)
+		}
+	}
+	return configs, enodes, nil
+}
+
+func createConfigs(base gethConfig, initDir string, prefix string, ips []string, ports []int, extraEnodes []*enode.Node, connectOneExtraEnodes bool, staticConnect bool) ([]gethConfig, []*enode.Node, error) {
+	if len(ips) != len(ports) {
+		return nil, nil, errors.New("mismatch of size and length of ports")
+	}
+	size := len(ips)
+	enodes := make([]*enode.Node, size)
+	for i := 0; i < size; i++ {
+		nodeConfig := base.Node
+		nodeConfig.DataDir = path.Join(initDir, fmt.Sprintf("%s%d", prefix, i))
+		stack, err := node.New(&nodeConfig)
+		if err != nil {
+			return nil, nil, err
+		}
+		pk := stack.Config().NodeKey()
+		enodes[i] = enode.NewV4(&pk.PublicKey, net.ParseIP(ips[i]), ports[i], ports[i])
+	}
+
+	allEnodes := append(enodes, extraEnodes...)
+	configs := make([]gethConfig, size)
+	for i := 0; i < size; i++ {
+		index := i
+		if connectOneExtraEnodes {
+			// only connect to one extra enode with same index
+			allEnodes = []*enode.Node{enodes[i], extraEnodes[i]}
+			index = 0
+		}
+		configs[i] = createNodeConfig(base, ips[i], ports[i], allEnodes, index, staticConnect)
+	}
+	return configs, enodes, nil
 }
 
 func writeConfig(inGenesisFile *os.File, config gethConfig, dir string) error {

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -496,7 +496,7 @@ func initNetwork(ctx *cli.Context) error {
 	}
 	if ctx.Bool(utils.InitEVNValidatorRegister.Name) {
 		for i := 0; i < size; i++ {
-			configs[i].Eth.ValidatorNodeIDsToAdd = []enode.ID{nodeIDs[i]}
+			configs[i].Eth.EVNNodeIDsToAdd = []enode.ID{nodeIDs[i]}
 		}
 	}
 	if enableSentryNode && ctx.Bool(utils.InitEVNSentryWhitelist.Name) {
@@ -506,7 +506,7 @@ func initNetwork(ctx *cli.Context) error {
 	}
 	if enableSentryNode && ctx.Bool(utils.InitEVNSentryRegister.Name) {
 		for i := 0; i < size; i++ {
-			configs[i].Eth.ValidatorNodeIDsToAdd = append(configs[i].Eth.ValidatorNodeIDsToAdd, sentryNodeIDs[i])
+			configs[i].Eth.EVNNodeIDsToAdd = append(configs[i].Eth.EVNNodeIDsToAdd, sentryNodeIDs[i])
 		}
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1165,11 +1165,11 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 	}
 	InitEVNSentryWhitelist = &cli.BoolFlag{
 		Name:  "init.evn-sentry-whitelist",
-		Usage: "whether to add evn sentry NodeIDs in Node.P2P.EVNNodeIdsWhitelist",
+		Usage: "whether to add evn sentry NodeIDs in Node.P2P.EVNNodeIDsWhitelist",
 	}
 	InitEVNValidatorWhitelist = &cli.BoolFlag{
 		Name:  "init.evn-validator-whitelist",
-		Usage: "whether to add evn validator NodeIDs in Node.P2P.EVNNodeIdsWhitelist",
+		Usage: "whether to add evn validator NodeIDs in Node.P2P.EVNNodeIDsWhitelist",
 	}
 	InitEVNSentryRegister = &cli.BoolFlag{
 		Name:  "init.evn-sentry-register",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1125,14 +1125,10 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Usage: "the p2p port of the nodes in the network",
 		Value: 30311,
 	}
-	InitSentryNode = &cli.BoolFlag{
-		Name:  "init.sentrynode",
-		Usage: "whether to add a sentry node to the network",
-	}
 	InitSentryNodeSize = &cli.IntFlag{
 		Name:  "init.sentrynode-size",
 		Usage: "the size of the sentry node",
-		Value: 1,
+		Value: 0,
 	}
 	InitSentryNodeIPs = &cli.StringFlag{
 		Name:  "init.sentrynode-ips",
@@ -1144,14 +1140,10 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Usage: "the ports of each sentry node in the network, example '30311,30312'",
 		Value: "",
 	}
-	InitFullNode = &cli.BoolFlag{
-		Name:  "init.fullnode",
-		Usage: "whether to add a full node to the network",
-	}
 	InitFullNodeSize = &cli.IntFlag{
 		Name:  "init.fullnode-size",
 		Usage: "the size of the full node",
-		Value: 1,
+		Value: 0,
 	}
 	InitFullNodeIPs = &cli.StringFlag{
 		Name:  "init.fullnode-ips",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1165,11 +1165,11 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 	}
 	InitEVNSentryRegister = &cli.BoolFlag{
 		Name:  "init.evn-sentry-register",
-		Usage: "whether to add evn sentry NodeIDs in ETH.ValidatorNodeIDsToAdd",
+		Usage: "whether to add evn sentry NodeIDs in ETH.EVNNodeIDsToAdd",
 	}
 	InitEVNValidatorRegister = &cli.BoolFlag{
 		Name:  "init.evn-validator-register",
-		Usage: "whether to add evn validator NodeIDs in ETH.ValidatorNodeIDsToAdd",
+		Usage: "whether to add evn validator NodeIDs in ETH.EVNNodeIDsToAdd",
 	}
 	MetricsInfluxDBOrganizationFlag = &cli.StringFlag{
 		Name:     "metrics.influxdb.organization",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1129,6 +1129,56 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Name:  "init.sentrynode",
 		Usage: "whether to add a sentry node to the network",
 	}
+	InitSentryNodeSize = &cli.IntFlag{
+		Name:  "init.sentrynode-size",
+		Usage: "the size of the sentry node",
+		Value: 1,
+	}
+	InitSentryNodeIPs = &cli.StringFlag{
+		Name:  "init.sentrynode-ips",
+		Usage: "the ips of each sentry node in the network, example '192.168.0.1,192.168.0.2'",
+		Value: "",
+	}
+	InitSentryNodePorts = &cli.StringFlag{
+		Name:  "init.sentrynode-ports",
+		Usage: "the ports of each sentry node in the network, example '30311,30312'",
+		Value: "",
+	}
+	InitFullNode = &cli.BoolFlag{
+		Name:  "init.fullnode",
+		Usage: "whether to add a full node to the network",
+	}
+	InitFullNodeSize = &cli.IntFlag{
+		Name:  "init.fullnode-size",
+		Usage: "the size of the full node",
+		Value: 1,
+	}
+	InitFullNodeIPs = &cli.StringFlag{
+		Name:  "init.fullnode-ips",
+		Usage: "the ips of each full node in the network, example '192.168.0.1,192.168.0.2'",
+		Value: "",
+	}
+	InitFullNodePorts = &cli.StringFlag{
+		Name:  "init.fullnode-ports",
+		Usage: "the ports of each full node in the network, example '30311,30312'",
+		Value: "",
+	}
+	InitEVNSentryWhitelist = &cli.BoolFlag{
+		Name:  "init.evn-sentry-whitelist",
+		Usage: "whether to add evn sentry NodeIDs in Node.P2P.EVNNodeIdsWhitelist",
+	}
+	InitEVNValidatorWhitelist = &cli.BoolFlag{
+		Name:  "init.evn-validator-whitelist",
+		Usage: "whether to add evn validator NodeIDs in Node.P2P.EVNNodeIdsWhitelist",
+	}
+	InitEVNSentryRegister = &cli.BoolFlag{
+		Name:  "init.evn-sentry-register",
+		Usage: "whether to add evn sentry NodeIDs in ETH.ValidatorNodeIDsToAdd",
+	}
+	InitEVNValidatorRegister = &cli.BoolFlag{
+		Name:  "init.evn-validator-register",
+		Usage: "whether to add evn validator NodeIDs in ETH.ValidatorNodeIDsToAdd",
+	}
 	MetricsInfluxDBOrganizationFlag = &cli.StringFlag{
 		Name:     "metrics.influxdb.organization",
 		Usage:    "InfluxDB organization name (v2 only)",

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -838,7 +838,7 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		for i := len(transfer); i < len(peers); i++ {
 			if peers[i].ProxyedValidatorFlag.Load() {
 				morePeers = append(morePeers, peers[i])
-				log.Debug("add extra whitelist broadcast peer in EVN", "peer", peers[i].ID())
+				log.Debug("add extra proxyed validator broadcast peer in EVN", "peer", peers[i].ID())
 				continue
 			}
 			if fullBroadcastInEVN && peers[i].EVNPeerFlag.Load() {


### PR DESCRIPTION
### Description

This PR supports more scenarios for local/QA testing, it can create fullnode, enable more EVN features for testing, and refactor some code.

### Example

```bash
./bin/geth init-network -h                              
NAME:
   geth init-network - Bootstrap and initialize a new genesis block, and nodekey, config files for network nodes

USAGE:
   geth init-network [command options] <genesisPath>

CATEGORY:
   BLOCKCHAIN COMMANDS

DESCRIPTION:
   
   The init-network command initializes a new genesis block, definition for the network, config files for network nodes.
   It expects the genesis file as argument.

OPTIONS:
   
    --init.dir value                                                      
          the direction to store initial network data
   
    --init.evn-sentry-register          (default: false)                  
          whether to add evn sentry NodeIDs in ETH.ValidatorNodeIDsToAdd
   
    --init.evn-sentry-whitelist         (default: false)                  
          whether to add evn sentry NodeIDs in Node.P2P.EVNNodeIdsWhitelist
   
    --init.evn-validator-register       (default: false)                  
          whether to add evn validator NodeIDs in ETH.ValidatorNodeIDsToAdd
   
    --init.evn-validator-whitelist      (default: false)                  
          whether to add evn validator NodeIDs in Node.P2P.EVNNodeIdsWhitelist
   
    --init.fullnode                     (default: false)                  
          whether to add a full node to the network
   
    --init.fullnode-ips value                                             
          the ips of each full node in the network, example '192.168.0.1,192.168.0.2'
   
    --init.fullnode-ports value                                           
          the ports of each full node in the network, example '30311,30312'
   
    --init.fullnode-size value          (default: 1)                      
          the size of the full node
   
    --init.ips value                                                      
          the ips of each node in the network, example '192.168.0.1,192.168.0.2'
   
    --init.p2p-port value               (default: 30311)                  
          the p2p port of the nodes in the network
   
    --init.sentrynode                   (default: false)                  
          whether to add a sentry node to the network
   
    --init.sentrynode-ips value                                           
          the ips of each sentry node in the network, example '192.168.0.1,192.168.0.2'
   
    --init.sentrynode-ports value                                         
          the ports of each sentry node in the network, example '30311,30312'
   
    --init.sentrynode-size value        (default: 1)                      
          the size of the sentry node
   
    --init.size value                   (default: 1)                      
          the size of the network

   ETHEREUM

   
    --config value                                                         ($GETH_CONFIG)
          TOML configuration file
```

### Changes

Notable changes: 
* chore: support more evn configuration in tool;
* ...
