### PR TITLE
evn: add support for node id removal

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -544,21 +544,21 @@ func (s *Ethereum) waitForSyncAndMaxwell(parlia *parlia.Parlia) {
 				continue
 			}
 			log.Info("Node is synced and Maxwell fork is active, proceeding with node ID registration")
-			err := s.registerNodeID(parlia)
+			err := s.updateNodeID(parlia)
 			if err == nil {
 				return
 			}
 			retryCount++
 			if retryCount > 3 {
-				log.Error("Failed to register node ID exceed max retry count", "retryCount", retryCount, "err", err)
+				log.Error("Failed to update node ID exceed max retry count", "retryCount", retryCount, "err", err)
 				return
 			}
 		}
 	}
 }
 
-// registerNodeID registers the node ID with the StakeHub contract
-func (s *Ethereum) registerNodeID(parlia *parlia.Parlia) error {
+// updateNodeID registers the node ID with the StakeHub contract
+func (s *Ethereum) updateNodeID(parlia *parlia.Parlia) error {
 	nonce, err := s.APIBackend.GetPoolNonce(context.Background(), s.etherbase)
 	if err != nil {
 		return fmt.Errorf("failed to get nonce: %v", err)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -559,46 +559,112 @@ func (s *Ethereum) waitForSyncAndMaxwell(parlia *parlia.Parlia) {
 
 // registerNodeID registers the node ID with the StakeHub contract
 func (s *Ethereum) registerNodeID(parlia *parlia.Parlia) error {
-	// Check if node ID is already registered
-	nodeIDs, err := parlia.GetNodeIDs()
+	nonce, err := s.APIBackend.GetPoolNonce(context.Background(), s.etherbase)
+	if err != nil {
+		return fmt.Errorf("failed to get nonce: %v", err)
+	}
+
+	// Handle removals first
+	if err := s.handleRemovals(parlia, nonce); err != nil {
+		return err
+	}
+	nonce++
+
+	// Handle additions
+	return s.handleAdditions(parlia, nonce)
+}
+
+func (s *Ethereum) handleRemovals(parlia *parlia.Parlia, nonce uint64) error {
+	if len(s.config.EVNNodeIDsToRemove) == 0 {
+		return nil
+	}
+
+	// Handle wildcard removal
+	if len(s.config.EVNNodeIDsToRemove) == 1 {
+		var zeroID enode.ID // This will be all zeros
+		if s.config.EVNNodeIDsToRemove[0] == zeroID {
+			trx, err := parlia.RemoveNodeIDs([]enode.ID{}, nonce)
+			if err != nil {
+				return fmt.Errorf("failed to create node ID removal transaction: %v", err)
+			}
+			if err := s.txPool.Add([]*types.Transaction{trx}, false); err != nil {
+				return fmt.Errorf("failed to add node ID removal transaction to pool: %v", err)
+			}
+			log.Info("Submitted node ID removal transaction for all node IDs")
+			return nil
+		}
+	}
+
+	// Create a set of node IDs to add for quick lookup
+	addSet := make(map[enode.ID]struct{}, len(s.config.EVNNodeIDsToAdd))
+	for _, id := range s.config.EVNNodeIDsToAdd {
+		addSet[id] = struct{}{}
+	}
+
+	// Filter out node IDs that are in the add set
+	nodeIDsToRemove := make([]enode.ID, 0, len(s.config.EVNNodeIDsToRemove))
+	for _, id := range s.config.EVNNodeIDsToRemove {
+		if _, exists := addSet[id]; !exists {
+			nodeIDsToRemove = append(nodeIDsToRemove, id)
+		} else {
+			log.Debug("Skipping node ID removal", "id", id, "reason", "also in EVNNodeIDsToAdd")
+		}
+	}
+
+	if len(nodeIDsToRemove) == 0 {
+		return nil
+	}
+
+	trx, err := parlia.RemoveNodeIDs(nodeIDsToRemove, nonce)
+	if err != nil {
+		return fmt.Errorf("failed to create node ID removal transaction: %v", err)
+	}
+	if err := s.txPool.Add([]*types.Transaction{trx}, false); err != nil {
+		return fmt.Errorf("failed to add node ID removal transaction to pool: %v", err)
+	}
+	log.Info("Submitted node ID removal transaction", "nodeIDs", nodeIDsToRemove)
+	return nil
+}
+
+func (s *Ethereum) handleAdditions(parlia *parlia.Parlia, nonce uint64) error {
+	if len(s.config.EVNNodeIDsToAdd) == 0 {
+		return nil
+	}
+
+	// Get currently registered node IDs
+	registeredIDs, err := parlia.GetNodeIDs()
 	if err != nil {
 		log.Error("Failed to get registered node IDs", "err", err)
 		return err
 	}
 
-	// Check which node IDs need to be registered
-	nodeIDsToAdd := make([]enode.ID, 0)
-	for _, idToRegister := range s.config.ValidatorNodeIDsToAdd {
-		isRegistered := false
-		for _, id := range nodeIDs {
-			if id == idToRegister {
-				isRegistered = true
-				break
-			}
-		}
-		if !isRegistered {
-			nodeIDsToAdd = append(nodeIDsToAdd, idToRegister)
+	// Create a set of registered IDs for quick lookup
+	registeredSet := make(map[enode.ID]struct{}, len(registeredIDs))
+	for _, id := range registeredIDs {
+		registeredSet[id] = struct{}{}
+	}
+
+	// Filter out already registered IDs in a single pass
+	nodeIDsToAdd := make([]enode.ID, 0, len(s.config.EVNNodeIDsToAdd))
+	for _, id := range s.config.EVNNodeIDsToAdd {
+		if _, exists := registeredSet[id]; !exists {
+			nodeIDsToAdd = append(nodeIDsToAdd, id)
 		}
 	}
 
-	if len(nodeIDsToAdd) > 0 {
-		// Get the current nonce for the validator address
-		nonce, err := s.APIBackend.GetPoolNonce(context.Background(), s.etherbase)
-		if err != nil {
-			return fmt.Errorf("failed to get nonce: %v", err)
-		}
-
-		trx, err := parlia.AddNodeIDs(nodeIDsToAdd, nonce)
-		if err != nil {
-			return fmt.Errorf("failed to create node ID registration transaction: %v", err)
-		}
-		if err := s.txPool.Add([]*types.Transaction{trx}, false); err != nil {
-			return fmt.Errorf("failed to add node ID registration transaction to pool: %v", err)
-		}
-		log.Info("Submitted node ID registration transaction", "nodeIDs", nodeIDsToAdd)
-	} else {
-		log.Info("All node IDs already registered", "nodeIDs", s.config.ValidatorNodeIDsToAdd)
+	if len(nodeIDsToAdd) == 0 {
+		log.Info("No new node IDs to register after deduplication")
+		return nil
 	}
+
+	trx, err := parlia.AddNodeIDs(nodeIDsToAdd, nonce)
+	if err != nil {
+		return fmt.Errorf("failed to create node ID registration transaction: %v", err)
+	}
+	if err := s.txPool.Add([]*types.Transaction{trx}, false); err != nil {
+		return fmt.Errorf("failed to add node ID registration transaction to pool: %v", err)
+	}
+	log.Info("Submitted node ID registration transaction", "nodeIDs", nodeIDsToAdd)
 	return nil
 }
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -94,7 +94,8 @@ type Config struct {
 	// transactions) or is continuously under high pressure (e.g., mempool is always full), then you can consider
 	// to turn it on.
 	DisablePeerTxBroadcast bool
-	ValidatorNodeIDsToAdd  []enode.ID
+	EVNNodeIDsToAdd        []enode.ID
+	EVNNodeIDsToRemove     []enode.ID
 	// This can be set to list of enrtree:// URLs which will be queried for
 	// nodes to connect to.
 	EthDiscoveryURLs   []string

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -21,7 +21,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		NetworkId               uint64
 		SyncMode                SyncMode
 		DisablePeerTxBroadcast  bool
-		ValidatorNodeIDsToAdd   []enode.ID
+		EVNNodeIDsToAdd         []enode.ID
+		EVNNodeIDsToRemove      []enode.ID
 		EthDiscoveryURLs        []string
 		SnapDiscoveryURLs       []string
 		TrustDiscoveryURLs      []string
@@ -76,7 +77,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.NetworkId = c.NetworkId
 	enc.SyncMode = c.SyncMode
 	enc.DisablePeerTxBroadcast = c.DisablePeerTxBroadcast
-	enc.ValidatorNodeIDsToAdd = c.ValidatorNodeIDsToAdd
+	enc.EVNNodeIDsToAdd = c.EVNNodeIDsToAdd
+	enc.EVNNodeIDsToRemove = c.EVNNodeIDsToRemove
 	enc.EthDiscoveryURLs = c.EthDiscoveryURLs
 	enc.SnapDiscoveryURLs = c.SnapDiscoveryURLs
 	enc.TrustDiscoveryURLs = c.TrustDiscoveryURLs
@@ -135,7 +137,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		NetworkId               *uint64
 		SyncMode                *SyncMode
 		DisablePeerTxBroadcast  *bool
-		ValidatorNodeIDsToAdd   []enode.ID
+		EVNNodeIDsToAdd         []enode.ID
+		EVNNodeIDsToRemove      []enode.ID
 		EthDiscoveryURLs        []string
 		SnapDiscoveryURLs       []string
 		TrustDiscoveryURLs      []string
@@ -201,8 +204,11 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.DisablePeerTxBroadcast != nil {
 		c.DisablePeerTxBroadcast = *dec.DisablePeerTxBroadcast
 	}
-	if dec.ValidatorNodeIDsToAdd != nil {
-		c.ValidatorNodeIDsToAdd = dec.ValidatorNodeIDsToAdd
+	if dec.EVNNodeIDsToAdd != nil {
+		c.EVNNodeIDsToAdd = dec.EVNNodeIDsToAdd
+	}
+	if dec.EVNNodeIDsToRemove != nil {
+		c.EVNNodeIDsToRemove = dec.EVNNodeIDsToRemove
 	}
 	if dec.EthDiscoveryURLs != nil {
 		c.EthDiscoveryURLs = dec.EthDiscoveryURLs


### PR DESCRIPTION
# Add support for node ID removal in EVN

## Description
This PR adds support for removing node IDs from the StakeHub contract, complementing the existing node ID registration functionality. The changes include both the contract interaction layer and the configuration management.

## Changes
1. Added `RemoveNodeIDs` function to Parlia consensus engine
   - Creates and signs transactions to remove node IDs from StakeHub
   - Handles gas estimation and transaction creation
   - Includes proper error handling and logging

2. Refactored node ID management in Ethereum backend
   - Split `registerNodeID` into `handleRemovals` and `handleAdditions`
   - Added support for wildcard removal (removing all node IDs)
   - Improved efficiency with map-based lookups
   - Added deduplication logic to prevent redundant operations

3. Updated configuration
   - Renamed `ValidatorNodeIDsToAdd` to `EVNNodeIDsToAdd` for consistency
   - Added new `EVNNodeIDsToRemove` configuration option
   - Updated TOML configuration handling

## Technical Details
- Uses proper 32-byte zero value comparison for wildcard removal
- Implements efficient filtering to skip node IDs that are in both add and remove lists
- Maintains proper nonce handling for transaction sequencing
- Includes comprehensive logging for debugging and monitoring

#3071 