### PR TITLE
config: apply two default miner option

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -641,7 +641,7 @@ var (
 	MinerRecommitIntervalFlag = &cli.DurationFlag{
 		Name:     "miner.recommit",
 		Usage:    "Time interval to recreate the block being mined",
-		Value:    ethconfig.Defaults.Miner.Recommit,
+		Value:    *ethconfig.Defaults.Miner.Recommit,
 		Category: flags.MinerCategory,
 	}
 	MinerDelayLeftoverFlag = &cli.DurationFlag{
@@ -1908,7 +1908,8 @@ func setMiner(ctx *cli.Context, cfg *minerconfig.Config) {
 		cfg.GasPrice = flags.GlobalBig(ctx, MinerGasPriceFlag.Name)
 	}
 	if ctx.IsSet(MinerRecommitIntervalFlag.Name) {
-		cfg.Recommit = ctx.Duration(MinerRecommitIntervalFlag.Name)
+		recommitIntervalFlag := ctx.Duration(MinerRecommitIntervalFlag.Name)
+		cfg.Recommit = &recommitIntervalFlag
 	}
 	if ctx.IsSet(MinerDelayLeftoverFlag.Name) {
 		minerDelayLeftover := ctx.Duration(MinerDelayLeftoverFlag.Name)
@@ -1919,7 +1920,8 @@ func setMiner(ctx *cli.Context, cfg *minerconfig.Config) {
 	}
 	if ctx.IsSet(MinerNewPayloadTimeoutFlag.Name) {
 		log.Warn("The flag --miner.newpayload-timeout is deprecated and will be removed, please use --miner.recommit")
-		cfg.Recommit = ctx.Duration(MinerNewPayloadTimeoutFlag.Name)
+		recommitIntervalFlag := ctx.Duration(MinerRecommitIntervalFlag.Name)
+		cfg.Recommit = &recommitIntervalFlag
 	}
 	if ctx.Bool(DisableVoteAttestationFlag.Name) {
 		cfg.DisableVoteAttestation = true

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -133,7 +133,7 @@ var (
 	MinerNewPayloadTimeoutFlag = &cli.DurationFlag{
 		Name:     "miner.newpayload-timeout",
 		Usage:    "Specify the maximum time allowance for creating a new payload (deprecated)",
-		Value:    ethconfig.Defaults.Miner.Recommit,
+		Value:    *ethconfig.Defaults.Miner.Recommit,
 		Category: flags.DeprecatedCategory,
 	}
 	MetricsEnabledExpensiveFlag = &cli.BoolFlag{

--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -67,8 +67,8 @@ var DefaultConfig = Config{
 	Recommit:      &defaultRecommit,
 	DelayLeftOver: &defaultDelayLeftOver,
 
-	// The default value is set to 30 seconds.
-	// Because the avg restart time in mainnet is around 30s, so the node try to wait for the next multi-proposals to be done.
+	// The default value is set to 45 seconds.
+	// Because the avg restart time in mainnet could be 30+ seconds, so the node try to wait for the next multi-proposals to be done.
 	MaxWaitProposalInSecs: &defaultMaxWaitProposalInSecs,
 
 	Mev: DefaultMevConfig,

--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -47,9 +47,9 @@ type Config struct {
 	GasFloor               uint64         // Target gas floor for mined blocks.
 	GasCeil                uint64         // Target gas ceiling for mined blocks.
 	GasPrice               *big.Int       // Minimum gas price for mining a transaction
-	Recommit               *time.Duration // The time interval for miner to re-create mining work.
+	Recommit               *time.Duration `toml:",omitempty"` // The time interval for miner to re-create mining work.
 	VoteEnable             bool           // Whether to vote when mining
-	MaxWaitProposalInSecs  *uint64        // The maximum time to wait for the proposal to be done, it's aimed to prevent validator being slashed when restarting
+	MaxWaitProposalInSecs  *uint64        `toml:",omitempty"` // The maximum time to wait for the proposal to be done, it's aimed to prevent validator being slashed when restarting
 	DisableVoteAttestation bool           // Whether to skip assembling vote attestation
 
 	Mev MevConfig // Mev configuration

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -282,7 +282,10 @@ func newWorker(config *minerconfig.Config, engine consensus.Engine, eth Backend,
 	worker.chainHeadSub = eth.BlockChain().SubscribeChainHeadEvent(worker.chainHeadCh)
 
 	// Sanitize recommit interval if the user-specified one is too short.
-	recommit := *worker.config.Recommit
+	recommit := minRecommitInterval
+	if worker.config.Recommit != nil && *worker.config.Recommit > minRecommitInterval {
+		recommit = *worker.config.Recommit
+	}
 	if recommit < minRecommitInterval {
 		log.Warn("Sanitizing miner recommit interval", "provided", recommit, "updated", minRecommitInterval)
 		recommit = minRecommitInterval

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -282,7 +282,7 @@ func newWorker(config *minerconfig.Config, engine consensus.Engine, eth Backend,
 	worker.chainHeadSub = eth.BlockChain().SubscribeChainHeadEvent(worker.chainHeadCh)
 
 	// Sanitize recommit interval if the user-specified one is too short.
-	recommit := worker.config.Recommit
+	recommit := *worker.config.Recommit
 	if recommit < minRecommitInterval {
 		log.Warn("Sanitizing miner recommit interval", "provided", recommit, "updated", minRecommitInterval)
 		recommit = minRecommitInterval
@@ -1168,7 +1168,7 @@ func (w *worker) generateWork(params *generateParams, witness bool) *newPayloadR
 
 	if !params.noTxs {
 		interrupt := new(atomic.Int32)
-		timer := time.AfterFunc(w.config.Recommit, func() {
+		timer := time.AfterFunc(*w.config.Recommit, func() {
 			interrupt.Store(commitInterruptTimeout)
 		})
 		defer timer.Stop()
@@ -1547,7 +1547,7 @@ func (w *worker) tryWaitProposalDoneWhenStopping() {
 	}
 
 	log.Info("Checking miner's next proposal block", "current", currentBlock,
-		"proposalStart", startBlock, "proposalEnd", endBlock, "maxWait", w.config.MaxWaitProposalInSecs)
+		"proposalStart", startBlock, "proposalEnd", endBlock, "maxWait", *w.config.MaxWaitProposalInSecs)
 	if endBlock <= currentBlock {
 		log.Warn("next proposal end block has passed, ignore")
 		return
@@ -1556,7 +1556,7 @@ func (w *worker) tryWaitProposalDoneWhenStopping() {
 	if err != nil {
 		log.Debug("failed to get BlockInterval when tryWaitProposalDoneWhenStopping")
 	}
-	if startBlock > currentBlock && ((startBlock-currentBlock)*blockInterval/1000) > w.config.MaxWaitProposalInSecs {
+	if startBlock > currentBlock && ((startBlock-currentBlock)*blockInterval/1000) > *w.config.MaxWaitProposalInSecs {
 		log.Warn("the next proposal start block is too far, just skip waiting")
 		return
 	}

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -66,9 +66,9 @@ var (
 	// Test transactions
 	pendingTxs []*types.Transaction
 	newTxs     []*types.Transaction
-
+	oneSecond  = time.Second
 	testConfig = &minerconfig.Config{
-		Recommit: time.Second,
+		Recommit: &oneSecond,
 		GasCeil:  params.GenesisGasLimit,
 	}
 )


### PR DESCRIPTION
### Description
**1.Apply default value for `Recommit` and `MaxWaitProposalInSecs`**
```
[Eth.Miner]
GasCeil = 70000000
GasPrice = 100000000
VoteEnable = true
```
with this configuration, `Eth.Miner.Recommit` & `Eth.Miner.MaxWaitProposalInSecs` will be 0, while their default value should be 3000000000 and 30 respectively.
This PR it to fix the default value issue of these 2 options.

**2.Change the default value of the two options.**
It would be more reasonable to change default value these 2 options:
- Recommit: from 3000000000(3 seconds) to 10000000000(10 seconds)
Notice: `Recommit` is a experimental value, it could be removed, but leave it for now as it has not big side effect.
- MaxWaitProposalInSecs: from 30s to 45s
Node restart could take ~40second
Here if one of the restart log from a BSC full node, it took ~37 seconds
```
t=05-08|12:45:18.092 lvl=info msg="Got interrupt, shutting down..."
...
t=05-08|12:45:27.198 lvl=info msg="Blockchain stopped"
...
t=05-08|12:45:38.295 lvl=info msg="Set global gas cap" cap=50000000
...
t=05-08|12:45:54.706 lvl=info msg="Imported new chain segment" number=49310151 hash=0x4261de33ce8f501b98431a210f8afd19fd6cff962c5ca2c1bef8c27819522ec8 miner=0x37e9627A91DD13e453246856D58797Ad6583D762 blocks=11 txs=1450 blobs=3 mgas=170.838265 elapsed=1.013s mgasps=168.48741502505274 snapdiffs="3.59 MiB" triediffs="189.36 MiB" triedirty="126.77 MiB" trieimutabledirty="0.00 B"
t=05-08|12:45:54.706 lvl=info msg="Enable transaction acceptance when synced."
```

It could be partial fix for https://github.com/bnb-chain/bsc/issues/2986
### Rationale
NA

### Example
NA

### Changes
NA