### PR TITLE
performance: track large tx execution cost

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -35,6 +35,8 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
+const largeTxGasLimit = 10000000 // 10M Gas, to measure the execution time of large tx
+
 // StateProcessor is a basic Processor, which takes care of transitioning
 // state from one point to another.
 //
@@ -191,11 +193,10 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 func ApplyTransactionWithEVM(msg *Message, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM, receiptProcessors ...ReceiptProcessor) (receipt *types.Receipt, err error) {
 	// Add timing measurement
 	var result *ExecutionResult
-	const largeTxGasLimit = 10000000 // 10M Gas
-	if tx.Gas() >= largeTxGasLimit {
+	if tx.Gas() > largeTxGasLimit {
 		start := time.Now()
 		defer func() {
-			if result != nil && result.UsedGas >= largeTxGasLimit {
+			if result != nil && result.UsedGas > largeTxGasLimit {
 				elapsed := time.Since(start)
 				log.Info("LargeTX execution time", "block", blockNumber, "tx", tx.Hash(), "gasUsed", result.UsedGas, "elapsed", elapsed)
 			}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -30,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -187,6 +189,19 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 // and uses the input parameters for its environment similar to ApplyTransaction. However,
 // this method takes an already created EVM instance as input.
 func ApplyTransactionWithEVM(msg *Message, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM, receiptProcessors ...ReceiptProcessor) (receipt *types.Receipt, err error) {
+	// Add timing measurement
+	var result *ExecutionResult
+	const largeTxGasLimit = 10000000 // 10M Gas
+	if tx.Gas() >= largeTxGasLimit {
+		start := time.Now()
+		defer func() {
+			if result != nil && result.UsedGas >= largeTxGasLimit {
+				elapsed := time.Since(start)
+				log.Info("LargeTX execution time", "block", blockNumber, "tx", tx.Hash(), "gasUsed", result.UsedGas, "elapsed", elapsed)
+			}
+		}()
+	}
+
 	if hooks := evm.Config.Tracer; hooks != nil {
 		if hooks.OnTxStart != nil {
 			hooks.OnTxStart(evm.GetVMContext(), tx, msg.From)
@@ -196,7 +211,7 @@ func ApplyTransactionWithEVM(msg *Message, gp *GasPool, statedb *state.StateDB, 
 		}
 	}
 	// Apply the transaction to the current state (included in the env).
-	result, err := ApplyMessage(evm, msg, gp)
+	result, err = ApplyMessage(evm, msg, gp)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +225,6 @@ func ApplyTransactionWithEVM(msg *Message, gp *GasPool, statedb *state.StateDB, 
 	*usedGas += result.UsedGas
 
 	// Merge the tx-local access event into the "block-local" one, in order to collect
-
 	// all values, so that the witness can be built.
 	if statedb.GetTrie().IsVerkle() {
 		statedb.AccessEvents().Merge(evm.AccessEvents)


### PR DESCRIPTION
### Description
Large tx could be one of the performance bottleneck, add log to track txs with GasUsed > 10M
log will be like:
```
t=2025-05-12T00:50:47+0000 lvl=info msg="LargeTX execution time" block=49511908 tx=0x47561786e7e5799af82bce56ac49ce6448fe7e24fdc7b185b6ebe3d5f3a11a12 gasUsed=10823496 elapsed=38.719084ms
t=2025-05-12T00:51:17+0000 lvl=info msg="LargeTX execution time" block=49511928 tx=0xa59a28c7be3198184308fc7001f7d0704899be81554fea01b3094b16bbac83b3 gasUsed=11245831 elapsed=45.162283ms
t=2025-05-12T01:00:06+0000 lvl=info msg="LargeTX execution time" block=49512281 tx=0xdabb2a40304787bfce1b61c4235b95734996c25d5d0a1e9a473a09a749e05310 gasUsed=16727624 elapsed=140.572166ms
t=2025-05-12T01:04:35+0000 lvl=info msg="LargeTX execution time" block=49512460 tx=0x8aa1a0a6cd0c785d06871fdba41080112d0563646472f74b579e6bb484ed94f3 gasUsed=11245819 elapsed=34.621168ms
t=2025-05-12T01:18:48+0000 lvl=info msg="LargeTX execution time" block=49513029 tx=0x5de6e8bfb1c3b8016c65a252f38a9eb4e85f7b78dc11e77c84a91d43ba2e456d gasUsed=11245819 elapsed=51.465352ms
t=2025-05-12T01:38:27+0000 lvl=info msg="LargeTX execution time" block=49513814 tx=0xf14d8caea138b9a5ecb1025c74f468e273c92946401820266d8b1cd5d2e72112 gasUsed=10753873 elapsed=1.53180642s

```

### Rationale
NA

### Example
NA

### Changes
NA