### PR TITLE
miner: reset recommit timer on new block

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -460,10 +460,12 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 			if p, ok := w.engine.(*parlia.Parlia); ok {
 				signedRecent, err := p.SignRecently(w.chain, head.Header)
 				if err != nil {
+					timer.Reset(recommit)
 					log.Debug("Not allowed to propose block", "err", err)
 					continue
 				}
 				if signedRecent {
+					timer.Reset(recommit)
 					log.Info("Signed recently, must wait")
 					continue
 				}


### PR DESCRIPTION
### Description
For historical reasons, `the reset timer` was added to fix a corner case issue, that the chain could be stuck.
The recommit code was kept, mainly because it has no obvious side-effect and the corner could is still there?(Personally, I prefer to keep right now, but also ok to remove it in the future.)

But it should be reseted on new block, this PT just do it.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
