### PR TITLE
metrics: optimize mev metrics

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1390,7 +1390,6 @@ LOOP:
 
 	// when out-turn, use bestWork to prevent bundle leakage.
 	// when in-turn, compare with remote work.
-	from := bestWork.coinbase
 	if w.bidFetcher != nil && bestWork.header.Difficulty.Cmp(diffInTurn) == 0 {
 		inturnBlocksGauge.Inc(1)
 		// We want to start sealing the block as late as possible here if mev is enabled, so we could give builder the chance to send their final bid.
@@ -1437,11 +1436,10 @@ LOOP:
 				bidWinGauge.Inc(1)
 
 				bestWork = bestBid.env
-				from = bestBid.bid.Builder
 
 				log.Info("[BUILDER BLOCK]",
 					"block", bestWork.header.Number.Uint64(),
-					"builder", from,
+					"builder", bestBid.bid.Builder,
 					"blockReward", weiToEtherStringF6(bestBid.packedBlockReward),
 					"validatorReward", weiToEtherStringF6(bestBid.packedValidatorReward),
 					"bid", bestBid.bid.Hash().TerminalString(),
@@ -1449,8 +1447,6 @@ LOOP:
 			}
 		}
 	}
-
-	metrics.GetOrRegisterCounter(fmt.Sprintf("block/from/%v", from), nil).Inc(1)
 
 	w.commit(bestWork, w.fullTaskHook, true, start)
 


### PR DESCRIPTION
### Description
**1.for metrics: `"bid/err/<...>"`**
```
// reportIssue reports the issue to the mev-sentry
func (b *bidSimulator) reportIssue(bidRuntime *BidRuntime, err error) {
	metrics.GetOrRegisterCounter(fmt.Sprintf("bid/err/%v", bidRuntime.bid.Builder), nil).Inc(1)
        ...
}
```
<img width="423" alt="image" src="https://github.com/user-attachments/assets/8a742012-e812-4bf6-89ac-4c8eea121d04" />

The error of "simulation abort due to better bid arrived" should not be taken as bid error, otherwise the metrics would be useless, as there would be lots of such kind of errors(hundreds per hour)

**2.for metrics: `"block/from/<...>"`**
```
metrics.GetOrRegisterCounter(fmt.Sprintf("block/from/%v", from), nil).Inc(1)
```
<img width="425" alt="image" src="https://github.com/user-attachments/assets/1b5c50ec-08de-407d-8645-64b853b7602a" />

a.it is inaccurate, as blocks that are committed in `commitWork()` does not mean it is a valid one, it could be rejected later in `taskLoop()` as block seal failed, like:
```
"Block sealing failed" err="unauthorized validator:<...>"
```
The most common case, would be it is triggered by the recommit timer, even unauthorized or recently signed validator could commitWork(), but failed to be failed.
b.it can be capture on chain
see: https://dune.com/bnbchain/bnb-smart-chain-mev-stats

### Rationale
NA

### Example
NA

### Changes
NA