### PR TITLE
metrics: add more monitor metrics for EVN;

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -829,6 +829,7 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		}
 
 		for _, peer := range transfer {
+			log.Debug("broadcast block to peer", "hash", hash, "peer", peer.ID(), "ProxyedValidatorFlag", peer.ProxyedValidatorFlag.Load(), "EVNPeerFlag", peer.EVNPeerFlag.Load())
 			peer.AsyncSendNewBlock(block, td)
 		}
 
@@ -838,25 +839,25 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		for i := len(transfer); i < len(peers); i++ {
 			if peers[i].ProxyedValidatorFlag.Load() {
 				morePeers = append(morePeers, peers[i])
-				log.Debug("add extra proxyed validator broadcast peer in EVN", "peer", peers[i].ID())
 				continue
 			}
 			if fullBroadcastInEVN && peers[i].EVNPeerFlag.Load() {
 				morePeers = append(morePeers, peers[i])
-				log.Debug("add extra full broadcast peer in EVN", "peer", peers[i].ID())
 				continue
 			}
 		}
 		for _, peer := range morePeers {
+			log.Debug("broadcast block to extra peer", "hash", hash, "peer", peer.ID(), "ProxyedValidatorFlag", peer.ProxyedValidatorFlag.Load(), "EVNPeerFlag", peer.EVNPeerFlag.Load())
 			peer.AsyncSendNewBlock(block, td)
 		}
 
-		log.Trace("Propagated block", "hash", hash, "recipients", len(transfer)+len(morePeers), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
+		log.Trace("Propagated block", "hash", hash, "recipients", len(transfer), "extra", len(morePeers), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
 		return
 	}
 	// Otherwise if the block is indeed in our own chain, announce it
 	if h.chain.HasBlock(hash, block.NumberU64()) {
 		for _, peer := range peers {
+			log.Debug("Announced block to peer", "hash", hash, "peer", peer.ID(), "ProxyedValidatorFlag", peer.ProxyedValidatorFlag.Load(), "EVNPeerFlag", peer.EVNPeerFlag.Load())
 			peer.AsyncSendNewBlockHash(block)
 		}
 		log.Trace("Announced block", "hash", hash, "recipients", len(peers), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -585,8 +585,11 @@ type PeerInfo struct {
 		Trusted       bool   `json:"trusted"`
 		Static        bool   `json:"static"`
 	} `json:"network"`
-	Protocols map[string]interface{} `json:"protocols"` // Sub-protocol specific metadata fields
-	Latency   int64                  `json:"latency"`   // the estimate latency from ping msg
+	Protocols            map[string]interface{} `json:"protocols"` // Sub-protocol specific metadata fields
+	Latency              int64                  `json:"latency"`   // the estimate latency from ping msg
+	EVNPeerFlag          bool                   `json:"evnPeerFlag"`
+	ProxyedValidatorFlag bool                   `json:"proxyedValidatorFlag"`
+	NoTxBroadcastFlag    bool                   `json:"noTxBroadcastFlag"`
 }
 
 // Info gathers and returns a collection of metadata known about a peer.
@@ -598,12 +601,15 @@ func (p *Peer) Info() *PeerInfo {
 	}
 	// Assemble the generic peer metadata
 	info := &PeerInfo{
-		Enode:     p.Node().URLv4(),
-		ID:        p.ID().String(),
-		Name:      p.Fullname(),
-		Caps:      caps,
-		Protocols: make(map[string]interface{}, len(p.running)),
-		Latency:   p.latency.Load(),
+		Enode:                p.Node().URLv4(),
+		ID:                   p.ID().String(),
+		Name:                 p.Fullname(),
+		Caps:                 caps,
+		Protocols:            make(map[string]interface{}, len(p.running)),
+		Latency:              p.latency.Load(),
+		EVNPeerFlag:          p.EVNPeerFlag.Load(),
+		ProxyedValidatorFlag: p.ProxyedValidatorFlag.Load(),
+		NoTxBroadcastFlag:    p.NoTxBroadcastFlag.Load(),
 	}
 	if p.Node().Seq() > 0 {
 		info.ENR = p.Node().String()


### PR DESCRIPTION
### Description

This PR adds more monitor metrics for EVN, it can be used for monitor the network improvement from EVM.

### Example

1. Monitor new block fetching feature:

```bash
# legacy block fetching cost time
eth_fetcher_block_legacy_cost{job=~"$jobs",quantile=~"$percentile"}
# new block fetching cost time
eth_fetcher_block_quick_cost{job=~"$jobs",quantile=~"$percentile"}
# new block fetching success rate
eth_fetcher_block_quick_success{job=~"$jobs"}/(eth_fetcher_block_quick_success{job=~"$jobs"}+eth_fetcher_block_quick_err{job=~"$jobs"})
# new block fetching fallback rate
eth_fetcher_block_quick_fallback{job=~"$jobs"}/(eth_fetcher_block_quick_success{job=~"$jobs"}+eth_fetcher_block_quick_err{job=~"$jobs"})
```

2. EVN Peer Monitor

```bash
# total peers
p2p_peers{job=~"$jobs"}
# even proxyed peers
evn_peer_proxed{job=~"$jobs"}
# even onchainValidator peers
evn_peer_ onchainValidator{job=~"$jobs"}
# even whiteList peers
evn_peer_ whiteList{job=~"$jobs"}
```

You can also query the peers RPC to get the detailed EVN feature flags for a peer.

```bash
./bsc attach --exec "admin.peers" ./geth.ipc
```

### Changes

Notable changes: 
* metrics: add evn peer monitor metrics;
* metrics: add block fetching timer, success rate;
* chore: opt some broadcast logs;
