### PR TITLE
chore: fix several occasional issues for EVN;

### DIFF
--- a/eth/protocols/bsc/dispatcher.go
+++ b/eth/protocols/bsc/dispatcher.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 )
 
@@ -52,6 +53,7 @@ func (d *Dispatcher) DispatchRequest(req *Request) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	log.Debug("send BlocksByRange request", "code", req.code, "requestId", req.requestID)
 	req.resCh = make(chan interface{}, 1)
 	req.cancelCh = make(chan string, 1)
 

--- a/eth/protocols/bsc/dispatcher.go
+++ b/eth/protocols/bsc/dispatcher.go
@@ -54,6 +54,7 @@ func (d *Dispatcher) DispatchRequest(req *Request) (interface{}, error) {
 	d.requests[req.requestID] = req
 	d.mu.Unlock()
 
+	log.Debug("send BlocksByRange request", "code", req.code, "requestId", req.requestID)
 	err := p2p.Send(d.peer.rw, req.code, req.data)
 	if err != nil {
 		return nil, err

--- a/eth/protocols/bsc/dispatcher.go
+++ b/eth/protocols/bsc/dispatcher.go
@@ -58,12 +58,14 @@ func (d *Dispatcher) DispatchRequest(req *Request) (interface{}, error) {
 	req.cancelCh = make(chan string, 1)
 
 	d.mu.Lock()
+	log.Debug("add the request", "requestId", req.requestID)
 	d.requests[req.requestID] = req
 	d.mu.Unlock()
 
 	// clean the requests when the request is done
 	defer func() {
 		d.mu.Lock()
+		log.Debug("clean the requests", "requestId", req.requestID)
 		delete(d.requests, req.requestID)
 		d.mu.Unlock()
 	}()
@@ -92,6 +94,7 @@ func (d *Dispatcher) getRequestByResp(res *Response) (*Request, error) {
 	if req.want != res.code {
 		return nil, fmt.Errorf("response mismatch: %d != %d", res.code, req.want)
 	}
+	log.Debug("get the request, then clean it", "requestId", req.requestID)
 	delete(d.requests, req.requestID)
 	return req, nil
 }

--- a/eth/protocols/bsc/handler.go
+++ b/eth/protocols/bsc/handler.go
@@ -174,7 +174,7 @@ func handleGetBlocksByRange(backend Backend, msg Decoder, peer *Peer) error {
 		blocks = append(blocks, NewBlockData(block))
 	}
 
-	log.Trace("reply GetBlocksByRange msg", "from", peer.id, "req", req.Count, "blocks", len(blocks))
+	log.Debug("reply GetBlocksByRange msg", "from", peer.id, "req", req.Count, "blocks", len(blocks))
 	return p2p.Send(peer.rw, BlocksByRangeMsg, &BlocksByRangePacket{
 		RequestId: req.RequestId,
 		Blocks:    blocks,
@@ -192,7 +192,7 @@ func handleBlocksByRange(backend Backend, msg Decoder, peer *Peer) error {
 		data:      res,
 		code:      BlocksByRangeMsg,
 	})
-	log.Debug("receive BlocksByRange response", "from", peer.id, "blocks", len(res.Blocks), "err", err)
+	log.Debug("receive BlocksByRange response", "from", peer.id, "requestId", res.RequestId, "blocks", len(res.Blocks), "err", err)
 	return nil
 }
 

--- a/eth/protocols/bsc/peer.go
+++ b/eth/protocols/bsc/peer.go
@@ -201,6 +201,7 @@ func (p *Peer) RequestBlocksByRange(startHeight uint64, startHash common.Hash, c
 		},
 		timeout: 400 * time.Millisecond,
 	})
+	log.Debug("RequestBlocksByRange result", "requestID", requestID, "ret", res == nil, "err", err)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

This PR will fix several occasional issues for EVN.

1. Failed to call getValidators

It reports this error log occasionally, which is caused by unstale chain state, here will use default `rpc.LatestBlockNumber`.

```bash
t=05-15|02:08:49.023 lvl=error msg="Failed to call getValidators" error="header not found"
t=05-15|02:08:49.023 lvl=error msg="Failed to get validators" error="failed to call getValidators: header not found"
```

2. New Block fetching request timeout
3. 
It reports this error log occasionally, which is caused by sending first.

```bash
t=05-15|06:21:04.069 lvl=debug msg="Quick block fetching" peer=56cee43c4bd981efba088f3b6360e0621e8f68c0ac0b4ae4fdeb2e78e8d2d523 hash=0x8720c104038d9798844732d7bf0d69134a27880ccbca0f018362b012736949c9
t=05-15|06:21:04.074 lvl=debug msg="receive BlocksByRange response" from=56cee43c4bd981efba088f3b6360e0621e8f68c0ac0b4ae4fdeb2e78e8d2d523 requestId=15565053124800979956 blocks=1 err="missing the request"
t=05-15|06:21:04.475 lvl=debug msg="Quick block fetching err" hash=0x8720c104038d9798844732d7bf0d69134a27880ccbca0f018362b012736949c9 err="request timeout"
```

### Changes

Notable changes: 
* chore: fix rpc call issue in parlia;
* p2p: fix a missed request issue;
