### PR TITLE
release: prepare for release v1.5.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,43 @@
 # Changelog
+## v1.5.13
+### FEATURE
+[\#3019](https://github.com/bnb-chain/bsc/pull/3019) BEP-524: Short Block Interval Phase Two: 0.75 seconds
+[\#3044](https://github.com/bnb-chain/bsc/pull/3044) params: double FullImmutabilityThreshold for BEP-520 & BEP-524
+[\#3045](https://github.com/bnb-chain/bsc/pull/3045) Feature: StakeHub Contract Interface Implementation
+[\#3040](https://github.com/bnb-chain/bsc/pull/3040) bsc: add new block fetching mechanism
+[\#3043](https://github.com/bnb-chain/bsc/pull/3043) p2p: support new msg broadcast features
+[\#3070](https://github.com/bnb-chain/bsc/pull/3070) chore: renaming for evn and some optmization
+[\#3073](https://github.com/bnb-chain/bsc/pull/3073) evn: add support for node id removal
+[\#3072](https://github.com/bnb-chain/bsc/pull/3072) config: support more evn configuration in tool
+[\#3075](https://github.com/bnb-chain/bsc/pull/3075) config: apply two default miner option
+[\#3083](https://github.com/bnb-chain/bsc/pull/3083) evn: improve node ID management with better error handling
+[\#3084](https://github.com/bnb-chain/bsc/pull/3084) metrics: add more monitor metrics for EVN
+[\#3087](https://github.com/bnb-chain/bsc/pull/3087) bsc2: fix block sidecar fetching issue
+[\#3090](https://github.com/bnb-chain/bsc/pull/3090) chore: update maxwell contrats addresses
+[\#3091](https://github.com/bnb-chain/bsc/pull/3091) chore: fix several occasional issues for EVN
+[\#3049](https://github.com/bnb-chain/bsc/pull/3049) upstream: pick bugfix and feature from latest geth v1.5.9
+[\#3096](https://github.com/bnb-chain/bsc/pull/3096) config: update BSC Testnet hardfork time: Maxwell
+
+### BUGFIX
+[\#3050](https://github.com/bnb-chain/bsc/pull/3050) miner: fix memory leak caused by no discard env
+[\#3061](https://github.com/bnb-chain/bsc/pull/3061) p2p: fix bscExt checking logic
+
+### IMPROVEMENT
+[\#3034](https://github.com/bnb-chain/bsc/pull/3034) miner: optimize clear up logic for envs
+[\#3039](https://github.com/bnb-chain/bsc/pull/3039) Revert "miner: limit block size to eth protocol msg size (#2696)"
+[\#3041](https://github.com/bnb-chain/bsc/pull/3041) feat: add json-rpc-api.md
+[\#3057](https://github.com/bnb-chain/bsc/pull/3057) eth/protocols/bsc: adjust vote reception limit
+[\#3067](https://github.com/bnb-chain/bsc/pull/3067) ethclient/gethclient: add deduplication and max keys limit to GetProof
+[\#3063](https://github.com/bnb-chain/bsc/pull/3063) rpc: add method name length limit and configurable message size limit
+[\#3077](https://github.com/bnb-chain/bsc/pull/3077) performance: track large tx execution cost
+[\#3074](https://github.com/bnb-chain/bsc/pull/3074) jsutils: add tool GetLargeTxs
+[\#3082](https://github.com/bnb-chain/bsc/pull/3082) metrics: optimize mev metrics
+[\#3081](https://github.com/bnb-chain/bsc/pull/3081) miner: reset recommit timer on new block
+[\#3062](https://github.com/bnb-chain/bsc/pull/3062) refactor: use slices.Contains to simplify code
+[\#3088](https://github.com/bnb-chain/bsc/pull/3088) core/vote: change waiting blocks for voting since start mining
+[\#3089](https://github.com/bnb-chain/bsc/pull/3089) core/systemcontracts: remove lorentz/rialto
+[\#3085](https://github.com/bnb-chain/bsc/pull/0000) miner: fix goroutine leak
+
 ## v1.5.12
 ### BUGFIX
 [\#3057](https://github.com/bnb-chain/bsc/pull/3057) eth/protocols/bsc: adjust vote reception limit

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1  // Major version component of the current release
 	Minor = 5  // Minor version component of the current release
-	Patch = 12 // Patch version component of the current release
+	Patch = 13 // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
## Description
v1.5.13 is for BSC Testnet [Maxwell hard fork](https://forum.bnbchain.org/t/bnb-chain-upgrades-testnet/934#p-1416-h-3-maxwell-wip-4), which is expected to be enabled at: `2025-05-26 07:05:00 AM UTC`, all BSC Testnet nodes need to be upgraded to v1.5.13 before the hard fork time. For this upgrade, simply binary replacement should be enough.


Maxwell includes 3 BEPs, mainly to reduce block interval from 1.5 seconds to 0.75 seconds:
- [BEP-524: shorter block interval phase two: 0.75 seconds](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-524.md)
- [ BEP-563: add Enhanced Validator Network proposal](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-563.md)
- [BEP-564: add New Block Fetching Messages proposal](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-564.md)

Besides the 0.75 seconds block interval update, there are several other key parameters will be updated:
- Epoch: will increase from 500 to 1000
- GasLimit: will decrease from 70M to 35M, so the overall throughput will stay unchanged
- Other Parameters: pls refer [BEP-524: Parameter Changes](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-524.md#41-parameter-changes)

Beside hard fork changes, there are several other items:
-  [upstream code sync]((https://github.com/bnb-chain/bsc/pull/3049)) mainly for Pectra related bugfix and improvements
- several non-critical bug-fix and improvements

For details, pls refer the change log.

## ChangeLog
### FEATURE
[\#3019](https://github.com/bnb-chain/bsc/pull/3019) BEP-524: Short Block Interval Phase Two: 0.75 seconds
[\#3044](https://github.com/bnb-chain/bsc/pull/3044) params: double FullImmutabilityThreshold for BEP-520 & BEP-524
[\#3045](https://github.com/bnb-chain/bsc/pull/3045) Feature: StakeHub Contract Interface Implementation
[\#3040](https://github.com/bnb-chain/bsc/pull/3040) bsc: add new block fetching mechanism
[\#3043](https://github.com/bnb-chain/bsc/pull/3043) p2p: support new msg broadcast features
[\#3070](https://github.com/bnb-chain/bsc/pull/3070) chore: renaming for evn and some optmization
[\#3073](https://github.com/bnb-chain/bsc/pull/3073) evn: add support for node id removal
[\#3072](https://github.com/bnb-chain/bsc/pull/3072) config: support more evn configuration in tool
[\#3075](https://github.com/bnb-chain/bsc/pull/3075) config: apply two default miner option
[\#3083](https://github.com/bnb-chain/bsc/pull/3083) evn: improve node ID management with better error handling
[\#3084](https://github.com/bnb-chain/bsc/pull/3084) metrics: add more monitor metrics for EVN
[\#3087](https://github.com/bnb-chain/bsc/pull/3087) bsc2: fix block sidecar fetching issue
[\#3090](https://github.com/bnb-chain/bsc/pull/3090) chore: update maxwell contrats addresses
[\#3091](https://github.com/bnb-chain/bsc/pull/3091) chore: fix several occasional issues for EVN
[\#3049](https://github.com/bnb-chain/bsc/pull/3049) upstream: pick bugfix and feature from latest geth v1.5.9
[\#3096](https://github.com/bnb-chain/bsc/pull/3096) config: update BSC Testnet hardfork time: Maxwell

### BUGFIX
[\#3050](https://github.com/bnb-chain/bsc/pull/3050) miner: fix memory leak caused by no discard env
[\#3061](https://github.com/bnb-chain/bsc/pull/3061) p2p: fix bscExt checking logic
[\#3085](https://github.com/bnb-chain/bsc/pull/0000) miner: fix goroutine leak

### IMPROVEMENT
[\#3034](https://github.com/bnb-chain/bsc/pull/3034) miner: optimize clear up logic for envs
[\#3039](https://github.com/bnb-chain/bsc/pull/3039) Revert "miner: limit block size to eth protocol msg size (#2696)"
[\#3041](https://github.com/bnb-chain/bsc/pull/3041) feat: add json-rpc-api.md
[\#3057](https://github.com/bnb-chain/bsc/pull/3057) eth/protocols/bsc: adjust vote reception limit
[\#3067](https://github.com/bnb-chain/bsc/pull/3067) ethclient/gethclient: add deduplication and max keys limit to GetProof
[\#3063](https://github.com/bnb-chain/bsc/pull/3063) rpc: add method name length limit and configurable message size limit
[\#3077](https://github.com/bnb-chain/bsc/pull/3077) performance: track large tx execution cost
[\#3074](https://github.com/bnb-chain/bsc/pull/3074) jsutils: add tool GetLargeTxs
[\#3082](https://github.com/bnb-chain/bsc/pull/3082) metrics: optimize mev metrics
[\#3081](https://github.com/bnb-chain/bsc/pull/3081) miner: reset recommit timer on new block
[\#3062](https://github.com/bnb-chain/bsc/pull/3062) refactor: use slices.Contains to simplify code
[\#3088](https://github.com/bnb-chain/bsc/pull/3088) core/vote: change waiting blocks for voting since start mining
[\#3089](https://github.com/bnb-chain/bsc/pull/3089) core/systemcontracts: remove lorentz/rialto
