### PR TITLE
config: update BSC Testnet hardfork time: Maxwell

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -236,7 +236,7 @@ var (
 		PascalTime:          newUint64(1740452880), // 2025-02-25 03:08:00 AM UTC
 		PragueTime:          newUint64(1740452880), // 2025-02-25 03:08:00 AM UTC
 		LorentzTime:         newUint64(1744097580), // 2025-04-08 07:33:00 AM UTC
-		MaxwellTime:         nil,
+		MaxwellTime:         newUint64(1748243100), // 2025-05-26 07:05:00 AM UTC
 
 		Parlia: &ParliaConfig{},
 		BlobScheduleConfig: &BlobScheduleConfig{


### PR DESCRIPTION
### Description
Maxwell hard fork will include 3 BEPs, mainly to reduce block interval to 0.75 seconds:
- [BEP-524: shorter block interval phase two: 0.75 seconds](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-524.md)
- [ BEP-563: add Enhanced Validator Network proposal](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-563.md)
- [BEP-564: add New Block Fetching Messages proposal](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-564.md)

The  expected Testnet Maxwell hard fork time: 2025-05-26 07:05:00 AM UTC

### Rationale
NA

### Example
NA

### Changes
NA