### PR TITLE
core: allow to close bloomProcessors more than once safely

### DIFF
--- a/core/receipt_processor.go
+++ b/core/receipt_processor.go
@@ -60,7 +60,9 @@ func (p *AsyncReceiptBloomGenerator) Apply(receipt *types.Receipt) {
 }
 
 func (p *AsyncReceiptBloomGenerator) Close() {
-	close(p.receipts)
-	p.isClosed = true
-	p.wg.Wait()
+	if !p.isClosed { // allow to close more than once
+		close(p.receipts)
+		p.isClosed = true
+		p.wg.Wait()
+	}
 }


### PR DESCRIPTION
### Description

core: allow to close bloomProcessors more than once safely

### Rationale


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
