### PR TITLE
metric: fix too large block handle delay metrics;

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -935,9 +935,9 @@ func (s *Ethereum) reportRecentBlocksLoop() {
 	}
 }
 
-func validTimeMetric(start, end int64) bool {
-	if start >= end {
+func validTimeMetric(startMs, endMs int64) bool {
+	if startMs >= endMs {
 		return false
 	}
-	return end-start <= MaxBlockHandleDelayMs
+	return endMs-startMs <= MaxBlockHandleDelayMs
 }


### PR DESCRIPTION
### Description

This PR will fix too large block handle delay metrics.

Current, the mining block time is too large, because of the most time of it is 0, so this metrics is so confusing.

This PR also optimizes other block handle delay times to avoid a large number when restarting.

### Example

Bad Metrics:

<img width="1236" alt="image" src="https://github.com/user-attachments/assets/ca45f770-c0c9-44c2-bfb5-191a40dba7fc" />

Optimized Metrics:

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/294e51d1-9f89-4f85-908d-6775f767c901" />


### Changes

Notable changes: 
* metric: fix too large block handle delay metrics;
* ...
