### PR TITLE
parlia.go: adjust timeForMining to 4/5 second

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1668,7 +1668,7 @@ func (p *Parlia) Delay(chain consensus.ChainReader, header *types.Header, leftOv
 	// The blocking time should be no more than half of period when snap.TurnLength == 1
 	timeForMining := time.Duration(snap.BlockInterval) * time.Millisecond / 2
 	if !snap.lastBlockInOneTurn(header.Number.Uint64()) {
-		timeForMining = time.Duration(snap.BlockInterval) * time.Millisecond * 2 / 3
+		timeForMining = time.Duration(snap.BlockInterval) * time.Millisecond * 4 / 5
 	}
 	if delay > timeForMining {
 		delay = timeForMining


### PR DESCRIPTION
### Description

adjust timeForMining from 2/3 to 4/5, 1/5 is enough for block finalize

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* parlia.go: adjust timeForMining
