### PR TITLE
p2p: fix bsc dispatcher request initial issue;

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -535,7 +535,8 @@ func initNetwork(ctx *cli.Context) error {
 	if ctx.Int(utils.InitFullNodeSize.Name) > 0 {
 		var extraEnodes []*enode.Node
 		if enableSentryNode {
-			extraEnodes = sentryEnodes
+			extraEnodes = append(extraEnodes, enodes...)
+			extraEnodes = append(extraEnodes, sentryEnodes...)
 		} else {
 			extraEnodes = enodes
 		}

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -506,10 +506,7 @@ func initNetwork(ctx *cli.Context) error {
 	}
 	if enableSentryNode && ctx.Bool(utils.InitEVNSentryWhitelist.Name) {
 		for i := 0; i < len(sentryConfigs); i++ {
-			// whitelist all sentry nodes + proxyed validator NodeID
-			wlNodeIDs := []enode.ID{nodeIDs[i]}
-			wlNodeIDs = append(wlNodeIDs, sentryNodeIDs...)
-			sentryConfigs[i].Node.P2P.EVNNodeIdsWhitelist = wlNodeIDs
+			sentryConfigs[i].Node.P2P.EVNNodeIdsWhitelist = sentryNodeIDs
 		}
 	}
 	if enableSentryNode && ctx.Bool(utils.InitEVNSentryRegister.Name) {
@@ -535,8 +532,7 @@ func initNetwork(ctx *cli.Context) error {
 	if ctx.Int(utils.InitFullNodeSize.Name) > 0 {
 		var extraEnodes []*enode.Node
 		if enableSentryNode {
-			extraEnodes = append(extraEnodes, enodes...)
-			extraEnodes = append(extraEnodes, sentryEnodes...)
+			extraEnodes = sentryEnodes
 		} else {
 			extraEnodes = enodes
 		}

--- a/eth/protocols/bsc/dispatcher.go
+++ b/eth/protocols/bsc/dispatcher.go
@@ -50,6 +50,8 @@ func (d *Dispatcher) GenRequestID() uint64 {
 // DispatchRequest send the request, and block until the later response
 func (d *Dispatcher) DispatchRequest(req *Request) (interface{}, error) {
 	// record the request before sending
+	req.resCh = make(chan interface{}, 1)
+	req.cancelCh = make(chan string, 1)
 	d.mu.Lock()
 	d.requests[req.requestID] = req
 	d.mu.Unlock()
@@ -59,8 +61,6 @@ func (d *Dispatcher) DispatchRequest(req *Request) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.resCh = make(chan interface{}, 1)
-	req.cancelCh = make(chan string, 1)
 
 	// clean the requests when the request is done
 	defer func() {


### PR DESCRIPTION
### Description

This PR fixes bsc dispatcher request initial issue. This will cause the read of the underlying connection to be blocked, indirectly causing a protocol timeout or EOF error.

The code will block here.

<img width="1676" alt="image" src="https://github.com/user-attachments/assets/e7e0534c-74e4-4acd-9470-55a53916855c" />

### Rationale

Especially in the intranet environment, the latency is very low and the messages are sent very fast. At this time, the parallel timing is random, and the use of uninitialized chan may cause blocking problems.

### Changes

Notable changes: 
* tool: fix fullnode forward tx issue;
* p2p: fix bsc dispatcher request initial issue;
