### PR TITLE
feat: add storagechange object pool for better performance

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -167,7 +167,7 @@ func (j *journal) copy() *journal {
 		dirties:        maps.Clone(j.dirties),
 		validRevisions: slices.Clone(j.validRevisions),
 		nextRevisionId: j.nextRevisionId,
-		storageEntries: slices.Clone(j.storageEntries),
+		storageEntries: make([]*storageChange, 0, defaultNumOfSlots),
 	}
 }
 


### PR DESCRIPTION
## Description
This PR introduces an object pool for `storageChange` entries in the state journal to improve memory allocation performance. The changes include:

1. Added a `sync.Pool` for `storageChange` objects to reduce GC pressure
2. Modified `storageChange` methods to work with pointers instead of values
3. Optimized memory allocations in journal operations

## Changes
- Introduced `storageChangePool` using `sync.Pool` for efficient object reuse
- Changed `storageChange` methods to use pointer receivers
- Optimized `journal.copy()` to pre-allocate slices with exact capacity
- Improved memory management in `storageChange` operations

## Performance Impact
The changes reduce memory allocations by:
- Reusing `storageChange` objects instead of creating new ones
- Reducing GC pressure through object pooling

## Benchmark
Old profile (note % not total GB as I was running it for different blocks)
<img width="1725" alt="Screenshot 2025-05-19 at 14 12 51" src="https://github.com/user-attachments/assets/536e9db7-3dee-4d20-8900-0b27d4b20839" />
New Profile after the change 
<img width="1725" alt="Screenshot 2025-05-19 at 13 39 48" src="https://github.com/user-attachments/assets/6ff81841-2e02-455d-a7ce-a132cf102654" />
