### PR TITLE
freezer: implement tail method in prunedfreezer;

### DIFF
--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -161,7 +161,7 @@ func (f *prunedfreezer) AncientDatadir() (string, error) {
 
 // Tail returns the number of first stored item in the freezer.
 func (f *prunedfreezer) Tail() (uint64, error) {
-	return 0, errNotSupported
+	return atomic.LoadUint64(&f.frozen), nil
 }
 
 // AncientSize returns the ancient size of the specified category, return 0.


### PR DESCRIPTION
### Description

This PR tries to fix a sync issue that occurs in v1.5.13, and it only occurs when node enable pruned ancient feature.

In v1.5.13, the `FullImmutabilityThreshold` value rises to 360000, but the previous geth data only keeps 90000 in the kvdb.

When the node upgrade to v1.5.13 and behind too far, it need sync blocks from remote peer. But the below code will try to find ancestor from head-36000.
```go
// Recap floor value for binary search
maxForkAncestry := FullMaxForkAncestry
if localHeight >= maxForkAncestry {
// We're above the max reorg threshold, find the earliest fork point
floor = int64(localHeight - maxForkAncestry)
}
// if we have pruned too much history, reset the floor
if tail, err := d.blockchain.AncientTail(); err == nil && tail > uint64(floor) {
floor = int64(tail)
}
```

If the node enables the pruned ancient feature, it prints the below err log.

```bash
t=2025-05-27T02:14:03+0000 lvl=warn msg="Synchronisation failed, retrying" peer=ca758ceb7046ef2e203c20404e7b39ad1ae418ac6a91445a881308c7427dd539 err="peer is unknown or unhealthy"
t=2025-05-27T02:14:07+0000 lvl=warn msg="Ancestor below allowance" peer=4ee5da04 number=49627603 hash=0x0000000000000000000000000000000000000000000000000000000000000000 allowance=49627603
t=2025-05-27T02:14:07+0000 lvl=warn msg="Synchronisation failed, dropping peer" peer=4ee5da046a2380b9ff3593e4418aed90b30dda001529ef66f0e48519c30f7ea0 name=Geth/v1.5.12-d60167c... td=100177262 err="retrieved ancestor is invalid"
t=2025-05-27T02:14:10+0000 lvl=warn msg="Ancestor below allowance" peer=9f446716 number=49627603 hash=0x0000000000000000000000000000000000000000000000000000000000000000 allowance=49627603
t=2025-05-27T02:14:10+0000 lvl=warn msg="Synchronisation failed, dropping peer" peer=9f446716136034f77f0c6f08af0a40423593f7c85b63e5867ae332d3ab45375c name=Geth/v1.5.12-d60167c... td=100177278 err="retrieved ancestor is invalid"
```

### Rationale

This PR implements the pruned freezer `Tail` method. It will reset the floor value for finding the ancestor correctly.

### Changes

Notable changes: 
* freezer: implement tail method in prunedfreezer;
* ...
