### PR TITLE
draft release v1.5.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
 # Changelog
+## v1.5.14
+### FEATURE
+[\#3130](https://github.com/bnb-chain/bsc/pull/3130) config: update BSC Mainnet hardfork time: Maxwell
+
+### BUGFIX
+[\#3117](https://github.com/bnb-chain/bsc/pull/3117) core, ethdb: introduce database sync function (#31703)
+[\#3122](https://github.com/bnb-chain/bsc/pull/3122) freezer: implement tail method in prunedfreezer
+[\#3121](https://github.com/bnb-chain/bsc/pull/3121) miner: discard outdated bids before simulation
+
+### IMPROVEMENT
+[\#3105](https://github.com/bnb-chain/bsc/pull/3105) parlia.go: adjust timeForMining to 4/5 second
+[\#3112](https://github.com/bnb-chain/bsc/pull/3112) feat: add storagechange object pool for better performance
+[\#3110](https://github.com/bnb-chain/bsc/pull/3110) refactor: use the built-in max/min to simplify the code
+[\#3120](https://github.com/bnb-chain/bsc/pull/3120) tx_pool: remove one non-necessary allocation
+[\#3123](https://github.com/bnb-chain/bsc/pull/3123) refactor: use maps.copy for cleaner map handling
+[\#3126](https://github.com/bnb-chain/bsc/pull/3126) jsutils: update getKeyParameters
+
 ## v1.5.13
 ### FEATURE
 [\#3019](https://github.com/bnb-chain/bsc/pull/3019) BEP-524: Short Block Interval Phase Two: 0.75 seconds

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -506,10 +506,7 @@ func initNetwork(ctx *cli.Context) error {
 	}
 	if enableSentryNode && ctx.Bool(utils.InitEVNSentryWhitelist.Name) {
 		for i := 0; i < len(sentryConfigs); i++ {
-			// whitelist all sentry nodes + proxyed validator NodeID
-			wlNodeIDs := []enode.ID{nodeIDs[i]}
-			wlNodeIDs = append(wlNodeIDs, sentryNodeIDs...)
-			sentryConfigs[i].Node.P2P.EVNNodeIdsWhitelist = wlNodeIDs
+			sentryConfigs[i].Node.P2P.EVNNodeIdsWhitelist = sentryNodeIDs
 		}
 	}
 	if enableSentryNode && ctx.Bool(utils.InitEVNSentryRegister.Name) {

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -1282,7 +1282,7 @@ func hbss2pbss(ctx *cli.Context) error {
 	defer stack.Close()
 
 	db := utils.MakeChainDatabase(ctx, stack, false, false)
-	db.BlockStore().Sync()
+	db.BlockStore().SyncAncient()
 	stateDiskDb := db.StateStore()
 	defer db.Close()
 

--- a/cmd/jsutils/getchainstatus.js
+++ b/cmd/jsutils/getchainstatus.js
@@ -29,6 +29,8 @@ function printUsage() {
     console.log("  GetLargeTxs: get large txs of a block range");
     console.log("\nOptions:");
     console.log("  --rpc       specify the url of RPC endpoint");
+    console.log("              mainnet: https://bsc-mainnet.nodereal.io/v1/454e504917db4f82b756bd0cf6317dce");
+    console.log("              testnet: https://bsc-testnet-dataseed.bnbchain.org");
     console.log("  --startNum  the start block number");
     console.log("  --endNum    the end block number");
     console.log("  --miner     the miner address");
@@ -36,9 +38,8 @@ function printUsage() {
     console.log("  --topNum    the topNum of blocks to be checked");
     console.log("  --blockNum  the block number to be checked");
     console.log("\nExample:");
-    // mainnet https://bsc-mainnet.nodereal.io/v1/454e504917db4f82b756bd0cf6317dce
     console.log("  node getchainstatus.js GetMaxTxCountInBlockRange --rpc https://bsc-testnet-dataseed.bnbchain.org --startNum 40000001  --endNum 40000005");
-    console.log("  node getchainstatus.js GetBinaryVersion --rpc https://bsc-testnet-dataseed.bnbchain.org --num 21 --turnLength 4");
+    console.log("  node getchainstatus.js GetBinaryVersion --rpc https://bsc-testnet-dataseed.bnbchain.org --num 21 --turnLength 8");
     console.log("  node getchainstatus.js GetTopAddr --rpc https://bsc-testnet-dataseed.bnbchain.org --startNum 40000001  --endNum 40000010 --topNum 10");
     console.log("  node getchainstatus.js GetSlashCount --rpc https://bsc-testnet-dataseed.bnbchain.org --blockNum 40000001"); // default: latest block
     console.log("  node getchainstatus.js GetPerformanceData --rpc https://bsc-testnet-dataseed.bnbchain.org --startNum 40000001  --endNum 40000010");
@@ -59,6 +60,7 @@ const addrValidatorSet = "0x0000000000000000000000000000000000001000";
 const addrSlash = "0x0000000000000000000000000000000000001001";
 const addrStakeHub = "0x0000000000000000000000000000000000002002";
 const addrGovernor = "0x0000000000000000000000000000000000002004";
+const TimelockContract = "0x0000000000000000000000000000000000002006";
 
 const validatorSetAbi = [
     "function validatorExtraSet(uint256 offset) external view returns (uint256, bool, bytes)",
@@ -92,17 +94,25 @@ const stakeHubAbi = [
     "function felonySlashAmount() public view returns (uint256)", // default 200BNB, valid: > max(100, downtimeSlashAmount)
     "function downtimeJailTime() public view returns (uint256)", // default 2days,
     "function felonyJailTime() public view returns (uint256)", // default 30days,
-];
+    "function getValidators(uint256, uint256) external view returns(address[], address[], uint256)",
+    "function getNodeIDs(address[] validatorsToQuery) external view returns(address[], bytes32[][])",
+    ];
+
 
 const governorAbi = [
     "function votingPeriod() public view returns (uint256)",
     "function lateQuorumVoteExtension() public view returns (uint64)", // it represents minPeriodAfterQuorum
 ];
 
+const timelockAbi = [
+    "function getMinDelay() public view returns (uint256)",
+];
+
 const validatorSet = new ethers.Contract(addrValidatorSet, validatorSetAbi, provider);
 const slashIndicator = new ethers.Contract(addrSlash, slashAbi, provider);
 const stakeHub = new ethers.Contract(addrStakeHub, stakeHubAbi, provider);
 const governor = new ethers.Contract(addrGovernor, governorAbi, provider);
+const timelock = new ethers.Contract(TimelockContract, timelockAbi, provider);
 
 const validatorMap = new Map([
     // BSC mainnet
@@ -279,7 +289,7 @@ async function getMaxTxCountInBlockRange() {
 // node getchainstatus.js GetBinaryVersion \
 //      --rpc https://bsc-testnet-dataseed.bnbchain.org \
 //       --num(optional): default 21, the number of blocks that will be checked
-//       --turnLength(optional): default 4, the consecutive block length
+//       --turnLength(optional): default 8, the consecutive block length
 async function getBinaryVersion() {
     const blockNum = await provider.getBlockNumber();
     let turnLength = program.turnLength;
@@ -408,7 +418,7 @@ async function getPerformanceData() {
     let gasUsedTotal = 0;
     let inturnBlocks = 0;
     let justifiedBlocks = 0;
-    let turnLength = 4;
+    let turnLength = 8;
     let lastTimestamp = null; 
     let parliaEnabled = true;
     
@@ -621,7 +631,7 @@ async function getKeyParameters() {
     let validatorTable = [];
     for (let i = 0; i < totalLength; i++) {
         validatorTable.push({
-            addr: consensusAddrs[i],
+            consensusAddr: consensusAddrs[i],
             votingPower: Number(votingPowers[i] / BigInt(10 ** 18)),
             voteAddr: voteAddrs[i],
             moniker: await getValidatorMoniker(consensusAddrs[i], blockNum),
@@ -629,6 +639,20 @@ async function getKeyParameters() {
     }
     validatorTable.sort((a, b) => b.votingPower - a.votingPower);
     console.table(validatorTable);
+    // get EVN node ids
+    let validators = await stakeHub.getValidators(0, 1000, { blockTag: blockNum });
+    let operatorAddrs = validators[0];
+    let nodeIdss = await stakeHub.getNodeIDs(Array.from(operatorAddrs), { blockTag: blockNum });
+    let consensusAddrs2 = nodeIdss[0];
+    let nodeIdArr = nodeIdss[1];
+    for (let i = 0; i < consensusAddrs2.length; i++) {
+        let addr = consensusAddrs2[i];
+        let nodeId = nodeIdArr[i];
+        if (nodeId.length > 0) {
+            console.log("consensusAddr:", addr, "nodeId:", nodeId);
+        }
+    }
+
 
     // part 4: governance
     let votingPeriod = await governor.votingPeriod({ blockTag: blockNum });
@@ -636,6 +660,11 @@ async function getKeyParameters() {
     console.log("\n##==== GovernorContract: 0x0000000000000000000000000000000000002004")
     console.log("\tvotingPeriod", Number(votingPeriod));
     console.log("\tminPeriodAfterQuorum", Number(minPeriodAfterQuorum));
+
+    // part 5: timelock
+    let minDelay = await timelock.getMinDelay({ blockTag: blockNum });
+    console.log("\n##==== TimelockContract: 0x0000000000000000000000000000000000002006")
+    console.log("\tminDelay", Number(minDelay));
 }
 
 // 9.cmd: "getEip7623", usage:

--- a/common/fdlimit/fdlimit_darwin.go
+++ b/common/fdlimit/fdlimit_darwin.go
@@ -24,17 +24,14 @@ const hardlimit = 10240
 // Raise tries to maximize the file descriptor allowance of this process
 // to the maximum hard-limit allowed by the OS.
 // Returns the size it was set to (may differ from the desired 'max')
-func Raise(max uint64) (uint64, error) {
+func Raise(maxVal uint64) (uint64, error) {
 	// Get the current limit
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
 	}
 	// Try to update the limit to the max allowance
-	limit.Cur = limit.Max
-	if limit.Cur > max {
-		limit.Cur = max
-	}
+	limit.Cur = min(limit.Max, maxVal)
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
 	}

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1668,7 +1668,7 @@ func (p *Parlia) Delay(chain consensus.ChainReader, header *types.Header, leftOv
 	// The blocking time should be no more than half of period when snap.TurnLength == 1
 	timeForMining := time.Duration(snap.BlockInterval) * time.Millisecond / 2
 	if !snap.lastBlockInOneTurn(header.Number.Uint64()) {
-		timeForMining = time.Duration(snap.BlockInterval) * time.Millisecond * 2 / 3
+		timeForMining = time.Duration(snap.BlockInterval) * time.Millisecond * 4 / 5
 	}
 	if delay > timeForMining {
 		delay = timeForMining

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -183,7 +183,7 @@ func benchInsertChain(b *testing.B, disk bool, gen func(int, *BlockGen)) {
 	if !disk {
 		db = rawdb.NewMemoryDatabase()
 	} else {
-		pdb, err := pebble.New(b.TempDir(), 128, 128, "", false, true)
+		pdb, err := pebble.New(b.TempDir(), 128, 128, "", false)
 		if err != nil {
 			b.Fatalf("cannot create temporary database: %v", err)
 		}
@@ -304,7 +304,7 @@ func makeChainForBench(db ethdb.Database, genesis *Genesis, full bool, count uin
 func benchWriteChain(b *testing.B, full bool, count uint64) {
 	genesis := &Genesis{Config: params.AllEthashProtocolChanges}
 	for i := 0; i < b.N; i++ {
-		pdb, err := pebble.New(b.TempDir(), 1024, 128, "", false, true)
+		pdb, err := pebble.New(b.TempDir(), 1024, 128, "", false)
 		if err != nil {
 			b.Fatalf("error opening database: %v", err)
 		}
@@ -317,7 +317,7 @@ func benchWriteChain(b *testing.B, full bool, count uint64) {
 func benchReadChain(b *testing.B, full bool, count uint64) {
 	dir := b.TempDir()
 
-	pdb, err := pebble.New(dir, 1024, 128, "", false, true)
+	pdb, err := pebble.New(dir, 1024, 128, "", false)
 	if err != nil {
 		b.Fatalf("error opening database: %v", err)
 	}
@@ -333,7 +333,7 @@ func benchReadChain(b *testing.B, full bool, count uint64) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		pdb, err = pebble.New(dir, 1024, 128, "", false, true)
+		pdb, err = pebble.New(dir, 1024, 128, "", false)
 		if err != nil {
 			b.Fatalf("error opening database: %v", err)
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1119,17 +1119,16 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 		// Ignore the error here since light client won't hit this path
 		frozen, _ := bc.db.BlockStore().Ancients()
 		if num+1 <= frozen {
-			// Truncate all relative data(header, total difficulty, body, receipt
-			// and canonical hash) from ancient store.
-			if _, err := bc.db.BlockStore().TruncateHead(num); err != nil {
-				log.Crit("Failed to truncate ancient data", "number", num, "err", err)
-			}
-			// Remove the hash <-> number mapping from the active store.
-			rawdb.DeleteHeaderNumber(db, hash)
+			// The chain segment, such as the block header, canonical hash,
+			// body, and receipt, will be removed from the ancient store
+			// in one go.
+			//
+			// The hash-to-number mapping in the key-value store will be
+			// removed by the hc.SetHead function.
 		} else {
-			// Remove relative body and receipts from the active store.
-			// The header, total difficulty and canonical hash will be
-			// removed in the hc.SetHead function.
+			// Remove the associated body and receipts from the key-value store.
+			// The header, hash-to-number mapping, and canonical hash will be
+			// removed by the hc.SetHead function.
 			rawdb.DeleteBody(db, hash, num)
 			rawdb.DeleteBlobSidecars(db, hash, num)
 			rawdb.DeleteReceipts(db, hash, num)
@@ -1599,7 +1598,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		size += writeSize
 
 		// Sync the ancient store explicitly to ensure all data has been flushed to disk.
-		if err := bc.db.BlockStore().Sync(); err != nil {
+		if err := bc.db.BlockStore().SyncAncient(); err != nil {
 			return 0, err
 		}
 		// Update the current snap block because all block data is now present in DB.

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -1767,7 +1767,7 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 	datadir := t.TempDir()
 	ancient := filepath.Join(datadir, "ancient")
 
-	pdb, err := pebble.New(datadir, 0, 0, "", false, true)
+	pdb, err := pebble.New(datadir, 0, 0, "", false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent key-value database: %v", err)
 	}
@@ -1861,7 +1861,7 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 	chain.stopWithoutSaving()
 
 	// Start a new blockchain back up and see where the repair leads us
-	pdb, err = pebble.New(datadir, 0, 0, "", false, true)
+	pdb, err = pebble.New(datadir, 0, 0, "", false)
 	if err != nil {
 		t.Fatalf("Failed to reopen persistent key-value database: %v", err)
 	}
@@ -1926,7 +1926,7 @@ func testIssue23496(t *testing.T, scheme string) {
 	datadir := t.TempDir()
 	ancient := filepath.Join(datadir, "ancient")
 
-	pdb, err := pebble.New(datadir, 0, 0, "", false, true)
+	pdb, err := pebble.New(datadir, 0, 0, "", false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent key-value database: %v", err)
 	}
@@ -1984,7 +1984,7 @@ func testIssue23496(t *testing.T, scheme string) {
 	chain.stopWithoutSaving()
 
 	// Start a new blockchain back up and see where the repair leads us
-	pdb, err = pebble.New(datadir, 0, 0, "", false, true)
+	pdb, err = pebble.New(datadir, 0, 0, "", false)
 	if err != nil {
 		t.Fatalf("Failed to reopen persistent key-value database: %v", err)
 	}

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -1971,7 +1971,7 @@ func testSetHeadWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme 
 	datadir := t.TempDir()
 	ancient := filepath.Join(datadir, "ancient")
 
-	pdb, err := pebble.New(datadir, 0, 0, "", false, true)
+	pdb, err := pebble.New(datadir, 0, 0, "", false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent key-value database: %v", err)
 	}

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -66,7 +66,7 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 	datadir := t.TempDir()
 	ancient := filepath.Join(datadir, "ancient")
 
-	pdb, err := pebble.New(datadir, 0, 0, "", false, true)
+	pdb, err := pebble.New(datadir, 0, 0, "", false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent key-value database: %v", err)
 	}
@@ -257,7 +257,7 @@ func (snaptest *crashSnapshotTest) test(t *testing.T) {
 	chain.triedb.Close()
 
 	// Start a new blockchain back up and see where the repair leads us
-	pdb, err := pebble.New(snaptest.datadir, 0, 0, "", false, true)
+	pdb, err := pebble.New(snaptest.datadir, 0, 0, "", false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent key-value database: %v", err)
 	}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -2670,7 +2670,7 @@ func testSideImportPrunedBlocks(t *testing.T, scheme string) {
 	datadir := t.TempDir()
 	ancient := path.Join(datadir, "ancient")
 
-	pdb, err := pebble.New(datadir, 0, 0, "", false, true)
+	pdb, err := pebble.New(datadir, 0, 0, "", false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent key-value database: %v", err)
 	}

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -695,18 +695,51 @@ func (hc *HeaderChain) setHead(headBlock uint64, headTime uint64, updateFn Updat
 				hashes = append(hashes, hdr.Hash())
 			}
 			for _, hash := range hashes {
+				// Remove the associated block body and receipts if required.
+				//
+				// If the block is in the chain freezer, then this delete operation
+				// is actually ineffective.
 				if delFn != nil {
 					delFn(blockBatch, hash, num)
 				}
+				// Remove the hash->number mapping along with the header itself
 				rawdb.DeleteHeader(blockBatch, hash, num)
 				rawdb.DeleteTd(blockBatch, hash, num)
 			}
+			// Remove the number->hash mapping
 			rawdb.DeleteCanonicalHash(blockBatch, num)
 		}
 	}
 	// Flush all accumulated deletions.
 	if err := blockBatch.Write(); err != nil {
-		log.Crit("Failed to rewind block", "error", err)
+		log.Crit("Failed to commit batch in setHead", "err", err)
+	}
+	// Explicitly flush the pending writes in the key-value store to disk, ensuring
+	// data durability of the previous deletions.
+	if err := hc.chainDb.SyncKeyValue(); err != nil {
+		log.Crit("Failed to sync the key-value store in setHead", "err", err)
+	}
+	// Truncate the excessive chain segments in the ancient store.
+	// These are actually deferred deletions from the loop above.
+	//
+	// This step must be performed after synchronizing the key-value store;
+	// otherwise, in the event of a panic, it's theoretically possible to
+	// lose recent key-value store writes while the ancient store deletions
+	// remain, leading to data inconsistency, e.g., the gap between the key
+	// value store and ancient can be created due to unclean shutdown.
+	if delFn != nil {
+		// Ignore the error here since light client won't hit this path
+		frozen, _ := hc.chainDb.Ancients()
+		header := hc.CurrentHeader()
+
+		// Truncate the excessive chain segment above the current chain head
+		// in the ancient store.
+		if header.Number.Uint64()+1 < frozen {
+			_, err := hc.chainDb.BlockStore().TruncateHead(header.Number.Uint64() + 1)
+			if err != nil {
+				log.Crit("Failed to truncate head block", "err", err)
+			}
+		}
 	}
 	// Clear out any stale content from the caches
 	hc.headerCache.Purge()

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -309,7 +309,7 @@ func (f *chainFreezer) freeze(db ethdb.KeyValueStore) {
 			continue
 		}
 		// Batch of blocks have been frozen, flush them before wiping from key-value store
-		if err := f.Sync(); err != nil {
+		if err := f.SyncAncient(); err != nil {
 			log.Crit("Failed to flush frozen tables", "err", err)
 		}
 		// Wipe out all data from the active database

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -235,8 +235,8 @@ func (db *nofreezedb) ResetTable(kind string, startAt uint64, onlyEmpty bool) er
 	return errNotSupported
 }
 
-// Sync returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) Sync() error {
+// SyncAncient returns an error as we don't have a backing chain freezer.
+func (db *nofreezedb) SyncAncient() error {
 	return errNotSupported
 }
 
@@ -391,8 +391,8 @@ func (db *emptyfreezedb) ResetTable(kind string, startAt uint64, onlyEmpty bool)
 	return nil
 }
 
-// Sync returns nil for pruned db that we don't have a backing chain freezer.
-func (db *emptyfreezedb) Sync() error {
+// SyncAncient returns nil for pruned db that we don't have a backing chain freezer.
+func (db *emptyfreezedb) SyncAncient() error {
 	return nil
 }
 

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -386,8 +386,8 @@ func (f *Freezer) TruncateTail(tail uint64) (uint64, error) {
 	return old, nil
 }
 
-// Sync flushes all data tables to disk.
-func (f *Freezer) Sync() error {
+// SyncAncient flushes all data tables to disk.
+func (f *Freezer) SyncAncient() error {
 	var errs []error
 	for _, table := range f.tables {
 		if err := table.Sync(); err != nil {
@@ -600,7 +600,7 @@ func (f *Freezer) ResetTable(kind string, startAt uint64, onlyEmpty bool) error 
 		return nil
 	}
 
-	if err := f.Sync(); err != nil {
+	if err := f.SyncAncient(); err != nil {
 		return err
 	}
 	nt, err := t.resetItems(startAt - f.offset)

--- a/core/rawdb/freezer_memory.go
+++ b/core/rawdb/freezer_memory.go
@@ -410,8 +410,8 @@ func (f *MemoryFreezer) TruncateTail(tail uint64) (uint64, error) {
 	return old, nil
 }
 
-// Sync flushes all data tables to disk.
-func (f *MemoryFreezer) Sync() error {
+// SyncAncient flushes all data tables to disk.
+func (f *MemoryFreezer) SyncAncient() error {
 	return nil
 }
 

--- a/core/rawdb/freezer_resettable.go
+++ b/core/rawdb/freezer_resettable.go
@@ -226,12 +226,12 @@ func (f *resettableFreezer) ResetTable(kind string, startAt uint64, onlyEmpty bo
 	return f.freezer.ResetTable(kind, startAt, onlyEmpty)
 }
 
-// Sync flushes all data tables to disk.
-func (f *resettableFreezer) Sync() error {
+// SyncAncient flushes all data tables to disk.
+func (f *resettableFreezer) SyncAncient() error {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 
-	return f.freezer.Sync()
+	return f.freezer.SyncAncient()
 }
 
 // AncientDatadir returns the path of the ancient store.

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -493,7 +493,7 @@ func TestFreezerCloseSync(t *testing.T) {
 	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.Sync(); err == nil {
+	if err := f.SyncAncient(); err == nil {
 		t.Fatalf("want error, have nil")
 	} else if have, want := err.Error(), "[closed closed]"; have != want {
 		t.Fatalf("want %v, have %v", have, want)

--- a/core/rawdb/prunedfreezer.go
+++ b/core/rawdb/prunedfreezer.go
@@ -161,7 +161,7 @@ func (f *prunedfreezer) AncientDatadir() (string, error) {
 
 // Tail returns the number of first stored item in the freezer.
 func (f *prunedfreezer) Tail() (uint64, error) {
-	return 0, errNotSupported
+	return atomic.LoadUint64(&f.frozen), nil
 }
 
 // AncientSize returns the ancient size of the specified category, return 0.

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -143,10 +143,10 @@ func (t *table) TruncateTail(items uint64) (uint64, error) {
 	return t.db.TruncateTail(items)
 }
 
-// Sync is a noop passthrough that just forwards the request to the underlying
+// SyncAncient is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) Sync() error {
-	return t.db.Sync()
+func (t *table) SyncAncient() error {
+	return t.db.SyncAncient()
 }
 
 // AncientDatadir returns the ancient datadir of the underlying database.
@@ -222,6 +222,12 @@ func (t *table) Compact(start []byte, limit []byte) error {
 	}
 	// Range correctly calculated based on table prefix, delegate down
 	return t.db.Compact(start, limit)
+}
+
+// SyncKeyValue ensures that all pending writes are flushed to disk,
+// guaranteeing data durability up to the point.
+func (t *table) SyncKeyValue() error {
+	return t.db.SyncKeyValue()
 }
 
 // NewBatch creates a write-only database that buffers changes to its host db

--- a/eth/protocols/bsc/dispatcher.go
+++ b/eth/protocols/bsc/dispatcher.go
@@ -50,6 +50,8 @@ func (d *Dispatcher) GenRequestID() uint64 {
 // DispatchRequest send the request, and block until the later response
 func (d *Dispatcher) DispatchRequest(req *Request) (interface{}, error) {
 	// record the request before sending
+	req.resCh = make(chan interface{}, 1)
+	req.cancelCh = make(chan string, 1)
 	d.mu.Lock()
 	d.requests[req.requestID] = req
 	d.mu.Unlock()
@@ -59,8 +61,6 @@ func (d *Dispatcher) DispatchRequest(req *Request) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.resCh = make(chan interface{}, 1)
-	req.cancelCh = make(chan string, 1)
 
 	// clean the requests when the request is done
 	defer func() {

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -326,6 +326,22 @@ func (db *Database) Path() string {
 	return db.fn
 }
 
+// SyncKeyValue flushes all pending writes in the write-ahead-log to disk,
+// ensuring data durability up to that point.
+func (db *Database) SyncKeyValue() error {
+	// In theory, the WAL (Write-Ahead Log) can be explicitly synchronized using
+	// a write operation with SYNC=true. However, there is no dedicated key reserved
+	// for this purpose, and even a nil key (key=nil) is considered a valid
+	// database entry.
+	//
+	// In LevelDB, writes are blocked until the data is written to the WAL, meaning
+	// recent writes won't be lost unless a power failure or system crash occurs.
+	// Additionally, LevelDB is no longer the default database engine and is likely
+	// only used by hash-mode archive nodes. Given this, the durability guarantees
+	// without explicit sync are acceptable in the context of LevelDB.
+	return nil
+}
+
 // meter periodically retrieves internal leveldb counters and reports them to
 // the metrics subsystem.
 func (db *Database) meter(refresh time.Duration, namespace string) {

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -277,6 +277,12 @@ func (db *Database) Compact(start []byte, limit []byte) error {
 	return nil
 }
 
+// SyncKeyValue ensures that all pending writes are flushed to disk,
+// guaranteeing data durability up to the point.
+func (db *Database) SyncKeyValue() error {
+	return nil
+}
+
 // Len returns the number of entries currently present in the memory database.
 //
 // Note, this method is only used for testing (i.e. not public in general) and

--- a/ethdb/pebble/pebble_test.go
+++ b/ethdb/pebble/pebble_test.go
@@ -17,6 +17,7 @@
 package pebble
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/cockroachdb/pebble"
@@ -53,4 +54,27 @@ func BenchmarkPebbleDB(b *testing.B) {
 			db: db,
 		}
 	})
+}
+
+func TestPebbleLogData(t *testing.T) {
+	db, err := pebble.Open("", &pebble.Options{
+		FS: vfs.NewMem(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = db.Get(nil)
+	if !errors.Is(err, pebble.ErrNotFound) {
+		t.Fatal("Unknown database entry")
+	}
+
+	b := db.NewBatch()
+	b.LogData(nil, nil)
+	db.Apply(b, pebble.Sync)
+
+	_, _, err = db.Get(nil)
+	if !errors.Is(err, pebble.ErrNotFound) {
+		t.Fatal("Unknown database entry")
+	}
 }

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -172,7 +172,7 @@ func (db *Database) ResetTable(kind string, startAt uint64, onlyEmpty bool) erro
 	panic("not supported")
 }
 
-func (db *Database) Sync() error {
+func (db *Database) SyncAncient() error {
 	return nil
 }
 
@@ -197,6 +197,10 @@ func (db *Database) AncientDatadir() (string, error) {
 }
 
 func (db *Database) Compact(start []byte, limit []byte) error {
+	return nil
+}
+
+func (db *Database) SyncKeyValue() error {
 	return nil
 }
 

--- a/metrics/label.go
+++ b/metrics/label.go
@@ -47,7 +47,5 @@ func (l *Label) Snapshot() *LabelSnapshot {
 func (l *Label) Mark(value map[string]interface{}) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	for k, v := range value {
-		l.value[k] = v
-	}
+	maps.Copy(l.value, value)
 }

--- a/node/database.go
+++ b/node/database.go
@@ -41,10 +41,6 @@ type openOptions struct {
 	IsLastOffset     bool
 	PruneAncientData bool
 	MultiDataBase    bool
-	// Ephemeral means that filesystem sync operations should be avoided:
-	// data integrity in the face of a crash is not important. This option
-	// should typically be used in tests.
-	Ephemeral bool
 }
 
 // openDatabase opens both a disk-based key-value database such as leveldb or pebble, but also
@@ -92,7 +88,7 @@ func openKeyValueDatabase(o openOptions) (ethdb.Database, error) {
 	}
 	if o.Type == rawdb.DBPebble || existingDb == rawdb.DBPebble {
 		log.Info("Using pebble as the backing database")
-		return newPebbleDBDatabase(o.Directory, o.Cache, o.Handles, o.Namespace, o.ReadOnly, o.Ephemeral)
+		return newPebbleDBDatabase(o.Directory, o.Cache, o.Handles, o.Namespace, o.ReadOnly)
 	}
 	if o.Type == rawdb.DBLeveldb || existingDb == rawdb.DBLeveldb {
 		log.Info("Using leveldb as the backing database")
@@ -100,7 +96,7 @@ func openKeyValueDatabase(o openOptions) (ethdb.Database, error) {
 	}
 	// No pre-existing database, no user-requested one either. Default to Pebble.
 	log.Info("Defaulting to pebble as the backing database")
-	return newPebbleDBDatabase(o.Directory, o.Cache, o.Handles, o.Namespace, o.ReadOnly, o.Ephemeral)
+	return newPebbleDBDatabase(o.Directory, o.Cache, o.Handles, o.Namespace, o.ReadOnly)
 }
 
 // newLevelDBDatabase creates a persistent key-value database without a freezer
@@ -116,8 +112,8 @@ func newLevelDBDatabase(file string, cache int, handles int, namespace string, r
 
 // newPebbleDBDatabase creates a persistent key-value database without a freezer
 // moving immutable chain segments into cold storage.
-func newPebbleDBDatabase(file string, cache int, handles int, namespace string, readonly bool, ephemeral bool) (ethdb.Database, error) {
-	db, err := pebble.New(file, cache, handles, namespace, readonly, ephemeral)
+func newPebbleDBDatabase(file string, cache int, handles int, namespace string, readonly bool) (ethdb.Database, error) {
+	db, err := pebble.New(file, cache, handles, namespace, readonly)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/dnsdisc/tree.go
+++ b/p2p/dnsdisc/tree.go
@@ -202,10 +202,7 @@ func (t *Tree) build(entries []entry) entry {
 	}
 	var subtrees []entry
 	for len(entries) > 0 {
-		n := maxChildren
-		if len(entries) < n {
-			n = len(entries)
-		}
+		n := min(len(entries), maxChildren)
 		sub := t.build(entries[:n])
 		entries = entries[n:]
 		subtrees = append(subtrees, sub)

--- a/p2p/msgrate/msgrate.go
+++ b/p2p/msgrate/msgrate.go
@@ -378,10 +378,7 @@ func (t *Trackers) TargetTimeout() time.Duration {
 // targetTimeout is the internal lockless version of TargetTimeout to be used
 // during QoS tuning.
 func (t *Trackers) targetTimeout() time.Duration {
-	timeout := time.Duration(ttlScaling * float64(t.roundtrip) / t.confidence)
-	if timeout > t.OverrideTTLLimit {
-		timeout = t.OverrideTTLLimit
-	}
+	timeout := min(time.Duration(ttlScaling*float64(t.roundtrip)/t.confidence), t.OverrideTTLLimit)
 	return timeout
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -190,7 +190,7 @@ var (
 		PascalTime:          newUint64(1742436600), // 2025-03-20 02:10:00 AM UTC
 		PragueTime:          newUint64(1742436600), // 2025-03-20 02:10:00 AM UTC
 		LorentzTime:         newUint64(1745903100), // 2025-04-29 05:05:00 AM UTC
-		MaxwellTime:         nil,
+		MaxwellTime:         newUint64(1751250600), // 2025-06-30 02:30:00 AM UTC
 
 		Parlia: &ParliaConfig{},
 		BlobScheduleConfig: &BlobScheduleConfig{

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -314,10 +314,7 @@ func decodeSliceElems(s *Stream, val reflect.Value, elemdec decoder) error {
 	for ; ; i++ {
 		// grow slice if necessary
 		if i >= val.Cap() {
-			newcap := val.Cap() + val.Cap()/2
-			if newcap < 4 {
-				newcap = 4
-			}
+			newcap := max(val.Cap()+val.Cap()/2, 4)
 			newv := reflect.MakeSlice(val.Type(), val.Len(), newcap)
 			reflect.Copy(newv, val)
 			val.Set(newv)

--- a/rpc/client_opt.go
+++ b/rpc/client_opt.go
@@ -17,6 +17,7 @@
 package rpc
 
 import (
+	"maps"
 	"net/http"
 
 	"github.com/gorilla/websocket"
@@ -89,9 +90,7 @@ func WithHeader(key, value string) ClientOption {
 func WithHeaders(headers http.Header) ClientOption {
 	return optionFunc(func(cfg *clientConfig) {
 		cfg.initHeaders()
-		for k, vs := range headers {
-			cfg.httpHeaders[k] = vs
-		}
+		maps.Copy(cfg.httpHeaders, headers)
 	})
 }
 

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"mime"
 	"net/http"
@@ -147,9 +148,7 @@ func newClientTransportHTTP(endpoint string, cfg *clientConfig) reconnectFunc {
 	headers := make(http.Header, 2+len(cfg.httpHeaders))
 	headers.Set("accept", contentType)
 	headers.Set("content-type", contentType)
-	for key, values := range cfg.httpHeaders {
-		headers[key] = values
-	}
+	maps.Copy(headers, cfg.httpHeaders)
 
 	client := cfg.httpClient
 	if client == nil {

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -240,9 +241,7 @@ func newClientTransportWS(endpoint string, cfg *clientConfig) (reconnectFunc, er
 	if err != nil {
 		return nil, err
 	}
-	for key, values := range cfg.httpHeaders {
-		header[key] = values
-	}
+	maps.Copy(header, cfg.httpHeaders)
 
 	connect := func(ctx context.Context) (ServerCodec, error) {
 		header := header.Clone()

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -824,6 +824,7 @@ func (s *spongeDb) NewBatch() ethdb.Batch                    { return &spongeBat
 func (s *spongeDb) NewBatchWithSize(size int) ethdb.Batch    { return &spongeBatch{s} }
 func (s *spongeDb) Stat() (string, error)                    { panic("implement me") }
 func (s *spongeDb) Compact(start []byte, limit []byte) error { panic("implement me") }
+func (s *spongeDb) SyncKeyValue() error                      { return nil }
 func (s *spongeDb) Close() error                             { return nil }
 func (s *spongeDb) Put(key []byte, value []byte) error {
 	var (

--- a/triedb/pathdb/buffer.go
+++ b/triedb/pathdb/buffer.go
@@ -145,10 +145,13 @@ func (b *buffer) flush(db ethdb.KeyValueStore, freezer ethdb.AncientWriter, node
 		start = time.Now()
 		batch = db.NewBatchWithSize(b.nodes.dbsize() * 11 / 10) // extra 10% for potential pebble internal stuff
 	)
-	// Explicitly sync the state freezer, ensuring that all written
-	// data is transferred to disk before updating the key-value store.
+	// Explicitly sync the state freezer to ensure all written data is persisted to disk
+	// before updating the key-value store.
+	//
+	// This step is crucial to guarantee that the corresponding state history remains
+	// available for state rollback.
 	if freezer != nil {
-		if err := freezer.Sync(); err != nil {
+		if err := freezer.SyncAncient(); err != nil {
 			return err
 		}
 	}

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -475,6 +475,15 @@ func (db *Database) Recover(root common.Hash) error {
 		db.tree.reset(dl)
 	}
 	db.DeleteTrieJournal(db.diskdb)
+
+	// Explicitly sync the key-value store to ensure all recent writes are
+	// flushed to disk. This step is crucial to prevent a scenario where
+	// recent key-value writes are lost due to an application panic, while
+	// the associated state histories have already been removed, resulting
+	// in the inability to perform a state rollback.
+	if err := db.diskdb.SyncKeyValue(); err != nil {
+		return err
+	}
 	_, err := truncateFromHead(db.diskdb, db.freezer, dl.stateID())
 	if err != nil {
 		return err

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1  // Major version component of the current release
 	Minor = 5  // Minor version component of the current release
-	Patch = 13 // Patch version component of the current release
+	Patch = 14 // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
## Description
v1.5.14 is for BSC Mainnet [Maxwell hard fork](https://forum.bnbchain.org/t/bnb-chain-roadmap-mainnet/936#p-1418-h-3-maxwell-wip-10), which is expected to be enabled at: `2025-06-30 02:30:00 AM UTC`, all BSC Mainnet nodes need to be upgraded to v1.5.14 before the hard fork time. For this upgrade, simply binary replacement should be enough.

Maxwell includes 3 BEPs, mainly to reduce block interval from 1.5 seconds to 0.75 seconds:
- [BEP-524: shorter block interval phase two: 0.75 seconds](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-524.md)
- [ BEP-563: add Enhanced Validator Network proposal](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-563.md)
- [BEP-564: add New Block Fetching Messages proposal](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-564.md)

Besides the 0.75 seconds block interval update, there are several other key parameters will be updated:
- Epoch: will increase from 500 to 1000
- TurnLength: will increase from 8 to 16
- Other Parameters: pls refer [BEP-524: Parameter Changes](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-524.md#41-parameter-changes)

Beside hard fork changes, there are several other improvements and bug fixes, For details, pls refer the change log.
## ChangeLog
### FEATURE
[\#3130](https://github.com/bnb-chain/bsc/pull/3130) config: update BSC Mainnet hardfork time: Maxwell

### BUGFIX
[\#3117](https://github.com/bnb-chain/bsc/pull/3117) core, ethdb: introduce database sync function (#31703)
[\#3122](https://github.com/bnb-chain/bsc/pull/3122) freezer: implement tail method in prunedfreezer
[\#3121](https://github.com/bnb-chain/bsc/pull/3121) miner: discard outdated bids before simulation

### IMPROVEMENT
[\#3105](https://github.com/bnb-chain/bsc/pull/3105) parlia.go: adjust timeForMining to 4/5 second
[\#3112](https://github.com/bnb-chain/bsc/pull/3112) feat: add storagechange object pool for better performance
[\#3110](https://github.com/bnb-chain/bsc/pull/3110) refactor: use the built-in max/min to simplify the code
[\#3120](https://github.com/bnb-chain/bsc/pull/3120) tx_pool: remove one non-necessary allocation
[\#3123](https://github.com/bnb-chain/bsc/pull/3123) refactor: use maps.copy for cleaner map handling
[\#3126](https://github.com/bnb-chain/bsc/pull/3126) jsutils: update getKeyParameters