### PR TITLE
cmd/geth: align master code to develop

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -506,10 +506,7 @@ func initNetwork(ctx *cli.Context) error {
 	}
 	if enableSentryNode && ctx.Bool(utils.InitEVNSentryWhitelist.Name) {
 		for i := 0; i < len(sentryConfigs); i++ {
-			// whitelist all sentry nodes + proxyed validator NodeID
-			wlNodeIDs := []enode.ID{nodeIDs[i]}
-			wlNodeIDs = append(wlNodeIDs, sentryNodeIDs...)
-			sentryConfigs[i].Node.P2P.EVNNodeIdsWhitelist = wlNodeIDs
+			sentryConfigs[i].Node.P2P.EVNNodeIdsWhitelist = sentryNodeIDs
 		}
 	}
 	if enableSentryNode && ctx.Bool(utils.InitEVNSentryRegister.Name) {


### PR DESCRIPTION
### Description

cmd/geth: align master code to develop

### Rationale
code of master is not aligned to develop after merging develop branch

some error may happen when resolving conflicts, this PR to fix it.


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
