### PR TITLE
feat: remove gc restriction for large mem;

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2025,12 +2025,17 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			ctx.Set(CacheFlag.Name, strconv.Itoa(allowance))
 		}
 	}
-	// Ensure Go's GC ignores the database cache for trigger percentage
-	cache := ctx.Int(CacheFlag.Name)
-	gogc := math.Max(20, math.Min(100, 100/(float64(cache)/1024)))
+	// if the total memory is greater than 64GB, skip the GC trigger sanitization
+	if err == nil && int(mem.Total/1024/1024) > 64000 {
+		log.Info("Skipping Go's GC trigger sanitization", "total", mem.Total/1024/1024)
+	} else {
+		// Ensure Go's GC ignores the database cache for trigger percentage
+		cache := ctx.Int(CacheFlag.Name)
+		gogc := math.Max(20, math.Min(100, 100/(float64(cache)/1024)))
 
-	log.Debug("Sanitizing Go's GC trigger", "percent", int(gogc))
-	godebug.SetGCPercent(int(gogc))
+		log.Info("Sanitizing Go's GC trigger", "percent", int(gogc))
+		godebug.SetGCPercent(int(gogc))
+	}
 
 	if ctx.IsSet(SyncTargetFlag.Name) {
 		cfg.SyncMode = ethconfig.FullSync // dev sync target forces full sync


### PR DESCRIPTION
### Description

In the bsc code, the parameter settings for gogc are relatively strict, which will greatly waste memory space for the currently recommended configuration.

In the current code, if a 256GB machine is set to `--cache 64000`, then `gogc=20`, which will trigger gogc very frequently and affect performance.

In this PR, the parameter conditions of gogc are optimized. When the machine memory is large enough, the current threshold is 64GB, and gogc will use the default value.

In actual tests, on the i7i.8xlarge machine, removing the gogc restriction improves the performance of daily traffic in mainnet by ~10%.

At the same time, the performance jitter of the program is less when restarting.

In addition, based on this PR, users can still use GOGC=100 to continue optimizing gogc parameters.

### Example
As shown in the figure below, after optimizing the gogc parameters, the insert time was reduced by ~10% over 5 days of mainnet natural traffic.

<img width="1665" alt="image" src="https://github.com/user-attachments/assets/edf0a280-1fee-4d21-9d9c-bdbcc76a9341" />

Node1, 10.213.32.160:
--cache 18000
Use optimized gogc version

Node1, 10.213.32.78:
--cache18000
v1.5.12

### Changes

Notable changes: 
* feat: remove gc restriction for large mem;
* ...
