### PR TITLE
feat: support to disable txindexer;

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -344,7 +344,12 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	shouldPreserve := func(header *types.Header) bool {
 		return false
 	}
-	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, shouldPreserve, &config.TransactionHistory, bcOps...)
+	txLookupLimit := &config.TransactionHistory
+	if !config.EnableTxIndexer {
+		log.Warn("The TxIndexer is disabled. Please note that the next time you re-enable it, it may affect the node performance because of rebuilding the tx index.")
+		txLookupLimit = nil
+	}
+	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, shouldPreserve, txLookupLimit, bcOps...)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -124,6 +124,8 @@ type Config struct {
 	PathSyncFlush      bool   `toml:",omitempty"` // State scheme used to store ethereum state and merkle trie nodes on top
 	JournalFileEnabled bool   // Whether the TrieJournal is stored using journal file
 
+	EnableTxIndexer bool `toml:",omitempty"` // Whether to enable the transaction indexer
+
 	// RequiredBlocks is a set of block number -> hash mappings which must be in the
 	// canonical chain of all remote peers. Setting the option makes geth verify the
 	// presence of these blocks for every new peer connection.

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -39,6 +39,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		StateScheme             string `toml:",omitempty"`
 		PathSyncFlush           bool   `toml:",omitempty"`
 		JournalFileEnabled      bool
+		EnableTxIndexer         bool                   `toml:",omitempty"`
 		RequiredBlocks          map[uint64]common.Hash `toml:"-"`
 		SkipBcVersionCheck      bool                   `toml:"-"`
 		DatabaseHandles         int                    `toml:"-"`
@@ -95,6 +96,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.StateScheme = c.StateScheme
 	enc.PathSyncFlush = c.PathSyncFlush
 	enc.JournalFileEnabled = c.JournalFileEnabled
+	enc.EnableTxIndexer = c.EnableTxIndexer
 	enc.RequiredBlocks = c.RequiredBlocks
 	enc.SkipBcVersionCheck = c.SkipBcVersionCheck
 	enc.DatabaseHandles = c.DatabaseHandles
@@ -155,6 +157,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		StateScheme             *string `toml:",omitempty"`
 		PathSyncFlush           *bool   `toml:",omitempty"`
 		JournalFileEnabled      *bool
+		EnableTxIndexer         *bool                  `toml:",omitempty"`
 		RequiredBlocks          map[uint64]common.Hash `toml:"-"`
 		SkipBcVersionCheck      *bool                  `toml:"-"`
 		DatabaseHandles         *int                   `toml:"-"`
@@ -257,6 +260,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.JournalFileEnabled != nil {
 		c.JournalFileEnabled = *dec.JournalFileEnabled
+	}
+	if dec.EnableTxIndexer != nil {
+		c.EnableTxIndexer = *dec.EnableTxIndexer
 	}
 	if dec.RequiredBlocks != nil {
 		c.RequiredBlocks = dec.RequiredBlocks


### PR DESCRIPTION
### Description
In BSC, txindexer consumes considerable CPU and io resources in the background, and txindex data is mainly used for API to query transactions or receipt services based on txhash. Currently, it is of little use to roles such as validators, and an optional configuration can be provided to disable it.

After disabling txindexer, performance has improved to a certain extent.

Note that it is currently only recommended for validators to use this function. When txindexer is disabled and then re-enabled, a large number of missing txindexes will be built in the background, which will have a very large impact on performance.

<img width="1722" alt="image" src="https://github.com/user-attachments/assets/d4ff0bee-6fc8-42fc-9e47-2445b29cfe3a" />

### Example

<img width="1661" alt="image" src="https://github.com/user-attachments/assets/9eecce07-6a2e-4bc4-a117-6d937e0f045d" />

In a 5-day observation of mainnet traffic, when txindexer is disabled, the insert time is reduced by ~7%.

Node1, 10.213.32.90:
--cache 18000
Use disable txindexer version

Node1, 10.213.32.78:
--cache18000
v1.5.12

### Changes

Notable changes: 
* feat: support to disable txindexer;
* ...
