### PR TITLE
ci: update musl-cross download link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           go mod download
-          wget https://musl.cc/x86_64-linux-musl-cross.tgz
+          wget https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/x86_64-linux-musl-cross.tgz
           tar -xvf ./x86_64-linux-musl-cross.tgz
           GIT_COMMIT=$(git rev-parse HEAD)
           GIT_COMMIT_DATE=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
@@ -70,7 +70,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           go mod download
-          wget https://musl.cc/aarch64-linux-musl-cross.tgz
+          wget https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/aarch64-linux-musl-cross.tgz
           tar -xvf ./aarch64-linux-musl-cross.tgz
           GIT_COMMIT=$(git rev-parse HEAD)
           GIT_COMMIT_DATE=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           go mod download
-          wget https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/x86_64-linux-musl-cross.tgz
+          wget ${{ env.MUSL_CROSS_URL }}/x86_64-linux-musl-cross.tgz
           tar -xvf ./x86_64-linux-musl-cross.tgz
           GIT_COMMIT=$(git rev-parse HEAD)
           GIT_COMMIT_DATE=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
@@ -70,7 +70,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           go mod download
-          wget https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/aarch64-linux-musl-cross.tgz
+          wget ${{ env.MUSL_CROSS_URL }}/aarch64-linux-musl-cross.tgz
           tar -xvf ./aarch64-linux-musl-cross.tgz
           GIT_COMMIT=$(git rev-parse HEAD)
           GIT_COMMIT_DATE=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')


### PR DESCRIPTION
### Description
From https://musl.cc/:
`2025-05-27: GitHub Actions has been blocked wholesale due to [abuse similar to this](https://github.com/orgs/community/discussions/27906#discussioncomment-3332440).`

Github action failed to download musl-cross, which blocks the release workflow.

### Rationale
comparing to other solutions like: Git Large File Storage(LFS), uploaded the musl-cross to S3 could be an easy solution.

### Example
NA

### Changes
NA