### PR TITLE
release: bump v1.5.15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           go mod download
-          wget ${{ env.MUSL_CROSS_URL }}/x86_64-linux-musl-cross.tgz
+          wget ${{ vars.MUSL_CROSS_URL }}/x86_64-linux-musl-cross.tgz
           tar -xvf ./x86_64-linux-musl-cross.tgz
           GIT_COMMIT=$(git rev-parse HEAD)
           GIT_COMMIT_DATE=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
@@ -70,7 +70,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           go mod download
-          wget ${{ env.MUSL_CROSS_URL }}/aarch64-linux-musl-cross.tgz
+          wget ${{ vars.MUSL_CROSS_URL }}/aarch64-linux-musl-cross.tgz
           tar -xvf ./aarch64-linux-musl-cross.tgz
           GIT_COMMIT=$(git rev-parse HEAD)
           GIT_COMMIT_DATE=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## v1.5.14
+## v1.5.15
 ### FEATURE
 [\#3130](https://github.com/bnb-chain/bsc/pull/3130) config: update BSC Mainnet hardfork time: Maxwell
 
@@ -15,6 +15,9 @@
 [\#3120](https://github.com/bnb-chain/bsc/pull/3120) tx_pool: remove one non-necessary allocation
 [\#3123](https://github.com/bnb-chain/bsc/pull/3123) refactor: use maps.copy for cleaner map handling
 [\#3126](https://github.com/bnb-chain/bsc/pull/3126) jsutils: update getKeyParameters
+
+## v1.5.14
+deprecated, v1.5.14 was replaced by v1.5.15
 
 ## v1.5.13
 ### FEATURE

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1  // Major version component of the current release
 	Minor = 5  // Minor version component of the current release
-	Patch = 14 // Patch version component of the current release
+	Patch = 15 // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
### Description
v1.5.14 release failed due to a CI issue.
v1.5.15 is exactly same as v1.5.14, but fixed the CI issue.

### Rationale
NA

### Example
NA

### Changes
NA