### PR TITLE
vm: implement contract pool

### DIFF
--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -76,26 +76,6 @@ type Contract struct {
 	value *uint256.Int
 }
 
-// NewContract returns a new contract environment for the execution of EVM.
-func NewContract(caller ContractRef, object ContractRef, value *uint256.Int, gas uint64) *Contract {
-	c := &Contract{CallerAddress: caller.Address(), caller: caller, self: object}
-
-	if parent, ok := caller.(*Contract); ok {
-		// Reuse JUMPDEST analysis from parent context if available.
-		c.jumpdests = parent.jumpdests
-	} else {
-		c.jumpdests = make(map[common.Hash]bitvec)
-	}
-
-	// Gas should be a pointer so it can safely be reduced through the run
-	// This pointer will be off the state transition
-	c.Gas = gas
-	// ensures a value is set
-	c.value = value
-
-	return c
-}
-
 func (c *Contract) validJumpdest(dest *uint256.Int) bool {
 	udest, overflow := dest.Uint64WithOverflow()
 	// PC cannot go beyond len(code) and certainly can't be bigger than 63bits.

--- a/core/vm/contract_pool.go
+++ b/core/vm/contract_pool.go
@@ -1,0 +1,49 @@
+package vm
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+var contractPool = sync.Pool{
+	New: func() any {
+		return &Contract{}
+	},
+}
+
+// GetContract returns a contract from the pool or creates a new one
+func GetContract(caller ContractRef, object ContractRef, value *uint256.Int, gas uint64) *Contract {
+	contract := contractPool.Get().(*Contract)
+
+	// Reset the contract with new values
+	contract.CallerAddress = caller.Address()
+	contract.caller = caller
+	contract.self = object
+	contract.value = value
+	contract.Gas = gas
+	contract.Code = nil
+	contract.CodeHash = common.Hash{}
+	contract.CodeAddr = nil
+	contract.Input = nil
+	contract.IsDeployment = false
+	contract.IsSystemCall = false
+	if parent, ok := caller.(*Contract); ok {
+		// Reuse JUMPDEST analysis from parent context if available.
+		contract.jumpdests = parent.jumpdests
+	} else {
+		contract.jumpdests = make(map[common.Hash]bitvec)
+	}
+	contract.analysis = nil
+
+	return contract
+}
+
+// ReturnContract returns a contract to the pool
+func ReturnContract(contract *Contract) {
+	if contract == nil {
+		return
+	}
+	contractPool.Put(contract)
+}

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -576,10 +576,12 @@ func TestOpTstore(t *testing.T) {
 		caller       = common.Address{}
 		to           = common.Address{1}
 		contractRef  = contractRef{caller}
-		contract     = NewContract(contractRef, AccountRef(to), new(uint256.Int), 0)
+		contract     = GetContract(contractRef, AccountRef(to), new(uint256.Int), 0)
 		scopeContext = ScopeContext{mem, stack, contract}
 		value        = common.Hex2Bytes("abcdef00000000000000abba000000000deaf000000c0de00100000000133700")
 	)
+
+	defer ReturnContract(contract)
 
 	// Add a stateObject for the caller and the contract being called
 	statedb.CreateAccount(caller)

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -68,8 +68,10 @@ func runTrace(tracer *tracers.Tracer, vmctx *vmContext, chaincfg *params.ChainCo
 		gasLimit uint64 = 31000
 		startGas uint64 = 10000
 		value           = uint256.NewInt(0)
-		contract        = vm.NewContract(account{}, account{}, value, startGas)
+		contract        = vm.GetContract(account{}, account{}, value, startGas)
 	)
+	defer vm.ReturnContract(contract)
+
 	evm.SetTxContext(vmctx.txCtx)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x1, 0x0}
 	if contractCode != nil {
@@ -190,8 +192,9 @@ func TestHaltBetweenSteps(t *testing.T) {
 		t.Fatal(err)
 	}
 	scope := &vm.ScopeContext{
-		Contract: vm.NewContract(&account{}, &account{}, uint256.NewInt(0), 0),
+		Contract: vm.GetContract(&account{}, &account{}, uint256.NewInt(0), 0),
 	}
+	defer vm.ReturnContract(scope.Contract)
 	evm := vm.NewEVM(vm.BlockContext{BlockNumber: big.NewInt(1)}, &dummyStatedb{}, chainConfig, vm.Config{Tracer: tracer.Hooks})
 	evm.SetTxContext(vm.TxContext{GasPrice: big.NewInt(1)})
 	tracer.OnTxStart(evm.GetVMContext(), types.NewTx(&types.LegacyTx{}), common.Address{})
@@ -287,9 +290,12 @@ func TestEnterExit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	contract := vm.GetContract(&account{}, &account{}, uint256.NewInt(0), 0)
+	defer vm.ReturnContract(contract)
 	scope := &vm.ScopeContext{
-		Contract: vm.NewContract(&account{}, &account{}, uint256.NewInt(0), 0),
+		Contract: contract,
 	}
+
 	tracer.OnEnter(1, byte(vm.CALL), scope.Contract.Caller(), scope.Contract.Address(), []byte{}, 1000, new(big.Int))
 	tracer.OnExit(1, []byte{}, 400, nil, false)
 

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -59,8 +59,10 @@ func TestStoreCapture(t *testing.T) {
 	var (
 		logger   = NewStructLogger(nil)
 		evm      = vm.NewEVM(vm.BlockContext{}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Tracer: logger.Hooks()})
-		contract = vm.NewContract(&dummyContractRef{}, &dummyContractRef{}, new(uint256.Int), 100000)
+		contract = vm.GetContract(&dummyContractRef{}, &dummyContractRef{}, new(uint256.Int), 100000)
 	)
+	defer vm.ReturnContract(contract)
+
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x0, byte(vm.SSTORE)}
 	var index common.Hash
 	logger.OnTxStart(evm.GetVMContext(), nil, common.Address{})

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -307,8 +307,9 @@ func runBenchmark(b *testing.B, t *StateTest) {
 			evm.SetTxContext(txContext)
 
 			// Create "contract" for sender to cache code analysis.
-			sender := vm.NewContract(vm.AccountRef(msg.From), vm.AccountRef(msg.From),
+			sender := vm.GetContract(vm.AccountRef(msg.From), vm.AccountRef(msg.From),
 				nil, 0)
+			defer vm.ReturnContract(sender)
 
 			var (
 				gasUsed uint64


### PR DESCRIPTION
# Optimize Contract Pool Implementation

## Changes
- Replaced custom contract pool implementation with a global `sync.Pool`
- Simplified the API by removing the `ContractPool` struct and making functions package-level
- Improved JUMPDEST analysis reuse by properly handling parent contract context
- Removed unnecessary cleanup and size tracking functions
- Optimized memory usage by letting `sync.Pool` handle object lifecycle

## Technical Details
- Changed from instance-based pool to a global `sync.Pool` for better performance
- Removed manual mutex locking as `sync.Pool` is thread-safe by design
- Improved JUMPDEST analysis reuse by checking parent contract context before creating new map
- Removed redundant cleanup of contract fields as they are reset on next use
- Simplified the API to just `GetContract` and `ReturnContract` functions

## Benefits
- Better performance through optimized object reuse
- Reduced memory allocations
- Automatic cleanup of unused objects by garbage collector
- Thread-safe by design using `sync.Pool`
- More efficient JUMPDEST analysis reuse

## Benchmarks
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/d47f4aaa-7260-41ca-8eea-8452adfbe306" />
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/af180c28-b879-4898-b050-59b57b4510e0" />
