### PR TITLE
eth: not begin to sync during processing broadcasted blocks or hash

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -192,7 +192,7 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 
 		// Re-check local head to see if it has caught up
 		if _, latestTD := cs.modeAndLocalHead(); ourTD.Cmp(latestTD) < 0 {
-			log.Debug("The local head is already caught up; synchronization is not required.")
+			log.Trace("The local head is already caught up; synchronization is not required.")
 			return nil
 		}
 	}


### PR DESCRIPTION
### Description

eth: not begin to sync during processing broadcasted blocks or hash

### Rationale

A node may begin syncing after receiving a block but before it has been fully imported.
While syncing, fast finality voting is disabled. Since syncing can occasionally take up to a minute, the validator may miss one or more voting opportunities.
This behavior is unnecessary and should be avoided.

in testnet, sync too many times
<img width="639" alt="image" src="https://github.com/user-attachments/assets/f12b96c5-d8dc-4109-be89-f5da99ee8b59" />

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
