### PR TITLE
ethdb: enlarge the number of memory tables

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -168,9 +168,10 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 	// Taken from https://github.com/cockroachdb/pebble/blob/master/internal/constants/constants.go
 	maxMemTableSize := (1<<31)<<(^uint(0)>>63) - 1
 
-	// Two memory tables is configured which is identical to leveldb,
-	// including a frozen memory table and another live one.
-	memTableLimit := 2
+	// Six memory tables are configured
+	// Maintaining the same total memory limit but dividing it into multiple
+	// smaller memtables enables smoother flush operations.
+	memTableLimit := 6
 	memTableSize := cache * 1024 * 1024 / 2 / memTableLimit
 
 	// The memory table size is currently capped at maxMemTableSize-1 due to a


### PR DESCRIPTION
### Description

In the current BSC validator and miner workflow, write stalls frequently occur during the commit or block synchronization processes. Specifically, operations like writeStateID or writing block data often experience write delays of several hundred milliseconds, which negatively impacts commit performance and causes miners to exceed the 750ms block production time. 

Pebble allows configuring multiple memtables for buffering unflushed data，if too many memtables are blocked and are waiting to be flushed, subsequent writes will stall, especially when Pebble performs a background flush while compaction is also ongoing. By default, Pebble is configured with only 2 memtables, each potentially exceeding 1GB in size. This behavior can be mitigated by increasing the number of memtables, which allows background flushes to be performed more smoothly and efficiently in a queue-like manner, thereby reducing the likelihood of write stalls under heavy load.
After shortening the BSC block interval, more frequent writes and compactions significantly increase the likelihood of write stalls. Adjusting the number of Pebble memtables is necessary to mitigate this issue.

### Rationale

Improve the performance of commit db and reduce write stall.  Testing shows that after tuning the Pebble parameters, write stalls were reduced by approximately 75%, and commit performance at the p99 percentile improved by around 30%.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
