### PR TITLE
chore: fix a incorrect metric

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -718,7 +718,6 @@ func (s *StateDB) getStateObject(addr common.Address) *stateObject {
 	// Insert into the live set
 	obj := newObject(s, addr, acct)
 	s.setStateObject(obj)
-	s.AccountLoaded++
 	return obj
 }
 


### PR DESCRIPTION
### Description

The metrics are incorrect due to a duplicated counter, and remove it.

### Rationale
https://github.com/bnb-chain/bsc/blob/d2dec2c39bec3db21d543bfa6e5658777272ea13/core/state/statedb.go#L687-L723

692 line and 721 line is duplicated.


### Example

N/A.

### Changes

Notable changes: 
* N/A.
