### PR TITLE
miner: only recommit bids when no error happens

### DIFF
--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -694,6 +694,9 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 			b.DelBestBidToRun(parentHash, bidRuntime.bid)
 		}
 
+		if err != nil {
+			return
+		}
 		// only recommit last best bid when newBidCh is empty
 		if len(b.newBidCh) > 0 {
 			return
@@ -721,7 +724,7 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 	// if the left time is not enough to do simulation, return
 	delay := b.engine.Delay(b.chain, bidRuntime.env.header, &b.delayLeftOver)
 	if delay == nil || *delay <= 0 {
-		log.Info("BidSimulator: abort commit, no time to begin simulating")
+		err = errors.New("no time to begin simulating")
 		return
 	}
 
@@ -794,7 +797,7 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 	delay = b.engine.Delay(b.chain, bidRuntime.env.header, &b.delayLeftOver)
 	if delay != nil && *delay < 0 {
 		bidSimTimeoutCounter.Inc(1)
-		log.Info("BidSimulator: fail to commit, timeout when simulating completed")
+		err = errors.New("timeout when simulating completed")
 		return
 	}
 


### PR DESCRIPTION
### Description

miner: only recommit bids when no error happens

### Rationale

a bug is introduced by PR https://github.com/bnb-chain/bsc/pull/3135/files
it will lead to log flusing:
<img width="808" alt="image" src="https://github.com/user-attachments/assets/b38a7ed5-ab5f-43b2-9c4a-0ec6d9af835f" />


this PR is to fix it.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
