### PR TITLE
chore: fix struct comment

### DIFF
--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -319,7 +319,9 @@ func (b *testHandler) close() {
 	b.chain.Stop()
 }
 
-// newTestVotePool creates a mock vote pool.
+// testVotePool is a mock vote pool that simply collects and stores votes.
+// Its purpose is to simulate vote collection behavior without implementing
+// complex validation and consensus rules.
 type testVotePool struct {
 	pool map[common.Hash]*types.VoteEnvelope // Hash map of collected votes
 


### PR DESCRIPTION
### Description

The comments here and below are identical, but the struct names are inconsistent.

https://github.com/bnb-chain/bsc/blob/develop/eth/handler_test.go#L330

 I have made the corresponding modifications based on the comments before the `testTxPool` struct and the `newTestTxPool` method.  https://github.com/bnb-chain/bsc/blob/develop/eth/handler_test.go#L59


### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
