### PR TITLE
params: only enable sharedStorage on special blocks

### DIFF
--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -54,7 +54,7 @@ func (p *statePrefetcher) Prefetch(transactions types.Transactions, header *type
 	for i := 0; i < prefetchThread; i++ {
 		go func() {
 			newStatedb := statedb.CopyDoPrefetch()
-			if !p.config.IsHertzfix(header.Number) {
+			if p.config.NeedSharedStorage(header.Number) {
 				newStatedb.EnableWriteOnSharedStorage()
 			}
 
@@ -106,10 +106,6 @@ func (p *statePrefetcher) PrefetchMining(txs TransactionsByPriceAndNonce, header
 	for i := 0; i < prefetchThread; i++ {
 		go func(startCh <-chan *types.Transaction, stopCh <-chan struct{}) {
 			newStatedb := statedb.CopyDoPrefetch()
-			if !p.config.IsHertzfix(header.Number) { // need in local env before Hertzfix hard fork
-				newStatedb.EnableWriteOnSharedStorage()
-			}
-
 			evm := vm.NewEVM(NewEVMBlockContext(header, p.chain, nil), newStatedb, p.config, cfg)
 			idx := 0
 			// Iterate over and process the individual transactions

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -54,7 +54,7 @@ func (p *statePrefetcher) Prefetch(transactions types.Transactions, header *type
 	for i := 0; i < prefetchThread; i++ {
 		go func() {
 			newStatedb := statedb.CopyDoPrefetch()
-			if p.config.NeedSharedStorage(header.Number) {
+			if p.config.NeedBadSharedStorage(header.Number) {
 				newStatedb.EnableWriteOnSharedStorage()
 			}
 

--- a/params/config.go
+++ b/params/config.go
@@ -967,6 +967,22 @@ func (c *ChainConfig) IsHertzfix(num *big.Int) bool {
 	return isBlockForked(c.HertzfixBlock, num)
 }
 
+func (c *ChainConfig) NeedSharedStorage(num *big.Int) bool {
+	if c.IsHertzfix(num) {
+		return false
+	}
+
+	if c.ChainID.Cmp(big.NewInt(56)) == 0 && num.Cmp(big.NewInt(33851236)) == 0 {
+		return true
+	}
+
+	if c.ChainID.Cmp(big.NewInt(97)) == 0 && (num.Cmp(big.NewInt(35547779)) == 0 || num.Cmp(big.NewInt(35548081)) == 0) {
+		return true
+	}
+
+	return false
+}
+
 func (c *ChainConfig) IsOnHertzfix(num *big.Int) bool {
 	return configBlockEqual(c.HertzfixBlock, num)
 }

--- a/params/config.go
+++ b/params/config.go
@@ -967,7 +967,7 @@ func (c *ChainConfig) IsHertzfix(num *big.Int) bool {
 	return isBlockForked(c.HertzfixBlock, num)
 }
 
-func (c *ChainConfig) NeedSharedStorage(num *big.Int) bool {
+func (c *ChainConfig) NeedBadSharedStorage(num *big.Int) bool {
 	if c.IsHertzfix(num) {
 		return false
 	}


### PR DESCRIPTION
### Description

params: only enable sharedStorage on special blocks

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
