### PR TITLE
downloader: number of headers from peer can be 0

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -899,8 +899,8 @@ func (d *Downloader) findAncestorBinarySearch(p *peerConnection, mode SyncMode, 
 		}
 		// Make sure the peer actually gave something valid
 		if len(headers) != 1 {
-			p.log.Warn("Multiple headers for single request", "headers", len(headers))
-			return 0, fmt.Errorf("%w: multiple headers (%d) for single request", errBadPeer, len(headers))
+			p.log.Warn("Multiple or zero headers for single request", "headers", len(headers))
+			return 0, fmt.Errorf("%w: multiple or zero headers (%d) for single request", errBadPeer, len(headers))
 		}
 		// Modify the search interval based on the response
 		h := hashes[0]


### PR DESCRIPTION
### Description

update of log to account for the case when number of headers returned could also be 0. 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
