### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/core/state_prefetcher_test.go
+++ b/core/state_prefetcher_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"runtime/pprof"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -138,11 +139,5 @@ func matchesLabel(sample *profile.Sample, key, expectedValue string) bool {
 		return false
 	}
 
-	for _, value := range values {
-		if value == expectedValue {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(values, expectedValue)
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -589,10 +590,8 @@ func (st *stateTransition) validateAuthorization(auth *types.SetCodeAuthorizatio
 	if err != nil {
 		return authority, fmt.Errorf("%w: %v", ErrAuthorizationInvalidSignature, err)
 	}
-	for _, blackListAddr := range types.NanoBlackList {
-		if blackListAddr == authority {
-			return authority, errors.New("block blacklist account")
-		}
+	if slices.Contains(types.NanoBlackList, authority) {
+		return authority, errors.New("block blacklist account")
 	}
 	// Check the authority account
 	//  1) doesn't have code or has existing delegation

--- a/eth/peerset_test.go
+++ b/eth/peerset_test.go
@@ -2,6 +2,7 @@ package eth
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"sync/atomic"
@@ -348,10 +349,5 @@ func existProxyedValidator(ps *mockPeerSet, address common.Address, proxyedList 
 
 // contains checks if a string slice contains a specific string
 func contains(slice []string, str string) bool {
-	for _, s := range slice {
-		if s == str {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, str)
 }

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -19,6 +19,7 @@ package native
 import (
 	"encoding/json"
 	"math/big"
+	"slices"
 	"strconv"
 	"sync/atomic"
 
@@ -75,12 +76,7 @@ func newFourByteTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *p
 
 // isPrecompiled returns whether the addr is a precompile. Logic borrowed from newJsTracer in eth/tracers/js/tracer.go
 func (t *fourByteTracer) isPrecompiled(addr common.Address) bool {
-	for _, p := range t.activePrecompiles {
-		if p == addr {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(t.activePrecompiles, addr)
 }
 
 // store saves the given identifier and datasize.


### PR DESCRIPTION
### Description

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
