### PR TITLE
ethdb: fix disable freezer when enable multidb

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -1438,7 +1438,7 @@ func inspectHistory(ctx *cli.Context) error {
 		if header == nil {
 			return 0, fmt.Errorf("block #%d is not existent", blockNumber)
 		}
-		id := rawdb.ReadStateID(db, header.Root)
+		id := rawdb.ReadStateID(db.GetStateStore(), header.Root)
 		if id == nil {
 			first, last, err := triedb.HistoryRange()
 			if err == nil {

--- a/core/rawdb/ancient_utils.go
+++ b/core/rawdb/ancient_utils.go
@@ -143,11 +143,7 @@ func InspectFreezerTable(ancient string, freezerName string, tableName string, s
 	)
 	switch freezerName {
 	case ChainFreezerName:
-		if multiDatabase {
-			path, tables = resolveChainFreezerDir(filepath.Dir(ancient)+"/block/ancient"), chainFreezerNoSnappy
-		} else {
-			path, tables = resolveChainFreezerDir(ancient), chainFreezerNoSnappy
-		}
+		path, tables = resolveChainFreezerDir(ancient), chainFreezerNoSnappy
 
 	case MerkleStateFreezerName, VerkleStateFreezerName:
 		if multiDatabase {

--- a/node/node.go
+++ b/node/node.go
@@ -774,7 +774,6 @@ func (n *Node) OpenAndMergeDatabase(name string, namespace string, readonly bool
 	var (
 		err                          error
 		stateDiskDb                  ethdb.Database
-		disableChainDbFreeze         = false
 		chainDataHandles             = config.DatabaseHandles
 		chainDbCache                 = config.DatabaseCache
 		stateDbCache, stateDbHandles int
@@ -791,17 +790,16 @@ func (n *Node) OpenAndMergeDatabase(name string, namespace string, readonly bool
 
 		stateDbCache = config.DatabaseCache - chainDbCache
 		stateDbHandles = config.DatabaseHandles - chainDataHandles
-		disableChainDbFreeze = true
 	}
 
-	chainDB, err := n.OpenDatabaseWithFreezer(name, chainDbCache, chainDataHandles, config.DatabaseFreezer, namespace, readonly, disableChainDbFreeze)
+	chainDB, err := n.OpenDatabaseWithFreezer(name, chainDbCache, chainDataHandles, config.DatabaseFreezer, namespace, readonly, false)
 	if err != nil {
 		return nil, err
 	}
 
 	if isMultiDatabase {
 		// Allocate half of the  handles and chainDbCache to this separate state data database
-		stateDiskDb, err = n.OpenDatabaseWithFreezer(name+"/state", stateDbCache, stateDbHandles, "", "eth/db/statedata/", readonly, true)
+		stateDiskDb, err = n.OpenDatabaseWithFreezer(name+"/state", stateDbCache, stateDbHandles, "", "eth/db/statedata/", readonly, false)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Description

The old blockstore code has set the disableFreezer as true  to make the ancient store in blockstore, which is not removed clearly.  This  bug only affects the multidb .

### Rationale
set disableFreezer  as false

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
