### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"maps"
 	gomath "math"
 	"math/big"
 	"math/rand"
@@ -3128,9 +3129,7 @@ func testDeleteRecreateSlotsAcrossManyBlocks(t *testing.T, scheme string) {
 		var exp = new(expectation)
 		exp.blocknum = i + 1
 		exp.values = make(map[int]int)
-		for k, v := range current.values {
-			exp.values[k] = v
-		}
+		maps.Copy(exp.values, current.values)
 		exp.exist = current.exist
 
 		b.SetCoinbase(common.Address{1})

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -19,6 +19,7 @@ package snapshot
 import (
 	"encoding/binary"
 	"fmt"
+	maps0 "maps"
 	"math"
 	"math/rand"
 	"slices"
@@ -408,9 +409,7 @@ func (dl *diffLayer) flatten() snapshot {
 	if parent.stale.Swap(true) {
 		panic("parent diff layer is stale") // we've flattened into the same parent from two children, boo
 	}
-	for hash, data := range dl.accountData {
-		parent.accountData[hash] = data
-	}
+	maps0.Copy(parent.accountData, dl.accountData)
 	// Overwrite all the updated storage slots (individually)
 	for accountHash, storage := range dl.storageData {
 		// If storage didn't exist (or was deleted) in the parent, overwrite blindly

--- a/core/state/snapshot/difflayer_test.go
+++ b/core/state/snapshot/difflayer_test.go
@@ -19,6 +19,7 @@ package snapshot
 import (
 	"bytes"
 	crand "crypto/rand"
+	"maps"
 	"math/rand"
 	"testing"
 
@@ -30,9 +31,7 @@ import (
 
 func copyAccounts(accounts map[common.Hash][]byte) map[common.Hash][]byte {
 	copy := make(map[common.Hash][]byte)
-	for hash, blob := range accounts {
-		copy[hash] = blob
-	}
+	maps.Copy(copy, accounts)
 	return copy
 }
 
@@ -40,9 +39,7 @@ func copyStorage(storage map[common.Hash]map[common.Hash][]byte) map[common.Hash
 	copy := make(map[common.Hash]map[common.Hash][]byte)
 	for accHash, slots := range storage {
 		copy[accHash] = make(map[common.Hash][]byte)
-		for slotHash, blob := range slots {
-			copy[accHash][slotHash] = blob
-		}
+		maps.Copy(copy[accHash], slots)
 	}
 	return copy
 }

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -19,6 +19,7 @@ package txpool
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"sync"
 
@@ -385,9 +386,7 @@ func (p *TxPool) Add(txs []*types.Transaction, sync bool) []error {
 func (p *TxPool) Pending(filter PendingFilter) map[common.Address][]*LazyTransaction {
 	txs := make(map[common.Address][]*LazyTransaction)
 	for _, subpool := range p.subpools {
-		for addr, set := range subpool.Pending(filter) {
-			txs[addr] = set
-		}
+		maps.Copy(txs, subpool.Pending(filter))
 	}
 	return txs
 }
@@ -456,12 +455,8 @@ func (p *TxPool) Content() (map[common.Address][]*types.Transaction, map[common.
 	for _, subpool := range p.subpools {
 		run, block := subpool.Content()
 
-		for addr, txs := range run {
-			runnable[addr] = txs
-		}
-		for addr, txs := range block {
-			blocked[addr] = txs
-		}
+		maps.Copy(runnable, run)
+		maps.Copy(blocked, block)
 	}
 	return runnable, blocked
 }


### PR DESCRIPTION
### Description

use maps.Copy for cleaner map handling

https://pkg.go.dev/maps#Copy

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
