### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -639,15 +640,12 @@ func (w *worker) resultLoop() {
 			if prev, ok := w.recentMinedBlocks.Get(block.NumberU64()); ok {
 				doubleSign := false
 				prevParents := prev
-				for _, prevParent := range prevParents {
-					if prevParent == block.ParentHash() {
-						log.Error("Reject Double Sign!!", "block", block.NumberU64(),
-							"hash", block.Hash(),
-							"root", block.Root(),
-							"ParentHash", block.ParentHash())
-						doubleSign = true
-						break
-					}
+				if slices.Contains(prevParents, block.ParentHash()) {
+					log.Error("Reject Double Sign!!", "block", block.NumberU64(),
+						"hash", block.Hash(),
+						"root", block.Root(),
+						"ParentHash", block.ParentHash())
+					doubleSign = true
 				}
 				if doubleSign {
 					continue

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -203,10 +203,8 @@ func (p *Peer) Caps() []Cap {
 // versions is supported by both this node and the peer p.
 func (p *Peer) RunningCap(protocol string, versions []uint) bool {
 	if proto, ok := p.running[protocol]; ok {
-		for _, ver := range versions {
-			if proto.Version == ver {
-				return true
-			}
+		if slices.Contains(versions, proto.Version) {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
### Description

use slices.Contains to simplify code

Inspired by https://github.com/bnb-chain/bsc/pull/3223 and find all.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
