### PR TITLE
freezer: change freeze batch size;

### DIFF
--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -40,7 +40,9 @@ const (
 
 	// freezerBatchLimit is the maximum number of blocks to freeze in one batch
 	// before doing an fsync and deleting it from the key-value store.
-	freezerBatchLimit = 30000
+	// TODO(galaio): For BSC, the 0.75 interval and freezing of 30,000 blocks will seriously affect performance.
+	// It is temporarily adjusted to 100, and improves the freezing performance later.
+	freezerBatchLimit = 100
 )
 
 var (

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -177,7 +177,7 @@ func (f *chainFreezer) freezeThreshold(db ethdb.Reader) (uint64, error) {
 //
 // This functionality is deliberately broken off from block importing to avoid
 // incurring additional data shuffling delays on block propagation.
-func (f *chainFreezer) freeze(db ethdb.KeyValueStore) {
+func (f *chainFreezer) freeze(db ethdb.KeyValueStore, continueFreeze bool) {
 	var (
 		backoff   bool
 		triggered chan struct{} // Used in tests
@@ -413,11 +413,14 @@ func (f *chainFreezer) freeze(db ethdb.KeyValueStore) {
 
 		// TODO(galaio): Temporarily comment that the current BSC is suitable for small-volume writes,
 		// and then the large-volume mode will be enabled after optimizing the freeze performance of ancient.
+		if !continueFreeze {
+			backoff = true
+			continue
+		}
 		// Avoid database thrashing with tiny writes
-		// if frozen-first < freezerBatchLimit {
-		// 	backoff = true
-		// }
-		backoff = true
+		if frozen-first < freezerBatchLimit {
+			backoff = true
+		}
 	}
 }
 

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -502,7 +502,7 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, ancient string, namespace st
 	if !disableFreeze && !readonly {
 		frdb.wg.Add(1)
 		go func() {
-			frdb.freeze(db)
+			frdb.freeze(db, false)
 			frdb.wg.Done()
 		}()
 	}


### PR DESCRIPTION
### Description

In the recent v1.5.18 upgrade, the previous pruneancient was replaced by tail-deletion, but some cases were found in the grayscale test to cause import performance degradation.

Nodes using the "--pruneancient" flag are affected. We observed that if you enable "--pruneancient" for the first time, it will delete the ancient directory to save storage, but due to a code bug, new blocks will not continue to be deleted and will continue to accumulate in pebbledb.

If "--pruneancient" is enabled and the node is upgraded to v1.5.18, a large number of historical block deletions will be triggered, which will cause great pressure on the disk. At the same time, you will also have high latency when accessing ancient data, which affects the import performance.

This PR reduces the `freezerBatchLimit` value to avoid excessive impact on BSC nodes.

### Changes

Notable changes: 
* freezer: change freeze batch size;
* ...
