### PR TITLE
release: prepare for release v1.5.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## v1.5.19
+### BUGFIX
+[\#3251](https://github.com/bnb-chain/bsc/pull/3251) freezer: change freeze batch size
+
+### IMPROVEMENT
+[\#3243](https://github.com/bnb-chain/bsc/pull/3178) build(deps): bump golang.org/x/oauth2 from 0.24.0 to 0.27.0
+[\#3235](https://github.com/bnb-chain/bsc/pull/3178) refactor: use maps.Copy for cleaner map handling
+
 ## v1.5.18
 ### FEATURE
 [\#3158](https://github.com/bnb-chain/bsc/pull/3158) feat: blind bid serves the validator's best interest

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1  // Major version component of the current release
 	Minor = 5  // Minor version component of the current release
-	Patch = 18 // Patch version component of the current release
+	Patch = 19 // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
## Description
v1.5.19 is a hot fix release for v1.5.18, which has a critical issue for nodes that are running with flag: `--pruneancient`.
The issue of v1.5.18 is about performance, as nodes could be stuck for ~1 min during block import due to an exclusive write lock of ancientDB.
The issue has been mitigated by: https://github.com/bnb-chain/bsc/pull/3251

## ChangeList
### BUGFIX
[\#3251](https://github.com/bnb-chain/bsc/pull/3251) freezer: change freeze batch size

### IMPROVEMENT
[\#3243](https://github.com/bnb-chain/bsc/pull/3178) build(deps): bump golang.org/x/oauth2 from 0.24.0 to 0.27.0
[\#3235](https://github.com/bnb-chain/bsc/pull/3178) refactor: use maps.Copy for cleaner map handling

### Changes
NA