### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/internal/cmdtest/test_cmd.go
+++ b/internal/cmdtest/test_cmd.go
@@ -255,8 +255,8 @@ type testlogger struct {
 }
 
 func (tl *testlogger) Write(b []byte) (n int, err error) {
-	lines := bytes.Split(b, []byte("\n"))
-	for _, line := range lines {
+	lines := bytes.SplitSeq(b, []byte("\n"))
+	for line := range lines {
 		if len(line) > 0 {
 			tl.t.Logf("(stderr:%v) %s", tl.name, line)
 		}

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -217,7 +217,7 @@ func (*HandlerT) Stacks(filter *string) string {
 		dump := buf.String()
 		buf.Reset()
 
-		for _, trace := range strings.Split(dump, "\n\n") {
+		for trace := range strings.SplitSeq(dump, "\n\n") {
 			if ok, _ := expr.Evaluate(map[string]string{"Value": trace}); ok {
 				buf.WriteString(trace)
 				buf.WriteString("\n\n")

--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -86,7 +86,7 @@ func (h *GlogHandler) Verbosity(level slog.Level) {
 //	 sets V to 3 in all files of any packages whose import path contains "foo"
 func (h *GlogHandler) Vmodule(ruleset string) error {
 	var filter []pattern
-	for _, rule := range strings.Split(ruleset, ",") {
+	for rule := range strings.SplitSeq(ruleset, ",") {
 		// Empty strings such as from a trailing comma can be ignored
 		if len(rule) == 0 {
 			continue
@@ -113,7 +113,7 @@ func (h *GlogHandler) Vmodule(ruleset string) error {
 		}
 		// Compile the rule pattern into a regular expression
 		matcher := ".*"
-		for _, comp := range strings.Split(parts[0], "/") {
+		for comp := range strings.SplitSeq(parts[0], "/") {
 			if comp == "*" {
 				matcher += "(/.*)?"
 			} else if comp != "" {

--- a/node/api.go
+++ b/node/api.go
@@ -186,19 +186,19 @@ func (api *adminAPI) StartHTTP(host *string, port *int, cors *string, apis *stri
 	}
 	if cors != nil {
 		config.CorsAllowedOrigins = nil
-		for _, origin := range strings.Split(*cors, ",") {
+		for origin := range strings.SplitSeq(*cors, ",") {
 			config.CorsAllowedOrigins = append(config.CorsAllowedOrigins, strings.TrimSpace(origin))
 		}
 	}
 	if vhosts != nil {
 		config.Vhosts = nil
-		for _, vhost := range strings.Split(*host, ",") {
+		for vhost := range strings.SplitSeq(*host, ",") {
 			config.Vhosts = append(config.Vhosts, strings.TrimSpace(vhost))
 		}
 	}
 	if apis != nil {
 		config.Modules = nil
-		for _, m := range strings.Split(*apis, ",") {
+		for m := range strings.SplitSeq(*apis, ",") {
 			config.Modules = append(config.Modules, strings.TrimSpace(m))
 		}
 	}
@@ -265,13 +265,13 @@ func (api *adminAPI) StartWS(host *string, port *int, allowedOrigins *string, ap
 	}
 	if apis != nil {
 		config.Modules = nil
-		for _, m := range strings.Split(*apis, ",") {
+		for m := range strings.SplitSeq(*apis, ",") {
 			config.Modules = append(config.Modules, strings.TrimSpace(m))
 		}
 	}
 	if allowedOrigins != nil {
 		config.Origins = nil
-		for _, origin := range strings.Split(*allowedOrigins, ",") {
+		for origin := range strings.SplitSeq(*allowedOrigins, ",") {
 			config.Origins = append(config.Origins, strings.TrimSpace(origin))
 		}
 	}

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -74,8 +74,8 @@ type originTest struct {
 // and trims excessive white space from the substrings.
 // Copied over from flags.go
 func splitAndTrim(input string) (ret []string) {
-	l := strings.Split(input, ",")
-	for _, r := range l {
+	l := strings.SplitSeq(input, ",")
+	for r := range l {
 		r = strings.TrimSpace(r)
 		if len(r) > 0 {
 			ret = append(ret, r)


### PR DESCRIPTION
### Description

Optimize code using a more modern writing style which can make the code more efficient and cleaner.

Official support by Go Team. https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
