### PR TITLE
prefetch: lower prefetch threshold from 100 to 50

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -117,7 +117,7 @@ const (
 	maxFutureBlocks     = 256
 	maxTimeFutureBlocks = 30
 	maxBeyondBlocks     = 2048
-	prefetchTxNumber    = 100
+	prefetchTxNumber    = 50
 
 	// BlockChainVersion ensures that an incompatible database forces a resync from scratch.
 	//

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-const prefetchTxNumber = 100
+const prefetchTxNumber = 50
 
 var (
 	bidPreCheckTimer     = metrics.NewRegisteredTimer("bid/preCheck", nil)


### PR DESCRIPTION
### Description
100 was for previous 3 seconds block interval, with shorter block interval it is better to be a smaller value, could be helpful for bid simulate and block import

### Rationale
NA

### Example
NA

### Changes
NA