### PR TITLE
api.go: add retry for snapshots stale error

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1064,7 +1064,6 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 
 	// Retry once if snapshot error
 	if derr != nil && errors.Is(derr, snapshot.ErrSnapshotStale) {
-		log.Info("eth_call snapshot error, retrying", "to", args.To, "from", args.From, "err", derr)
 
 		select {
 		case <-time.After(100 * time.Millisecond):


### PR DESCRIPTION
### Description

This is an edge case that occurs when perform an `eth_call` during diff layer flattening in the snapshot mechanism.  This pr implementing a retry mechanism when encounter this problem. Fixed #3270 .

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
