### PR TITLE
freezer: slow down freeze when live sync;

### DIFF
--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -744,7 +744,7 @@ func (f *chainFreezer) SyncAncient() error {
 }
 
 func trySlowdownFreeze(head *types.Header) {
-	if time.Since(time.Unix(int64(head.Time), 0)) > SlowdownFreezeWindow {
+	if time.Since(time.UnixMilli(int64(head.MilliTimestamp()))) > SlowdownFreezeWindow {
 		return
 	}
 	if freezerBatchLimit == SlowFreezerBatchLimit {


### PR DESCRIPTION
### Description

In version 1.5.19, the freeze limit parameter was lowered. Previously, a large amount of data was left in pebble due to the "pruneanceint" feature. See https://github.com/bnb-chain/bsc/pull/3251.

This PR uses a freeze limit of 30,000 records during historical synchronization. When synchronization is about to end, it is changed to a freeze limit of 100 records to avoid performance issues.

related issue: https://github.com/bnb-chain/bsc/issues/3307

### Changes

Notable changes: 
* freezer: slow down freeze when live sync; 
* ...
