### PR TITLE
ethdb : add expand mode for migration tool

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -134,6 +134,11 @@ var (
 		Value:    node.DefaultConfig.DBEngine,
 		Category: flags.EthCategory,
 	}
+	ExpandModeFlag = &cli.BoolFlag{
+		Name:     "expandmode",
+		Usage:    "Enable expand mode for migration: write data to target database instead of in-place migration",
+		Category: flags.EthCategory,
+	}
 	AncientFlag = &flags.DirectoryFlag{
 		Name:     "datadir.ancient",
 		Usage:    "Root directory for ancient data (default = inside chaindata)",


### PR DESCRIPTION
### Description

add  expand mode 
`geth --datadir /data/ethereum --expandmode db migrate /target/dir 5`
last number is the version

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
