### PR TITLE
core/filtermaps: stop indexing if target block is pruned

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -816,6 +816,7 @@ func (bc *BlockChain) loadLastState() error {
 	}
 	if posa, ok := bc.engine.(consensus.PoSA); ok {
 		if currentFinalizedHeader := posa.GetFinalizedHeader(bc, headHeader); currentFinalizedHeader != nil {
+			bc.currentFinalBlock.Store(currentFinalizedHeader)
 			if currentFinalizedBlock := bc.GetBlockByHash(currentFinalizedHeader.Hash()); currentFinalizedBlock != nil {
 				finalTd := bc.GetTd(currentFinalizedBlock.Hash(), currentFinalizedBlock.NumberU64())
 				log.Info("Loaded most recent local finalized block", "number", currentFinalizedBlock.Number(), "hash", currentFinalizedBlock.Hash(), "root", currentFinalizedBlock.Root(), "td", finalTd, "age", common.PrettyAge(time.Unix(int64(currentFinalizedBlock.Time()), 0)))

--- a/core/filtermaps/filtermaps.go
+++ b/core/filtermaps/filtermaps.go
@@ -400,6 +400,15 @@ func (f *FilterMaps) init() error {
 	if initBlockNumber < f.historyCutoff {
 		return errors.New("cannot start indexing before history cutoff point")
 	}
+	if initBlockNumber < f.targetView.headNumber {
+		// genesis block still exists even after pruning
+		if initBlockNumber == 0 {
+			initBlockNumber = 1
+		}
+		if f.indexedView.chain.GetCanonicalHash(initBlockNumber) == (common.Hash{}) {
+			return fmt.Errorf("cannot start indexing: blockNumber=%d is pruned", initBlockNumber)
+		}
+	}
 	batch := f.db.NewBatch()
 	for epoch := range bestLen {
 		cp := checkpoints[bestIdx][epoch]


### PR DESCRIPTION
### Description

core/filtermaps: stop indexing if target block is pruned

### Rationale

fix https://github.com/bnb-chain/bsc/issues/3317

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
