### PR TITLE
ci: fix truffer error

### DIFF
--- a/docker/Dockerfile.truffle
+++ b/docker/Dockerfile.truffle
@@ -6,6 +6,7 @@ RUN git clone https://github.com/bnb-chain/canonical-upgradeable-bep20.git /usr/
 
 WORKDIR /usr/app/canonical-upgradeable-bep20
 COPY docker/truffle-config.js /usr/app/canonical-upgradeable-bep20
+COPY docker/solc-0.6.4 /usr/app/canonical-upgradeable-bep20
 
 RUN npm install -g --unsafe-perm truffle@v5.1.14
 RUN npm install

--- a/docker/truffle-config.js
+++ b/docker/truffle-config.js
@@ -59,10 +59,11 @@ module.exports = {
     // Configure your compilers
     compilers: {
       solc: {
-        version: "0.6.4",    // Fetch exact version from solc-bin (default: truffle's version)
+        version: "native",    // Fetch exact version from solc-bin (default: truffle's version)
         docker: false,        // Use "0.5.1" you've installed locally with docker (default: false)
         settings: {          // See the solidity docs for advice about optimization and evmVersion
-         optimizer: {
+          compilerPath: "./solc-0.6.4", // Path to the solc binary
+          optimizer: {
            enabled: true,
            runs: 200
          }

--- a/tests/truffle/docker-compose.yml
+++ b/tests/truffle/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   genesis:
     image: bsc-genesis


### PR DESCRIPTION
### Description

solc-0.6.4 can not be downloaded from truffle solc-bin


### Rationale
NA

### Example
NA

### Changes
NA