### PR TITLE
ci: ignore nancy failre of rs/cors@v1.8.2

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,2 +1,3 @@
 CVE-2024-34478 # "CWE-754: Improper Check for Unusual or Exceptional Conditions." This vulnerability is BTC only, BSC does not have the issue.
 CVE-2021-43668 # "CWE-476: NULL Pointer Dereference", the repo: syndtr/goleveldb is not actively maintained, seems there is no fix for this crash yet, BSC used pebbleDB to replaced levelDB, so ignore this vulnerability.
+CVE-2025-47908 # "CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')", This vulnerability is only for RPC nodes which have specifically enabled malicous Cors options, which is unlikely to happen.


### PR DESCRIPTION
### Description
It is an issue reported in https://github.com/rs/cors/issues/170 and fixed by https://github.com/rs/cors/pull/171, which was included in release v1.11.0(Apr 2024): https://github.com/rs/cors/releases/tag/v1.11.0

But v1.8.2 was released in Dec 2021, which may have a lot difference. And this vulnerability is limitted only to RPC nodes with maliciously configuration in config.toml:
[Node]
HTTPCors = ["\<malicious cors\>",...]

So instead of upgrade to v1.11.0+, simply add it to nancy ignore for now

### Rationale
NA

### Example
NA

### Changes
NA