### PR TITLE
ethdb:  support multidb mode with dedicated snapshot DB and index DB

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -360,6 +360,17 @@ func initGenesis(ctx *cli.Context) error {
 			utils.Fatalf("Failed to open separate trie database: %v", dbErr)
 		}
 		chaindb.SetStateStore(statediskdb)
+		snapDB, err := stack.OpenDatabase("chaindata/snapshot", 0, 0, "", false, true)
+		if err != nil {
+			utils.Fatalf("Failed to open separate snapshot database: %v", err)
+		}
+		chaindb.SetSnapStore(snapDB)
+
+		txIndexDB, err := stack.OpenDatabase("chaindata/txindex", 0, 0, "", false, true)
+		if err != nil {
+			utils.Fatalf("Failed to open separate snapshot database: %v", err)
+		}
+		chaindb.SetTxIndexStore(txIndexDB)
 		log.Warn("Multi-database is an experimental feature")
 	}
 

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -355,22 +355,10 @@ func initGenesis(ctx *cli.Context) error {
 	name := "chaindata"
 	// if the trie data dir has been set, new trie db with a new state database
 	if ctx.IsSet(utils.MultiDataBaseFlag.Name) {
-		statediskdb, dbErr := stack.OpenDatabaseWithFreezer(name+"/state", 0, 0, "", "", false)
-		if dbErr != nil {
-			utils.Fatalf("Failed to open separate trie database: %v", dbErr)
-		}
-		chaindb.SetStateStore(statediskdb)
-		snapDB, err := stack.OpenDatabase("chaindata/snapshot", 0, 0, "", false, true)
+		err = stack.SetMultiDBs(chaindb, name, 0, 0, false)
 		if err != nil {
-			utils.Fatalf("Failed to open separate snapshot database: %v", err)
+			utils.Fatalf("Failed to init multi-database: %v", err)
 		}
-		chaindb.SetSnapStore(snapDB)
-
-		txIndexDB, err := stack.OpenDatabase("chaindata/txindex", 0, 0, "", false, true)
-		if err != nil {
-			utils.Fatalf("Failed to open separate snapshot database: %v", err)
-		}
-		chaindb.SetTxIndexStore(txIndexDB)
 		log.Warn("Multi-database is an experimental feature")
 	}
 

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -748,8 +748,7 @@ func dumpGenesis(ctx *cli.Context) error {
 
 	// set the separate state & block database
 	if stack.CheckIfMultiDataBase() && err == nil {
-		stateDiskDb := utils.MakeStateDataBase(ctx, stack, true)
-		db.SetStateStore(stateDiskDb)
+		stack.SetMultiDBs(db, "chaindata", 0, 0, true)
 	}
 
 	genesis, err = core.ReadGenesis(db)

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -22,11 +22,14 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -39,6 +42,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/ethdb/leveldb"
+	"github.com/ethereum/go-ethereum/ethdb/pebble"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
@@ -93,6 +98,8 @@ Remove blockchain and state databases`,
 			dbTrieDeleteCmd,
 			dbDeleteTrieStateCmd,
 			ancientInspectCmd,
+			dbInspectHistoryCmd,
+			dbMigrateCmd,
 		},
 	}
 	dbInspectCmd = &cli.Command{
@@ -274,6 +281,30 @@ of ancientStore, will also displays the reserved number of blocks in ancientStor
 			},
 		}, utils.NetworkFlags, utils.DatabaseFlags),
 		Description: "This command queries the history of the account or storage slot within the specified block range",
+	}
+	dbMigrateCmd = &cli.Command{
+		Action:    migrateDatabase,
+		Name:      "migrate",
+		Usage:     "Migrate single database to multi-database format (in-place)",
+		ArgsUsage: "",
+		Flags: slices.Concat([]cli.Flag{
+			utils.DataDirFlag,
+			utils.SyncModeFlag,
+			utils.CacheFlag,
+			utils.CacheDatabaseFlag,
+		}, utils.NetworkFlags),
+		Description: `This command migrates a single chaindb database to multi-database format IN-PLACE.
+The source database will be read from --datadir/chaindata directory, and data will be split into:
+  - chaindata/           - chain and metadata (remaining)
+  - chaindata/state      - state trie data
+  - chaindata/snapshot   - snapshot data
+  - chaindata/txindex    - transaction index data
+ 
+Usage examples:
+  geth --datadir /data/ethereum db migrate
+  geth --datadir ~/.ethereum db migrate
+ 
+WARNING: This operation may take a very long time to finish for large databases (2TB+).`,
 	}
 )
 
@@ -1341,4 +1372,609 @@ func inspectHistory(ctx *cli.Context) error {
 		return inspectAccount(triedb, start, end, address, ctx.Bool("raw"))
 	}
 	return inspectStorage(triedb, start, end, address, slot, ctx.Bool("raw"))
+}
+
+// migrateDatabase migrates a single database to multi-database format
+func migrateDatabase(ctx *cli.Context) error {
+	if ctx.NArg() != 0 {
+		return fmt.Errorf("no arguments expected")
+	}
+
+	cacheSize := ctx.Int(utils.CacheFlag.Name)
+	cacheDB := ctx.Int(utils.CacheDatabaseFlag.Name)
+
+	// Create source stack using standard geth configuration (handles --datadir)
+	sourceStack, _ := makeConfigNode(ctx)
+	defer sourceStack.Close()
+
+	// Get source database path
+	sourceChainDataPath := sourceStack.ResolvePath("chaindata")
+
+	log.Info("Starting in-place database migration", "source", sourceChainDataPath)
+
+	// Open source database for read/write (NOT readonly) without using the
+	// Node helper to avoid auto-opening separate state/snapshot/txindex DBs.
+	// We only need the hot key-value store for in-place extraction & deletion.
+	sourceDB, err := openTargetDatabase(sourceChainDataPath, cacheSize*cacheDB*7/100, 64)
+	if err != nil {
+		return fmt.Errorf("failed to open source chain database: %v", err)
+	}
+	defer sourceDB.Close()
+
+	// Create target directory structure (separate databases within source chaindata)
+	targetStatePath := filepath.Join(sourceChainDataPath, "state")
+	targetSnapshotPath := filepath.Join(sourceChainDataPath, "snapshot")
+	targetTxIndexPath := filepath.Join(sourceChainDataPath, "txindex")
+
+	for _, dir := range []string{targetStatePath, targetSnapshotPath, targetTxIndexPath} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %v", dir, err)
+		}
+	}
+
+	// Create target databases for extracted data
+	// State database with freezer
+	stateKVDB, err := pebble.New(targetStatePath, cacheSize*cacheDB*50/100, 128, "", false)
+	if err != nil {
+		return fmt.Errorf("failed to create state key-value database: %v", err)
+	}
+	ancientPath := filepath.Join(targetStatePath, "ancient")
+	stateDB, err := rawdb.NewDatabaseWithFreezer(stateKVDB, ancientPath, "eth/db/statedata/", false)
+	if err != nil {
+		stateKVDB.Close()
+		return fmt.Errorf("failed to create target state database: %v", err)
+	}
+	defer stateDB.Close()
+
+	// Snapshot database
+	snapDB, err := openTargetDatabase(targetSnapshotPath, cacheSize*cacheDB*24/100, 32)
+	if err != nil {
+		return fmt.Errorf("failed to create target snapshot database: %v", err)
+	}
+	defer snapDB.Close()
+
+	// TxIndex database
+	indexDB, err := openTargetDatabase(targetTxIndexPath, cacheSize*cacheDB*15/100, 32)
+	if err != nil {
+		return fmt.Errorf("failed to create target txindex database: %v", err)
+	}
+	defer indexDB.Close()
+
+	// Note: limit and verbose flags are no longer used in the new implementation
+
+	// Start in-place migration
+	return performInPlaceMigration(sourceDB, stateDB, snapDB, indexDB, sourceChainDataPath)
+}
+
+// openTargetDatabase creates a key-value database at the specified path
+func openTargetDatabase(dbPath string, cache, handles int) (ethdb.Database, error) {
+	// Determine database type from the path or default to pebble
+	dbType := rawdb.PreexistingDatabase(dbPath)
+	if dbType == "" {
+		dbType = rawdb.DBPebble // Default to pebble
+	}
+
+	var kvdb ethdb.KeyValueStore
+	var err error
+
+	if dbType == rawdb.DBPebble {
+		kvdb, err = pebble.New(dbPath, cache, handles, "", false)
+	} else {
+		kvdb, err = leveldb.New(dbPath, cache, handles, "", false)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap with rawdb to get full ethdb.Database interface
+	return rawdb.NewDatabase(kvdb), nil
+}
+
+// KeyValuePair represents a key-value pair with its target database type
+type KeyValuePair struct {
+	Key      []byte
+	Value    []byte
+	TargetDB string
+}
+
+// MigrationStats holds thread-safe migration statistics
+type MigrationStats struct {
+	total      int64
+	chain      int64
+	state      int64
+	snapshot   int64
+	txindex    int64
+	chainBytes int64
+	stateBytes int64
+	snapBytes  int64
+	indexBytes int64
+	startTime  time.Time
+}
+
+// Add atomically increments counters
+func (s *MigrationStats) Add(targetDB string, keySize, valueSize int) {
+	atomic.AddInt64(&s.total, 1)
+	dataSize := int64(keySize + valueSize)
+
+	switch targetDB {
+	case "chain":
+		atomic.AddInt64(&s.chain, 1)
+		atomic.AddInt64(&s.chainBytes, dataSize)
+	case "state":
+		atomic.AddInt64(&s.state, 1)
+		atomic.AddInt64(&s.stateBytes, dataSize)
+	case "snapshot":
+		atomic.AddInt64(&s.snapshot, 1)
+		atomic.AddInt64(&s.snapBytes, dataSize)
+	case "txindex":
+		atomic.AddInt64(&s.txindex, 1)
+		atomic.AddInt64(&s.indexBytes, dataSize)
+	}
+}
+
+// Get returns current counter values atomically
+func (s *MigrationStats) Get() (int64, int64, int64, int64, int64) {
+	return atomic.LoadInt64(&s.total),
+		atomic.LoadInt64(&s.chain),
+		atomic.LoadInt64(&s.state),
+		atomic.LoadInt64(&s.snapshot),
+		atomic.LoadInt64(&s.txindex)
+}
+
+// GetBytes returns current byte counter values atomically
+func (s *MigrationStats) GetBytes() (int64, int64, int64, int64) {
+	return atomic.LoadInt64(&s.chainBytes),
+		atomic.LoadInt64(&s.stateBytes),
+		atomic.LoadInt64(&s.snapBytes),
+		atomic.LoadInt64(&s.indexBytes)
+}
+
+// progressMonitor logs migration progress periodically
+func progressMonitor(stats *MigrationStats, stop <-chan struct{}) {
+	ticker := time.NewTicker(8 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			total, chain, state, snapshot, txindex := stats.Get()
+			log.Info("Migration progress",
+				"total", total,
+				"chain", chain,
+				"state", state,
+				"snapshot", snapshot,
+				"txindex", txindex,
+				"elapsed", common.PrettyDuration(time.Since(stats.startTime)),
+				"rate", fmt.Sprintf("%.1f items/s", float64(total)/time.Since(stats.startTime).Seconds()))
+		case <-stop:
+			return
+		}
+	}
+}
+
+// isTrieKey determines if a key-value pair belongs to trie data that should go to state database
+// Logic reference from user's code
+func isTrieKey(key, value []byte) bool {
+	switch {
+	case rawdb.IsLegacyTrieNode(key, value):
+		return true
+	case bytes.HasPrefix(key, []byte("L")) && len(key) == (1+common.HashLength): // stateIDPrefix
+		return true
+	case rawdb.IsAccountTrieNode(key):
+		return true
+	case rawdb.IsStorageTrieNode(key):
+		return true
+	case bytes.HasPrefix(key, rawdb.PreimagePrefix) && len(key) == (len(rawdb.PreimagePrefix)+common.HashLength):
+		return true
+	// Skip CHT and BloomTrie checks as these constants may not be available
+	default:
+		// Check specific metadata keys
+		keyStr := string(key)
+		if keyStr == "TrieSync" || keyStr == "TrieJournal" || keyStr == "LastStateID" {
+			return true
+		}
+	}
+	return false
+}
+
+// categorizeDataByKey categorizes database entries based on key prefixes
+// Returns the target database name: "state", "snapshot", "txindex", or "chain"
+func categorizeDataByKey(key, value []byte) string {
+	// State trie data - use the comprehensive trie key logic
+	if isTrieKey(key, value) {
+		return "state"
+	}
+
+	// Snapshot data - account snapshots
+	if bytes.HasPrefix(key, rawdb.SnapshotAccountPrefix) && len(key) == (len(rawdb.SnapshotAccountPrefix)+common.HashLength) {
+		return "snapshot"
+	}
+
+	// Snapshot metadata keys
+	keyStr := string(key)
+	snapshotMetadataKeys := []string{
+		"SnapshotRoot", "SnapshotJournal", "SnapshotGenerator",
+		"SnapshotRecovery", "SnapshotSyncStatus", "SnapSyncStatus",
+	}
+	for _, metaKey := range snapshotMetadataKeys {
+		if keyStr == metaKey {
+			return "snapshot"
+		}
+	}
+
+	// Transaction index data
+	if bytes.HasPrefix(key, []byte("l")) && len(key) == (1+common.HashLength) { // txLookupPrefix
+		return "txindex"
+	}
+
+	// Transaction index metadata
+	txIndexMetadataKeys := []string{
+		"TransactionIndexTail",       // txIndexTailKey - tracks the oldest indexed block
+		"FastTransactionLookupLimit", // fastTxLookupLimitKey - deprecated but kept for completeness
+	}
+	for _, metaKey := range txIndexMetadataKeys {
+		if keyStr == metaKey {
+			return "txindex"
+		}
+	}
+
+	// Everything else goes to chain database
+	return "chain"
+}
+
+// performInPlaceMigration performs in-place data migration by extracting data from source DB
+func performInPlaceMigration(sourceDB, stateDB, snapDB, indexDB ethdb.Database, sourceChainDataPath string) error {
+	stats := &MigrationStats{startTime: time.Now()}
+
+	log.Info("Starting in-place data migration")
+
+	// Progress monitoring goroutine
+	stopProgress := make(chan struct{})
+	go progressMonitor(stats, stopProgress)
+
+	// Extract all data in single pass
+	if err := extractAllDataInOnePass(sourceDB, sourceDB, stateDB, snapDB, indexDB, stats); err != nil {
+		close(stopProgress)
+		return fmt.Errorf("failed to extract data: %v", err)
+	}
+
+	close(stopProgress)
+
+	total, chain, state, snapshot, txindex := stats.Get()
+	chainBytes, stateBytes, snapBytes, indexBytes := stats.GetBytes()
+	elapsed := time.Since(stats.startTime)
+
+	log.Info("In-place migration completed",
+		"total", total,
+		"chain", chain,
+		"state", state,
+		"snapshot", snapshot,
+		"txindex", txindex,
+		"elapsed", common.PrettyDuration(elapsed))
+
+	log.Info("Final data sizes",
+		"chainMB", chainBytes/(1024*1024),
+		"stateMB", stateBytes/(1024*1024),
+		"snapMB", snapBytes/(1024*1024),
+		"indexMB", indexBytes/(1024*1024),
+		"totalExtractedMB", (stateBytes+snapBytes+indexBytes)/(1024*1024))
+
+	log.Info("✅ In-place migration completed successfully!")
+
+	// Handle ancient state data migration
+	if err := moveAncientData(sourceChainDataPath); err != nil {
+		log.Error("Failed to move ancient state data", "error", err)
+		return fmt.Errorf("failed to move ancient state data: %v", err)
+	}
+
+	// Show directory sizes for debugging
+	log.Info("Checking database directory sizes...")
+	checkDirectorySize := func(path, name string) {
+		if !common.FileExist(path) {
+			log.Info("Directory size", "name", name, "status", "not found")
+			return
+		}
+		// Try to get directory size using du command
+		cmd := exec.Command("du", "-sh", path)
+		output, err := cmd.Output()
+		if err != nil {
+			log.Info("Directory size", "name", name, "status", "unable to measure")
+		} else {
+			sizeStr := strings.Fields(string(output))[0]
+			log.Info("Directory size", "name", name, "size", sizeStr)
+		}
+	}
+
+	// Get the chaindata base directory from the source path
+	baseDir := sourceChainDataPath
+	checkDirectorySize(baseDir, "chaindata (remaining)")
+	checkDirectorySize(filepath.Join(baseDir, "state"), "state")
+	checkDirectorySize(filepath.Join(baseDir, "snapshot"), "snapshot")
+	checkDirectorySize(filepath.Join(baseDir, "txindex"), "txindex")
+
+	if err := performDatabaseCompaction(sourceDB, stateDB, snapDB, indexDB); err != nil {
+		log.Error("Failed to compact databases", "error", err)
+		return fmt.Errorf("failed to compact databases: %v", err)
+	}
+
+	log.Info("Migration completed successfully with proper ancient data structure and compaction!")
+	return nil
+}
+
+// CategorizedData represents a key-value pair with its target category
+type CategorizedData struct {
+	Key      []byte
+	Value    []byte
+	Category string
+}
+
+// stat stores sizes and count for a parameter (copied from core/rawdb)
+type stat struct {
+	size  common.StorageSize
+	count int64
+}
+
+// Add size to the stat and increase the counter by 1
+func (s *stat) Add(size int) {
+	s.size += common.StorageSize(size)
+	s.count++
+}
+
+// BatchWriteRequest represents a batch write request for async processing
+type BatchWriteRequest struct {
+	BatchType string
+	Batch     ethdb.Batch
+}
+
+// Create channels and synchronization structures for async processing
+const (
+	threadPoolSize    = 40
+	channelBufferSize = 50
+)
+
+// extractAllDataInOnePass extracts all data types using multi-threaded async processing
+func extractAllDataInOnePass(sourceDB, chainDB, stateDB, snapDB, indexDB ethdb.Database, stats *MigrationStats) error {
+	log.Info("🚀 Starting multi-threaded async data extraction",
+		"architecture", "1 reader + 50 unified writers = 51 threads")
+
+	// Create unified channel for all write requests
+	writeRequestChannel := make(chan BatchWriteRequest, channelBufferSize)
+
+	// Error channels to collect errors from goroutines
+	errorChannel := make(chan error, threadPoolSize+1) // threadPoolSize writers + 1 reader
+
+	// WaitGroup to coordinate all goroutines
+	var wg sync.WaitGroup
+
+	// Error handling for async writes
+	var writeError atomic.Value // stores first write error
+
+	// Start 40 unified async writer goroutines using thread pool
+	log.Info("🚀 Starting async writer goroutines", "threadCount", threadPoolSize)
+	for i := 0; i < threadPoolSize; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for req := range writeRequestChannel {
+				if err := req.Batch.Write(); err != nil {
+					// Store first error and continue processing to avoid deadlock
+					writeError.CompareAndSwap(nil, fmt.Errorf("failed to write %s batch: %v", req.BatchType, err))
+					errorChannel <- err
+					continue
+				}
+				req.Batch.Reset()
+			}
+		}()
+	}
+
+	// Main reader goroutine - process source database
+	log.Info("📖 Starting main reader thread with unified async writers...")
+
+	var (
+		chainBatch = chainDB.NewBatch()
+		stateBatch = stateDB.NewBatch()
+		snapBatch  = snapDB.NewBatch()
+		indexBatch = indexDB.NewBatch()
+		batchSize  = 0
+		chainStat  = &stat{}
+		stateStat  = &stat{}
+		snapStat   = &stat{}
+		indexStat  = &stat{}
+	)
+
+	it := sourceDB.NewIterator(nil, nil)
+	defer it.Release()
+
+	processedCount := 0
+	for it.Next() {
+		processedCount++
+		key := make([]byte, len(it.Key()))
+		value := make([]byte, len(it.Value()))
+		copy(key, it.Key())
+		copy(value, it.Value())
+		kvSize := len(key) + len(value)
+		batchSize += kvSize
+		chainStat.Add(kvSize)
+
+		// put the key into the state, snap, or index database and delete from chaindb
+		category := categorizeDataByKey(key, value)
+		switch category {
+		case "state":
+			stateBatch.Put(key, value)
+			chainBatch.Delete(key)
+			stateStat.Add(kvSize)
+			stats.Add(category, len(key), len(value))
+		case "snapshot":
+			snapBatch.Put(key, value)
+			chainBatch.Delete(key)
+			snapStat.Add(kvSize)
+			stats.Add(category, len(key), len(value))
+		case "txindex":
+			// indexBatch.Put(key, value)
+			chainBatch.Delete(key)
+			indexStat.Add(kvSize)
+			stats.Add(category, len(key), len(value))
+		}
+
+		// flush the batch if it's too large
+		if batchSize >= 256*1024*1024 {
+			log.Info("sending batches to async thread pool...", "chain count", chainStat.count, "chain size", chainStat.size,
+				"state count", stateStat.count, "state size", stateStat.size, "snap count", snapStat.count,
+				"snap size", snapStat.size, "index count", indexStat.count, "index size", indexStat.size)
+
+			// Send other batches to async writers
+			if stateBatch.ValueSize() > 0 {
+				select {
+				case writeRequestChannel <- BatchWriteRequest{BatchType: "state", Batch: stateBatch}:
+					stateBatch = stateDB.NewBatch()
+				case err := <-errorChannel:
+					return fmt.Errorf("async write error during state batch processing: %v", err)
+				}
+			}
+
+			if snapBatch.ValueSize() > 0 {
+				select {
+				case writeRequestChannel <- BatchWriteRequest{BatchType: "snap", Batch: snapBatch}:
+					snapBatch = snapDB.NewBatch()
+				case err := <-errorChannel:
+					return fmt.Errorf("async write error during snap batch processing: %v", err)
+				}
+			}
+
+			if indexBatch.ValueSize() > 0 {
+				select {
+				case writeRequestChannel <- BatchWriteRequest{BatchType: "index", Batch: indexBatch}:
+					indexBatch = indexDB.NewBatch()
+				case err := <-errorChannel:
+					return fmt.Errorf("async write error during index batch processing: %v", err)
+				}
+			}
+
+			// save first, then delete
+			if chainBatch.ValueSize() > 0 {
+				select {
+				case writeRequestChannel <- BatchWriteRequest{BatchType: "chain", Batch: chainBatch}:
+					chainBatch = chainDB.NewBatch()
+				case err := <-errorChannel:
+					return fmt.Errorf("async write error during chain batch processing: %v", err)
+				}
+			}
+
+			batchSize = 0
+		}
+		// Check for errors periodically
+		select {
+		case err := <-errorChannel:
+			return fmt.Errorf("async write error during processing: %v", err)
+		default:
+			// Continue processing
+		}
+	}
+
+	// Check for iterator errors
+	if err := it.Error(); err != nil {
+		return fmt.Errorf("iterator error: %v", err)
+	}
+
+	// flush the remaining kvs
+	if batchSize > 0 {
+		log.Info("sending remaining batches to async thread pool...", "chain count", chainStat.count, "chain size", chainStat.size,
+			"state count", stateStat.count, "state size", stateStat.size, "snap count", snapStat.count,
+			"snap size", snapStat.size, "index count", indexStat.count, "index size", indexStat.size)
+
+		// Send remaining batches to async writers
+		if stateBatch.ValueSize() > 0 {
+			writeRequestChannel <- BatchWriteRequest{BatchType: "state", Batch: stateBatch}
+		}
+		if snapBatch.ValueSize() > 0 {
+			writeRequestChannel <- BatchWriteRequest{BatchType: "snap", Batch: snapBatch}
+		}
+		if indexBatch.ValueSize() > 0 {
+			writeRequestChannel <- BatchWriteRequest{BatchType: "index", Batch: indexBatch}
+		}
+		if chainBatch.ValueSize() > 0 {
+			writeRequestChannel <- BatchWriteRequest{BatchType: "chain", Batch: chainBatch}
+		}
+	}
+
+	// Close channels to signal completion to worker goroutines
+	close(writeRequestChannel)
+
+	// Wait for all goroutines to complete
+	log.Info("⏳ Waiting for all async workers to complete...")
+	wg.Wait()
+
+	// Check for any errors from worker goroutines
+	close(errorChannel)
+	for err := range errorChannel {
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Info("✅ Multi-threaded async data extraction completed",
+		"chain count", chainStat.count, "chain size", chainStat.size,
+		"state count", stateStat.count, "state size", stateStat.size, "snap count", snapStat.count,
+		"snap size", snapStat.size, "index count", indexStat.count, "index size", indexStat.size,
+		"threadsUsed", fmt.Sprintf("%d (1 reader + %d unified writers)", threadPoolSize+1, threadPoolSize))
+	return nil
+}
+
+// performDatabaseCompaction compacts all databases after migration to reclaim space
+func performDatabaseCompaction(sourceDB, stateDB, snapDB, indexDB ethdb.Database) error {
+	databases := []struct {
+		db   ethdb.Database
+		name string
+	}{
+		{sourceDB, "chaindata"},
+		{stateDB, "state"},
+		{snapDB, "snapshot"},
+		{indexDB, "txindex"},
+	}
+
+	for _, dbInfo := range databases {
+		log.Info("Compacting database", "name", dbInfo.name)
+
+		// Perform full database compaction (nil, nil means compact everything)
+		if err := dbInfo.db.Compact(nil, nil); err != nil {
+			log.Warn("Database compaction failed", "name", dbInfo.name, "error", err)
+			// Don't return error for compaction failure, just log it
+			continue
+		}
+		log.Info("✅ Database compacted successfully", "name", dbInfo.name)
+	}
+
+	log.Info("🗜️  Database compaction completed for all databases")
+	return nil
+}
+
+// moveAncientData handles moving ancient state data to proper location
+func moveAncientData(sourceChainDataPath string) error {
+	// Check if ancient directory exists in source chaindata
+	sourceAncientPath := filepath.Join(sourceChainDataPath, "ancient")
+	if !common.FileExist(sourceAncientPath) {
+		log.Info("No ancient data found in source", "path", sourceAncientPath)
+		return nil
+	}
+
+	// Target ancient path should be in state directory
+	targetStatePath := filepath.Join(sourceChainDataPath, "state")
+	targetAncientPath := filepath.Join(targetStatePath, "ancient")
+
+	// Check if target ancient already exists
+	if common.FileExist(targetAncientPath) {
+		log.Info("Ancient data already exists in target", "path", targetAncientPath)
+		return nil
+	}
+
+	log.Info("Moving ancient data", "from", sourceAncientPath, "to", targetAncientPath)
+
+	// Move ancient directory
+	if err := os.Rename(sourceAncientPath, targetAncientPath); err != nil {
+		return fmt.Errorf("failed to move ancient data: %v", err)
+	}
+
+	log.Info("✅ Ancient data moved successfully")
+	return nil
 }

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -1686,7 +1686,6 @@ func traverseAndMigrate(chainDB ethdb.Database) error {
 			}
 			indexBatch.Reset()
 		}
-		batchSize = 0
 	}
 	log.Info("migrate completed", "chain", chainStat, "state", stateStat, "snap", snapStat,
 		"index", indexStat, "elapsed", common.PrettyDuration(time.Since(start)))

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -581,9 +581,10 @@ func dbStats(ctx *cli.Context) error {
 	defer db.Close()
 
 	showDBStats(db)
-	if db.HasSeparateStateStore() {
-		fmt.Println("show stats of state store")
+	if stack.CheckIfMultiDataBase() {
+		fmt.Println("show stats of StateStore and SnapStore")
 		showDBStats(db.GetStateStore())
+		showDBStats(db.GetSnapStore())
 	}
 
 	return nil
@@ -600,8 +601,10 @@ func dbCompact(ctx *cli.Context) error {
 	showDBStats(db)
 
 	if stack.CheckIfMultiDataBase() {
-		fmt.Println("show stats of state store")
+		fmt.Println("show stats of StatStore and SnapStore")
 		showDBStats(db.GetStateStore())
+		showDBStats(db.GetSnapStore())
+		showDBStats(db.GetTxIndexStore())
 	}
 
 	log.Info("Triggering compaction")
@@ -612,7 +615,15 @@ func dbCompact(ctx *cli.Context) error {
 
 	if stack.CheckIfMultiDataBase() {
 		if err := db.GetStateStore().Compact(nil, nil); err != nil {
-			log.Error("Compact err", "error", err)
+			log.Error("Statestore Compact err", "error", err)
+			return err
+		}
+		if err := db.GetSnapStore().Compact(nil, nil); err != nil {
+			log.Error("Snapstore Compact err", "error", err)
+			return err
+		}
+		if err := db.GetTxIndexStore().Compact(nil, nil); err != nil {
+			log.Error("IndexStore Compact err", "error", err)
 			return err
 		}
 	}
@@ -620,8 +631,12 @@ func dbCompact(ctx *cli.Context) error {
 	log.Info("Stats after compaction")
 	showDBStats(db)
 	if stack.CheckIfMultiDataBase() {
-		fmt.Println("show stats of state store after compaction")
+		log.Info("show stats of state store after compaction")
 		showDBStats(db.GetStateStore())
+		log.Info("show stats of snapshot store after compaction")
+		showDBStats(db.GetSnapStore())
+		log.Info("show stats of index store after compaction")
+		showDBStats(db.GetTxIndexStore())
 	}
 	return nil
 }

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -87,7 +87,6 @@ Remove blockchain and state databases`,
 			dbExportCmd,
 			dbMetadataCmd,
 			dbCheckStateContentCmd,
-			dbInspectHistoryCmd,
 
 			// only defined in bsc
 			dbInspectTrieCmd,

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -524,20 +524,20 @@ func inspect(ctx *cli.Context) error {
 	db := utils.MakeChainDatabase(ctx, stack, true)
 	defer db.Close()
 	fmt.Println("Inspecting chain database...")
-	if err := rawdb.InspectDatabase(db, prefix, start); err != nil {
+	if err := rawdb.InspectDatabase(db, prefix, start, true); err != nil {
 		return err
 	}
 	if stack.CheckIfMultiDataBase() {
 		fmt.Println("Inspecting state database...")
-		if err := rawdb.InspectDatabase(db.GetStateStore(), prefix, start); err != nil {
+		if err := rawdb.InspectDatabase(db.GetStateStore(), prefix, start, true); err != nil {
 			return err
 		}
 		fmt.Println("Inspecting snap database...")
-		if err := rawdb.InspectDatabase(rawdb.NewDatabase(db.GetSnapStore()), prefix, start); err != nil {
+		if err := rawdb.InspectDatabase(rawdb.NewDatabase(db.GetSnapStore()), prefix, start, false); err != nil {
 			return err
 		}
 		fmt.Println("Inspecting index database...")
-		if err := rawdb.InspectDatabase(rawdb.NewDatabase(db.GetTxIndexStore()), prefix, start); err != nil {
+		if err := rawdb.InspectDatabase(rawdb.NewDatabase(db.GetTxIndexStore()), prefix, start, false); err != nil {
 			return err
 		}
 	}

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -364,7 +364,7 @@ func traverseState(ctx *cli.Context) error {
 			}
 		}
 		if !bytes.Equal(acc.CodeHash, types.EmptyCodeHash.Bytes()) {
-			if !rawdb.HasCode(chaindb, common.BytesToHash(acc.CodeHash)) {
+			if !rawdb.HasCode(chaindb.StateStoreReader(), common.BytesToHash(acc.CodeHash)) {
 				log.Error("Code is missing", "hash", common.BytesToHash(acc.CodeHash))
 				return errors.New("missing code")
 			}
@@ -522,7 +522,7 @@ func traverseRawState(ctx *cli.Context) error {
 				}
 			}
 			if !bytes.Equal(acc.CodeHash, types.EmptyCodeHash.Bytes()) {
-				if !rawdb.HasCode(chaindb, common.BytesToHash(acc.CodeHash)) {
+				if !rawdb.HasCode(chaindb.StateStoreReader(), common.BytesToHash(acc.CodeHash)) {
 					log.Error("Code is missing", "account", common.BytesToHash(accIter.LeafKey()))
 					return errors.New("missing code")
 				}
@@ -572,7 +572,7 @@ func dumpState(ctx *cli.Context) error {
 		AsyncBuild: false,
 	}
 	triesInMemory := ctx.Uint64(utils.TriesInMemoryFlag.Name)
-	snaptree, err := snapshot.New(snapConfig, db, triedb, root, int(triesInMemory), false)
+	snaptree, err := snapshot.New(snapConfig, db.GetSnapStore(), triedb, root, int(triesInMemory), false)
 	if err != nil {
 		return err
 	}
@@ -605,7 +605,7 @@ func dumpState(ctx *cli.Context) error {
 			AddressHash: accIt.Hash().Bytes(),
 		}
 		if !conf.SkipCode && !bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
-			da.Code = rawdb.ReadCode(db, common.BytesToHash(account.CodeHash))
+			da.Code = rawdb.ReadCode(db.StateStoreReader(), common.BytesToHash(account.CodeHash))
 		}
 		if !conf.SkipStorage {
 			da.Storage = make(map[common.Hash]string)
@@ -669,7 +669,7 @@ func snapshotExportPreimages(ctx *cli.Context) error {
 		NoBuild:    true,
 		AsyncBuild: false,
 	}
-	snaptree, err := snapshot.New(snapConfig, chaindb, triedb, root, 128, false)
+	snaptree, err := snapshot.New(snapConfig, chaindb.GetSnapStore(), triedb, root, 128, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2583,16 +2583,9 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 			EraDirectory:      ctx.String(EraFlag.Name),
 		}
 		chainDb, err = stack.OpenDatabaseWithOptions("chaindata", options)
-		// set the separate state database
+		// set the separate databases
 		if stack.CheckIfMultiDataBase() && err == nil {
-			stateDiskDb := MakeStateDataBase(ctx, stack, readonly)
-			chainDb.SetStateStore(stateDiskDb)
-
-			snapDiskDb := MakeSnapDataBase(ctx, stack, readonly)
-			chainDb.SetSnapStore(snapDiskDb)
-
-			indexDiskDb := MakeTxIndexDatabase(ctx, stack, readonly)
-			chainDb.SetTxIndexStore(indexDiskDb)
+			stack.SetMultiDBs(chainDb, "chaindata", cache, handles, readonly)
 		}
 	}
 	if err != nil {
@@ -2617,7 +2610,13 @@ func MakeStateDataBase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 func MakeSnapDataBase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.KeyValueStore {
 	cache := ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) * node.SnapDbResourcePercentage / 100
 	handles := MakeDatabaseHandles(ctx.Int(FDLimitFlag.Name)) * node.SnapDbResourcePercentage / 100
-	snapdb, err := stack.OpenDatabase("chaindata/snapshot", cache, handles, "eth/db/snapdata/", readonly, true)
+	snapdb, err := stack.OpenDatabaseWithOptions("chaindata/snapshot", node.DatabaseOptions{
+		Cache:            cache,
+		Handles:          handles,
+		MetricsNamespace: "eth/db/snapdata/",
+		ReadOnly:         readonly,
+		IsKeyValueDb:     true,
+	})
 	if err != nil {
 		Fatalf("Failed to open separate snapshot database: %v", err)
 	}
@@ -2629,7 +2628,13 @@ func MakeSnapDataBase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.K
 func MakeTxIndexDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.KeyValueStore {
 	cache := ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) * node.IndexDbResourcePercentage / 100
 	handles := MakeDatabaseHandles(ctx.Int(FDLimitFlag.Name)) * node.IndexDbResourcePercentage / 100
-	indexdb, err := stack.OpenDatabase("chaindata/txindex", cache, handles, "eth/db/txindex/", readonly, true)
+	indexdb, err := stack.OpenDatabaseWithOptions("chaindata/txindex", node.DatabaseOptions{
+		Cache:            cache,
+		Handles:          handles,
+		MetricsNamespace: "eth/db/txindex/",
+		ReadOnly:         readonly,
+		IsKeyValueDb:     true,
+	})
 	if err != nil {
 		Fatalf("Failed to open separate tx index database: %v", err)
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2587,6 +2587,12 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 		if stack.CheckIfMultiDataBase() && err == nil {
 			stateDiskDb := MakeStateDataBase(ctx, stack, readonly)
 			chainDb.SetStateStore(stateDiskDb)
+
+			snapDiskDb := MakeSnapDataBase(ctx, stack, readonly)
+			chainDb.SetSnapStore(snapDiskDb)
+
+			indexDiskDb := MakeTxIndexDatabase(ctx, stack, readonly)
+			chainDb.SetTxIndexStore(indexDiskDb)
 		}
 	}
 	if err != nil {
@@ -2597,13 +2603,37 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 
 // MakeStateDataBase open a separate state database using the flags passed to the client and will hard crash if it fails.
 func MakeStateDataBase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.Database {
-	cache := ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) / 100
-	handles := MakeDatabaseHandles(ctx.Int(FDLimitFlag.Name)) * 90 / 100
+	cache := ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) * node.StateStoreResourcePercentage / 100
+	handles := MakeDatabaseHandles(ctx.Int(FDLimitFlag.Name)) * node.StateStoreResourcePercentage / 100
 	statediskdb, err := stack.OpenDatabaseWithFreezer("chaindata/state", cache, handles, "", "", readonly)
 	if err != nil {
 		Fatalf("Failed to open separate trie database: %v", err)
 	}
+
 	return statediskdb
+}
+
+// MakeSnapDataBase opens a separate snapshot database using the flags passed to the client and will hard crash if it fails.
+func MakeSnapDataBase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.KeyValueStore {
+	cache := ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) * node.SnapDbResourcePercentage / 100
+	handles := MakeDatabaseHandles(ctx.Int(FDLimitFlag.Name)) * node.SnapDbResourcePercentage / 100
+	snapdb, err := stack.OpenDatabase("chaindata/snapshot", cache, handles, "eth/db/snapdata/", readonly, true)
+	if err != nil {
+		Fatalf("Failed to open separate snapshot database: %v", err)
+	}
+
+	return snapdb
+}
+
+// MakeTxIndexDatabase opens a separate tx index database using the flags passed to the client and will hard crash if it fails.
+func MakeTxIndexDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.KeyValueStore {
+	cache := ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) * node.IndexDbResourcePercentage / 100
+	handles := MakeDatabaseHandles(ctx.Int(FDLimitFlag.Name)) * node.IndexDbResourcePercentage / 100
+	indexdb, err := stack.OpenDatabase("chaindata/txindex", cache, handles, "eth/db/txindex/", readonly, true)
+	if err != nil {
+		Fatalf("Failed to open separate tx index database: %v", err)
+	}
+	return indexdb
 }
 
 func PathDBConfigAddJournalFilePath(stack *node.Node, config *pathdb.Config) *pathdb.Config {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2594,53 +2594,6 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 	return chainDb
 }
 
-// MakeStateDataBase open a separate state database using the flags passed to the client and will hard crash if it fails.
-func MakeStateDataBase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.Database {
-	cache := ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) * node.StateStoreResourcePercentage / 100
-	handles := MakeDatabaseHandles(ctx.Int(FDLimitFlag.Name)) * node.StateStoreResourcePercentage / 100
-	statediskdb, err := stack.OpenDatabaseWithFreezer("chaindata/state", cache, handles, "", "", readonly)
-	if err != nil {
-		Fatalf("Failed to open separate trie database: %v", err)
-	}
-
-	return statediskdb
-}
-
-// MakeSnapDataBase opens a separate snapshot database using the flags passed to the client and will hard crash if it fails.
-func MakeSnapDataBase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.KeyValueStore {
-	cache := ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) * node.SnapDbResourcePercentage / 100
-	handles := MakeDatabaseHandles(ctx.Int(FDLimitFlag.Name)) * node.SnapDbResourcePercentage / 100
-	snapdb, err := stack.OpenDatabaseWithOptions("chaindata/snapshot", node.DatabaseOptions{
-		Cache:            cache,
-		Handles:          handles,
-		MetricsNamespace: "eth/db/snapdata/",
-		ReadOnly:         readonly,
-		IsKeyValueDb:     true,
-	})
-	if err != nil {
-		Fatalf("Failed to open separate snapshot database: %v", err)
-	}
-
-	return snapdb
-}
-
-// MakeTxIndexDatabase opens a separate tx index database using the flags passed to the client and will hard crash if it fails.
-func MakeTxIndexDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.KeyValueStore {
-	cache := ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) * node.IndexDbResourcePercentage / 100
-	handles := MakeDatabaseHandles(ctx.Int(FDLimitFlag.Name)) * node.IndexDbResourcePercentage / 100
-	indexdb, err := stack.OpenDatabaseWithOptions("chaindata/txindex", node.DatabaseOptions{
-		Cache:            cache,
-		Handles:          handles,
-		MetricsNamespace: "eth/db/txindex/",
-		ReadOnly:         readonly,
-		IsKeyValueDb:     true,
-	})
-	if err != nil {
-		Fatalf("Failed to open separate tx index database: %v", err)
-	}
-	return indexdb
-}
-
 func PathDBConfigAddJournalFilePath(stack *node.Node, config *pathdb.Config) *pathdb.Config {
 	path := fmt.Sprintf("%s/%s", stack.ResolvePath("chaindata"), eth.JournalFileName)
 	config.JournalFilePath = path

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1410,7 +1410,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	go func() {
 		defer dbWg.Done()
 
-		batch := bc.db.NewBatch()
+		batch := bc.db.GetTxIndexStore().NewBatch()
 		rawdb.WriteTxLookupEntriesByBlock(batch, block)
 
 		// Flush the whole batch into the disk, exit the node if failed

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -510,7 +510,7 @@ func NewBlockChain(db ethdb.Database, genesis *Genesis, engine consensus.Engine,
 			// state data consistent.
 			var diskRoot common.Hash
 			if bc.cfg.SnapshotLimit > 0 && bc.cfg.StateScheme == rawdb.HashScheme {
-				diskRoot = rawdb.ReadSnapshotRoot(bc.db)
+				diskRoot = rawdb.ReadSnapshotRoot(bc.db.GetSnapStore())
 				log.Debug("Head state missing, ReadSnapshotRoot", "snap root", diskRoot)
 			}
 			if bc.triedb.Scheme() == rawdb.PathScheme && !bc.NoTries() {

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -495,7 +495,7 @@ func (bc *BlockChain) StateAt(root common.Hash) (*state.StateDB, error) {
 // Live states are not available and won't be served, please use `State`
 // or `StateAt` instead.
 func (bc *BlockChain) HistoricState(root common.Hash) (*state.StateDB, error) {
-	return state.New(root, state.NewHistoricDatabase(bc.db, bc.triedb))
+	return state.New(root, state.NewHistoricDatabase(bc.db.GetStateStore(), bc.triedb))
 }
 
 // Config retrieves the chain's fork configuration.

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -426,7 +426,7 @@ func (bc *BlockChain) HasState(hash common.Hash) bool {
 			return bc.snaps.Snapshot(hash) != nil
 		}
 		// snaps is nil when the blockchain creates
-		found, err := snapshot.PreCheckSnapshot(bc.db, hash)
+		found, err := snapshot.PreCheckSnapshot(bc.db.GetSnapStore(), hash)
 		if err != nil {
 			log.Warn("Check HasState in NoTries mode failed", "root", hash, "err", err)
 			return false

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -33,7 +33,7 @@ import (
 )
 
 // DecodeTxLookupEntry decodes the supplied tx lookup data.
-func DecodeTxLookupEntry(data []byte, db ethdb.Reader) *uint64 {
+func DecodeTxLookupEntry(data []byte, db ethdb.KeyValueReader) *uint64 {
 	// Database v6 tx lookup just stores the block number
 	if len(data) < common.HashLength {
 		number := new(big.Int).SetBytes(data).Uint64()
@@ -55,7 +55,7 @@ func DecodeTxLookupEntry(data []byte, db ethdb.Reader) *uint64 {
 // ReadTxLookupEntry retrieves the positional metadata associated with a transaction
 // hash to allow retrieving the transaction or receipt by hash.
 func ReadTxLookupEntry(db ethdb.Reader, hash common.Hash) *uint64 {
-	data, _ := db.Get(txLookupKey(hash))
+	data, _ := db.IndexStoreReader().Get(txLookupKey(hash))
 	if len(data) == 0 {
 		return nil
 	}

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -379,7 +379,7 @@ func unindexTransactionsForTesting(db ethdb.Database, from uint64, to uint64, in
 
 // PruneTransactionIndex removes all tx index entries below a certain block number.
 func PruneTransactionIndex(db ethdb.Database, pruneBlock uint64) {
-	tail := ReadTxIndexTail(db)
+	tail := ReadTxIndexTail(db.IndexStoreReader())
 	if tail == nil || *tail > pruneBlock {
 		return // no index, or index ends above pruneBlock
 	}
@@ -387,7 +387,7 @@ func PruneTransactionIndex(db ethdb.Database, pruneBlock uint64) {
 	// their entries. Note if this fails, the index is messed up, but tail still points to
 	// the old tail.
 	var count, removed int
-	DeleteAllTxLookupEntries(db, func(txhash common.Hash, v []byte) bool {
+	DeleteAllTxLookupEntries(db.GetTxIndexStore(), func(txhash common.Hash, v []byte) bool {
 		count++
 		if count%10000000 == 0 {
 			log.Info("Pruning tx index", "count", count, "removed", removed)
@@ -403,7 +403,7 @@ func PruneTransactionIndex(db ethdb.Database, pruneBlock uint64) {
 		}
 		return false
 	})
-	WriteTxIndexTail(db, pruneBlock)
+	WriteTxIndexTail(db.GetTxIndexStore(), pruneBlock)
 }
 
 func decodeNumber(b []byte) uint64 {

--- a/core/rawdb/chain_iterator_test.go
+++ b/core/rawdb/chain_iterator_test.go
@@ -160,7 +160,7 @@ func TestIndexTransactions(t *testing.T) {
 			if i == 0 {
 				continue
 			}
-			number := ReadTxLookupEntry(chainDB.IndexStoreReader(), txs[i-1].Hash())
+			number := ReadTxLookupEntry(chainDB, txs[i-1].Hash())
 			if exist && number == nil {
 				t.Fatalf("Transaction index %d missing", i)
 			}

--- a/core/rawdb/chain_iterator_test.go
+++ b/core/rawdb/chain_iterator_test.go
@@ -160,7 +160,7 @@ func TestIndexTransactions(t *testing.T) {
 			if i == 0 {
 				continue
 			}
-			number := ReadTxLookupEntry(chainDB, txs[i-1].Hash())
+			number := ReadTxLookupEntry(chainDB.IndexStoreReader(), txs[i-1].Hash())
 			if exist && number == nil {
 				t.Fatalf("Transaction index %d missing", i)
 			}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -45,7 +45,10 @@ type freezerdb struct {
 	readOnly    bool
 	ancientRoot string
 
-	stateStore ethdb.Database
+	ethdb.AncientFreezer
+	stateStore   ethdb.Database
+	snapStore    ethdb.KeyValueStore
+	txIndexStore ethdb.KeyValueStore
 }
 
 func (frdb *freezerdb) StateStoreReader() ethdb.Reader {
@@ -53,6 +56,13 @@ func (frdb *freezerdb) StateStoreReader() ethdb.Reader {
 		return frdb
 	}
 	return frdb.stateStore
+}
+
+func (frdb *freezerdb) IndexStoreReader() ethdb.KeyValueReader {
+	if frdb.txIndexStore != nil {
+		return frdb.txIndexStore
+	}
+	return frdb.KeyValueStore
 }
 
 // AncientDatadir returns the path of root ancient directory.
@@ -72,6 +82,16 @@ func (frdb *freezerdb) Close() error {
 	}
 	if frdb.HasSeparateStateStore() {
 		if err := frdb.GetStateStore().Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if frdb.HasSeparateSnapStore() {
+		if err := frdb.GetSnapStore().Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if frdb.HasSeparateTxIndexStore() {
+		if err := frdb.GetTxIndexStore().Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -97,6 +117,42 @@ func (frdb *freezerdb) GetStateStore() ethdb.Database {
 
 func (frdb *freezerdb) HasSeparateStateStore() bool {
 	return frdb.stateStore != nil
+}
+
+func (frdb *freezerdb) SetSnapStore(snapStore ethdb.KeyValueStore) {
+	if frdb.snapStore != nil {
+		frdb.snapStore.Close()
+	}
+	frdb.snapStore = snapStore
+}
+
+func (frdb *freezerdb) GetSnapStore() ethdb.KeyValueStore {
+	if frdb.snapStore != nil {
+		return frdb.snapStore
+	}
+	return frdb.KeyValueStore
+}
+
+func (frdb *freezerdb) HasSeparateSnapStore() bool {
+	return frdb.snapStore != nil
+}
+
+func (frdb *freezerdb) SetTxIndexStore(store ethdb.KeyValueStore) {
+	if frdb.txIndexStore != nil {
+		frdb.txIndexStore.Close()
+	}
+	frdb.txIndexStore = store
+}
+
+func (frdb *freezerdb) GetTxIndexStore() ethdb.KeyValueStore {
+	if frdb.txIndexStore != nil {
+		return frdb.txIndexStore
+	}
+	return frdb.KeyValueStore
+}
+
+func (frdb *freezerdb) HasSeparateTxIndexStore() bool {
+	return frdb.txIndexStore != nil
 }
 
 // Freeze is a helper method used for external testing to trigger and block until
@@ -125,7 +181,9 @@ func (frdb *freezerdb) SetupFreezerEnv(env *ethdb.FreezerEnv, blockHistory uint6
 // nofreezedb is a database wrapper that disables freezer data retrievals.
 type nofreezedb struct {
 	ethdb.KeyValueStore
-	stateStore ethdb.Database
+	stateStore   ethdb.Database
+	snapStore    ethdb.KeyValueStore
+	txIndexStore ethdb.KeyValueStore
 }
 
 // Ancient returns an error as we don't have a backing chain freezer.
@@ -203,6 +261,49 @@ func (db *nofreezedb) StateStoreReader() ethdb.Reader {
 		return db.stateStore
 	}
 	return db
+}
+
+func (db *nofreezedb) IndexStoreReader() ethdb.KeyValueReader {
+	if db.txIndexStore != nil {
+		return db.txIndexStore
+	}
+	return db.KeyValueStore
+}
+
+func (db *nofreezedb) SetSnapStore(snapStore ethdb.KeyValueStore) {
+	if db.snapStore != nil {
+		db.snapStore.Close()
+	}
+	db.snapStore = snapStore
+}
+
+func (db *nofreezedb) GetSnapStore() ethdb.KeyValueStore {
+	if db.snapStore != nil {
+		return db.snapStore
+	}
+	return db.KeyValueStore
+}
+
+func (db *nofreezedb) HasSeparateSnapStore() bool {
+	return db.snapStore != nil
+}
+
+func (db *nofreezedb) SetTxIndexStore(store ethdb.KeyValueStore) {
+	if db.txIndexStore != nil {
+		db.txIndexStore.Close()
+	}
+	db.txIndexStore = store
+}
+
+func (db *nofreezedb) GetTxIndexStore() ethdb.KeyValueStore {
+	if db.txIndexStore != nil {
+		return db.txIndexStore
+	}
+	return db.KeyValueStore
+}
+
+func (db *nofreezedb) HasSeparateTxIndexStore() bool {
+	return db.txIndexStore != nil
 }
 
 func (db *nofreezedb) ReadAncients(fn func(reader ethdb.AncientReaderOp) error) (err error) {
@@ -295,10 +396,17 @@ func (db *emptyfreezedb) SyncAncient() error {
 	return nil
 }
 
-func (db *emptyfreezedb) GetStateStore() ethdb.Database      { return db }
-func (db *emptyfreezedb) SetStateStore(state ethdb.Database) {}
-func (db *emptyfreezedb) StateStoreReader() ethdb.Reader     { return db }
-func (db *emptyfreezedb) HasSeparateStateStore() bool        { return false }
+func (db *emptyfreezedb) GetStateStore() ethdb.Database              { return db }
+func (db *emptyfreezedb) SetStateStore(state ethdb.Database)         {}
+func (db *emptyfreezedb) StateStoreReader() ethdb.Reader             { return db }
+func (db *emptyfreezedb) HasSeparateStateStore() bool                { return false }
+func (db *emptyfreezedb) GetSnapStore() ethdb.KeyValueStore          { return db.KeyValueStore }
+func (db *emptyfreezedb) SetSnapStore(snapStore ethdb.KeyValueStore) {}
+func (db *emptyfreezedb) HasSeparateSnapStore() bool                 { return false }
+func (db *emptyfreezedb) GetTxIndexStore() ethdb.KeyValueStore       { return db.KeyValueStore }
+func (db *emptyfreezedb) SetTxIndexStore(store ethdb.KeyValueStore)  {}
+func (db *emptyfreezedb) HasSeparateTxIndexStore() bool              { return false }
+func (db *emptyfreezedb) IndexStoreReader() ethdb.KeyValueReader     { return db.KeyValueStore }
 func (db *emptyfreezedb) ReadAncients(fn func(reader ethdb.AncientReaderOp) error) (err error) {
 	return nil
 }
@@ -626,6 +734,18 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		defer trieIter.Release()
 	}
 
+	var snapDbIter ethdb.Iterator
+	if db.HasSeparateSnapStore() {
+		snapDbIter = db.GetSnapStore().NewIterator(keyPrefix, nil)
+		defer snapDbIter.Release()
+	}
+
+	var txIndexDbIter ethdb.Iterator
+	if db.HasSeparateTxIndexStore() {
+		txIndexDbIter = db.GetTxIndexStore().NewIterator(keyPrefix, nil)
+		defer txIndexDbIter.Release()
+	}
+
 	var (
 		count  int64
 		start  = time.Now()
@@ -820,6 +940,73 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			}
 		}
 		log.Info("Inspecting separate state database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
+	}
+	// inspect separate snapshot db
+	if snapDbIter != nil {
+		count = 0
+		logged = time.Now()
+		for snapDbIter.Next() {
+			var (
+				key   = snapDbIter.Key()
+				value = snapDbIter.Value()
+				size  = common.StorageSize(len(key) + len(value))
+			)
+			total += size
+
+			switch {
+			case bytes.HasPrefix(key, SnapshotAccountPrefix) && len(key) == (len(SnapshotAccountPrefix)+common.HashLength):
+				accountSnaps.Add(size)
+			case bytes.HasPrefix(key, SnapshotStoragePrefix) && len(key) == (len(SnapshotStoragePrefix)+2*common.HashLength):
+				storageSnaps.Add(size)
+			default:
+				var accounted bool
+				for _, meta := range [][]byte{
+					SnapshotRootKey, snapshotJournalKey, snapshotGeneratorKey, snapshotRecoveryKey, snapshotSyncStatusKey,
+				} {
+					if bytes.Equal(key, meta) {
+						metadata.Add(size)
+						accounted = true
+						break
+					}
+				}
+				if !accounted {
+					unaccounted.Add(size)
+				}
+			}
+			count++
+			if count%1000 == 0 && time.Since(logged) > 8*time.Second {
+				log.Info("Inspecting separate snapshot database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
+				logged = time.Now()
+			}
+		}
+		log.Info("Inspecting separate snapshot database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
+	}
+
+	// inspect separate txindex db
+	if txIndexDbIter != nil {
+		count = 0
+		logged = time.Now()
+		for txIndexDbIter.Next() {
+			var (
+				key   = txIndexDbIter.Key()
+				value = txIndexDbIter.Value()
+				size  = common.StorageSize(len(key) + len(value))
+			)
+			total += size
+
+			switch {
+			case bytes.HasPrefix(key, txLookupPrefix) && len(key) == (len(txLookupPrefix)+common.HashLength):
+				txLookups.Add(size)
+			default:
+				unaccounted.Add(size)
+			}
+			count++
+			if count%1000 == 0 && time.Since(logged) > 8*time.Second {
+				log.Info("Inspecting separate txindex database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
+				logged = time.Now()
+			}
+		}
+		log.Info("Inspecting separate txindex database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
 	}
 	// Display the database statistic of key-value store.
 	stats := [][]string{

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -728,24 +728,6 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 	it := db.NewIterator(keyPrefix, keyStart)
 	defer it.Release()
 
-	var trieIter ethdb.Iterator
-	if db.HasSeparateStateStore() {
-		trieIter = db.GetStateStore().NewIterator(keyPrefix, nil)
-		defer trieIter.Release()
-	}
-
-	var snapDbIter ethdb.Iterator
-	if db.HasSeparateSnapStore() {
-		snapDbIter = db.GetSnapStore().NewIterator(keyPrefix, nil)
-		defer snapDbIter.Release()
-	}
-
-	var txIndexDbIter ethdb.Iterator
-	if db.HasSeparateTxIndexStore() {
-		txIndexDbIter = db.GetTxIndexStore().NewIterator(keyPrefix, nil)
-		defer txIndexDbIter.Release()
-	}
-
 	var (
 		count  int64
 		start  = time.Now()
@@ -898,116 +880,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			logged = time.Now()
 		}
 	}
-	// inspect separate trie db
-	if trieIter != nil {
-		count = 0
-		logged = time.Now()
-		for trieIter.Next() {
-			var (
-				key   = trieIter.Key()
-				value = trieIter.Value()
-				size  = common.StorageSize(len(key) + len(value))
-			)
-			total += size
 
-			switch {
-			case IsLegacyTrieNode(key, value):
-				legacyTries.Add(size)
-			case bytes.HasPrefix(key, stateIDPrefix) && len(key) == len(stateIDPrefix)+common.HashLength:
-				stateLookups.Add(size)
-			case IsAccountTrieNode(key):
-				accountTries.Add(size)
-			case IsStorageTrieNode(key):
-				storageTries.Add(size)
-			default:
-				var accounted bool
-				for _, meta := range [][]byte{
-					fastTrieProgressKey, persistentStateIDKey, trieJournalKey, snapSyncStatusFlagKey} {
-					if bytes.Equal(key, meta) {
-						metadata.Add(size)
-						accounted = true
-						break
-					}
-				}
-				if !accounted {
-					unaccounted.Add(size)
-				}
-			}
-			count++
-			if count%1000 == 0 && time.Since(logged) > 8*time.Second {
-				log.Info("Inspecting separate state database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
-				logged = time.Now()
-			}
-		}
-		log.Info("Inspecting separate state database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
-	}
-	// inspect separate snapshot db
-	if snapDbIter != nil {
-		count = 0
-		logged = time.Now()
-		for snapDbIter.Next() {
-			var (
-				key   = snapDbIter.Key()
-				value = snapDbIter.Value()
-				size  = common.StorageSize(len(key) + len(value))
-			)
-			total += size
-
-			switch {
-			case bytes.HasPrefix(key, SnapshotAccountPrefix) && len(key) == (len(SnapshotAccountPrefix)+common.HashLength):
-				accountSnaps.Add(size)
-			case bytes.HasPrefix(key, SnapshotStoragePrefix) && len(key) == (len(SnapshotStoragePrefix)+2*common.HashLength):
-				storageSnaps.Add(size)
-			default:
-				var accounted bool
-				for _, meta := range [][]byte{
-					SnapshotRootKey, snapshotJournalKey, snapshotGeneratorKey, snapshotRecoveryKey, snapshotSyncStatusKey,
-				} {
-					if bytes.Equal(key, meta) {
-						metadata.Add(size)
-						accounted = true
-						break
-					}
-				}
-				if !accounted {
-					unaccounted.Add(size)
-				}
-			}
-			count++
-			if count%1000 == 0 && time.Since(logged) > 8*time.Second {
-				log.Info("Inspecting separate snapshot database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
-				logged = time.Now()
-			}
-		}
-		log.Info("Inspecting separate snapshot database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
-	}
-
-	// inspect separate txindex db
-	if txIndexDbIter != nil {
-		count = 0
-		logged = time.Now()
-		for txIndexDbIter.Next() {
-			var (
-				key   = txIndexDbIter.Key()
-				value = txIndexDbIter.Value()
-				size  = common.StorageSize(len(key) + len(value))
-			)
-			total += size
-
-			switch {
-			case bytes.HasPrefix(key, txLookupPrefix) && len(key) == (len(txLookupPrefix)+common.HashLength):
-				txLookups.Add(size)
-			default:
-				unaccounted.Add(size)
-			}
-			count++
-			if count%1000 == 0 && time.Since(logged) > 8*time.Second {
-				log.Info("Inspecting separate txindex database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
-				logged = time.Now()
-			}
-		}
-		log.Info("Inspecting separate txindex database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
-	}
 	// Display the database statistic of key-value store.
 	stats := [][]string{
 		{"Key-Value store", "Headers", headers.Size(), headers.Count()},
@@ -1054,31 +927,17 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		total += ancient.size()
 	}
 
-	// inspect ancient state in separate trie db if exist
-	if trieIter != nil {
-		stateAncients, err := inspectFreezers(db.GetStateStore())
-		if err != nil {
-			return err
-		}
-		for _, ancient := range stateAncients {
-			for _, table := range ancient.sizes {
-				if ancient.name == "chain" {
-					break
-				}
-				stats = append(stats, []string{
-					fmt.Sprintf("Ancient store (%s)", strings.Title(ancient.name)),
-					strings.Title(table.name),
-					table.size.String(),
-					fmt.Sprintf("%d", ancient.count()),
-				})
-			}
-			total += ancient.size()
-		}
-	}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Database", "Category", "Size", "Items"})
 	table.SetFooter([]string{"", "Total", total.String(), " "})
-	table.AppendBulk(stats)
+	// only print count > 0
+	validStats := [][]string{}
+	for _, s := range stats {
+		if s[3] != "0" && s[3] != "" {
+			validStats = append(validStats, s)
+		}
+	}
+	table.AppendBulk(validStats)
 	table.Render()
 
 	if unaccounted.size > 0 {

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -222,8 +222,36 @@ func (t *table) HasSeparateStateStore() bool {
 	return false
 }
 
-func (t *table) StateStoreReader() ethdb.Reader {
+func (t *table) SetSnapStore(state ethdb.KeyValueStore) {
+	panic("not implement")
+}
+
+func (t *table) GetSnapStore() ethdb.KeyValueStore {
 	return nil
+}
+
+func (t *table) HasSeparateSnapStore() bool {
+	return false
+}
+
+func (t *table) StateStoreReader() ethdb.Reader {
+	return t.db.StateStoreReader()
+}
+
+func (t *table) IndexStoreReader() ethdb.KeyValueReader {
+	return t.db.IndexStoreReader()
+}
+
+func (t *table) SetTxIndexStore(store ethdb.KeyValueStore) {
+	panic("not implement")
+}
+
+func (t *table) GetTxIndexStore() ethdb.KeyValueStore {
+	return nil
+}
+
+func (t *table) HasSeparateTxIndexStore() bool {
+	return false
 }
 
 // NewBatchWithSize creates a write-only database batch with pre-allocated buffer.

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -96,7 +96,7 @@ func NewPruner(db ethdb.Database, config Config, triesInMemory uint64) (*Pruner,
 		NoBuild:    true,
 		AsyncBuild: false,
 	}
-	snaptree, err := snapshot.New(snapconfig, db, triedb, headBlock.Root(), int(triesInMemory), false)
+	snaptree, err := snapshot.New(snapconfig, db.GetSnapStore(), triedb, headBlock.Root(), int(triesInMemory), false)
 	if err != nil {
 		return nil, err // The relevant snapshot(s) might not exist
 	}
@@ -391,7 +391,7 @@ func RecoverPruning(datadir string, db ethdb.Database, triesInMemory uint64) err
 	}
 	// Offline pruning is only supported in legacy hash based scheme.
 	triedb := triedb.NewDatabase(db, triedb.HashDefaults)
-	snaptree, err := snapshot.New(snapconfig, db, triedb, headBlock.Root(), int(triesInMemory), false)
+	snaptree, err := snapshot.New(snapconfig, db.GetSnapStore(), triedb, headBlock.Root(), int(triesInMemory), false)
 	if err != nil {
 		return err // The relevant snapshot(s) might not exist
 	}

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -67,7 +67,7 @@ func GenerateTrie(snaptree *Tree, root common.Hash, src ethdb.Database, dst ethd
 	got, err := generateTrieRoot(dst, scheme, acctIt, common.Hash{}, stackTrieGenerate, func(dst ethdb.KeyValueWriter, accountHash, codeHash common.Hash, stat *generateStats) (common.Hash, error) {
 		// Migrate the code first, commit the contract code into the tmp db.
 		if codeHash != types.EmptyCodeHash {
-			code := rawdb.ReadCode(src, codeHash)
+			code := rawdb.ReadCode(src.StateStoreReader(), codeHash)
 			if len(code) == 0 {
 				return common.Hash{}, errors.New("failed to read contract code")
 			}

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -224,6 +224,7 @@ func New(config Config, diskdb ethdb.KeyValueStore, triedb *triedb.Database, roo
 		snap.layers[head.Root()] = head
 		head = head.Parent()
 	}
+
 	log.Info("Snapshot loaded", "diskRoot", snap.diskRoot(), "root", root)
 	return snap, nil
 }

--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -202,7 +202,7 @@ func (test *stateTest) run() bool {
 			Recovery:   false,
 			NoBuild:    false,
 			AsyncBuild: false,
-		}, disk, tdb, types.EmptyRootHash, 128, false)
+		}, disk.GetSnapStore(), tdb, types.EmptyRootHash, 128, false)
 	}
 	for i, actions := range test.actions {
 		root := types.EmptyRootHash

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -740,7 +740,7 @@ func testIncompleteStateSync(t *testing.T, scheme string) {
 		} else {
 			t.Logf("has code: %v", node)
 		}
-		rawdb.DeleteCode(dstDb, node)
+		rawdb.DeleteCode(dstDb.GetStateStore(), node)
 		if err := checkStateConsistency(dstDb, ndb.Scheme(), srcRoot); err == nil {
 			t.Errorf("trie inconsistency not caught, missing: %x", node)
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -257,7 +257,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		overrides.OverrideVerkle = config.OverrideVerkle
 	}
 
-	// startup ancient freeze
+	// startup ancient freezer
 	freezeDb := chainDb
 	if err = freezeDb.SetupFreezerEnv(&ethdb.FreezerEnv{
 		ChainCfg:         chainConfig,

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -927,7 +927,7 @@ func (s *Syncer) saveSyncStatus() {
 	if err != nil {
 		panic(err) // This can only fail during implementation
 	}
-	rawdb.WriteSnapshotSyncStatus(s.db, status)
+	rawdb.WriteSnapshotSyncStatus(s.db.GetSnapStore(), status)
 }
 
 // Progress returns the snap sync status statistics.

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1905,7 +1905,7 @@ func (s *Syncer) processAccountResponse(res *accountResponse) {
 	for i, account := range res.accounts {
 		// Check if the account is a contract with an unknown code
 		if !bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
-			if !rawdb.HasCodeWithPrefix(s.db, common.BytesToHash(account.CodeHash)) {
+			if !rawdb.HasCodeWithPrefix(s.db.StateStoreReader(), common.BytesToHash(account.CodeHash)) {
 				res.task.codeTasks[common.BytesToHash(account.CodeHash)] = struct{}{}
 				res.task.needCode[i] = true
 				res.task.pend++

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -210,12 +210,19 @@ type StateStoreReader interface {
 	StateStoreReader() Reader
 }
 
+// IndexStoreReader wraps the IndexStoreReader method.
+// It provides a read-only view over the transaction index store which is a pure key-value store.
+type IndexStoreReader interface {
+	IndexStoreReader() KeyValueReader
+}
+
 // Reader contains the methods required to read data from both key-value as well as
 // immutable ancient data.
 type Reader interface {
 	KeyValueReader
 	AncientReader
 	StateStoreReader
+	IndexStoreReader
 }
 
 // AncientStore contains all the methods required to allow handling different
@@ -233,6 +240,18 @@ type StateStore interface {
 	HasSeparateStateStore() bool
 }
 
+type SnapStore interface {
+	SetSnapStore(state KeyValueStore)
+	GetSnapStore() KeyValueStore
+	HasSeparateSnapStore() bool
+}
+
+type TxIndexStore interface {
+	SetTxIndexStore(state KeyValueStore)
+	GetTxIndexStore() KeyValueStore
+	HasSeparateTxIndexStore() bool
+}
+
 // ResettableAncientStore extends the AncientStore interface by adding a Reset method.
 type ResettableAncientStore interface {
 	AncientStore
@@ -246,6 +265,9 @@ type ResettableAncientStore interface {
 type Database interface {
 	StateStore
 	StateStoreReader
+	SnapStore
+	TxIndexStore
+	IndexStoreReader
 	AncientFreezer
 
 	KeyValueStore

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -287,10 +287,26 @@ func (db *Database) Len() int {
 }
 
 func (db *Database) StateStoreReader() ethdb.Reader {
-	if db.stateStore == nil {
-		return db
+	if db.stateStore != nil {
+		return db.stateStore
 	}
-	return db.stateStore
+	return db
+}
+
+func (db *Database) IndexStoreReader() ethdb.KeyValueReader {
+	return db
+}
+
+func (db *Database) GetTxIndexStore() ethdb.KeyValueStore {
+	return db
+}
+
+func (db *Database) SetTxIndexStore(store ethdb.KeyValueStore) {
+	// No-op for memory database
+}
+
+func (db *Database) HasSeparateTxIndexStore() bool {
+	return false
 }
 
 // keyvalue is a key-value tuple tagged with a deletion field to allow creating

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -87,8 +87,36 @@ func (db *Database) HasSeparateStateStore() bool {
 	panic("not supported")
 }
 
+func (db *Database) SetSnapStore(state ethdb.KeyValueStore) {
+	panic("not supported")
+}
+
+func (db *Database) GetSnapStore() ethdb.KeyValueStore {
+	panic("not supported")
+}
+
+func (db *Database) HasSeparateSnapStore() bool {
+	panic("not supported")
+}
+
 func (db *Database) StateStoreReader() ethdb.Reader {
 	return db
+}
+
+func (db *Database) IndexStoreReader() ethdb.KeyValueReader {
+	return db
+}
+
+func (db *Database) GetTxIndexStore() ethdb.KeyValueStore {
+	return db
+}
+
+func (db *Database) SetTxIndexStore(store ethdb.KeyValueStore) {
+	// No-op for remote database
+}
+
+func (db *Database) HasSeparateTxIndexStore() bool {
+	return false
 }
 
 func (db *Database) ReadAncients(fn func(op ethdb.AncientReaderOp) error) (err error) {

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/protolambda/zrnt v0.34.1
 	github.com/protolambda/ztyp v0.2.2
 	github.com/prysmaticlabs/prysm/v5 v5.3.2
-	github.com/rs/cors v1.8.2
+	github.com/rs/cors v1.11.1
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -1010,8 +1010,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=
-github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=

--- a/node/database.go
+++ b/node/database.go
@@ -35,11 +35,11 @@ type DatabaseOptions struct {
 	// ancient/chain or a directory specified via an absolute path.
 	EraDirectory string
 
-	MetricsNamespace   string // the namespace for database relevant metrics
-	Cache              int    // the capacity(in megabytes) of the data caching
-	Handles            int    // number of files to be open simultaneously
-	ReadOnly           bool   // if true, no writes can be performed
-	isKeyValueDataBase bool
+	MetricsNamespace string // the namespace for database relevant metrics
+	Cache            int    // the capacity(in megabytes) of the data caching
+	Handles          int    // number of files to be open simultaneously
+	ReadOnly         bool   // if true, no writes can be performed
+	IsKeyValueDb     bool   // if true, open as pure key-value database without ancients
 }
 
 type internalOpenOptions struct {

--- a/node/database.go
+++ b/node/database.go
@@ -35,10 +35,11 @@ type DatabaseOptions struct {
 	// ancient/chain or a directory specified via an absolute path.
 	EraDirectory string
 
-	MetricsNamespace string // the namespace for database relevant metrics
-	Cache            int    // the capacity(in megabytes) of the data caching
-	Handles          int    // number of files to be open simultaneously
-	ReadOnly         bool   // if true, no writes can be performed
+	MetricsNamespace   string // the namespace for database relevant metrics
+	Cache              int    // the capacity(in megabytes) of the data caching
+	Handles            int    // number of files to be open simultaneously
+	ReadOnly           bool   // if true, no writes can be performed
+	isKeyValueDataBase bool
 }
 
 type internalOpenOptions struct {

--- a/node/node.go
+++ b/node/node.go
@@ -76,13 +76,13 @@ const (
 	runningState
 	closedState
 	// ChainDbResourcePercentage is estimated from on-disk size proportions of metadata and block data.
-	ChainDbResourcePercentage = 7
+	ChainDbResourcePercentage = 5
 	// SnapDbResourcePercentage is estimated from on-disk size proportions of snapshot data.
-	SnapDbResourcePercentage = 36
+	SnapDbResourcePercentage = 30
 	// StateStoreResourcePercentage is estimated from on-disk size proportions of trie data.
-	StateStoreResourcePercentage = 50
-	// IndexDbResourcePercentage is estimated from on-disk size proportions of transaction index data.
-	IndexDbResourcePercentage = 7
+	StateStoreResourcePercentage = 60
+	// IndexDbResourcePercentage is lower because it is rarely accessed.
+	IndexDbResourcePercentage = 5
 )
 
 const StateDBNamespace = "eth/db/statedata/"

--- a/node/node.go
+++ b/node/node.go
@@ -78,11 +78,11 @@ const (
 	// ChainDbResourcePercentage is estimated from on-disk size proportions of metadata and block data.
 	ChainDbResourcePercentage = 7
 	// SnapDbResourcePercentage is estimated from on-disk size proportions of snapshot data.
-	SnapDbResourcePercentage = 24
+	SnapDbResourcePercentage = 36
 	// StateStoreResourcePercentage is estimated from on-disk size proportions of trie data.
 	StateStoreResourcePercentage = 50
 	// IndexDbResourcePercentage is estimated from on-disk size proportions of transaction index data.
-	IndexDbResourcePercentage = 19
+	IndexDbResourcePercentage = 7
 )
 
 const StateDBNamespace = "eth/db/statedata/"
@@ -762,7 +762,7 @@ func (n *Node) OpenDatabaseWithOptions(name string, opt DatabaseOptions) (ethdb.
 			ReadOnly:         opt.ReadOnly,
 		})
 	} else {
-		if !opt.isKeyValueDataBase {
+		if !opt.IsKeyValueDb {
 			opt.AncientsDirectory = n.ResolveAncient(name, opt.AncientsDirectory)
 		}
 		db, err = openDatabase(internalOpenOptions{
@@ -792,32 +792,16 @@ func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, r
 
 func (n *Node) OpenAndMergeDatabase(name string, namespace string, readonly bool, config *ethconfig.Config) (ethdb.Database, error) {
 	var (
-		err                          error
-		stateDiskDb                  ethdb.Database
-		chainDataHandles             = config.DatabaseHandles
-		chainDbCache                 = config.DatabaseCache
-		stateDbCache, stateDbHandles int
-		snapDbCache, snapDbHandles   int
-		indexDbCache, indexDbHandles int
+		err              error
+		chainDataHandles = config.DatabaseHandles
+		chainDbCache     = config.DatabaseCache
 	)
 
 	isMultiDatabase := n.CheckIfMultiDataBase()
 	// Open the separated state database if the state directory exists
 	if isMultiDatabase {
-		// Resource allocation rules:
-		// 1) Allocate a fixed percentage of memory for chainDb based on chainDbMemoryPercentage & chainDbHandlesPercentage.
-		// 2) Allocate the remaining resources to stateDb.
 		chainDbCache = int(float64(config.DatabaseCache) * ChainDbResourcePercentage / 100)
 		chainDataHandles = int(float64(config.DatabaseHandles) * ChainDbResourcePercentage / 100)
-
-		snapDbCache = int(float64(config.DatabaseCache) * SnapDbResourcePercentage / 100)
-		snapDbHandles = int(float64(config.DatabaseHandles) * SnapDbResourcePercentage / 100)
-
-		indexDbCache = int(float64(config.DatabaseCache) * IndexDbResourcePercentage / 100)
-		indexDbHandles = int(float64(config.DatabaseHandles) * IndexDbResourcePercentage / 100)
-
-		stateDbCache = config.DatabaseCache - chainDbCache - snapDbCache - indexDbCache
-		stateDbHandles = config.DatabaseHandles - chainDataHandles - snapDbHandles - indexDbHandles
 	}
 
 	chainDB, err := n.OpenDatabaseWithFreezer(name, chainDbCache, chainDataHandles, config.DatabaseFreezer, namespace, readonly)
@@ -825,31 +809,12 @@ func (n *Node) OpenAndMergeDatabase(name string, namespace string, readonly bool
 		return nil, err
 	}
 
-	if isMultiDatabase {
-		log.Warn("Multi-database is an experimental feature")
-		// Allocate half of the  handles and chainDbCache to this separate state data database
-		stateDiskDb, err = n.OpenDatabaseWithFreezer(name+"/state", stateDbCache, stateDbHandles, "", "eth/db/statedata/", readonly)
+	// set the separate state database
+	if isMultiDatabase && err == nil {
+		err = n.SetMultiDBs(chainDB, "chaindata", config.DatabaseCache, config.DatabaseHandles, readonly)
 		if err != nil {
 			return nil, err
 		}
-
-		chainDB.SetStateStore(stateDiskDb)
-		// Open the snapshot database as a pure key-value store
-		snapshotDb, err := n.OpenDatabase(name+"/snapshot", snapDbCache, snapDbHandles, "eth/db/snapdata/", readonly, true)
-		if err != nil {
-			log.Error("Failed to open separate snapshot database", "err", err)
-			return nil, err
-		}
-
-		chainDB.SetSnapStore(snapshotDb)
-
-		// Open the tx index database as a pure key-value store
-		indexDb, err := n.OpenDatabase(name+"/txindex", indexDbCache, indexDbHandles, "eth/db/txindex/", readonly, true)
-		if err != nil {
-			log.Error("Failed to open separate tx index database", "err", err)
-			return nil, err
-		}
-		chainDB.SetTxIndexStore(indexDb)
 	}
 
 	return chainDB, nil
@@ -893,6 +858,62 @@ func (n *Node) CheckIfMultiDataBase() bool {
 		return false
 	}
 	panic("data corruption! missing state, snapshot or txindex dir.")
+}
+
+func (n *Node) SetMultiDBs(chainDB ethdb.Database, name string, cache, handles int, readonly bool) error {
+	var (
+		err                          error
+		stateDiskDb                  ethdb.Database
+		stateDbCache, stateDbHandles int
+		snapDbCache, snapDbHandles   int
+		indexDbCache, indexDbHandles int
+	)
+	snapDbCache = int(float64(cache) * SnapDbResourcePercentage / 100)
+	snapDbHandles = int(float64(handles) * SnapDbResourcePercentage / 100)
+
+	indexDbCache = int(float64(cache) * IndexDbResourcePercentage / 100)
+	indexDbHandles = int(float64(handles) * IndexDbResourcePercentage / 100)
+
+	stateDbCache = int(float64(cache) * StateStoreResourcePercentage / 100)
+	stateDbHandles = int(float64(handles) * StateStoreResourcePercentage / 100)
+	log.Warn("Multi-database is an experimental feature")
+
+	// Allocate half of the  handles and chainDbCache to this separate state data database
+	stateDiskDb, err = n.OpenDatabaseWithFreezer(name+"/state", stateDbCache, stateDbHandles, "", "eth/db/statedata/", readonly)
+	if err != nil {
+		return err
+	}
+
+	chainDB.SetStateStore(stateDiskDb)
+	// Open the snapshot database as a pure key-value store
+	snapshotDb, err := n.OpenDatabaseWithOptions(name+"/snapshot", DatabaseOptions{
+		Cache:            snapDbCache,
+		Handles:          snapDbHandles,
+		MetricsNamespace: "eth/db/snapdata/",
+		ReadOnly:         readonly,
+		IsKeyValueDb:     true,
+	})
+	if err != nil {
+		log.Error("Failed to open separate snapshot database", "err", err)
+		return err
+	}
+
+	chainDB.SetSnapStore(snapshotDb)
+
+	// Open the tx index database as a pure key-value store
+	indexDb, err := n.OpenDatabaseWithOptions(name+"/txindex", DatabaseOptions{
+		Cache:            indexDbCache,
+		Handles:          indexDbHandles,
+		MetricsNamespace: "eth/db/txindex/",
+		ReadOnly:         readonly,
+		IsKeyValueDb:     true,
+	})
+	if err != nil {
+		log.Error("Failed to open separate tx index database", "err", err)
+		return err
+	}
+	chainDB.SetTxIndexStore(indexDb)
+	return nil
 }
 
 // ResolvePath returns the absolute path of a resource in the instance directory.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -153,7 +153,7 @@ func TestNodeCloseClosesDB(t *testing.T) {
 	stack, _ := New(testNodeConfig())
 	defer stack.Close()
 
-	db, err := stack.OpenDatabase("mydb", 0, 0, "", false)
+	db, err := stack.OpenDatabase("mydb", 0, 0, "", false, false)
 	if err != nil {
 		t.Fatal("can't open DB:", err)
 	}
@@ -176,7 +176,7 @@ func TestNodeOpenDatabaseFromLifecycleStart(t *testing.T) {
 	var err error
 	stack.RegisterLifecycle(&InstrumentedService{
 		startHook: func() {
-			db, err = stack.OpenDatabase("mydb", 0, 0, "", false)
+			db, err = stack.OpenDatabase("mydb", 0, 0, "", false, false)
 			if err != nil {
 				t.Fatal("can't open DB:", err)
 			}
@@ -197,7 +197,7 @@ func TestNodeOpenDatabaseFromLifecycleStop(t *testing.T) {
 
 	stack.RegisterLifecycle(&InstrumentedService{
 		stopHook: func() {
-			db, err := stack.OpenDatabase("mydb", 0, 0, "", false)
+			db, err := stack.OpenDatabase("mydb", 0, 0, "", false, false)
 			if err != nil {
 				t.Fatal("can't open DB:", err)
 			}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -153,7 +153,7 @@ func TestNodeCloseClosesDB(t *testing.T) {
 	stack, _ := New(testNodeConfig())
 	defer stack.Close()
 
-	db, err := stack.OpenDatabase("mydb", 0, 0, "", false, false)
+	db, err := stack.OpenDatabase("mydb", 0, 0, "", false)
 	if err != nil {
 		t.Fatal("can't open DB:", err)
 	}
@@ -176,7 +176,7 @@ func TestNodeOpenDatabaseFromLifecycleStart(t *testing.T) {
 	var err error
 	stack.RegisterLifecycle(&InstrumentedService{
 		startHook: func() {
-			db, err = stack.OpenDatabase("mydb", 0, 0, "", false, false)
+			db, err = stack.OpenDatabase("mydb", 0, 0, "", false)
 			if err != nil {
 				t.Fatal("can't open DB:", err)
 			}
@@ -197,7 +197,7 @@ func TestNodeOpenDatabaseFromLifecycleStop(t *testing.T) {
 
 	stack.RegisterLifecycle(&InstrumentedService{
 		stopHook: func() {
-			db, err := stack.OpenDatabase("mydb", 0, 0, "", false, false)
+			db, err := stack.OpenDatabase("mydb", 0, 0, "", false)
 			if err != nil {
 				t.Fatal("can't open DB:", err)
 			}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -536,7 +536,7 @@ func MakePreState(db ethdb.Database, accounts types.GenesisAlloc, snapshotter bo
 			NoBuild:    false,
 			AsyncBuild: false,
 		}
-		snaps, _ = snapshot.New(snapconfig, db, triedb, root, 128, false)
+		snaps, _ = snapshot.New(snapconfig, db.GetStateStore(), triedb, root, 128, false)
 	}
 	sdb = state.NewDatabase(triedb, snaps)
 	statedb, _ = state.New(root, sdb)

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -332,7 +332,7 @@ func (s *Sync) AddCodeEntry(hash common.Hash, path []byte, parent common.Hash, p
 	// sync is expected to run with a fresh new node. Even there
 	// exists the code with legacy format, fetch and store with
 	// new scheme anyway.
-	if rawdb.HasCodeWithPrefix(s.database, hash) {
+	if rawdb.HasCodeWithPrefix(s.database.StateStoreReader(), hash) {
 		return
 	}
 	// Assemble the new sub-trie sync request

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -121,8 +121,9 @@ func NewDatabase(diskdb ethdb.Database, config *Config) *Database {
 	if config.Preimages {
 		preimages = newPreimageStore(triediskdb)
 	}
+
 	db := &Database{
-		disk:      diskdb,
+		disk:      triediskdb,
 		config:    config,
 		preimages: preimages,
 	}

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -141,12 +141,13 @@ func NewDatabase(diskdb ethdb.Database, config *Config) *Database {
 		if rawdb.ReadStateScheme(triediskdb) == rawdb.HashScheme {
 			log.Warn("Incompatible state scheme", "old", rawdb.HashScheme, "new", rawdb.PathScheme)
 		}
-		db.backend = pathdb.New(triediskdb, config.PathDB, config.IsVerkle)
+		// The new pathdb implementation needs to support both trie and snap storage
+		db.backend = pathdb.New(diskdb, config.PathDB, config.IsVerkle)
 	} else if strings.Compare(dbScheme, rawdb.PathScheme) == 0 {
 		if config.PathDB == nil {
 			config.PathDB = pathdb.Defaults
 		}
-		db.backend = pathdb.New(triediskdb, config.PathDB, config.IsVerkle)
+		db.backend = pathdb.New(diskdb, config.PathDB, config.IsVerkle)
 	} else {
 		if config.HashDB == nil {
 			config.HashDB = hashdb.Defaults

--- a/triedb/pathdb/buffer.go
+++ b/triedb/pathdb/buffer.go
@@ -197,7 +197,6 @@ func (b *buffer) flush(root common.Hash, db ethdb.Database, separateSnapDB ethdb
 				return
 			}
 		} else {
-			log.Info("multidb concurrent flushing")
 			var wg sync.WaitGroup
 			var trieErr, snapErr error
 

--- a/triedb/pathdb/buffer.go
+++ b/triedb/pathdb/buffer.go
@@ -212,7 +212,7 @@ func (b *buffer) flush(root common.Hash, db ethdb.Database, separateSnapDB ethdb
 			}()
 
 			wg.Add(1)
-			// TODO(flywukong) the split increases the risk of unintended snapshot regeneration on partial failure. Make the writes atomic.
+			// TODO(flywukong) WritePersistentStateID and WriteSnapshotRoot in two separate writings increases the risk of unintended snapshot regeneration.
 			go func() {
 				defer wg.Done()
 				accounts, slots = b.states.write(snapBatch, progress, statesCache)

--- a/triedb/pathdb/buffer.go
+++ b/triedb/pathdb/buffer.go
@@ -199,7 +199,7 @@ func (b *buffer) flush(root common.Hash, db ethdb.Database, separateSnapDB ethdb
 		} else {
 			var wg sync.WaitGroup
 			var trieErr, snapErr error
-
+			// Write snapshot and trie data concurrently in separate goroutines.
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -212,6 +212,7 @@ func (b *buffer) flush(root common.Hash, db ethdb.Database, separateSnapDB ethdb
 			}()
 
 			wg.Add(1)
+			// TODO(flywukong) the split increases the risk of unintended snapshot regeneration on partial failure. Make the writes atomic.
 			go func() {
 				defer wg.Done()
 				accounts, slots = b.states.write(snapBatch, progress, statesCache)

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -406,7 +406,7 @@ func (db *Database) setStateGenerator() error {
 	// Construct the generator and link it to the disk layer, ensuring that the
 	// generation progress is resolved to prevent accessing uncovered states
 	// regardless of whether background state snapshot generation is allowed.
-	dl.setGenerator(newGenerator(db.snapdb, noBuild, generator.Marker, stats))
+	dl.setGenerator(newGenerator(db.snapdb, db.diskdb, noBuild, generator.Marker, stats))
 
 	// Short circuit if the background generation is not permitted
 	if noBuild || db.waitSync {

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -284,7 +284,7 @@ func New(diskdb ethdb.Database, config *Config, isVerkle bool) *Database {
 		log.Crit("Failed to repair state history", "err", err)
 	}
 	// Disable database in case node is still in the initial state sync stage.
-	if rawdb.ReadSnapSyncStatusFlag(db.diskdb) == rawdb.StateSyncRunning && !db.readOnly {
+	if rawdb.ReadSnapSyncStatusFlag(db.snapdb) == rawdb.StateSyncRunning && !db.readOnly {
 		if err := db.Disable(); err != nil {
 			log.Crit("Failed to disable database", "err", err) // impossible to happen
 		}
@@ -494,7 +494,7 @@ func (db *Database) Disable() error {
 	disk.markStale()
 
 	// Write the initial sync flag to persist it across restarts.
-	rawdb.WriteSnapSyncStatusFlag(db.diskdb, rawdb.StateSyncRunning)
+	rawdb.WriteSnapSyncStatusFlag(db.snapdb, rawdb.StateSyncRunning)
 	log.Info("Disabled trie database due to state sync")
 	return nil
 }
@@ -547,7 +547,7 @@ func (db *Database) Enable(root common.Hash) error {
 	}
 	// Re-enable the database as the final step.
 	db.waitSync = false
-	rawdb.WriteSnapSyncStatusFlag(db.diskdb, rawdb.StateSyncFinished)
+	rawdb.WriteSnapSyncStatusFlag(db.snapdb, rawdb.StateSyncFinished)
 
 	// Re-construct a new disk layer backed by persistent state
 	// and schedule the state snapshot generation if it's permitted.

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -233,7 +233,7 @@ type Database struct {
 
 	config    *Config                      // Configuration for database
 	diskdb    ethdb.Database               // Persistent storage for matured trie nodes
-	snapdb    ethdb.KeyValueStore          // Persistent storage for snapshot flat data
+	snapdb    ethdb.KeyValueStore          // Persistent storage for snapshot data
 	tree      *layerTree                   // The group for all known layers
 	freezer   ethdb.ResettableAncientStore // Freezer for storing trie histories, nil possible in tests
 	lock      sync.RWMutex                 // Lock to prevent mutations from happening at the same time
@@ -521,8 +521,13 @@ func (db *Database) Enable(root common.Hash) error {
 	// reset the persistent state id back to zero.
 	batch := db.diskdb.NewBatch()
 	db.DeleteTrieJournal(batch)
-	rawdb.DeleteSnapshotRoot(batch)
 	rawdb.WritePersistentStateID(batch, 0)
+	if db.isMultiDB {
+		// SnapshotRoot store in snap db if multidb enabled
+		rawdb.DeleteSnapshotRoot(db.snapdb)
+	} else {
+		rawdb.DeleteSnapshotRoot(batch)
+	}
 	if err := batch.Write(); err != nil {
 		return err
 	}

--- a/triedb/pathdb/generate.go
+++ b/triedb/pathdb/generate.go
@@ -187,7 +187,7 @@ func generateSnapshot(triedb *Database, root common.Hash, noBuild bool) *diskLay
 		genMarker = []byte{} // Initialized but empty!
 	)
 	dl := newDiskLayer(root, 0, triedb, nil, nil, newBuffer(triedb.config.WriteBufferSize, nil, nil, 0), nil)
-	dl.setGenerator(newGenerator(triedb.diskdb, noBuild, genMarker, stats))
+	dl.setGenerator(newGenerator(triedb.snapdb, noBuild, genMarker, stats))
 
 	if !noBuild {
 		dl.generator.run(root)

--- a/triedb/pathdb/generate.go
+++ b/triedb/pathdb/generate.go
@@ -92,10 +92,11 @@ type generator struct {
 	noBuild bool // Flag indicating whether snapshot generation is permitted
 	running bool // Flag indicating whether the background generation is running
 
-	db    ethdb.KeyValueStore // Key-value store containing the snapshot data
-	stats *generatorStats     // Generation statistics used throughout the entire life cycle
-	abort chan chan struct{}  // Notification channel to abort generating the snapshot in this layer
-	done  chan struct{}       // Notification channel when generation is done
+	db         ethdb.KeyValueStore // Key-value store containing the snapshot data
+	triediskdb ethdb.KeyValueStore // Key-value store containing the trie data
+	stats      *generatorStats     // Generation statistics used throughout the entire life cycle
+	abort      chan chan struct{}  // Notification channel to abort generating the snapshot in this layer
+	done       chan struct{}       // Notification channel when generation is done
 
 	progress []byte       // Progress marker of the state generation, nil means it's completed
 	lock     sync.RWMutex // Lock which protects the progress, only generator can mutate the progress
@@ -109,17 +110,18 @@ type generator struct {
 // progress indicates the starting position for resuming snapshot generation.
 // It must be provided even if generation is not allowed; otherwise, uncovered
 // states may be exposed for serving.
-func newGenerator(db ethdb.KeyValueStore, noBuild bool, progress []byte, stats *generatorStats) *generator {
+func newGenerator(snapdb ethdb.KeyValueStore, triedb ethdb.KeyValueStore, noBuild bool, progress []byte, stats *generatorStats) *generator {
 	if stats == nil {
 		stats = &generatorStats{start: time.Now()}
 	}
 	return &generator{
-		noBuild:  noBuild,
-		progress: progress,
-		db:       db,
-		stats:    stats,
-		abort:    make(chan chan struct{}),
-		done:     make(chan struct{}),
+		noBuild:    noBuild,
+		progress:   progress,
+		db:         snapdb,
+		triediskdb: triedb,
+		stats:      stats,
+		abort:      make(chan chan struct{}),
+		done:       make(chan struct{}),
 	}
 }
 
@@ -188,7 +190,7 @@ func generateSnapshot(triedb *Database, root common.Hash, noBuild bool) *diskLay
 	)
 	dl := newDiskLayer(root, 0, triedb, nil, nil, newBuffer(triedb.config.WriteBufferSize, nil, nil, 0), nil)
 	// snapshot need to be generated in the snapshot db
-	dl.setGenerator(newGenerator(triedb.snapdb, noBuild, genMarker, stats))
+	dl.setGenerator(newGenerator(triedb.snapdb, triedb.diskdb, noBuild, genMarker, stats))
 
 	if !noBuild {
 		dl.generator.run(root)
@@ -360,7 +362,7 @@ func (g *generator) proveRange(ctx *generatorContext, trieId *trie.ID, prefix []
 		return &proofResult{keys: keys, vals: vals}, nil
 	}
 	// Snap state is chunked, generate edge proofs for verification.
-	tr, err := trie.New(trieId, &diskStore{db: g.db})
+	tr, err := trie.New(trieId, &diskStore{db: g.triediskdb})
 	if err != nil {
 		log.Info("Trie missing, snapshotting paused", "state", ctx.root, "kind", kind, "root", trieId.Root)
 		return nil, errMissingTrie
@@ -482,7 +484,7 @@ func (g *generator) generateRange(ctx *generatorContext, trieId *trie.ID, prefix
 	// if it's already opened with some nodes resolved.
 	tr := result.tr
 	if tr == nil {
-		tr, err = trie.New(trieId, &diskStore{db: g.db})
+		tr, err = trie.New(trieId, &diskStore{db: g.triediskdb})
 		if err != nil {
 			log.Info("Trie missing, snapshotting paused", "state", ctx.root, "kind", kind, "root", trieId.Root)
 			return false, nil, errMissingTrie

--- a/triedb/pathdb/generate.go
+++ b/triedb/pathdb/generate.go
@@ -187,6 +187,7 @@ func generateSnapshot(triedb *Database, root common.Hash, noBuild bool) *diskLay
 		genMarker = []byte{} // Initialized but empty!
 	)
 	dl := newDiskLayer(root, 0, triedb, nil, nil, newBuffer(triedb.config.WriteBufferSize, nil, nil, 0), nil)
+	// snapshot need to be generated in the snapshot db
 	dl.setGenerator(newGenerator(triedb.snapdb, noBuild, genMarker, stats))
 
 	if !noBuild {

--- a/triedb/pathdb/iterator_binary.go
+++ b/triedb/pathdb/iterator_binary.go
@@ -65,7 +65,7 @@ func (dl *diskLayer) initBinaryAccountIterator(seek common.Hash) *binaryIterator
 		// is constructed, no matter the referenced disk layer is stale or not
 		// later.
 		a: newDiffAccountIterator(seek, accountList, nil),
-		b: newDiskAccountIterator(dl.db.diskdb, seek),
+		b: newDiskAccountIterator(dl.db.snapdb, seek),
 	}
 	l.aDone = !l.a.Next()
 	l.bDone = !l.b.Next()

--- a/triedb/pathdb/iterator_binary.go
+++ b/triedb/pathdb/iterator_binary.go
@@ -137,7 +137,7 @@ func (dl *diskLayer) initBinaryStorageIterator(account common.Hash, seek common.
 		// is constructed, no matter the referenced disk layer is stale or not
 		// later.
 		a: newDiffStorageIterator(account, seek, storageList, nil),
-		b: newDiskStorageIterator(dl.db.diskdb, account, seek),
+		b: newDiskStorageIterator(dl.db.snapdb, account, seek),
 	}
 	l.aDone = !l.a.Next()
 	l.bDone = !l.b.Next()

--- a/triedb/pathdb/iterator_fast.go
+++ b/triedb/pathdb/iterator_fast.go
@@ -103,7 +103,7 @@ func newFastIterator(db *Database, root common.Hash, account common.Hash, seek c
 					priority: depth,
 				})
 				fi.iterators = append(fi.iterators, &weightedIterator{
-					it:       newDiskAccountIterator(dl.db.diskdb, seek),
+					it:       newDiskAccountIterator(dl.db.snapdb, seek),
 					priority: depth + 1,
 				})
 			case *diffLayer:

--- a/triedb/pathdb/iterator_fast.go
+++ b/triedb/pathdb/iterator_fast.go
@@ -145,7 +145,7 @@ func newFastIterator(db *Database, root common.Hash, account common.Hash, seek c
 					priority: depth,
 				})
 				fi.iterators = append(fi.iterators, &weightedIterator{
-					it:       newDiskStorageIterator(dl.db.diskdb, account, seek),
+					it:       newDiskStorageIterator(dl.db.snapdb, account, seek),
 					priority: depth + 1,
 				})
 			case *diffLayer:

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -234,7 +234,7 @@ type journalGenerator struct {
 }
 
 // loadGenerator loads the state generation progress marker from the database.
-func loadGenerator(db ethdb.KeyValueReader, hash nodeHasher) (*journalGenerator, common.Hash, error) {
+func loadGenerator(db ethdb.KeyValueReader, snapdb ethdb.KeyValueReader, hash nodeHasher) (*journalGenerator, common.Hash, error) {
 	trieRoot, err := hash(rawdb.ReadAccountTrieNode(db, nil))
 	if err != nil {
 		return nil, common.Hash{}, err
@@ -258,7 +258,7 @@ func loadGenerator(db ethdb.KeyValueReader, hash nodeHasher) (*journalGenerator,
 	// with each other, both in the legacy state snapshot and the path database.
 	// Therefore, if the SnapshotRoot does not match the trie root,
 	// the entire generator is considered stale and must be discarded.
-	stateRoot := rawdb.ReadSnapshotRoot(db)
+	stateRoot := rawdb.ReadSnapshotRoot(snapdb)
 	if trieRoot != stateRoot {
 		log.Info("State snapshot is not consistent", "trie", trieRoot, "state", stateRoot)
 		return nil, trieRoot, nil

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -234,13 +234,15 @@ type journalGenerator struct {
 }
 
 // loadGenerator loads the state generation progress marker from the database.
-func loadGenerator(db ethdb.KeyValueReader, snapdb ethdb.KeyValueReader, hash nodeHasher) (*journalGenerator, common.Hash, error) {
-	trieRoot, err := hash(rawdb.ReadAccountTrieNode(db, nil))
+// By default, triedb and snapdb point to the same pathdb disk database.
+// In multi-DB mode, pass a dedicated snapshot database for snapdb.
+func loadGenerator(triedb ethdb.KeyValueReader, snapdb ethdb.KeyValueReader, hash nodeHasher) (*journalGenerator, common.Hash, error) {
+	trieRoot, err := hash(rawdb.ReadAccountTrieNode(triedb, nil))
 	if err != nil {
 		return nil, common.Hash{}, err
 	}
 	// State generation progress marker is lost, rebuild it
-	blob := rawdb.ReadSnapshotGenerator(db)
+	blob := rawdb.ReadSnapshotGenerator(snapdb)
 	if len(blob) == 0 {
 		log.Info("State snapshot generator is not found")
 		return nil, trieRoot, nil


### PR DESCRIPTION
### Description
This PR primarily implements the following features:

1）Support storing snapshot data in a dedicated independent DB instance.
2）Store contract code in the trie database 
3）Support storing  transaction index data in a dedicated  independent DB database 
4）Support  separate  snapshot db after the snapshot being integrated into Pbss
This feature increases the number of databases supported by BSC in multi-DB mode from 2 to 4, providing greater scalability and deployment flexibility.


**Usage:** When --multidatabase is enabled, it means that /snapshot/txnIndex/Trie data will both run in three separate database. Run from gensis:
` ./geth --config config.toml  --datadir data-seed init --multidatabase  genesis.json 

### Rationale


make scalabilty stronger and this serves as the foundation for further sharding of the database.
<img width="916" height="512" alt="image" src="https://github.com/user-attachments/assets/9d15f8d8-39b2-4c03-bb09-d11416171264" />


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
