### PR TITLE
log: downupgrade header fetch failed log level

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -326,7 +326,7 @@ func ReadHeaderRange(db ethdb.Reader, number uint64, count uint64) []rlp.RawValu
 	// read remaining from ancients, cap at 2M
 	data, err := db.AncientRange(ChainFreezerHeaderTable, i+1-count, count, 2*1024*1024)
 	if err != nil {
-		log.Error("Failed to read headers from freezer", "err", err, "start", i+1-count, "count", count, "number", number)
+		log.Debug("Failed to read headers from freezer", "err", err, "start", i+1-count, "count", count, "number", number)
 		return rlpHeaders
 	}
 	if uint64(len(data)) != count {

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -1037,7 +1037,6 @@ func (t *freezerTable) retrieveItems(start, count, maxBytes uint64) ([]byte, []i
 	// Ensure the start is written, not deleted from the tail, and that the
 	// caller actually wants something
 	if items <= start || hidden > start || count == 0 {
-		log.Debug("retrieveItems out of bounds", "table name", t.name, "items", items, "hidden", hidden, "start", start, "count", count)
 		return nil, nil, errOutOfBounds
 	}
 	if start+count > items {


### PR DESCRIPTION
### Description
This is for https://github.com/bnb-chain/bsc/issues/3345
Some BSC nodes will run with flag: `--history.blocks=360000`, which only keep the recent 360000 blocks. When remote peer tries to fetch older blocks, it will failed and there would be log spam.
It is not an issue in this case, as the remote peer will drop and retry with other peers, so just downgrade the log level to debug to avoid log spam.

### Rationale
NA

### Example
NA

### Changes
NA