### PR TITLE
chore: fix SnapSyncWithBlobs UT issues;

### DIFF
--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -300,7 +300,9 @@ func newTestParliaHandlerAfterCancun(t *testing.T, config *params.ChainConfig, m
 		Alloc:  types.GenesisAlloc{testAddr: {Balance: new(big.Int).SetUint64(10 * params.Ether)}},
 	}
 	engine := &mockParlia{}
-	chain, _ := core.NewBlockChain(db, gspec, engine, nil)
+	cfg := core.DefaultConfig()
+	cfg.StateScheme = rawdb.PathScheme
+	chain, _ := core.NewBlockChain(db, gspec, engine, cfg)
 	signer := types.LatestSigner(config)
 
 	_, bs, _ := core.GenerateChainWithGenesis(gspec, engine, int(preCancunBlks+postCancunBlks), func(i int, gen *core.BlockGen) {

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -138,7 +138,7 @@ func testChainSyncWithBlobs(t *testing.T, mode downloader.SyncMode, preCancunBlk
 	// Sync up the two handlers via both `eth` and `snap`
 	caps := []p2p.Cap{{Name: "eth", Version: ethVer}, {Name: "snap", Version: snapVer}}
 
-	emptyPipeEth, fullPipeEth := p2p.MsgPipe()
+	emptyPipeEth, fullPipeEth := p2p.MsgPipe(true)
 	defer emptyPipeEth.Close()
 	defer fullPipeEth.Close()
 
@@ -154,7 +154,7 @@ func testChainSyncWithBlobs(t *testing.T, mode downloader.SyncMode, preCancunBlk
 		return eth.Handle((*ethHandler)(full.handler), peer)
 	})
 
-	emptyPipeSnap, fullPipeSnap := p2p.MsgPipe()
+	emptyPipeSnap, fullPipeSnap := p2p.MsgPipe(true)
 	defer emptyPipeSnap.Close()
 	defer fullPipeSnap.Close()
 


### PR DESCRIPTION
### Description

This PR primarily addresses occasional execution timeouts in TestSnapSyncWithBlobs.

The root cause is that when using MsgPipe, write blocking occurs, preventing normal P2P message processing. See the following gouroutine stack trace:

```bash
goroutine 15154 [select]:
github.com/ethereum/go-ethereum/eth/protocols/eth.(*Peer).dispatchResponse(0x14000016ff0, 0x14001e15440, 0x1400130f668)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/dispatcher.go:149 +0x11c
github.com/ethereum/go-ethereum/eth/protocols/eth.handleReceipts[...]({0x1055e9f60, 0x60?}, {0x106b58978?, 0x14001e15140}, 0x14000016ff0)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/handlers.go:483 +0x270
github.com/ethereum/go-ethereum/eth/protocols/eth.handleMessage({0x106b6f190, 0x14000456480}, 0x14000016ff0)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/handler.go:241 +0x3b4
github.com/ethereum/go-ethereum/eth/protocols/eth.Handle({0x106b6f190, 0x14000456480}, 0x14000016ff0)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/handler.go:159 +0x38
github.com/ethereum/go-ethereum/eth.testChainSyncWithBlobs.func1.1(0x1400130fe78?)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/sync_test.go:159 +0x34
github.com/ethereum/go-ethereum/eth.(*handler).runEthPeer(0x14000456480, 0x14000016ff0, 0x1400130ffb0)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/handler.go:595 +0x11c8
github.com/ethereum/go-ethereum/eth.testChainSyncWithBlobs.func1()
        /Users/jacksen/GolandProjects/galaio-bsc/eth/sync_test.go:158 +0x3c
created by github.com/ethereum/go-ethereum/eth.testChainSyncWithBlobs in goroutine 8578
        /Users/jacksen/GolandProjects/galaio-bsc/eth/sync_test.go:157 +0x48c

goroutine 15155 [select]:
github.com/ethereum/go-ethereum/p2p.(*MsgPipeRW).WriteMsg(0x140013c5820, {0x4, 0x22f, {0x106b4ef20, 0x14001c24220}, {0x0, 0x0, 0x0}, {{0x0, 0x0}, ...}, ...})
        /Users/jacksen/GolandProjects/galaio-bsc/p2p/message.go:188 +0x164
github.com/ethereum/go-ethereum/p2p.Send({0x14e87e950, 0x140013c5820}, 0x4, {0x10675f3e0?, 0x14001c24200?})
        /Users/jacksen/GolandProjects/galaio-bsc/p2p/message.go:104 +0xb8
github.com/ethereum/go-ethereum/eth/protocols/eth.(*Peer).ReplyBlockHeadersRLP(...)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/peer.go:335
github.com/ethereum/go-ethereum/eth/protocols/eth.handleGetBlockHeaders({0x106b6f190, 0x14002126780}, {0x106b58978, 0x1400172b560}, 0x140000170e0)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/handlers.go:47 +0x398
github.com/ethereum/go-ethereum/eth/protocols/eth.handleMessage({0x106b6f190, 0x14002126780}, 0x140000170e0)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/handler.go:241 +0x3b4
github.com/ethereum/go-ethereum/eth/protocols/eth.Handle({0x106b6f190, 0x14002126780}, 0x140000170e0)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/handler.go:159 +0x38
github.com/ethereum/go-ethereum/eth.testChainSyncWithBlobs.func2.1(0x1400130be78?)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/sync_test.go:169 +0x34
github.com/ethereum/go-ethereum/eth.(*handler).runEthPeer(0x14002126780, 0x140000170e0, 0x1400130bfb0)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/handler.go:595 +0x11c8
github.com/ethereum/go-ethereum/eth.testChainSyncWithBlobs.func2()
        /Users/jacksen/GolandProjects/galaio-bsc/eth/sync_test.go:168 +0x3c
created by github.com/ethereum/go-ethereum/eth.testChainSyncWithBlobs in goroutine 8578
        /Users/jacksen/GolandProjects/galaio-bsc/eth/sync_test.go:167 +0x4d4

goroutine 15153 [select]:
github.com/ethereum/go-ethereum/eth/protocols/eth.(*Peer).dispatcher(0x140000170e0)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/dispatcher.go:194 +0xcc
created by github.com/ethereum/go-ethereum/eth/protocols/eth.NewPeer in goroutine 8578
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/peer.go:118 +0x424

goroutine 15040 [chan receive]:
github.com/ethereum/go-ethereum/eth/protocols/eth.(*Peer).dispatchRequest(...)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/dispatcher.go:133
github.com/ethereum/go-ethereum/eth/protocols/eth.(*Peer).RequestBodies(0x14000016ff0, {0x140013e84e0, 0x1, 0x1}, 0x140020a3e30)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/peer.go:455 +0x2ac
github.com/ethereum/go-ethereum/eth/downloader.(*bodyQueue).request(0x140015eeea0, 0x14001407320, 0x14001ba4040, 0x140020a3e30)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/downloader/fetchers_concurrent_bodies.go:86 +0x238
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).concurrentFetch(0x140015eeea0, {0x106b72610, 0x140015eeea0}, 0x0)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/downloader/fetchers_concurrent.go:194 +0x15fc
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).fetchBodies(0x140015eeea0, 0x1, 0x0)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/downloader/downloader.go:1243 +0xac
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).syncWithPeer.func4()
        /Users/jacksen/GolandProjects/galaio-bsc/eth/downloader/downloader.go:628 +0x24
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).spawnSync.func1()
        /Users/jacksen/GolandProjects/galaio-bsc/eth/downloader/downloader.go:662 +0x58
created by github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).spawnSync in goroutine 8578
        /Users/jacksen/GolandProjects/galaio-bsc/eth/downloader/downloader.go:662 +0x60

goroutine 15149 [select]:
github.com/ethereum/go-ethereum/p2p.(*MsgPipeRW).WriteMsg(0x140013c5800, {0x5, 0x2c, {0x106b4ef20, 0x14001c24380}, {0x0, 0x0, 0x0}, {{0x0, 0x0}, ...}, ...})
        /Users/jacksen/GolandProjects/galaio-bsc/p2p/message.go:188 +0x164
github.com/ethereum/go-ethereum/p2p.Send({0x14e87e950, 0x140013c5800}, 0x5, {0x10687e620?, 0x140015a3240?})
        /Users/jacksen/GolandProjects/galaio-bsc/p2p/message.go:104 +0xb8
github.com/ethereum/go-ethereum/eth/protocols/eth.(*Peer).dispatcher(0x14000016ff0)
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/dispatcher.go:200 +0x36c
created by github.com/ethereum/go-ethereum/eth/protocols/eth.NewPeer in goroutine 8578
        /Users/jacksen/GolandProjects/galaio-bsc/eth/protocols/eth/peer.go:118 +0x424


```
Both peers are blocked on writes, causing timeouts. Introducing the no-blocking msgpipe effectively resolves this issue.

### Changes

Notable changes: 
* chore: fix SnapSyncWithBlobs UT issues;
* ...
