### PR TITLE
BEP-619: Short Block Interval Phase Three: 0.45 Seconds

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -280,7 +280,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	}
 	if ctx.IsSet(utils.OverrideMinBlocksForBlobRequests.Name) {
 		params.MinBlocksForBlobRequests = ctx.Uint64(utils.OverrideMinBlocksForBlobRequests.Name)
-		params.MinTimeDurationForBlobRequests = uint64(float64(params.MinBlocksForBlobRequests) * 0.75 /*maxwellBlockInterval*/)
+		params.MinTimeDurationForBlobRequests = uint64(float64(params.MinBlocksForBlobRequests) * 0.45 /*fermiBlockInterval*/)
 	}
 	if ctx.IsSet(utils.OverrideDefaultExtraReserveForBlobRequests.Name) {
 		params.DefaultExtraReserveForBlobRequests = ctx.Uint64(utils.OverrideDefaultExtraReserveForBlobRequests.Name)

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -61,6 +61,7 @@ const (
 	defaultBlockInterval uint64 = 3000 // Default block interval in milliseconds
 	lorentzBlockInterval uint64 = 1500 // Block interval starting from the Lorentz hard fork
 	maxwellBlockInterval uint64 = 750  // Block interval starting from the Maxwell hard fork
+	fermiBlockInterval   uint64 = 450  // Block interval starting from the Fermi hard fork
 	defaultTurnLength    uint8  = 1    // Default consecutive number of blocks a validator receives priority for block production
 
 	extraVanity      = 32 // Fixed number of extra-data prefix bytes reserved for signer vanity
@@ -788,7 +789,9 @@ func (p *Parlia) snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 				blockHeader := chain.GetHeaderByNumber(number)
 				if blockHeader != nil {
 					blockHash = blockHeader.Hash()
-					if p.chainConfig.IsMaxwell(blockHeader.Number, blockHeader.Time) {
+					if p.chainConfig.IsFermi(blockHeader.Number, blockHeader.Time) {
+						blockInterval = fermiBlockInterval
+					} else if p.chainConfig.IsMaxwell(blockHeader.Number, blockHeader.Time) {
 						blockInterval = maxwellBlockInterval
 					} else if p.chainConfig.IsLorentz(blockHeader.Number, blockHeader.Time) {
 						blockInterval = lorentzBlockInterval

--- a/consensus/parlia/ramanujanfork.go
+++ b/consensus/parlia/ramanujanfork.go
@@ -12,7 +12,7 @@ import (
 const (
 	wiggleTimeBeforeFork       = 500 * time.Millisecond // Random delay (per signer) to allow concurrent signers
 	fixedBackOffTimeBeforeFork = 200 * time.Millisecond
-	millisecondsUnit           = 250 // not enforced at the consensus level
+	millisecondsUnit           = 50 // not enforced at the consensus level
 )
 
 func (p *Parlia) delayForRamanujanFork(snap *Snapshot, header *types.Header) time.Duration {

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -342,7 +342,9 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 
 		snap.RecentForkHashes[number] = hex.EncodeToString(header.Extra[extraVanity-nextForkHashSize : extraVanity])
 
-		if chainConfig.IsMaxwell(header.Number, header.Time) {
+		if chainConfig.IsFermi(header.Number, header.Time) {
+			snap.BlockInterval = fermiBlockInterval
+		} else if chainConfig.IsMaxwell(header.Number, header.Time) {
 			snap.BlockInterval = maxwellBlockInterval
 		} else if chainConfig.IsLorentz(header.Number, header.Time) {
 			snap.BlockInterval = lorentzBlockInterval

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -22,7 +22,7 @@ import (
 // the new node may cast votes for the same block height that the previous node already voted on.
 // To avoid double-voting issues, the node should wait for a few blocks
 // before participating in voting after it starts mining.
-const blocksNumberSinceMining = 20
+const blocksNumberSinceMining = 40
 
 var diffInTurn = big.NewInt(2) // Block difficulty for in-turn signatures
 var votesManagerCounter = metrics.NewRegisteredCounter("votesManager/local", nil)

--- a/core/vote/vote_pool_test.go
+++ b/core/vote/vote_pool_test.go
@@ -284,7 +284,7 @@ func testVotePool(t *testing.T, isValidRules bool) {
 	// Test future votes scenario: votes number within latestBlockHeader ~ latestBlockHeader + 11
 	futureVote := &types.VoteEnvelope{
 		Data: &types.VoteData{
-			TargetNumber: 294,
+			TargetNumber: 314,
 		},
 	}
 	if err := voteManager.signer.SignVote(futureVote); err != nil {
@@ -304,7 +304,7 @@ func testVotePool(t *testing.T, isValidRules bool) {
 	// Test duplicate vote case, shouldn'd be put into vote pool
 	duplicateVote := &types.VoteEnvelope{
 		Data: &types.VoteData{
-			TargetNumber: 294,
+			TargetNumber: 314,
 		},
 	}
 	if err := voteManager.signer.SignVote(duplicateVote); err != nil {
@@ -333,14 +333,14 @@ func testVotePool(t *testing.T, isValidRules bool) {
 		t.Fatalf("put vote failed")
 	}
 
-	// Test transfer votes from future to cur, latest block header is #308 after the following generation
-	// For the above BlockNumber 279, it did not have blockHash, should be assigned as well below.
-	curNumber := 288
+	// Test transfer votes from future to cur, latest block header is #328 after the following generation
+	// For the above BlockNumber 314, it did not have blockHash, should be assigned as well below.
+	curNumber := 308
 	var futureBlockHash common.Hash
 	for i := 0; i < 20; i++ {
 		bs, _ = core.GenerateChain(params.TestChainConfig, bs[len(bs)-1], ethash.NewFaker(), db, 1, nil)
 		curNumber += 1
-		if curNumber == 294 {
+		if curNumber == 314 {
 			futureBlockHash = bs[0].Hash()
 			futureVotesMap := votePool.futureVotes
 			voteBox := futureVotesMap[common.Hash{}]

--- a/eth/protocols/bsc/peer.go
+++ b/eth/protocols/bsc/peer.go
@@ -23,8 +23,8 @@ const (
 	// used to avoid of DDOS attack
 	// It's the max number of received votes per second from one peer
 	// 21 validators exist now, so 21 votes will be produced every one block interval
-	// so the limit is 28 = 21/0.75, here set it to 40 with a buffer.
-	receiveRateLimitPerSecond = 40
+	// so the limit is 47 ~= 21/0.45, here set it to 68 with a buffer.
+	receiveRateLimitPerSecond = 68
 
 	// the time span of one period
 	secondsPerPeriod = float64(30)

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -508,7 +508,7 @@ func (b *bidSimulator) newBidLoop() {
 // get block interval for current block by using parent header
 func (b *bidSimulator) getBlockInterval(parentHeader *types.Header) uint64 {
 	if parentHeader == nil {
-		return 750 // maxwellBlockInterval
+		return 450 // fermiBlockInterval
 	}
 	parlia, _ := b.engine.(*parlia.Parlia)
 	// only `Number` and `ParentHash` are used when `BlockInterval`

--- a/params/network_params.go
+++ b/params/network_params.go
@@ -29,5 +29,5 @@ var (
 	// considered immutable (i.e. soft finality). It is used by the downloader as a
 	// hard limit against deep ancestors, by the blockchain against deep reorgs, by
 	// the freezer as the cutoff threshold and by clique as the snapshot trust limit.
-	FullImmutabilityThreshold uint64 = 360_000
+	FullImmutabilityThreshold uint64 = 600_000
 )

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -192,10 +192,10 @@ const (
 )
 
 var (
-	// maxwellBlockInterval                      = 0.75
+	// fermiBlockInterval                        = 0.45
 	MinTimeDurationForBlobRequests     uint64 = uint64(float64(24*3600) * 18.2)                        // it keeps blob data available for 18.2 days in local
-	MinBlocksForBlobRequests           uint64 = uint64(float64(MinTimeDurationForBlobRequests) / 0.75) // ref: https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-524.md#421-change-table.
-	DefaultExtraReserveForBlobRequests uint64 = uint64(24 * 3600 / 0.75)                               // it adds more time for expired blobs for some request cases, like expiry blob when remote peer is syncing, default 1 day.
+	MinBlocksForBlobRequests           uint64 = uint64(float64(MinTimeDurationForBlobRequests) / 0.45) // ref: https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-524.md#421-change-table.
+	DefaultExtraReserveForBlobRequests uint64 = uint64(24 * 3600 / 0.45)                               // it adds more time for expired blobs for some request cases, like expiry blob when remote peer is syncing, default 1 day.
 
 	BreatheBlockInterval uint64 = 24 * 3600 // Controls the interval for updateValidatorSetV2
 


### PR DESCRIPTION
### Description

[BEP-619: Short Block Interval Phase Three: 0.45 Seconds](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-619.md)

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
