### PR TITLE
Implement BEP-592: Non-Consensus Based Block-Level Access List

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -146,6 +146,7 @@ var (
 		utils.MinerRecommitIntervalFlag,
 		utils.MinerNewPayloadTimeoutFlag, // deprecated
 		utils.MinerDelayLeftoverFlag,
+		utils.EnableBALFlag,
 		// utils.MinerNewPayloadTimeout,
 		utils.NATFlag,
 		utils.NoDiscoverFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -182,6 +182,11 @@ var (
 		Usage:    "Chapel network: pre-configured Proof-of-Stake-Authority BSC test network",
 		Category: flags.EthCategory,
 	}
+	EnableBALFlag = &cli.BoolFlag{
+		Name:     "enablebal",
+		Usage:    "Enable block access list feature, validator will generate BAL for each block",
+		Category: flags.EthCategory,
+	}
 	// Dev mode
 	DeveloperFlag = &cli.BoolFlag{
 		Name:     "dev",
@@ -1743,6 +1748,9 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	if ctx.IsSet(DisableSnapProtocolFlag.Name) {
 		cfg.DisableSnapProtocol = ctx.Bool(DisableSnapProtocolFlag.Name)
 	}
+	if ctx.IsSet(EnableBALFlag.Name) {
+		cfg.EnableBAL = ctx.Bool(EnableBALFlag.Name)
+	}
 	if ctx.IsSet(RangeLimitFlag.Name) {
 		cfg.RangeLimit = ctx.Bool(RangeLimitFlag.Name)
 	}
@@ -2041,6 +2049,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(CacheNoPrefetchFlag.Name) {
 		cfg.NoPrefetch = ctx.Bool(CacheNoPrefetchFlag.Name)
+	}
+	if ctx.IsSet(EnableBALFlag.Name) {
+		cfg.EnableBAL = ctx.Bool(EnableBALFlag.Name)
 	}
 	// Read the value from the flag no matter if it's set or not.
 	cfg.Preimages = ctx.Bool(CachePreimagesFlag.Name)
@@ -2697,6 +2708,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 	options := &core.BlockChainConfig{
 		TrieCleanLimit: ethconfig.Defaults.TrieCleanCache,
 		NoPrefetch:     ctx.Bool(CacheNoPrefetchFlag.Name),
+		EnableBAL:      ctx.Bool(EnableBALFlag.Name),
 		TrieDirtyLimit: ethconfig.Defaults.TrieDirtyCache,
 		ArchiveMode:    ctx.String(GCModeFlag.Name) == "archive",
 		TrieTimeLimit:  ethconfig.Defaults.TrieTimeout,

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -491,6 +491,15 @@ func (beacon *Beacon) SealHash(header *types.Header) common.Hash {
 	return beacon.ethone.SealHash(header)
 }
 
+func (beacon *Beacon) SignBAL(blockAccessList *types.BlockAccessListEncode) error {
+	return nil
+}
+
+// VerifyBAL verifies the BAL of the block
+func (beacon *Beacon) VerifyBAL(block *types.Block, bal *types.BlockAccessListEncode) error {
+	return nil
+}
+
 // CalcDifficulty is the difficulty adjustment algorithm. It returns
 // the difficulty that a new block should have when created at time
 // given the parent block's time and difficulty.

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -787,3 +787,11 @@ func encodeSigHeader(w io.Writer, header *types.Header) {
 		panic("can't encode: " + err.Error())
 	}
 }
+
+func (c *Clique) SignBAL(bal *types.BlockAccessListEncode) error {
+	return nil
+}
+
+func (c *Clique) VerifyBAL(block *types.Block, bal *types.BlockAccessListEncode) error {
+	return nil
+}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -136,6 +136,12 @@ type Engine interface {
 	// SealHash returns the hash of a block prior to it being sealed.
 	SealHash(header *types.Header) common.Hash
 
+	// SignBAL signs the BAL of the block
+	SignBAL(blockAccessList *types.BlockAccessListEncode) error
+
+	// VerifyBAL verifies the BAL of the block
+	VerifyBAL(block *types.Block, bal *types.BlockAccessListEncode) error
+
 	// CalcDifficulty is the difficulty adjustment algorithm. It returns the difficulty
 	// that a new block should have.
 	CalcDifficulty(chain ChainHeaderReader, time uint64, parent *types.Header) *big.Int

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -76,3 +76,11 @@ func (ethash *Ethash) Close() error {
 func (ethash *Ethash) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
 	panic("ethash (pow) sealing not supported any more")
 }
+
+func (ethash *Ethash) SignBAL(bal *types.BlockAccessListEncode) error {
+	return nil
+}
+
+func (ethash *Ethash) VerifyBAL(block *types.Block, bal *types.BlockAccessListEncode) error {
+	return nil
+}

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1755,6 +1755,71 @@ func (p *Parlia) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 	return nil
 }
 
+func (p *Parlia) SignBAL(blockAccessList *types.BlockAccessListEncode) error {
+	p.lock.RLock()
+	val, signFn := p.val, p.signFn
+	p.lock.RUnlock()
+
+	data, err := rlp.EncodeToBytes([]interface{}{blockAccessList.Version, blockAccessList.Number, blockAccessList.Hash, blockAccessList.Accounts})
+	if err != nil {
+		log.Error("Encode to bytes failed when sealing", "err", err)
+		return errors.New("encode to bytes failed")
+	}
+
+	if len(data) > int(params.MaxBALSize) {
+		log.Error("data is too large", "dataSize", len(data), "maxSize", params.MaxBALSize)
+		return errors.New("data is too large")
+	}
+
+	sig, err := signFn(accounts.Account{Address: val}, accounts.MimetypeParlia, data)
+	if err != nil {
+		log.Error("Sign for the block header failed when sealing", "err", err)
+		return errors.New("sign for the block header failed")
+	}
+
+	copy(blockAccessList.SignData, sig)
+	return nil
+}
+
+func (p *Parlia) VerifyBAL(block *types.Block, bal *types.BlockAccessListEncode) error {
+	if bal.Version != 0 {
+		log.Error("invalid BAL version", "version", bal.Version)
+		return errors.New("invalid BAL version")
+	}
+
+	if len(bal.SignData) != 65 {
+		log.Error("invalid BAL signature", "signatureSize", len(bal.SignData))
+		return errors.New("invalid BAL signature")
+	}
+
+	// Recover the public key and the Ethereum address
+	data, err := rlp.EncodeToBytes([]interface{}{bal.Version, block.Number(), block.Hash(), bal.Accounts})
+	if err != nil {
+		log.Error("encode to bytes failed", "err", err)
+		return errors.New("encode to bytes failed")
+	}
+
+	if len(data) > int(params.MaxBALSize) {
+		log.Error("data is too large", "dataSize", len(data), "maxSize", params.MaxBALSize)
+		return errors.New("data is too large")
+	}
+
+	pubkey, err := crypto.Ecrecover(crypto.Keccak256(data), bal.SignData)
+	if err != nil {
+		return err
+	}
+	var pubkeyAddr common.Address
+	copy(pubkeyAddr[:], crypto.Keccak256(pubkey[1:])[12:])
+
+	signer := block.Header().Coinbase
+	if signer != pubkeyAddr {
+		log.Error("BAL signer mismatch", "signer", signer, "pubkeyAddr", pubkeyAddr, "bal.Number", bal.Number, "bal.Hash", bal.Hash)
+		return errors.New("signer mismatch")
+	}
+
+	return nil
+}
+
 func (p *Parlia) shouldWaitForCurrentBlockProcess(chain consensus.ChainHeaderReader, header *types.Header, snap *Snapshot) bool {
 	if header.Difficulty.Cmp(diffInTurn) == 0 {
 		return false

--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -62,7 +62,7 @@ func (st *insertStats) report(chain []*types.Block, index int, snapDiffItems, sn
 		context := []interface{}{
 			"number", end.Number(), "hash", end.Hash(), "miner", end.Coinbase(),
 			"blocks", st.processed, "txs", txs, "blobs", blobs, "mgas", float64(st.usedGas) / 1000000,
-			"elapsed", common.PrettyDuration(elapsed), "mgasps", mgasps,
+			"elapsed", common.PrettyDuration(elapsed), "mgasps", mgasps, "BAL", end.BAL() != nil,
 		}
 		blockInsertMgaspsGauge.Update(int64(mgasps))
 		if timestamp := time.Unix(int64(end.Time()), 0); time.Since(timestamp) > time.Minute {

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -203,6 +203,11 @@ func (bc *BlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {
 	}
 	sidecars := rawdb.ReadBlobSidecars(bc.db, hash, number)
 	block = block.WithSidecars(sidecars)
+
+	bal := rawdb.ReadBAL(bc.db, hash, number)
+	if bal != nil {
+		block = block.WithBAL(bal)
+	}
 	// Cache the found block for next time and return
 	bc.blockCache.Add(block.Hash(), block)
 	return block
@@ -476,6 +481,9 @@ func (bc *BlockChain) State() (*state.StateDB, error) {
 // StateAt returns a new mutable state based on a particular point in time.
 func (bc *BlockChain) StateAt(root common.Hash) (*state.StateDB, error) {
 	stateDb, err := state.New(root, bc.statedb)
+	if bc.cfg.EnableBAL {
+		stateDb.InitBlockAccessList()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/core/data_availability.go
+++ b/core/data_availability.go
@@ -60,7 +60,7 @@ func IsDataAvailable(chain consensus.ChainHeaderReader, block *types.Block) (err
 
 	// refer logic in ValidateBody
 	if !chain.Config().IsCancun(block.Number(), block.Time()) {
-		if block.Sidecars() != nil {
+		if len(block.Sidecars()) != 0 {
 			return errors.New("sidecars present in block body before cancun")
 		}
 		return nil

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -1122,3 +1122,376 @@ func TestHeadersRLPStorage(t *testing.T) {
 	checkSequence(1, 1)    // Only block 1
 	checkSequence(1, 2)    // Genesis + block 1
 }
+
+// Tests BAL (Block Access List) storage and retrieval operations.
+func TestBALStorage(t *testing.T) {
+	db := NewMemoryDatabase()
+
+	// Create test BAL data
+	bal := &types.BlockAccessListEncode{
+		Version:  1,
+		SignData: make([]byte, 65),
+		Accounts: []types.AccountAccessListEncode{
+			{
+				TxIndex: 0,
+				Address: common.HexToAddress("0x1234567890123456789012345678901234567890"),
+				StorageItems: []types.StorageAccessItem{
+					{Key: common.HexToHash("0x01"), TxIndex: 0, Dirty: false},
+					{Key: common.HexToHash("0x02"), TxIndex: 1, Dirty: true},
+				},
+			},
+			{
+				TxIndex: 1,
+				Address: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+				StorageItems: []types.StorageAccessItem{
+					{Key: common.HexToHash("0x03"), TxIndex: 2, Dirty: false},
+				},
+			},
+		},
+	}
+
+	// Fill SignData with test data
+	copy(bal.SignData, []byte("test_signature_data_for_bal_testing_12345678901234567890123456789"))
+
+	hash := common.HexToHash("0x123456789abcdef")
+	number := uint64(42)
+
+	// Test non-existent BAL retrieval
+	if entry := ReadBAL(db, hash, number); entry != nil {
+		t.Fatalf("Non-existent BAL returned: %v", entry)
+	}
+	if entry := ReadBALRLP(db, hash, number); len(entry) != 0 {
+		t.Fatalf("Non-existent raw BAL returned: %v", entry)
+	}
+
+	// Test BAL storage and retrieval
+	WriteBAL(db, hash, number, bal)
+	if entry := ReadBAL(db, hash, number); entry == nil {
+		t.Fatalf("Stored BAL not found")
+	} else if !balEqual(entry, bal) {
+		t.Fatalf("Retrieved BAL mismatch: have %v, want %v", entry, bal)
+	}
+
+	// Test raw BAL retrieval
+	if entry := ReadBALRLP(db, hash, number); len(entry) == 0 {
+		t.Fatalf("Stored raw BAL not found")
+	}
+
+	// Test BAL deletion
+	DeleteBAL(db, hash, number)
+	if entry := ReadBAL(db, hash, number); entry != nil {
+		t.Fatalf("Deleted BAL still returned: %v", entry)
+	}
+	if entry := ReadBALRLP(db, hash, number); len(entry) != 0 {
+		t.Fatalf("Deleted raw BAL still returned: %v", entry)
+	}
+}
+
+func TestBALRLPStorage(t *testing.T) {
+	db := NewMemoryDatabase()
+
+	// Test different BAL configurations
+	testCases := []struct {
+		name   string
+		bal    *types.BlockAccessListEncode
+		hash   common.Hash
+		number uint64
+	}{
+		{
+			name: "empty accounts",
+			bal: &types.BlockAccessListEncode{
+				Version:  0,
+				SignData: make([]byte, 65),
+				Accounts: []types.AccountAccessListEncode{},
+			},
+			hash:   common.HexToHash("0x1111"),
+			number: 1,
+		},
+		{
+			name: "single account with multiple storage items",
+			bal: &types.BlockAccessListEncode{
+				Version:  2,
+				SignData: make([]byte, 65),
+				Accounts: []types.AccountAccessListEncode{
+					{
+						TxIndex: 0,
+						Address: common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+						StorageItems: []types.StorageAccessItem{
+							{Key: common.HexToHash("0x0a"), TxIndex: 0, Dirty: true},
+							{Key: common.HexToHash("0x0b"), TxIndex: 1, Dirty: false},
+							{Key: common.HexToHash("0x0c"), TxIndex: 2, Dirty: true},
+						},
+					},
+				},
+			},
+			hash:   common.HexToHash("0x2222"),
+			number: 2,
+		},
+		{
+			name: "multiple accounts",
+			bal: &types.BlockAccessListEncode{
+				Version:  ^uint32(0), // Max uint32 value
+				SignData: make([]byte, 65),
+				Accounts: []types.AccountAccessListEncode{
+					{
+						TxIndex: 0,
+						Address: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+						StorageItems: []types.StorageAccessItem{
+							{Key: common.HexToHash("0x01"), TxIndex: 0, Dirty: false},
+						},
+					},
+					{
+						TxIndex: 1,
+						Address: common.HexToAddress("0x3333333333333333333333333333333333333333"),
+						StorageItems: []types.StorageAccessItem{
+							{Key: common.HexToHash("0x04"), TxIndex: 3, Dirty: true},
+							{Key: common.HexToHash("0x05"), TxIndex: 4, Dirty: false},
+						},
+					},
+					{
+						TxIndex:      2,
+						Address:      common.HexToAddress("0x4444444444444444444444444444444444444444"),
+						StorageItems: []types.StorageAccessItem{},
+					},
+				},
+			},
+			hash:   common.HexToHash("0x3333"),
+			number: 100,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Fill SignData with unique test data
+			sigData := fmt.Sprintf("test_signature_for_%s_123456789012345678901234567890123456789012345678901234567890", tc.name)
+			copy(tc.bal.SignData, []byte(sigData))
+
+			// Store BAL
+			WriteBAL(db, tc.hash, tc.number, tc.bal)
+
+			// Test RLP retrieval
+			rawData := ReadBALRLP(db, tc.hash, tc.number)
+			if len(rawData) == 0 {
+				t.Fatalf("Failed to store/retrieve raw BAL data")
+			}
+
+			// Test structured retrieval
+			retrieved := ReadBAL(db, tc.hash, tc.number)
+			if retrieved == nil {
+				t.Fatalf("Failed to retrieve structured BAL")
+			}
+
+			// Compare values
+			if !balEqual(retrieved, tc.bal) {
+				t.Fatalf("Retrieved BAL doesn't match stored BAL")
+			}
+
+			// Test deletion
+			DeleteBAL(db, tc.hash, tc.number)
+			if ReadBAL(db, tc.hash, tc.number) != nil {
+				t.Fatalf("BAL not properly deleted")
+			}
+		})
+	}
+}
+
+func TestBALCorruptedData(t *testing.T) {
+	db := NewMemoryDatabase()
+	hash := common.HexToHash("0x9999")
+	number := uint64(123)
+
+	// Store corrupted RLP data directly
+	corruptedData := []byte{0xff, 0xff, 0xff, 0xff} // Invalid RLP
+	if err := db.Put(blockBALKey(number, hash), corruptedData); err != nil {
+		t.Fatalf("Failed to store corrupted data: %v", err)
+	}
+
+	// ReadBALRLP should return the corrupted data
+	rawData := ReadBALRLP(db, hash, number)
+	if !bytes.Equal(rawData, corruptedData) {
+		t.Fatalf("ReadBALRLP should return raw data even if corrupted")
+	}
+
+	// ReadBAL should return nil for corrupted data
+	bal := ReadBAL(db, hash, number)
+	if bal != nil {
+		t.Fatalf("ReadBAL should return nil for corrupted data, got: %v", bal)
+	}
+}
+
+func TestBALLargeData(t *testing.T) {
+	db := NewMemoryDatabase()
+
+	// Create BAL with large amount of data
+	accounts := make([]types.AccountAccessListEncode, 1000)
+	for i := 0; i < 1000; i++ {
+		storageItems := make([]types.StorageAccessItem, 10)
+		for j := 0; j < 10; j++ {
+			storageItems[j] = types.StorageAccessItem{
+				Key:     common.BigToHash(big.NewInt(int64(i*10 + j))),
+				TxIndex: uint32(i*10 + j),
+				Dirty:   (i+j)%2 == 0,
+			}
+		}
+		accounts[i] = types.AccountAccessListEncode{
+			TxIndex:      uint32(i),
+			Address:      common.BigToAddress(big.NewInt(int64(i))),
+			StorageItems: storageItems,
+		}
+	}
+
+	bal := &types.BlockAccessListEncode{
+		Version:  12345,
+		SignData: make([]byte, 65),
+		Accounts: accounts,
+	}
+
+	// Fill SignData
+	copy(bal.SignData, []byte("large_data_test_signature_123456789012345678901234567890123456789"))
+
+	hash := common.HexToHash("0xaaaa")
+	number := uint64(999)
+
+	// Test storage and retrieval of large data
+	WriteBAL(db, hash, number, bal)
+
+	retrieved := ReadBAL(db, hash, number)
+	if retrieved == nil {
+		t.Fatalf("Failed to retrieve large BAL data")
+	}
+
+	if !balEqual(retrieved, bal) {
+		t.Fatalf("Large BAL data integrity check failed")
+	}
+
+	// Test deletion
+	DeleteBAL(db, hash, number)
+	if ReadBAL(db, hash, number) != nil {
+		t.Fatalf("Large BAL data not properly deleted")
+	}
+}
+
+func TestBALMultipleBlocks(t *testing.T) {
+	db := NewMemoryDatabase()
+
+	// Store BALs for multiple blocks
+	blocks := []struct {
+		hash   common.Hash
+		number uint64
+		bal    *types.BlockAccessListEncode
+	}{
+		{
+			hash:   common.HexToHash("0xaaaa"),
+			number: 1,
+			bal: &types.BlockAccessListEncode{
+				Version:  1,
+				SignData: make([]byte, 65),
+				Accounts: []types.AccountAccessListEncode{
+					{
+						TxIndex: 0,
+						Address: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+						StorageItems: []types.StorageAccessItem{
+							{Key: common.HexToHash("0x01"), TxIndex: 0, Dirty: false},
+						},
+					},
+				},
+			},
+		},
+		{
+			hash:   common.HexToHash("0xbbbb"),
+			number: 2,
+			bal: &types.BlockAccessListEncode{
+				Version:  2,
+				SignData: make([]byte, 65),
+				Accounts: []types.AccountAccessListEncode{
+					{
+						TxIndex: 0,
+						Address: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+						StorageItems: []types.StorageAccessItem{
+							{Key: common.HexToHash("0x02"), TxIndex: 1, Dirty: true},
+						},
+					},
+				},
+			},
+		},
+		{
+			hash:   common.HexToHash("0xcccc"),
+			number: 3,
+			bal: &types.BlockAccessListEncode{
+				Version:  3,
+				SignData: make([]byte, 65),
+				Accounts: []types.AccountAccessListEncode{},
+			},
+		},
+	}
+
+	// Store all BALs
+	for i, block := range blocks {
+		sigData := fmt.Sprintf("signature_for_block_%d_123456789012345678901234567890123456789012345678901234567890", i)
+		copy(block.bal.SignData, []byte(sigData))
+		WriteBAL(db, block.hash, block.number, block.bal)
+	}
+
+	// Verify all can be retrieved independently
+	for i, block := range blocks {
+		retrieved := ReadBAL(db, block.hash, block.number)
+		if retrieved == nil {
+			t.Fatalf("Failed to retrieve BAL for block %d", i)
+		}
+		if !balEqual(retrieved, block.bal) {
+			t.Fatalf("BAL mismatch for block %d", i)
+		}
+	}
+
+	// Delete middle block
+	DeleteBAL(db, blocks[1].hash, blocks[1].number)
+
+	// Verify first and third blocks still exist
+	if ReadBAL(db, blocks[0].hash, blocks[0].number) == nil {
+		t.Fatalf("Block 0 BAL was incorrectly deleted")
+	}
+	if ReadBAL(db, blocks[1].hash, blocks[1].number) != nil {
+		t.Fatalf("Block 1 BAL was not deleted")
+	}
+	if ReadBAL(db, blocks[2].hash, blocks[2].number) == nil {
+		t.Fatalf("Block 2 BAL was incorrectly deleted")
+	}
+}
+
+// Helper function to compare two BlockAccessListEncode structs
+func balEqual(a, b *types.BlockAccessListEncode) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Version != b.Version {
+		return false
+	}
+	if !bytes.Equal(a.SignData, b.SignData) {
+		return false
+	}
+	if len(a.Accounts) != len(b.Accounts) {
+		return false
+	}
+	for i, accountA := range a.Accounts {
+		accountB := b.Accounts[i]
+		if accountA.TxIndex != accountB.TxIndex {
+			return false
+		}
+		if accountA.Address != accountB.Address {
+			return false
+		}
+		if len(accountA.StorageItems) != len(accountB.StorageItems) {
+			return false
+		}
+		for j, storageA := range accountA.StorageItems {
+			storageB := accountB.StorageItems[j]
+			if storageA.Key != storageB.Key || storageA.TxIndex != storageB.TxIndex || storageA.Dirty != storageB.Dirty {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -638,6 +638,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		tds                stat
 		numHashPairings    stat
 		blobSidecars       stat
+		bals               stat
 		hashNumPairings    stat
 		legacyTries        stat
 		stateLookups       stat
@@ -692,6 +693,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			tds.Add(size)
 		case bytes.HasPrefix(key, BlockBlobSidecarsPrefix):
 			blobSidecars.Add(size)
+		case bytes.HasPrefix(key, BlockBALPrefix):
+			bals.Add(size)
 		case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerHashSuffix):
 			numHashPairings.Add(size)
 		case bytes.HasPrefix(key, headerNumberPrefix) && len(key) == (len(headerNumberPrefix)+common.HashLength):
@@ -828,6 +831,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Receipt lists", receipts.Size(), receipts.Count()},
 		{"Key-Value store", "Difficulties", tds.Size(), tds.Count()},
 		{"Key-Value store", "BlobSidecars", blobSidecars.Size(), blobSidecars.Count()},
+		{"Key-Value store", "Block access list", bals.Size(), bals.Count()},
 		{"Key-Value store", "Block number->hash", numHashPairings.Size(), numHashPairings.Count()},
 		{"Key-Value store", "Block hash->number", hashNumPairings.Size(), hashNumPairings.Count()},
 		{"Key-Value store", "Transaction index", txLookups.Size(), txLookups.Count()},

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -143,6 +143,8 @@ var (
 
 	BlockBlobSidecarsPrefix = []byte("blobs")
 
+	BlockBALPrefix = []byte("bal") // blockBALPrefix + blockNumber (uint64 big endian) + blockHash -> block access list
+
 	// new log index
 	filterMapsPrefix         = "fm-"
 	filterMapsRangeKey       = []byte(filterMapsPrefix + "R")
@@ -211,6 +213,11 @@ func blockReceiptsKey(number uint64, hash common.Hash) []byte {
 // blockBlobSidecarsKey = BlockBlobSidecarsPrefix + blockNumber (uint64 big endian) + blockHash
 func blockBlobSidecarsKey(number uint64, hash common.Hash) []byte {
 	return append(append(BlockBlobSidecarsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+}
+
+// blockBALKey = blockBALPrefix + blockNumber (uint64 big endian) + blockHash
+func blockBALKey(number uint64, hash common.Hash) []byte {
+	return append(append(BlockBALPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
 }
 
 // txLookupKey = txLookupPrefix + hash

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -138,6 +138,9 @@ type StateDB struct {
 	accessList   *accessList
 	accessEvents *AccessEvents
 
+	// block level access list
+	blockAccessList *types.BlockAccessListRecord
+
 	// Transient storage
 	transientStorage transientStorage
 
@@ -190,12 +193,20 @@ func NewWithReader(root common.Hash, db Database, reader Reader) (*StateDB, erro
 		preimages:            make(map[common.Hash][]byte),
 		journal:              newJournal(),
 		accessList:           newAccessList(),
+		blockAccessList:      nil,
 		transientStorage:     newTransientStorage(),
 	}
 	if db.TrieDB().IsVerkle() {
 		sdb.accessEvents = NewAccessEvents(db.PointCache())
 	}
 	return sdb, nil
+}
+
+func (s *StateDB) InitBlockAccessList() {
+	if s.blockAccessList != nil {
+		log.Warn("prepareBAL blockAccessList is not nil")
+	}
+	s.blockAccessList = &types.BlockAccessListRecord{Accounts: make(map[common.Address]types.AccountAccessListRecord)}
 }
 
 func (s *StateDB) SetNeedBadSharedStorage(needBadSharedStorage bool) {
@@ -375,6 +386,43 @@ func (s *StateDB) GetNonce(addr common.Address) uint64 {
 	return 0
 }
 
+func (s *StateDB) PreloadAccount(addr common.Address) {
+	if s.Empty(addr) {
+		return
+	}
+	s.GetCode(addr)
+}
+
+func (s *StateDB) PreloadStorage(addr common.Address, key common.Hash) {
+	if s.Empty(addr) {
+		return
+	}
+	s.GetState(addr, key)
+}
+func (s *StateDB) PreloadAccountTrie(addr common.Address) {
+	if s.prefetcher == nil {
+		return
+	}
+
+	addressesToPrefetch := []common.Address{addr}
+	if err := s.prefetcher.prefetch(common.Hash{}, s.originalRoot, common.Address{}, addressesToPrefetch, nil, false); err != nil {
+		log.Error("Failed to prefetch addresses", "addresses", len(addressesToPrefetch), "err", err)
+	}
+}
+
+func (s *StateDB) PreloadStorageTrie(addr common.Address, key common.Hash) {
+	if s.prefetcher == nil {
+		return
+	}
+	obj := s.getStateObject(addr)
+	if obj == nil {
+		return
+	}
+	if err := s.prefetcher.prefetch(obj.addrHash, obj.origin.Root, obj.address, nil, []common.Hash{key}, true); err != nil {
+		log.Error("Failed to prefetch storage slot", "addr", obj.address, "key", key, "err", err)
+	}
+}
+
 // GetStorageRoot retrieves the storage root from the given address or empty
 // if object not found.
 func (s *StateDB) GetStorageRoot(addr common.Address) common.Hash {
@@ -424,6 +472,7 @@ func (s *StateDB) GetCodeHash(addr common.Address) common.Hash {
 func (s *StateDB) GetState(addr common.Address, hash common.Hash) common.Hash {
 	stateObject := s.getStateObject(addr)
 	if stateObject != nil {
+		s.blockAccessList.AddStorage(addr, hash, uint32(s.txIndex), false)
 		return stateObject.GetState(hash)
 	}
 	return common.Hash{}
@@ -506,6 +555,7 @@ func (s *StateDB) SetCode(addr common.Address, code []byte) (prev []byte) {
 }
 
 func (s *StateDB) SetState(addr common.Address, key, value common.Hash) common.Hash {
+	s.blockAccessList.AddStorage(addr, key, uint32(s.txIndex), true)
 	if stateObject := s.getOrNewStateObject(addr); stateObject != nil {
 		return stateObject.SetState(key, value)
 	}
@@ -635,6 +685,7 @@ func (s *StateDB) deleteStateObject(addr common.Address) {
 // getStateObject retrieves a state object given by the address, returning nil if
 // the object is not found or was deleted in this execution context.
 func (s *StateDB) getStateObject(addr common.Address) *stateObject {
+	s.blockAccessList.AddAccount(addr, uint32(s.txIndex))
 	// Prefer live objects if any is available
 	if obj := s.stateObjects[addr]; obj != nil {
 		return obj
@@ -725,6 +776,14 @@ func (s *StateDB) CopyDoPrefetch() *StateDB {
 	return s.copyInternal(true)
 }
 
+func (s *StateDB) TransferBlockAccessList(prev *StateDB) {
+	if prev == nil {
+		return
+	}
+	s.blockAccessList = prev.blockAccessList
+	prev.blockAccessList = nil
+}
+
 // If doPrefetch is true, it tries to reuse the prefetcher, the copied StateDB will do active trie prefetch.
 // otherwise, just do inactive copy trie prefetcher.
 func (s *StateDB) copyInternal(doPrefetch bool) *StateDB {
@@ -753,6 +812,7 @@ func (s *StateDB) copyInternal(doPrefetch bool) *StateDB {
 		// empty lists, so we do it anyway to not blow up if we ever decide copy them
 		// in the middle of a transaction.
 		accessList:       s.accessList.Copy(),
+		blockAccessList:  nil,
 		transientStorage: s.transientStorage.Copy(),
 		journal:          s.journal.copy(),
 	}
@@ -1594,4 +1654,54 @@ func (s *StateDB) AccessEvents() *AccessEvents {
 func (s *StateDB) IsAddressInMutations(addr common.Address) bool {
 	_, ok := s.mutations[addr]
 	return ok
+}
+
+func (s *StateDB) DumpAccessList(block *types.Block) {
+	if s.blockAccessList == nil {
+		return
+	}
+	accountCount := 0
+	storageCount := 0
+	dirtyStorageCount := 0
+	for addr, account := range s.blockAccessList.Accounts {
+		accountCount++
+		log.Debug("  DumpAccessList Address", "address", addr.Hex(), "txIndex", account.TxIndex)
+		for _, storageItem := range account.StorageItems {
+			log.Debug("  DumpAccessList Storage Item", "key", storageItem.Key.Hex(), "txIndex", storageItem.TxIndex, "dirty", storageItem.Dirty)
+			storageCount++
+			if storageItem.Dirty {
+				dirtyStorageCount++
+			}
+		}
+	}
+	log.Info("DumpAccessList", "blockNumber", block.NumberU64(), "GasUsed", block.GasUsed(),
+		"accountCount", accountCount, "storageCount", storageCount, "dirtyStorageCount", dirtyStorageCount)
+}
+
+// GetEncodedBlockAccessList: convert BlockAccessListRecord to BlockAccessListEncode
+func (s *StateDB) GetEncodedBlockAccessList(block *types.Block) *types.BlockAccessListEncode {
+	if s.blockAccessList == nil {
+		return nil
+	}
+	// encode block access list to rlp to propagate with the block
+	blockAccessList := types.BlockAccessListEncode{
+		Version:  0,
+		Number:   block.NumberU64(),
+		Hash:     block.Hash(),
+		SignData: make([]byte, 65),
+		Accounts: make([]types.AccountAccessListEncode, 0),
+	}
+	for addr, account := range s.blockAccessList.Accounts {
+		accountAccessList := types.AccountAccessListEncode{
+			TxIndex:      account.TxIndex,
+			Address:      addr,
+			StorageItems: make([]types.StorageAccessItem, 0),
+		}
+		for _, storageItem := range account.StorageItems {
+			accountAccessList.StorageItems = append(accountAccessList.StorageItems, storageItem)
+		}
+		blockAccessList.Accounts = append(blockAccessList.Accounts, accountAccessList)
+	}
+
+	return &blockAccessList
 }

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -25,11 +25,14 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"golang.org/x/sync/errgroup"
 )
 
 const prefetchMiningThread = 3
+const prefetchThreadBALSnapshot = 8
+const prefetchThreadBALTrie = 8
 const checkInterval = 10
 
 // statePrefetcher is a basic Prefetcher that executes transactions from a block
@@ -127,6 +130,147 @@ func (p *statePrefetcher) Prefetch(transactions types.Transactions, header *type
 	blockPrefetchTxsValidMeter.Mark(int64(len(transactions)) - fails.Load())
 	blockPrefetchTxsInvalidMeter.Mark(fails.Load())
 	return
+}
+
+func (p *statePrefetcher) PrefetchBALSnapshot(balPrefetch *types.BlockAccessListPrefetch, block *types.Block, txSize int, statedb *state.StateDB, interruptChan <-chan struct{}) {
+	accChan := make(chan struct {
+		txIndex uint32
+		accAddr common.Address
+	}, prefetchThreadBALSnapshot)
+
+	keyChan := make(chan struct {
+		txIndex uint32
+		accAddr common.Address
+		key     common.Hash
+	}, prefetchThreadBALSnapshot)
+
+	// prefetch snapshot cache
+	for i := 0; i < prefetchThreadBALSnapshot; i++ {
+		go func() {
+			newStatedb := statedb.CopyDoPrefetch()
+			for {
+				select {
+				case accAddr := <-accChan:
+					log.Debug("PrefetchBALSnapshot", "txIndex", accAddr.txIndex, "accAddr", accAddr.accAddr)
+					newStatedb.PreloadAccount(accAddr.accAddr)
+				case item := <-keyChan:
+					log.Debug("PrefetchBALSnapshot", "txIndex", item.txIndex, "accAddr", item.accAddr, "key", item.key)
+					newStatedb.PreloadStorage(item.accAddr, item.key)
+				case <-interruptChan:
+					return
+				}
+			}
+		}()
+	}
+	for txIndex := 0; txIndex < txSize; txIndex++ {
+		txAccessList := balPrefetch.AccessListItems[uint32(txIndex)]
+		for accAddr, storageItems := range txAccessList.Accounts {
+			select {
+			case accChan <- struct {
+				txIndex uint32
+				accAddr common.Address
+			}{
+				txIndex: uint32(txIndex),
+				accAddr: accAddr,
+			}:
+			case <-interruptChan:
+				return
+			}
+			for _, storageItem := range storageItems {
+				select {
+				case keyChan <- struct {
+					txIndex uint32
+					accAddr common.Address
+					key     common.Hash
+				}{
+					txIndex: uint32(txIndex),
+					accAddr: accAddr,
+					key:     storageItem.Key,
+				}:
+				case <-interruptChan:
+					return
+				}
+			}
+		}
+	}
+	log.Debug("PrefetchBALSnapshot dispatch finished")
+}
+
+func (p *statePrefetcher) PrefetchBALTrie(balPrefetch *types.BlockAccessListPrefetch, block *types.Block, statedb *state.StateDB, interruptChan <-chan struct{}) {
+	accItemsChan := make(chan struct {
+		txIndex uint32
+		accAddr common.Address
+		items   []types.StorageAccessItemPrefetch
+	}, prefetchThreadBALTrie)
+
+	for i := 0; i < prefetchThreadBALTrie; i++ {
+		go func() {
+			newStatedb := statedb.CopyDoPrefetch()
+			for {
+				select {
+				case accItem := <-accItemsChan:
+					newStatedb.PreloadAccountTrie(accItem.accAddr)
+					log.Debug("PrefetchBALTrie", "txIndex", accItem.txIndex, "accAddr", accItem.accAddr)
+					for _, storageItem := range accItem.items {
+						if storageItem.Dirty {
+							log.Debug("PrefetchBALTrie", "txIndex", accItem.txIndex, "accAddr", accItem.accAddr, "storageItem", storageItem.Key, "dirty", storageItem.Dirty)
+							statedb.PreloadStorageTrie(accItem.accAddr, storageItem.Key)
+						}
+					}
+				case <-interruptChan:
+					return
+				}
+			}
+		}()
+	}
+
+	for txIndex, txAccessList := range balPrefetch.AccessListItems {
+		for accAddr, storageItems := range txAccessList.Accounts {
+			select {
+			case accItemsChan <- struct {
+				txIndex uint32
+				accAddr common.Address
+				items   []types.StorageAccessItemPrefetch
+			}{
+				txIndex: txIndex,
+				accAddr: accAddr,
+				items:   storageItems,
+			}:
+			case <-interruptChan:
+				log.Warn("PrefetchBALTrie interrupted")
+				return
+			}
+		}
+	}
+	log.Debug("PrefetchBALTrie dispatch finished")
+}
+
+func (p *statePrefetcher) PrefetchBAL(block *types.Block, statedb *state.StateDB, interruptChan <-chan struct{}) {
+	if block.BAL() == nil {
+		return
+	}
+	transactions := block.Transactions()
+	blockAccessList := block.BAL()
+
+	// get index sorted block access list, each transaction has a list of accounts, each account has a list of storage items
+	// txIndex 0:
+	// 			 account1: storage1_1, storage1_2, storage1_3
+	// 			 account2: storage2_1, storage2_2, storage2_3
+	// txIndex 1:
+	// 			 account3: storage3_1, storage3_2, storage3_3
+	// ...
+	balPrefetch := types.BlockAccessListPrefetch{
+		AccessListItems: make(map[uint32]types.TxAccessListPrefetch),
+	}
+	for _, account := range blockAccessList.Accounts {
+		balPrefetch.Update(&account)
+	}
+
+	// prefetch snapshot cache
+	go p.PrefetchBALSnapshot(&balPrefetch, block, len(transactions), statedb, interruptChan)
+
+	// prefetch MPT trie node cache
+	go p.PrefetchBALTrie(&balPrefetch, block, statedb, interruptChan)
 }
 
 // PrefetchMining processes the state changes according to the Ethereum rules by running

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -181,7 +181,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	for _, receipt := range receipts {
 		allLogs = append(allLogs, receipt.Logs...)
 	}
-
+	statedb.DumpAccessList(block)
 	return &ProcessResult{
 		Receipts: receipts,
 		Requests: requests,

--- a/core/types.go
+++ b/core/types.go
@@ -49,6 +49,8 @@ type Prefetcher interface {
 	Prefetch(transactions types.Transactions, header *types.Header, gasLimit uint64, statedb *state.StateDB, cfg vm.Config, interrupt *atomic.Bool)
 	// PrefetchMining used for pre-caching transaction signatures and state trie nodes. Only used for mining stage.
 	PrefetchMining(txs TransactionsByPriceAndNonce, header *types.Header, gasLimit uint64, statedb *state.StateDB, cfg vm.Config, interruptCh <-chan struct{}, txCurr **types.Transaction)
+	// prefetch based on block access list
+	PrefetchBAL(block *types.Block, statedb *state.StateDB, interruptChan <-chan struct{})
 }
 
 // Processor is an interface for processing blocks using a given initial state.

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -235,6 +235,123 @@ type Body struct {
 	Withdrawals  []*Withdrawal `rlp:"optional"`
 }
 
+// StorageAccessItem is a single storage key that is accessed in a block.
+type StorageAccessItem struct {
+	TxIndex uint32 // index of the first transaction in the block that accessed the storage
+	Dirty   bool   // true if the storage was modified in the block, false if it was read only
+	Key     common.Hash
+}
+
+// AccountAccessListEncode & BlockAccessListEncode are for BAL serialization.
+type AccountAccessListEncode struct {
+	TxIndex      uint32 // index of the first transaction in the block that accessed the account
+	Address      common.Address
+	StorageItems []StorageAccessItem
+}
+
+type BlockAccessListEncode struct {
+	Version  uint32      // Version of the access list format
+	Number   uint64      // number of the block that the BAL is for
+	Hash     common.Hash // hash of the block that the BAL is for
+	SignData []byte      // sign data for BAL
+	Accounts []AccountAccessListEncode
+}
+
+// TxAccessListPrefetch & BlockAccessListPrefetch are for BAL prefetch
+type StorageAccessItemPrefetch struct {
+	Dirty bool
+	Key   common.Hash
+}
+
+type TxAccessListPrefetch struct {
+	Accounts map[common.Address][]StorageAccessItemPrefetch
+}
+
+type BlockAccessListPrefetch struct {
+	AccessListItems map[uint32]TxAccessListPrefetch
+}
+
+func (b *BlockAccessListPrefetch) Update(aclEncode *AccountAccessListEncode) {
+	if aclEncode == nil {
+		return
+	}
+	accAddr := aclEncode.Address
+	b.PrepareTxAccount(aclEncode.TxIndex, accAddr)
+	for _, storageItem := range aclEncode.StorageItems {
+		b.PrepareTxStorage(accAddr, storageItem)
+	}
+}
+
+func (b *BlockAccessListPrefetch) PrepareTxStorage(accAddr common.Address, storageItem StorageAccessItem) {
+	b.PrepareTxAccount(storageItem.TxIndex, accAddr)
+	txAccessList := b.AccessListItems[storageItem.TxIndex]
+	txAccessList.Accounts[accAddr] = append(txAccessList.Accounts[accAddr], StorageAccessItemPrefetch{
+		Dirty: storageItem.Dirty,
+		Key:   storageItem.Key,
+	})
+}
+func (b *BlockAccessListPrefetch) PrepareTxAccount(txIndex uint32, addr common.Address) {
+	// create the tx access list if not exists
+	if _, ok := b.AccessListItems[txIndex]; !ok {
+		b.AccessListItems[txIndex] = TxAccessListPrefetch{
+			Accounts: make(map[common.Address][]StorageAccessItemPrefetch),
+		}
+	}
+	// create the account access list if not exists
+	if _, ok := b.AccessListItems[txIndex].Accounts[addr]; !ok {
+		b.AccessListItems[txIndex].Accounts[addr] = make([]StorageAccessItemPrefetch, 0)
+	}
+}
+
+// BlockAccessListRecord & BlockAccessListRecord are used to record access list during tx execution.
+type AccountAccessListRecord struct {
+	TxIndex      uint32 // index of the first transaction in the block that accessed the account
+	StorageItems map[common.Hash]StorageAccessItem
+}
+
+type BlockAccessListRecord struct {
+	Version  uint32 // Version of the access list format
+	Accounts map[common.Address]AccountAccessListRecord
+}
+
+func (b *BlockAccessListRecord) AddAccount(addr common.Address, txIndex uint32) {
+	if b == nil {
+		return
+	}
+
+	if _, ok := b.Accounts[addr]; !ok {
+		b.Accounts[addr] = AccountAccessListRecord{
+			TxIndex:      txIndex,
+			StorageItems: make(map[common.Hash]StorageAccessItem),
+		}
+	}
+}
+
+func (b *BlockAccessListRecord) AddStorage(addr common.Address, key common.Hash, txIndex uint32, dirty bool) {
+	if b == nil {
+		return
+	}
+
+	if _, ok := b.Accounts[addr]; !ok {
+		b.Accounts[addr] = AccountAccessListRecord{
+			TxIndex:      txIndex,
+			StorageItems: make(map[common.Hash]StorageAccessItem),
+		}
+	}
+
+	if _, ok := b.Accounts[addr].StorageItems[key]; !ok {
+		b.Accounts[addr].StorageItems[key] = StorageAccessItem{
+			TxIndex: txIndex,
+			Dirty:   dirty,
+			Key:     key,
+		}
+	} else {
+		storageItem := b.Accounts[addr].StorageItems[key]
+		storageItem.Dirty = dirty
+		b.Accounts[addr].StorageItems[key] = storageItem
+	}
+}
+
 // Block represents an Ethereum block.
 //
 // Note the Block type tries to be 'immutable', and contains certain caches that rely
@@ -274,6 +391,10 @@ type Block struct {
 
 	// sidecars provides DA check
 	sidecars BlobSidecars
+
+	// bal provides block access list
+	bal     *BlockAccessListEncode
+	balSize atomic.Uint64
 }
 
 // "external" block encoding. used for eth protocol, etc.
@@ -496,6 +617,19 @@ func (b *Block) Size() uint64 {
 	return uint64(c)
 }
 
+func (b *Block) BALSize() uint64 {
+	if b.bal == nil {
+		return 0
+	}
+	if size := b.balSize.Load(); size > 0 {
+		return size
+	}
+	c := writeCounter(0)
+	rlp.Encode(&c, b.bal)
+	b.balSize.Store(uint64(c))
+	return uint64(c)
+}
+
 func (b *Block) SetRoot(root common.Hash) { b.header.Root = root }
 
 // SanityCheck can be used to prevent that unbounded fields are
@@ -506,6 +640,10 @@ func (b *Block) SanityCheck() error {
 
 func (b *Block) Sidecars() BlobSidecars {
 	return b.sidecars
+}
+
+func (b *Block) BAL() *BlockAccessListEncode {
+	return b.bal
 }
 
 func (b *Block) CleanSidecars() {
@@ -563,6 +701,7 @@ func (b *Block) WithSeal(header *Header) *Block {
 		withdrawals:  b.withdrawals,
 		witness:      b.witness,
 		sidecars:     b.sidecars,
+		bal:          b.bal,
 	}
 }
 
@@ -576,6 +715,7 @@ func (b *Block) WithBody(body Body) *Block {
 		withdrawals:  slices.Clone(body.Withdrawals),
 		witness:      b.witness,
 		sidecars:     b.sidecars,
+		bal:          b.bal,
 	}
 	for i := range body.Uncles {
 		block.uncles[i] = CopyHeader(body.Uncles[i])
@@ -591,6 +731,7 @@ func (b *Block) WithWithdrawals(withdrawals []*Withdrawal) *Block {
 		uncles:       b.uncles,
 		witness:      b.witness,
 		sidecars:     b.sidecars,
+		bal:          b.bal,
 	}
 	if withdrawals != nil {
 		block.withdrawals = make([]*Withdrawal, len(withdrawals))
@@ -607,12 +748,30 @@ func (b *Block) WithSidecars(sidecars BlobSidecars) *Block {
 		uncles:       b.uncles,
 		withdrawals:  b.withdrawals,
 		witness:      b.witness,
+		bal:          b.bal,
 	}
 	if sidecars != nil {
 		block.sidecars = make(BlobSidecars, len(sidecars))
 		copy(block.sidecars, sidecars)
 	}
 	return block
+}
+
+func (b *Block) WithBAL(bal *BlockAccessListEncode) *Block {
+	block := &Block{
+		header:       b.header,
+		transactions: b.transactions,
+		uncles:       b.uncles,
+		withdrawals:  b.withdrawals,
+		witness:      b.witness,
+		sidecars:     b.sidecars,
+	}
+	block.bal = bal
+	return block
+}
+
+func (b *Block) UpdateBAL(bal *BlockAccessListEncode) {
+	b.bal = bal
 }
 
 func (b *Block) WithWitness(witness *ExecutionWitness) *Block {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -324,6 +324,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		options = &core.BlockChainConfig{
 			TrieCleanLimit:   config.TrieCleanCache,
 			NoPrefetch:       config.NoPrefetch,
+			EnableBAL:        config.EnableBAL,
 			TrieDirtyLimit:   config.TrieDirtyCache,
 			ArchiveMode:      config.NoPruning,
 			TrieTimeLimit:    config.TrieTimeout,
@@ -430,6 +431,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		RequiredBlocks:            config.RequiredBlocks,
 		DirectBroadcast:           config.DirectBroadcast,
 		EnableEVNFeatures:         stack.Config().EnableEVNFeatures,
+		EnableBAL:                 config.EnableBAL,
 		EVNNodeIdsWhitelist:       stack.Config().P2P.EVNNodeIdsWhitelist,
 		ProxyedValidatorAddresses: stack.Config().P2P.ProxyedValidatorAddresses,
 		DisablePeerTxBroadcast:    config.DisablePeerTxBroadcast,

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -111,6 +111,7 @@ type Config struct {
 	NoPruning  bool // Whether to disable pruning and flush everything to disk
 	NoPrefetch bool // Whether to disable prefetching and only load state on demand
 
+	EnableBAL           bool
 	DirectBroadcast     bool
 	DisableSnapProtocol bool // Whether disable snap protocol
 	RangeLimit          bool

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -30,6 +30,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		BscDiscoveryURLs        []string
 		NoPruning               bool
 		NoPrefetch              bool
+		EnableBAL               bool
 		DirectBroadcast         bool
 		DisableSnapProtocol     bool
 		RangeLimit              bool
@@ -90,6 +91,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.BscDiscoveryURLs = c.BscDiscoveryURLs
 	enc.NoPruning = c.NoPruning
 	enc.NoPrefetch = c.NoPrefetch
+	enc.EnableBAL = c.EnableBAL
 	enc.DirectBroadcast = c.DirectBroadcast
 	enc.DisableSnapProtocol = c.DisableSnapProtocol
 	enc.RangeLimit = c.RangeLimit
@@ -154,6 +156,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		BscDiscoveryURLs        []string
 		NoPruning               *bool
 		NoPrefetch              *bool
+		EnableBAL               *bool
 		DirectBroadcast         *bool
 		DisableSnapProtocol     *bool
 		RangeLimit              *bool
@@ -240,6 +243,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.NoPrefetch != nil {
 		c.NoPrefetch = *dec.NoPrefetch
+	}
+	if dec.EnableBAL != nil {
+		c.EnableBAL = *dec.EnableBAL
 	}
 	if dec.DirectBroadcast != nil {
 		c.DirectBroadcast = *dec.DirectBroadcast

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -889,7 +889,7 @@ func (f *BlockFetcher) importBlocks(op *blockOrHeaderInject) {
 	hash := block.Hash()
 
 	// Run the import on a new thread
-	log.Debug("Importing propagated block", "peer", peer, "number", block.Number(), "hash", hash)
+	log.Debug("Importing propagated block", "peer", peer, "number", block.Number(), "hash", hash, "balSize", block.BALSize())
 	go func() {
 		// If the parent's unknown, abort insertion
 		parent := f.getBlock(block.ParentHash())

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -141,6 +141,7 @@ type handlerConfig struct {
 	PeerSet                   *peerSet
 	EnableQuickBlockFetching  bool
 	EnableEVNFeatures         bool
+	EnableBAL                 bool
 	EVNNodeIdsWhitelist       []enode.ID
 	ProxyedValidatorAddresses []common.Address
 }
@@ -150,6 +151,7 @@ type handler struct {
 	networkID                  uint64
 	disablePeerTxBroadcast     bool
 	enableEVNFeatures          bool
+	enableBAL                  bool
 	evnNodeIdsWhitelistMap     map[enode.ID]struct{}
 	proxyedValidatorAddressMap map[common.Address]struct{}
 
@@ -220,6 +222,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		requiredBlocks:             config.RequiredBlocks,
 		directBroadcast:            config.DirectBroadcast,
 		enableEVNFeatures:          config.EnableEVNFeatures,
+		enableBAL:                  config.EnableBAL,
 		evnNodeIdsWhitelistMap:     make(map[enode.ID]struct{}),
 		proxyedValidatorAddressMap: make(map[common.Address]struct{}),
 		quitSync:                   make(chan struct{}),
@@ -328,7 +331,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		if p.bscExt == nil {
 			return nil, fmt.Errorf("peer does not support bsc protocol, peer: %v", p.ID())
 		}
-		if p.bscExt.Version() != bsc.Bsc2 {
+		if p.bscExt.Version() < bsc.Bsc2 {
 			return nil, fmt.Errorf("remote peer does not support the required Bsc2 protocol version, peer: %v", p.ID())
 		}
 		res, err := p.bscExt.RequestBlocksByRange(startHeight, startHash, count)
@@ -340,6 +343,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		for i, item := range res {
 			block := types.NewBlockWithHeader(item.Header).WithBody(types.Body{Transactions: item.Txs, Uncles: item.Uncles})
 			block = block.WithSidecars(item.Sidecars)
+			block = block.WithBAL(item.BAL)
 			block.ReceivedAt = time.Now()
 			block.ReceivedFrom = p.ID()
 			if err := block.SanityCheck(); err != nil {
@@ -455,12 +459,15 @@ func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
 		peer.Log().Error("Snapshot extension barrier failed", "err", err)
 		return err
 	}
-	bsc, err := h.peers.waitBscExtension(peer)
+	bscExt, err := h.peers.waitBscExtension(peer)
 	if err != nil {
 		peer.Log().Error("Bsc extension barrier failed", "err", err)
 		return err
 	}
-
+	if bscExt != nil && bscExt.Version() == bsc.Bsc3 {
+		peer.CanHandleBAL.Store(true)
+		log.Debug("runEthPeer", "bscExt.Version", bscExt.Version(), "CanHandleBAL", peer.CanHandleBAL.Load())
+	}
 	// Execute the Ethereum handshake
 	var (
 		head   = h.chain.CurrentHeader()
@@ -510,7 +517,7 @@ func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
 	}
 
 	// Register the peer locally
-	if err := h.peers.registerPeer(peer, snap, bsc); err != nil {
+	if err := h.peers.registerPeer(peer, snap, bscExt); err != nil {
 		peer.Log().Error("Ethereum peer registration failed", "err", err)
 		return err
 	}
@@ -821,7 +828,8 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		}
 
 		for _, peer := range transfer {
-			log.Debug("broadcast block to peer", "hash", hash, "peer", peer.ID(), "EVNPeerFlag", peer.EVNPeerFlag.Load())
+			log.Debug("broadcast block to peer", "hash", hash, "peer", peer.ID(),
+				"EVNPeerFlag", peer.EVNPeerFlag.Load(), "CanHandleBAL", peer.CanHandleBAL.Load())
 			peer.AsyncSendNewBlock(block, td)
 		}
 
@@ -834,7 +842,8 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 				}
 			}
 			for _, peer := range morePeers {
-				log.Debug("broadcast block to extra peer", "hash", hash, "peer", peer.ID(), "EVNPeerFlag", peer.EVNPeerFlag.Load())
+				log.Debug("broadcast block to extra peer", "hash", hash, "peer", peer.ID(),
+					"EVNPeerFlag", peer.EVNPeerFlag.Load(), "CanHandleBAL", peer.CanHandleBAL.Load())
 				peer.AsyncSendNewBlock(block, td)
 			}
 		}
@@ -845,7 +854,8 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 	// Otherwise if the block is indeed in our own chain, announce it
 	if h.chain.HasBlock(hash, block.NumberU64()) {
 		for _, peer := range peers {
-			log.Debug("Announced block to peer", "hash", hash, "peer", peer.ID(), "EVNPeerFlag", peer.EVNPeerFlag.Load())
+			log.Debug("Announced block to peer", "hash", hash, "peer", peer.ID(),
+				"EVNPeerFlag", peer.EVNPeerFlag.Load(), "CanHandleBAL", peer.CanHandleBAL.Load())
 			peer.AsyncSendNewBlockHash(block)
 		}
 		log.Debug("Announced block", "hash", hash, "recipients", len(peers), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -141,6 +141,9 @@ func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, packet *eth.NewBlockPa
 	if sidecars != nil {
 		block = block.WithSidecars(sidecars)
 	}
+	if packet.Bal != nil && h.chain.Engine().VerifyBAL(block, packet.Bal) == nil {
+		block = block.WithBAL(packet.Bal)
+	}
 
 	// Schedule the block for import
 	log.Debug("handleBlockBroadcast", "peer", peer.ID(), "block", block.Number(), "hash", block.Hash())

--- a/eth/protocols/bsc/handler.go
+++ b/eth/protocols/bsc/handler.go
@@ -166,15 +166,17 @@ func handleGetBlocksByRange(backend Backend, msg Decoder, peer *Peer) error {
 		return fmt.Errorf("msg %v, cannot get start block: %v, %v", GetBlocksByRangeMsg, req.StartBlockHeight, req.StartBlockHash)
 	}
 	blocks = append(blocks, NewBlockData(block))
+	balSize := block.BALSize()
 	for i := uint64(1); i < req.Count; i++ {
 		block = backend.Chain().GetBlockByHash(block.ParentHash())
 		if block == nil {
 			break
 		}
+		balSize += block.BALSize()
 		blocks = append(blocks, NewBlockData(block))
 	}
 
-	log.Debug("reply GetBlocksByRange msg", "from", peer.id, "req", req.Count, "blocks", len(blocks))
+	log.Debug("reply GetBlocksByRange msg", "from", peer.id, "req", req.Count, "blocks", len(blocks), "balSize", balSize)
 	return p2p.Send(peer.rw, BlocksByRangeMsg, &BlocksByRangePacket{
 		RequestId: req.RequestId,
 		Blocks:    blocks,

--- a/eth/protocols/bsc/protocol.go
+++ b/eth/protocols/bsc/protocol.go
@@ -12,6 +12,7 @@ import (
 const (
 	Bsc1 = 1
 	Bsc2 = 2
+	Bsc3 = 3 // to BAL process
 )
 
 // ProtocolName is the official short name of the `bsc` protocol used during
@@ -20,11 +21,11 @@ const ProtocolName = "bsc"
 
 // ProtocolVersions are the supported versions of the `bsc` protocol (first
 // is primary).
-var ProtocolVersions = []uint{Bsc1, Bsc2}
+var ProtocolVersions = []uint{Bsc1, Bsc2, Bsc3}
 
 // protocolLengths are the number of implemented message corresponding to
 // different protocol versions.
-var protocolLengths = map[uint]uint64{Bsc1: 2, Bsc2: 4}
+var protocolLengths = map[uint]uint64{Bsc1: 2, Bsc2: 4, Bsc3: 4}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
 const maxMessageSize = 10 * 1024 * 1024
@@ -84,8 +85,9 @@ type BlockData struct {
 	Header      *types.Header
 	Txs         []*types.Transaction
 	Uncles      []*types.Header
-	Withdrawals []*types.Withdrawal `rlp:"optional"`
-	Sidecars    types.BlobSidecars  `rlp:"optional"`
+	Withdrawals []*types.Withdrawal          `rlp:"optional"`
+	Sidecars    types.BlobSidecars           `rlp:"optional"`
+	BAL         *types.BlockAccessListEncode `rlp:"optional"`
 }
 
 // NewBlockData creates a new BlockData object from a block
@@ -96,6 +98,7 @@ func NewBlockData(block *types.Block) *BlockData {
 		Uncles:      block.Uncles(),
 		Withdrawals: block.Withdrawals(),
 		Sidecars:    block.Sidecars(),
+		BAL:         block.BAL(),
 	}
 }
 

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -376,6 +376,13 @@ func handleNewBlock(backend Backend, msg Decoder, peer *Peer) error {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 
+	if ann.Bal != nil {
+		log.Debug("handleNewBlock, BAL", "number", ann.Block.NumberU64(), "hash", ann.Block.Hash(), "peer", peer.ID(),
+			"version", ann.Bal.Version, "signData", len(ann.Bal.SignData), "accounts", len(ann.Bal.Accounts), "balSize", ann.Block.BALSize())
+	} else {
+		log.Debug("handleNewBlock, no BAL", "number", ann.Block.NumberU64(), "hash", ann.Block.Hash(), "peer", peer.ID(),
+			"txNum", len(ann.Block.Transactions()), "balSize", ann.Block.BALSize())
+	}
 	// Now that we have our packet, perform operations using the interface methods
 	if err := ann.sanityCheck(); err != nil {
 		return err

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -25,6 +25,7 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -311,10 +312,23 @@ func (p *Peer) AsyncSendNewBlockHash(block *types.Block) {
 func (p *Peer) SendNewBlock(block *types.Block, td *big.Int) error {
 	// Mark all the block hash as known, but ensure we don't overflow our limits
 	p.knownBlocks.Add(block.Hash())
+	bal := block.BAL()
+	if !p.CanHandleBAL.Load() {
+		bal = nil
+	}
+	if bal != nil {
+		log.Debug("SendNewBlock", "number", block.NumberU64(), "hash", block.Hash(), "peer", p.ID(),
+			"balSize", block.BALSize(), "version", bal.Version, "canHandleBAL", p.CanHandleBAL.Load())
+	} else {
+		log.Debug("SendNewBlock no BAL", "number", block.NumberU64(), "hash", block.Hash(), "peer", p.ID(),
+			"txNum", len(block.Transactions()), "canHandleBAL", p.CanHandleBAL.Load())
+	}
+
 	return p2p.Send(p.rw, NewBlockMsg, &NewBlockPacket{
 		Block:    block,
 		TD:       td,
 		Sidecars: block.Sidecars(),
+		Bal:      bal,
 	})
 }
 

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -233,7 +233,8 @@ type BlockHeadersRLPPacket struct {
 type NewBlockPacket struct {
 	Block    *types.Block
 	TD       *big.Int
-	Sidecars types.BlobSidecars `rlp:"optional"`
+	Sidecars types.BlobSidecars           `rlp:"optional"`
+	Bal      *types.BlockAccessListEncode `rlp:"optional"`
 }
 
 // sanityCheck verifies that the values are reasonable, as a DoS protection

--- a/node/config.go
+++ b/node/config.go
@@ -104,6 +104,9 @@ type Config struct {
 	// EnableQuickBlockFetching indicates whether to fetch new blocks using new messages.
 	EnableQuickBlockFetching bool `toml:",omitempty"`
 
+	// EnableBAL enables the block access list feature
+	EnableBAL bool `toml:",omitempty"`
+
 	// RangeLimit enable 5000 blocks limit when handle range query
 	RangeLimit bool `toml:",omitempty"`
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -129,6 +129,9 @@ type Peer struct {
 	// it indicates the peer is in the validator network, it will directly broadcast when miner/sentry broadcast mined block,
 	// and won't broadcast any txs between EVN peers.
 	EVNPeerFlag atomic.Bool
+
+	// it indicates the peer can handle BAL(block access list) packet
+	CanHandleBAL atomic.Bool
 }
 
 // NewPeer returns a peer for testing purposes.

--- a/params/network_params.go
+++ b/params/network_params.go
@@ -22,6 +22,9 @@ package params
 const (
 	// StableStateThreshold is the reserve number of block state save to disk before delete ancientdb
 	StableStateThreshold uint64 = 128
+
+	// MaxBALSize is the maximum bytes of the rlp encoded block access list: 1MB
+	MaxBALSize uint64 = 1048576
 )
 
 var (

--- a/version/version.go
+++ b/version/version.go
@@ -17,8 +17,8 @@
 package version
 
 const (
-	Major = 1  // Major version component of the current release
-	Minor = 6  // Minor version component of the current release
-	Patch = 1  // Patch version component of the current release
-	Meta  = "" // Version metadata to append to the version string
+	Major = 1     // Major version component of the current release
+	Minor = 6     // Minor version component of the current release
+	Patch = 100   // Patch version component of the current release
+	Meta  = "BAL" // Version metadata to append to the version string
 )


### PR DESCRIPTION
## Description
This PR implements [BEP-592: Non-Consensus Based Block-Level Access List](https://github.com/bnb-chain/BEPs/pull/592) to improve block execution performance. The implementation introduces a block access list (BAL) feature that tracks account and storage access during transaction execution, enabling efficient prefetching of state data.

Key changes include:
- Implementation of BAL data structures for generation, propagation, and usage phases
- P2P protocol enhancements (BSC/3) to support BAL transmission between peers
- Integration with mining, state management, and prefetching systems

<img width="40%" alt="image" src="https://github.com/user-attachments/assets/f6c1fafc-c1a1-4496-8150-acb4d646137e" />

### 1.About Code
**a.BAL lifecycle**
Each BAL will mainly have three stages: Generation, Propagation and Prefetch. Each stage would have a data structure to represent.

- Stage#1: BAL generation: validator will generate the BAL data during mining phase
```golang
// BlockAccessListRecord & AccountAccessListRecord are used to record access list during Tx execution.
type AccountAccessListRecord struct {
	TxIndex      uint32 // index of the first transaction in the block that accessed the account
	StorageItems map[common.Hash]StorageAccessItem
}

type BlockAccessListRecord struct {
	Version  uint32 // Version of the access list format
	Accounts map[common.Address]AccountAccessListRecord
}
```
- Stage#2: BAL propagation
BAL will be encoded before propagation, it is represented by BlockAccessListEncode
```golang
// StorageAccessItem is a single storage key that is accessed in a block.
type StorageAccessItem struct {
	TxIndex uint32 // index of the first transaction in the block that accessed the storage
	Dirty   bool   // true if the storage was modified in the block, false if it was read only
	Key     common.Hash
}

// AccountAccessListEncode & BlockAccessListEncode are for BAL serialization.
type AccountAccessListEncode struct {
	TxIndex      uint32 // index of the first transaction in the block that accessed the account
	Address      common.Address
	StorageItems []StorageAccessItem
}

type BlockAccessListEncode struct {
	Version  uint32 // Version of the access list format
	Number   uint64      // number of the block that the BAL is for
	Hash     common.Hash // hash of the block that the BAL is for
	SignData []byte // sign data for BAL
	Accounts []AccountAccessListEncode
}
```
- 3.BAL Prefetch
Current BAL is mainly used during prefetch, so the data structure would be:
```golang
// TxAccessListPrefetch & BlockAccessListPrefetch are for BAL prefetch
type StorageAccessItemPrefetch struct {
	Dirty bool
	Key   common.Hash
}

type TxAccessListPrefetch struct {
	Accounts map[common.Address][]StorageAccessItemPrefetch
}

type BlockAccessListPrefetch struct {
	AccessListItems map[uint32]TxAccessListPrefetch
}
```

**b.BAL Prune**
In order to avoid adding extra complexity to the current freezer module, BAL will only be kept in KVDB, but only for the recent `FullImmutabilityThreshold(360_000)` blocks, elder BAL will be deleted.

**c.BSC/3 P2P protocol**
BSC/3 would be used to indicate the BAL capability of the remote peer, only peer with bsc/3 protocol will be able to handle BAL data.

### 2.Try It:
Currently, validator is the only producer of BAL, so validator needs to be upgraded first, then the connected full node can get the BAL data and use it to accelerate it syncing performance.

Enable BAL both on validator and connected full nodes, it can be done by running with flag `--enablebal`, or update the config.toml:
```
...
[Node]
EnableBAL = true
...
```
