### PR TITLE
readme: Fix typos and unify terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## BNB Smart Chain
 
-The goal of BNB Smart Chain is to bring programmability and interoperability to BNB Beacon Chain. In order to embrace the existing popular community and advanced technology, it will bring huge benefits by staying compatible with all the existing smart contracts on Ethereum and Ethereum tooling. And to achieve that, the easiest solution is to develop based on go-ethereum fork, as we respect the great work of Ethereum very much.
+The goal of BNB Smart Chain is to bring programmability and interoperability to BNB Beacon Chain. To embrace the existing community and advanced technology, it provides significant benefits by staying compatible with existing Ethereum smart contracts and tooling. To achieve that, the straightforward solution is to build on a go-ethereum fork, as we greatly respect the work of Ethereum.
 
-BNB Smart Chain starts its development based on go-ethereum fork. So you may see many toolings, binaries and also docs are based on Ethereum ones, such as the name "geth".
+BNB Smart Chain starts its development based on a go-ethereum fork. So you may see many tooling, binaries, and docs aligned with Ethereum, such as the name "geth".
 
 [![API Reference](
 https://pkg.go.dev/badge/github.com/ethereum/go-ethereum
@@ -10,52 +10,50 @@ https://pkg.go.dev/badge/github.com/ethereum/go-ethereum
 [![Build Test](https://github.com/bnb-chain/bsc/actions/workflows/build-test.yml/badge.svg)](https://github.com/bnb-chain/bsc/actions)
 [![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/z2VpC455eU)
 
-But from that baseline of EVM compatible, BNB Smart Chain introduces a system of 21 validators with Proof of Staked Authority (PoSA) consensus that can support short block time and lower fees. The most bonded validator candidates of staking will become validators and produce blocks. The double-sign detection and other slashing logic guarantee security, stability, and chain finality.
+From that EVM-compatible baseline, BNB Smart Chain introduces a system of 21 validators with Proof of Staked Authority (PoSA) consensus that supports short block times and lower fees. Validator candidates with the highest stake become validators and produce blocks. Double-sign detection and other slashing logic help guarantee security, stability, and chain finality.
 
 **The BNB Smart Chain** will be:
 
 - **A self-sovereign blockchain**: Provides security and safety with elected validators.
-- **EVM-compatible**: Supports all the existing Ethereum tooling along with faster finality and cheaper transaction fees.
-- **Distributed with on-chain governance**: Proof of Staked Authority brings in decentralization and community participants. As the native token, BNB will serve as both the gas of smart contract execution and tokens for staking.
+- **EVM-compatible**: Supports existing Ethereum tooling along with faster finality and cheaper transaction fees.
+- **Distributed with on-chain governance**: Proof of Staked Authority brings decentralization and community participation. As the native token, BNB serves as both gas for smart contract execution and the token for staking.
 
-More details in [White Paper](https://github.com/bnb-chain/whitepaper/blob/master/WHITEPAPER.md).
+More details are in the [White Paper](https://github.com/bnb-chain/whitepaper/blob/master/WHITEPAPER.md).
 
 ## Release Types
-There are three types of release, each with a clear purpose and version scheme:
+There are three release types, each with a clear purpose and version scheme:
 
-- **1.Stable Release**: production-ready builds for the vast majority of users.  Format: `v<Major>.<Minor>.<Patch>`, example: [v1.5.19](https://github.com/bnb-chain/bsc/releases/tag/v1.5.19).
-- **2.Feature Release**: early access to a single feature without affecting the core product. Format: `v<Major>.<Minor>.<Patch>-feature-<FeatureName>`, example: [v1.5.19-feature-SI](https://github.com/bnb-chain/bsc/releases/tag/v1.5.19-feature-SI).
-- **3.Preview Release**: bleeding-edge builds for users who want the latest code. Format: `v<Major>.<Minor>.<Patch>-<Meta>`, Meta values indicate maturity: alpha (experimental), beta (largely complete), rc (release candidate), example: [v1.5.0-alpha](https://github.com/bnb-chain/bsc/releases/tag/v1.5.0-alpha).
+- **1. Stable Release**: production-ready builds for the vast majority of users. Format: `v<Major>.<Minor>.<Patch>`, example: [v1.5.19](https://github.com/bnb-chain/bsc/releases/tag/v1.5.19).
+- **2. Feature Release**: early access to a single feature without affecting the core product. Format: `v<Major>.<Minor>.<Patch>-feature-<FeatureName>`, example: [v1.5.19-feature-SI](https://github.com/bnb-chain/bsc/releases/tag/v1.5.19-feature-SI).
+- **3. Preview Release**: bleeding-edge builds for users who want the latest code. Format: `v<Major>.<Minor>.<Patch>-<Meta>` where Meta values indicate maturity: alpha (experimental), beta (largely complete), rc (release candidate). Example: [v1.5.0-alpha](https://github.com/bnb-chain/bsc/releases/tag/v1.5.0-alpha).
 
 ## Key features
 
-### Proof of Staked Authority 
-Although Proof-of-Work (PoW) has been approved as a practical mechanism to implement a decentralized network, it is not friendly to the environment and also requires a large size of participants to maintain the security. 
+### Proof of Staked Authority
+Although Proof-of-Work (PoW) has been proven as a practical mechanism to implement a decentralized network, it is not environmentally friendly and requires a large number of participants to maintain security.
 
-Proof-of-Authority(PoA) provides some defense to 51% attack, with improved efficiency and tolerance to certain levels of Byzantine players (malicious or hacked). 
-Meanwhile, the PoA protocol is most criticized for being not as decentralized as PoW, as the validators, i.e. the nodes that take turns to produce blocks, have all the authorities and are prone to corruption and security attacks.
+Proof-of-Authority (PoA) provides some defense against 51% attacks, with improved efficiency and tolerance to certain levels of Byzantine actors (malicious or hacked). Meanwhile, PoA is often criticized for not being as decentralized as PoW, as validators (nodes that take turns producing blocks) hold concentrated authority and can be more prone to corruption and security attacks.
 
-Other blockchains, such as EOS and Cosmos both, introduce different types of Deputy Proof of Stake (DPoS) to allow the token holders to vote and elect the validator set. It increases the decentralization and favors community governance. 
+Other blockchains, such as EOS and Cosmos, introduce Delegated Proof of Stake (DPoS) to allow token holders to vote and elect the validator set. It increases decentralization and favors community governance.
 
-To combine DPoS and PoA for consensus, BNB Smart Chain implement a novel consensus engine called Parlia that:
+To combine DPoS and PoA for consensus, BNB Smart Chain implements a novel consensus engine called Parlia that:
 
 1. Blocks are produced by a limited set of validators.
 2. Validators take turns to produce blocks in a PoA manner, similar to Ethereum's Clique consensus engine.
-3. Validator set are elected in and out based on a staking based governance on BNB Smart Chain.
-4. Parlia consensus engine will interact with a set of [system contracts](https://docs.bnbchain.org/bnb-smart-chain/staking/overview/#system-contracts) to achieve liveness slash, revenue distributing and validator set renewing func.
+3. The validator set is elected in and out based on staking-based governance on BNB Smart Chain.
+4. The Parlia consensus engine interacts with a set of [system contracts](https://docs.bnbchain.org/bnb-smart-chain/staking/overview/#system-contracts) to perform liveness slashing, revenue distribution, and validator set renewal functions.
 
 ## Native Token
 
-BNB will run on BNB Smart Chain in the same way as ETH runs on Ethereum so that it remains as `native token` for BSC. This means,
-BNB will be used to:
+BNB runs on BNB Smart Chain in the same way as ETH runs on Ethereum, so it remains the `native token` for BSC. This means BNB will be used to:
 
-1. pay `gas` to deploy or invoke Smart Contract on BSC
+1. Pay `gas` to deploy or invoke smart contracts on BSC.
 
 ## Building the source
 
-Many of the below are the same as or similar to go-ethereum.
+Many of the steps below are the same as or similar to go-ethereum.
 
-For prerequisites and detailed build instructions please read the [Installation Instructions](https://geth.ethereum.org/docs/getting-started/installing-geth).
+For prerequisites and detailed build instructions, please read the [Installation Instructions](https://geth.ethereum.org/docs/getting-started/installing-geth).
 
 Building `geth` requires both a Go (version 1.24 or later) and a C compiler (GCC 5 or higher). You can install
 them using your favourite package manager. Once the dependencies are installed, run
@@ -70,13 +68,13 @@ or, to build the full suite of utilities:
 make all
 ```
 
-If you get such error when running the node with self built binary:
+If you get this error when running the node with a self-built binary:
 ```shell
-Caught SIGILL in blst_cgo_init, consult <blst>/bindinds/go/README.md.
+Caught SIGILL in blst_cgo_init, consult <blst>/bindings/go/README.md.
 ```
 please try to add the following environment variables and build again:
 ```shell
-export CGO_CFLAGS="-O -D__BLST_PORTABLE__" 
+export CGO_CFLAGS="-O -D__BLST_PORTABLE__"
 export CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
 ```
 
@@ -85,78 +83,78 @@ export CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
 The bsc project comes with several wrappers/executables found in the `cmd`
 directory.
 
-|  Command   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| :--------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`geth`** | Main BNB Smart Chain client binary. It is the entry point into the BSC network (main-, test- or private net), capable of running as a full node (default), archive node (retaining all historical state) or a light node (retrieving data live). It has the same and more RPC and other interface as go-ethereum and can be used by other processes as a gateway into the BSC network via JSON RPC endpoints exposed on top of HTTP, WebSocket and/or IPC transports. `geth --help` and the [CLI page](https://geth.ethereum.org/docs/interface/command-line-options) for command line options. |
-|   `clef`   | Stand-alone signing tool, which can be used as a backend signer for `geth`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-|  `devp2p`  | Utilities to interact with nodes on the networking layer, without running a full blockchain.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-|  `abigen`  | Source code generator to convert Ethereum contract definitions into easy to use, compile-time type-safe Go packages. It operates on plain [Ethereum contract ABIs](https://docs.soliditylang.org/en/develop/abi-spec.html) with expanded functionality if the contract bytecode is also available. However, it also accepts Solidity source files, making development much more streamlined. Please see our [Native DApps](https://geth.ethereum.org/docs/dapp/native-bindings) page for details.                                                                                               |
-| `bootnode` | Stripped down version of our Ethereum client implementation that only takes part in the network node discovery protocol, but does not run any of the higher level application protocols. It can be used as a lightweight bootstrap node to aid in finding peers in private networks.                                                                                                                                                                                                                                                                                                            |
-|   `evm`    | Developer utility version of the EVM (Ethereum Virtual Machine) that is capable of running bytecode snippets within a configurable environment and execution mode. Its purpose is to allow isolated, fine-grained debugging of EVM opcodes (e.g. `evm --code 60ff60ff --debug run`).                                                                                                                                                                                                                                                                                                            |
-| `rlpdump`  | Developer utility tool to convert binary RLP ([Recursive Length Prefix](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp)) dumps (data encoding used by the Ethereum protocol both network as well as consensus wise) to user-friendlier hierarchical representation (e.g. `rlpdump --hex CE0183FFFFFFC4C304050583616263`).                                                                                                                                                                                                                                                                                 |
+|  Command   | Description |
+| :--------: | ----------- |
+| **`geth`** | Main BNB Smart Chain client binary. It is the entry point into the BSC network (main-, test- or private net), capable of running as a full node (default), archive node (retaining all historical state) or a light node (retrieving data live). It has the same RPC interfaces (and more) as go-ethereum and can be used by other processes as a gateway into the BSC network via JSON RPC endpoints exposed on top of HTTP, WebSocket and/or IPC transports. See `geth --help` and the [CLI page](https://geth.ethereum.org/docs/interface/command-line-options) for command line options. |
+|   `clef`   | Stand-alone signing tool, which can be used as a backend signer for `geth`. |
+|  `devp2p`  | Utilities to interact with nodes on the networking layer, without running a full blockchain. |
+|  `abigen`  | Source code generator to convert Ethereum contract definitions into easy-to-use, compile-time type-safe Go packages. It operates on plain [Ethereum contract ABIs](https://docs.soliditylang.org/en/develop/abi-spec.html) with expanded functionality if the contract bytecode is also available. However, it also accepts Solidity source files, making development much more streamlined. Please see our [Native DApps](https://geth.ethereum.org/docs/dapp/native-bindings) page for details. |
+| `bootnode` | Stripped-down version of our Ethereum client implementation that only takes part in the network node discovery protocol, but does not run any of the higher-level application protocols. It can be used as a lightweight bootstrap node to aid in finding peers in private networks. |
+|   `evm`    | Developer utility version of the EVM (Ethereum Virtual Machine) that is capable of running bytecode snippets within a configurable environment and execution mode. Its purpose is to allow isolated, fine-grained debugging of EVM opcodes (e.g. `evm --code 60ff60ff --debug run`). |
+| `rlpdump`  | Developer utility tool to convert binary RLP ([Recursive Length Prefix](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp)) dumps (data encoding used by the Ethereum protocol both network as well as consensus-wise) to a more user-friendly hierarchical representation (e.g. `rlpdump --hex CE0183FFFFFFC4C304050583616263`). |
 
 ## Running `geth`
 
 Going through all the possible command line flags is out of scope here (please consult our
 [CLI Wiki page](https://geth.ethereum.org/docs/fundamentals/command-line-options)),
-but we've enumerated a few common parameter combos to get you up to speed quickly
+but we've enumerated a few common parameter combinations to get you up to speed quickly
 on how you can run your own `geth` instance.
 
 ### Hardware Requirements
 
 The hardware must meet certain requirements to run a full node on mainnet:
-- VPS running recent versions of Mac OS X, Linux, or Windows.
-- IMPORTANT 3 TB(Dec 2023) of free disk space, solid-state drive(SSD), gp3, 8k IOPS, 500 MB/S throughput, read latency <1ms. (if node is started with snap sync, it will need NVMe SSD)
-- 16 cores of CPU and 64 GB of memory (RAM)
-- Suggest m5zn.6xlarge or r7iz.4xlarge instance type on AWS, c2-standard-16 on Google cloud.
-- A broadband Internet connection with upload/download speeds of 5 MB/S
+- VPS running recent versions of macOS, Linux, or Windows.
+- **IMPORTANT:** 3 TB (Dec 2023) of free disk space; solid-state drive (SSD), gp3, 8k IOPS, 500 MB/s throughput, read latency < 1 ms. (If the node is started with snap sync, it will need an NVMe SSD.)
+- 16 cores of CPU and 64 GB of memory (RAM).
+- Suggested: `m5zn.6xlarge` or `r7iz.4xlarge` instance types on AWS; `c2-standard-16` on Google Cloud.
+- A broadband Internet connection with upload/download speeds of 5 MB/s.
 
-The requirement for testnet:
-- VPS running recent versions of Mac OS X, Linux, or Windows.
-- 500G of storage for testnet.
-- 4 cores of CPU and 16 gigabytes of memory (RAM).
+Requirements for testnet:
+- VPS running recent versions of macOS, Linux, or Windows.
+- 500 GB of storage for testnet.
+- 4 cores of CPU and 16 GB of memory (RAM).
 
 ### Steps to Run a Fullnode
 
-#### 1. Download the pre-build binaries
+#### 1. Download the pre-built binaries
 ```shell
 # Linux
-wget $(curl -s https://api.github.com/repos/bnb-chain/bsc/releases/latest |grep browser_ |grep geth_linux |cut -d\" -f4)
+wget $(curl -s https://api.github.com/repos/bnb-chain/bsc/releases/latest | grep browser_ | grep geth_linux | cut -d" -f4)
 mv geth_linux geth
 chmod -v u+x geth
 
-# MacOS
-wget $(curl -s https://api.github.com/repos/bnb-chain/bsc/releases/latest |grep browser_ |grep geth_mac |cut -d\" -f4)
+# macOS
+wget $(curl -s https://api.github.com/repos/bnb-chain/bsc/releases/latest | grep browser_ | grep geth_mac | cut -d" -f4)
 mv geth_macos geth
 chmod -v u+x geth
 ```
 
 #### 2. Download the config files
 ```shell
-//== mainnet
-wget $(curl -s https://api.github.com/repos/bnb-chain/bsc/releases/latest |grep browser_ |grep mainnet |cut -d\" -f4)
+# == mainnet
+wget $(curl -s https://api.github.com/repos/bnb-chain/bsc/releases/latest | grep browser_ | grep mainnet | cut -d" -f4)
 unzip mainnet.zip
 
-//== testnet
-wget $(curl -s https://api.github.com/repos/bnb-chain/bsc/releases/latest |grep browser_ |grep testnet |cut -d\" -f4)
+# == testnet
+wget $(curl -s https://api.github.com/repos/bnb-chain/bsc/releases/latest | grep browser_ | grep testnet | cut -d" -f4)
 unzip testnet.zip
 ```
 
 #### 3. Download snapshot
-Download latest chaindata snapshot from [here](https://github.com/bnb-chain/bsc-snapshots). Follow the guide to structure your files.
+Download the latest chaindata snapshot from [here](https://github.com/bnb-chain/bsc-snapshots). Follow the guide to structure your files.
 
 #### 4. Start a full node
 ```shell
-## It will run with Path-Base Storage Scheme by default and enable inline state prune, keeping the latest 90000 blocks' history state.
-./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --history.transactions 0
+# Runs with Path-Based Storage Scheme by default and enables inline state prune, keeping the latest 90,000 blocks' historical state.
+./geth --config ./config.toml --datadir ./node --cache 8000 --rpc.allow-unprotected-txs --history.transactions 0
 
-## It is recommend to run fullnode with `--tries-verify-mode none` if you want high performance and care little about state consistency.
-./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --history.transactions 0 --tries-verify-mode none
+# Recommended for high performance if you care little about state consistency.
+./geth --config ./config.toml --datadir ./node --cache 8000 --rpc.allow-unprotected-txs --history.transactions 0 --tries-verify-mode none
 ```
 
 #### 5. Monitor node status
 
-Monitor the log from **./node/bsc.log** by default. When the node has started syncing, should be able to see the following output:
+Monitor the log from **./node/bsc.log** by default. When the node has started syncing, you should see output like:
 ```shell
 t=2022-09-08T13:00:27+0000 lvl=info msg="Imported new chain segment"             blocks=1    txs=177   mgas=17.317   elapsed=31.131ms    mgasps=556.259  number=21,153,429 hash=0x42e6b54ba7106387f0650defc62c9ace3160b427702dab7bd1c5abb83a32d8db dirty="0.00 B"
 t=2022-09-08T13:00:29+0000 lvl=info msg="Imported new chain segment"             blocks=1    txs=251   mgas=39.638   elapsed=68.827ms    mgasps=575.900  number=21,153,430 hash=0xa3397b273b31b013e43487689782f20c03f47525b4cd4107c1715af45a88796e dirty="0.00 B"
@@ -164,11 +162,11 @@ t=2022-09-08T13:00:33+0000 lvl=info msg="Imported new chain segment"            
 ```
 
 #### 6. Interact with fullnode
-Start up `geth`'s built-in interactive [JavaScript console](https://geth.ethereum.org/docs/interface/javascript-console),
-(via the trailing `console` subcommand) through which you can interact using [`web3` methods](https://web3js.readthedocs.io/en/) 
+Start up `geth`'s built-in interactive [JavaScript console](https://geth.ethereum.org/docs/interface/javascript-console)
+(via the trailing `console` subcommand), through which you can interact using [`web3` methods](https://web3js.readthedocs.io/en/)
 (note: the `web3` version bundled within `geth` is very old, and not up to date with official docs),
 as well as `geth`'s own [management APIs](https://geth.ethereum.org/docs/rpc/server).
-This tool is optional and if you leave it out you can always attach to an already running
+This tool is optional, and if you leave it out you can always attach to an already running
 `geth` instance with `geth attach`.
 
 #### 7. More
@@ -183,66 +181,66 @@ accounts available between them.*
 
 ### Configuration
 
-As an alternative to passing the numerous flags to the `geth` binary, you can also pass a
+As an alternative to passing numerous flags to the `geth` binary, you can also pass a
 configuration file via:
 
 ```shell
-$ geth --config /path/to/your_config.toml
+geth --config /path/to/your_config.toml
 ```
 
-To get an idea of how the file should look like you can use the `dumpconfig` subcommand to
+To get an idea of how the file should look, you can use the `dumpconfig` subcommand to
 export your existing configuration:
 
 ```shell
-$ geth --your-favourite-flags dumpconfig
+geth --your-favourite-flags dumpconfig
 ```
 
 ### Programmatically interfacing `geth` nodes
 
 As a developer, sooner rather than later you'll want to start interacting with `geth` and the
 BSC network via your own programs and not manually through the console. To aid
-this, `geth` has built-in support for a JSON-RPC based APIs ([standard APIs](https://ethereum.org/en/developers/docs/apis/json-rpc/),
+this, `geth` has built-in support for JSON-RPC based APIs ([standard APIs](https://ethereum.org/en/developers/docs/apis/json-rpc/),
 [`geth` specific APIs](https://geth.ethereum.org/docs/interacting-with-geth/rpc), and [BSC's JSON-RPC API Reference](rpc/json-rpc-api.md)).
-These can be exposed via HTTP, WebSockets and IPC (UNIX sockets on UNIX based
+These can be exposed via HTTP, WebSockets, and IPC (UNIX sockets on UNIX-based
 platforms, and named pipes on Windows).
 
 The IPC interface is enabled by default and exposes all the APIs supported by `geth`,
-whereas the HTTP and WS interfaces need to manually be enabled and only expose a
+whereas the HTTP and WS interfaces need to be manually enabled and only expose a
 subset of APIs due to security reasons. These can be turned on/off and configured as
 you'd expect.
 
-HTTP based JSON-RPC API options:
+HTTP-based JSON-RPC API options:
 
   * `--http` Enable the HTTP-RPC server
   * `--http.addr` HTTP-RPC server listening interface (default: `localhost`)
   * `--http.port` HTTP-RPC server listening port (default: `8545`)
-  * `--http.api` API's offered over the HTTP-RPC interface (default: `eth,net,web3`)
-  * `--http.corsdomain` Comma separated list of domains from which to accept cross-origin requests (browser enforced)
+  * `--http.api` APIs offered over the HTTP-RPC interface (default: `eth,net,web3`)
+  * `--http.corsdomain` Comma-separated list of domains from which to accept cross-origin requests (browser enforced)
   * `--ws` Enable the WS-RPC server
   * `--ws.addr` WS-RPC server listening interface (default: `localhost`)
   * `--ws.port` WS-RPC server listening port (default: `8546`)
-  * `--ws.api` API's offered over the WS-RPC interface (default: `eth,net,web3`)
+  * `--ws.api` APIs offered over the WS-RPC interface (default: `eth,net,web3`)
   * `--ws.origins` Origins from which to accept WebSocket requests
   * `--ipcdisable` Disable the IPC-RPC server
   * `--ipcpath` Filename for IPC socket/pipe within the datadir (explicit paths escape it)
 
-You'll need to use your own programming environments' capabilities (libraries, tools, etc) to
-connect via HTTP, WS or IPC to a `geth` node configured with the above flags and you'll
+You'll need to use your own programming environment’s capabilities (libraries, tools, etc.) to
+connect via HTTP, WS, or IPC to a `geth` node configured with the above flags, and you'll
 need to speak [JSON-RPC](https://www.jsonrpc.org/specification) on all transports. You
 can reuse the same connection for multiple requests!
 
-**Note: Please understand the security implications of opening up an HTTP/WS based
+**Note: Please understand the security implications of opening up an HTTP/WS-based
 transport before doing so! Hackers on the internet are actively trying to subvert
 BSC nodes with exposed APIs! Further, all browser tabs can access locally
 running web servers, so malicious web pages could try to subvert locally available
 APIs!**
 
 ### Operating a private network
-- [BSC-Deploy](https://github.com/bnb-chain/node-deploy/): deploy tool for setting up BNB Smart Chain.
+- [BSC-Deploy](https://github.com/bnb-chain/node-deploy/): deployment tool for setting up BNB Smart Chain.
 
 ## Running a bootnode
 
-Bootnodes are super-lightweight nodes that are not behind a NAT and are running just discovery protocol. When you start up a node it should log your enode, which is a public identifier that others can use to connect to your node. 
+Bootnodes are super-lightweight nodes that are not behind a NAT and are running just the discovery protocol. When you start up a node, it should log your enode, which is a public identifier that others can use to connect to your node.
 
 First the bootnode requires a key, which can be created with the following command, which will save a key to boot.key:
 
@@ -256,7 +254,7 @@ This key can then be used to generate a bootnode as follows:
 bootnode -nodekey boot.key -addr :30311 -network bsc
 ```
 
-The choice of port passed to -addr is arbitrary. 
+The choice of port passed to `-addr` is arbitrary. 
 The bootnode command returns the following logs to the terminal, confirming that it is running:
 
 ```
@@ -271,11 +269,11 @@ INFO [09-01|02:46:26.234] New local node record                    seq=1,692,616
 ## Contribution
 
 Thank you for considering helping out with the source code! We welcome contributions
-from anyone on the internet, and are grateful for even the smallest of fixes!
+from anyone on the internet and are grateful for even the smallest fixes!
 
-If you'd like to contribute to bsc, please fork, fix, commit and send a pull request
+If you'd like to contribute to bsc, please fork, fix, commit, and send a pull request
 for the maintainers to review and merge into the main code base. If you wish to submit
-more complex changes though, please check up with the core devs first on [our discord channel](https://discord.gg/bnbchain)
+more complex changes, please check with the core devs first on [our Discord channel](https://discord.gg/bnbchain)
 to ensure those changes are in line with the general philosophy of the project and/or get
 some early feedback which can make both your efforts much lighter as well as our review
 and merge procedures quick and simple.
@@ -297,9 +295,9 @@ testing procedures.
 ## License
 
 The bsc library (i.e. all code outside of the `cmd` directory) is licensed under the
-[GNU Lesser General Public License v3.0](https://www.gnu.org/licenses/lgpl-3.0.en.html),
+[GNU Lesser General Public License v3.0](https://www.gnu.org/licenses/lgpl-3.0/en.html),
 also included in our repository in the `COPYING.LESSER` file.
 
-The bsc binaries (i.e. all code inside of the `cmd` directory) is licensed under the
+The bsc binaries (i.e. all code inside of the `cmd` directory) are licensed under the
 [GNU General Public License v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html), also
 included in our repository in the `COPYING` file.


### PR DESCRIPTION
Fix: typos and grammar (e.g., bindings, macOS, hyphenation in JSON-RPC).

Consistency: capitalization, units and spacing (e.g., “3 TB (Dec 2023)”, “500 MB/s”).

Clarify: wording in PoSA/Parlia section; minor readability tweaks.

Style: consistent bullets, headings, code fences, and link text.

Small edits: “Path-Based Storage Scheme”, “historical state”, thousands separators (90,000).

No behavioral or API changes; documentation only.

PR title
docs: minimal README cleanup (typos, consistency, wording)

PR description (template)

What: Minimal proofreading of README (spelling/grammar), consistent terminology and formatting.

Why: Improve clarity and reduce ambiguity without changing technical meaning.

Scope: Docs only; no code or behavior changes.

Notes: Happy to adjust wording if the team prefers US/UK variants (e.g., favorite/favourite).

### Description

add a description of your changes here...

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
