### PR TITLE
release: prepare for release v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
+
+## v1.6.2
+### FEATURE
+[\#3363](https://github.com/bnb-chain/bsc/pull/3363) websocket: add transactionReceipts for receipts notification
+[\#3367](https://github.com/bnb-chain/bsc/pull/3367) BEP-619: Short Block Interval Phase Three: 0.45 Seconds
+[\#3368](https://github.com/bnb-chain/bsc/pull/3368) BEP-590: Extended Voting Rules for Fast Finality Stability
+[\#3374](https://github.com/bnb-chain/bsc/pull/3374) Implement BEP-592: Non-Consensus Based Block-Level Access List
+[\#3372](https://github.com/bnb-chain/bsc/pull/3372) core/systemcontracts: define fermiUpgrade
+
+### BUGFIX
+[\#3373](https://github.com/bnb-chain/bsc/pull/3373) ethapi: reject oversize storage keys before hex decode
+
+### IMPROVEMENT
+NA
+
 ## v1.6.1
-v1.6.1-alpha is a preview release, which fixes several issues of the v1.6.0-alpha, it is more reliable than v1.6.0-alpha, so mark it as beta stage.
+v1.6.1-beta is a preview release, which fixes several issues of the v1.6.0-alpha, it is more reliable than v1.6.0-alpha, so mark it as beta stage.
 
 ### FEATURE
 NA

--- a/version/version.go
+++ b/version/version.go
@@ -17,8 +17,8 @@
 package version
 
 const (
-	Major = 1     // Major version component of the current release
-	Minor = 6     // Minor version component of the current release
-	Patch = 100   // Patch version component of the current release
-	Meta  = "BAL" // Version metadata to append to the version string
+	Major = 1  // Major version component of the current release
+	Minor = 6  // Minor version component of the current release
+	Patch = 2  // Patch version component of the current release
+	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
### Description
v1.6.2 is a maintenance release, which mainly implemented BEPs of next hardfork: [Fermi](https://forum.bnbchain.org/t/bnb-chain-roadmap-mainnet/936#p-1418-h-3-fermi-wip-11).

BSC's next hardfork is named as *Fermi*, which will be a critical upgrade to further reduce block interval from 750ms to 450ms, so users will have even better experience. Here is the list of Fermi BEPs:
- [BEP-590: Extended Voting Rules for Fast Finality Stability](https://github.com/bnb-chain/BEPs/pull/590)
- [BEP-592: Non-Consensus Based Block-Level Access List](https://github.com/bnb-chain/BEPs/pull/592)
- [BEP-619: Short Block Interval Phase Three: 0.45 Seconds](https://github.com/bnb-chain/BEPs/pull/619)

Besides the BEPs, v1.6.2 also include a new websocket RPC filter API for transaction receipts.

## ChangeLog
### FEATURE
[\#3363](https://github.com/bnb-chain/bsc/pull/3363) websocket: add transactionReceipts for receipts notification
[\#3367](https://github.com/bnb-chain/bsc/pull/3367) BEP-619: Short Block Interval Phase Three: 0.45 Seconds
[\#3368](https://github.com/bnb-chain/bsc/pull/3368) BEP-590: Extended Voting Rules for Fast Finality Stability
[\#3374](https://github.com/bnb-chain/bsc/pull/3374) Implement BEP-592: Non-Consensus Based Block-Level Access List
[\#3372](https://github.com/bnb-chain/bsc/pull/3372) core/systemcontracts: define fermiUpgrade

### BUGFIX
[\#3373](https://github.com/bnb-chain/bsc/pull/3373) ethapi: reject oversize storage keys before hex decode

### IMPROVEMENT
NA
