### PR TITLE
consensus/parlia: set kAncestorGenerationDepth to 3 in BEP-590

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -86,7 +86,7 @@ const (
 	// `finalityRewardInterval` should be smaller than `inMemorySnapshots`, otherwise, it will result in excessive computation.
 	finalityRewardInterval = 200
 
-	kAncestorGenerationDepth = 2
+	kAncestorGenerationDepth = 3
 )
 
 var (


### PR DESCRIPTION
### Description

consensus/parlia: set kAncestorGenerationDepth to 3 in BEP-590

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
