### PR TITLE
core/rawdb: fix WriteBAL

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -975,13 +975,16 @@ func ReadBAL(db ethdb.Reader, hash common.Hash, number uint64) *types.BlockAcces
 	}
 	var ret types.BlockAccessListEncode
 	if err := rlp.DecodeBytes(data, &ret); err != nil {
-		log.Error("Invalid blob array RLP", "hash", hash, "err", err)
+		log.Error("Invalid BAL RLP", "hash", hash, "err", err)
 		return nil
 	}
 	return &ret
 }
 
 func WriteBAL(db ethdb.KeyValueWriter, hash common.Hash, number uint64, bal *types.BlockAccessListEncode) {
+	if bal == nil {
+		return
+	}
 	data, err := rlp.EncodeToBytes(bal)
 	if err != nil {
 		log.Crit("Failed to encode block BAL", "err", err)


### PR DESCRIPTION
### Description

core/rawdb: fix WriteBAL

### Rationale

nil pointer will be encoded as `0x80`, which is 1 byte.
so after writing `nil` by using WriteBAL
ReadBAL will report error 
```
lvl=error msg="Invalid blob array RLP" hash=0x83a6bafedeb74ed9a9fd7c58635ab9ec618c8cac2cc31f832774bf4776808b0e err="rlp: too few elements for types.BlockAccessListEncode"
```

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
