### PR TITLE
fix: change lock to read lock in legacy pool

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -573,8 +573,8 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 	if filter.OnlyBlobTxs {
 		return nil
 	}
-	pool.mu.Lock()
-	defer pool.mu.Unlock()
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
 
 	// Convert the new uint256.Int types to the old big.Int ones used by the legacy pool
 	var (


### PR DESCRIPTION
### Description

This PR includes a minor change to legacy pool

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* change lock to read lock in `Pending()` method of legacy pool
