### PR TITLE
Revert "fix: change lock to read lock in legacypool (#3407)"

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -573,8 +573,9 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 	if filter.OnlyBlobTxs {
 		return nil
 	}
-	pool.mu.RLock()
-	defer pool.mu.RUnlock()
+	// NOTE: Must use write-lock as SortedMap may have concurrent access
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
 
 	// Convert the new uint256.Int types to the old big.Int ones used by the legacy pool
 	var (


### PR DESCRIPTION
This reverts commit a0fc9976d2dd7c963933b7b290af27a0224d28e3.

### Description

This PR is to revert #3407 

### Rationale

https://github.com/ethereum/go-ethereum/pull/32924

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
