### PR TITLE
eth: broadcast votes to evn peers regardless of deltaTdThreshold

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -1014,9 +1014,16 @@ func (h *handler) BroadcastVote(vote *types.VoteEnvelope) {
 	headBlock := h.chain.CurrentBlock()
 	currentTD := h.chain.GetTd(headBlock.Hash(), headBlock.Number.Uint64())
 	for _, peer := range peers {
+		if peer.bscExt == nil {
+			continue
+		}
+		if peer.EVNPeerFlag.Load() {
+			voteMap[peer] = vote
+			continue
+		}
 		_, peerTD := peer.Head()
 		deltaTD := new(big.Int).Abs(new(big.Int).Sub(currentTD, peerTD))
-		if deltaTD.Cmp(big.NewInt(deltaTdThreshold)) < 1 && peer.bscExt != nil {
+		if deltaTD.Cmp(big.NewInt(deltaTdThreshold)) <= 0 {
 			voteMap[peer] = vote
 		}
 	}


### PR DESCRIPTION
### Description

eth: broadcast votes to evn peers regardless of deltaTdThreshold

### Rationale

The validator is protected by its sentry node.

When the validator is not in turn for mining, it is unlikely to broadcast blocks to its sentry node.
As a result, from the sentry’s perspective, the validator’s peerTD appears significantly behind, and the sentry will not broadcast votes to it.

On mainnet, the validator also connects to other full nodes and can receive votes from them.
However, this introduces some delay compared to receiving votes directly from its sentry node.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
