### PR TITLE
miner: log time in header

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -67,7 +67,7 @@ func New(eth Backend, config *minerconfig.Config, mux *event.TypeMux, engine con
 		exitCh:  make(chan struct{}),
 		startCh: make(chan struct{}),
 		stopCh:  make(chan struct{}),
-		worker:  newWorker(config, engine, eth, mux, false),
+		worker:  newWorker(config, engine, eth, mux),
 	}
 
 	miner.bidSimulator = newBidSimulator(&config.Mev, config.DelayLeftOver, config.GasPrice, eth, eth.BlockChain().Config(), engine, miner.worker)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -161,7 +161,7 @@ func (b *testWorkerBackend) newRandomTx(creation bool) *types.Transaction {
 func newTestWorker(t *testing.T, chainConfig *params.ChainConfig, engine consensus.Engine, db ethdb.Database, blocks int) (*worker, *testWorkerBackend) {
 	backend := newTestWorkerBackend(t, chainConfig, engine, db, blocks)
 	backend.txPool.Add(pendingTxs, true)
-	w := newWorker(testConfig, engine, backend, new(event.TypeMux), false)
+	w := newWorker(testConfig, engine, backend, new(event.TypeMux))
 	w.setEtherbase(testBankAddress)
 	return w, backend
 }


### PR DESCRIPTION
### Description

miner: log time in header

### Rationale

block interval will be 450ms
header.time will not easy to be inferred, so log it to debug easily

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
