### PR TITLE
eth: increase the delta td threshold to broadcast votes

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -63,7 +63,7 @@ const (
 	voteChanSize = 256
 
 	// deltaTdThreshold is the threshold of TD difference for peers to broadcast votes.
-	deltaTdThreshold = 20
+	deltaTdThreshold = 1000
 
 	// txMaxBroadcastSize is the max size of a transaction that will be broadcasted.
 	// All transactions with a higher size will be announced and need to be fetched


### PR DESCRIPTION
### Description

eth: increase the delta td threshold to broadcast votes

### Rationale

only exclude peers lagging a lot to ensure votes broadcasted

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
