### PR TITLE
eth: fix stuck when handleBlockBroadcast

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -79,7 +79,7 @@ type chainSyncOp struct {
 func newChainSyncer(handler *handler) *chainSyncer {
 	return &chainSyncer{
 		handler:     handler,
-		peerEventCh: make(chan struct{}),
+		peerEventCh: make(chan struct{}, 10),
 	}
 }
 
@@ -186,9 +186,9 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 	} else if op.td.Cmp(new(big.Int).Add(ourTD, common.Big2)) <= 0 { // common.Big2: difficulty of an in-turn block
 		// On BSC, blocks are produced much faster than on Ethereum.
 		// If the node is only slightly behind (e.g., 1 block), syncing is unnecessary.
-		// It's likely still processing broadcasted blocks or block hash announcements.
-		// In most cases, the node will catch up within 3 seconds.
-		time.Sleep(3 * time.Second)
+		// It's likely still processing broadcasted blocks(such as including a big tx) or block hash announcements.
+		// In most cases, the node will catch up within 2 seconds.
+		time.Sleep(2 * time.Second)
 
 		// Re-check local head to see if it has caught up
 		if _, latestTD := cs.modeAndLocalHead(); ourTD.Cmp(latestTD) < 0 {


### PR DESCRIPTION
### Description

eth: fix stuck when handleBlockBroadcast

### Rationale

Consider two nodes, A and B, with B scheduled to produce blocks.
B produces **block N**, which contains a large transaction that takes **1.5 seconds** to execute, followed by **blocks N+1 and N+2**.

When **block N** first arrives at **node A**, A has not yet finished importing it. If **block N+1** then arrives:

* Node A’s local latest block is still **block N-1**.
* Receiving block N+1 requires setting the peer’s head to **block N**, which triggers the **sleep logic**.
* Consequently, the handling of **block N+2 and subsequent blocks** becomes **blocked**.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
