### PR TITLE
release: prepare for release v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
+## v1.6.3
+### FEATURE
+NA
+
+### BUGFIX
+[\#3429](https://github.com/bnb-chain/bsc/pull/3429) build(deps): bump github.com/consensys/gnark-crypto
+[\#3433](https://github.com/bnb-chain/bsc/pull/3433) internal/ethapi: fix eth_simulateV1
+[\#3431](https://github.com/bnb-chain/bsc/pull/3431) eth/tracers: fix crasher in TraceCall with BlockOverrides
+
+### IMPROVEMENT
+[\#3436](https://github.com/bnb-chain/bsc/pull/3436) revert: revert the nano check in parlia
+[\#3435](https://github.com/bnb-chain/bsc/pull/3435) eth: fix stuck when handleBlockBroadcast
 
 ## v1.6.2
 ### FEATURE

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1  // Major version component of the current release
 	Minor = 6  // Minor version component of the current release
-	Patch = 2  // Patch version component of the current release
+	Patch = 3  // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
### Description
v1.6.3 is a maintenance release, which fixes 2 RPC issues and with several enhancements, pls refer change log for detail.

## ChangeLog
### FEATURE
NA

### BUGFIX
[\#3429](https://github.com/bnb-chain/bsc/pull/3429) build(deps): bump github.com/consensys/gnark-crypto
[\#3433](https://github.com/bnb-chain/bsc/pull/3433) internal/ethapi: fix eth_simulateV1
[\#3431](https://github.com/bnb-chain/bsc/pull/3431) eth/tracers: fix crasher in TraceCall with BlockOverrides

### IMPROVEMENT
[\#3436](https://github.com/bnb-chain/bsc/pull/3436) revert: revert the nano check in parlia
[\#3435](https://github.com/bnb-chain/bsc/pull/3435) eth: fix stuck when handleBlockBroadcast
