### PR TITLE
TxPool: change lifetime back to 3 hours

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -174,7 +174,7 @@ var DefaultConfig = Config{
 	GlobalQueue:       4000,
 	OverflowPoolSlots: 0,
 
-	Lifetime:       10 * time.Minute,
+	Lifetime:       3 * time.Hour,
 	ReannounceTime: 10 * 365 * 24 * time.Hour,
 }
 


### PR DESCRIPTION
### Description
rollback the lifetime change made in PR#3111
3 hours could be reasonable for non-validator nodes

https://github.com/bnb-chain/bsc/issues/3432 also mention Tx refresh issue, 3 hours could be safer.
### Rationale
NA

### Example
NA

### Changes
