### PR TITLE
cmd/geth: stop supporting multidatabase flag

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -73,7 +73,7 @@ var (
 			utils.OverrideFermi,
 			utils.OverrideOsaka,
 			utils.OverrideVerkle,
-			utils.MultiDataBaseFlag,
+			// utils.MultiDataBaseFlag,
 		}, utils.DatabaseFlags),
 		Description: `
 The init command initializes a new genesis block and definition for the network.

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -129,7 +129,7 @@ var (
 		utils.CacheSnapshotFlag,
 		// utils.CacheNoPrefetchFlag,
 		utils.CachePreimagesFlag,
-		utils.MultiDataBaseFlag,
+		// utils.MultiDataBaseFlag,
 		utils.PruneAncientDataFlag, // deprecated
 		utils.CacheLogSizeFlag,
 		utils.FDLimitFlag,


### PR DESCRIPTION
### Description

cmd/geth: stop supporting multidatabase flag

### Rationale

the feature is broken on master/develop branch, so remove the flag to avoid misleading

https://github.com/bnb-chain/bsc/issues/3450

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
