### PR TITLE
go.mod: downgrade bls-eth-go-binary to run on windows

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -57,6 +57,11 @@ jobs:
           GIT_COMMIT_DATE=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
           GOOS=linux GOARCH=amd64 CGO_ENABLED=1 CC=$(pwd)/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc go build -ldflags "-X main.gitCommit=$GIT_COMMIT -X main.gitDate=$GIT_COMMIT_DATE -extldflags=-static" -o ./build/bin/geth -a ./cmd/geth
       
+      - name: Temporary replace BLS for Windows
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: go mod edit -replace=github.com/herumi/bls-eth-go-binary=github.com/herumi/bls-eth-go-binary@v0.0.0-20210917013441-d37c07cfda4e && go mod tidy
+
       - name: Build Binary for ${{matrix.os}}
         if: matrix.os != 'ubuntu-latest'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,12 @@ jobs:
           GIT_COMMIT_DATE=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
           GOOS=linux GOARCH=amd64 CGO_ENABLED=1 CC=$(pwd)/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc go build -ldflags "-X main.gitCommit=$GIT_COMMIT -X main.gitDate=$GIT_COMMIT_DATE -extldflags=-static" -o ./build/bin/geth -a ./cmd/geth
       
+      # ==============================
+      - name: Temporary replace BLS for Windows
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: go mod edit -replace=github.com/herumi/bls-eth-go-binary=github.com/herumi/bls-eth-go-binary@v0.0.0-20210917013441-d37c07cfda4e && go mod tidy
+
       - name: Build Binary for ${{matrix.os}}
         if: matrix.os != 'ubuntu-latest'
         run: |


### PR DESCRIPTION
### Description

go.mod: downgrade bls-eth-go-binary to run on windows

### Rationale

refer https://github.com/bnb-chain/bsc/pull/2907
to fix https://github.com/bnb-chain/bsc/issues/3269

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
