### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/accounts/abi/abifuzzer_test.go
+++ b/accounts/abi/abifuzzer_test.go
@@ -99,34 +99,35 @@ type arg struct {
 }
 
 func createABI(name string, stateMutability, payable *string, inputs []arg) (ABI, error) {
-	sig := fmt.Sprintf(`[{ "type" : "function", "name" : "%v" `, name)
+	var sig strings.Builder
+	sig.WriteString(fmt.Sprintf(`[{ "type" : "function", "name" : "%v" `, name))
 	if stateMutability != nil {
-		sig += fmt.Sprintf(`, "stateMutability": "%v" `, *stateMutability)
+		sig.WriteString(fmt.Sprintf(`, "stateMutability": "%v" `, *stateMutability))
 	}
 	if payable != nil {
-		sig += fmt.Sprintf(`, "payable": %v `, *payable)
+		sig.WriteString(fmt.Sprintf(`, "payable": %v `, *payable))
 	}
 	if len(inputs) > 0 {
-		sig += `, "inputs" : [ {`
+		sig.WriteString(`, "inputs" : [ {`)
 		for i, inp := range inputs {
-			sig += fmt.Sprintf(`"name" : "%v", "type" : "%v" `, inp.name, inp.typ)
+			sig.WriteString(fmt.Sprintf(`"name" : "%v", "type" : "%v" `, inp.name, inp.typ))
 			if i+1 < len(inputs) {
-				sig += ","
+				sig.WriteString(",")
 			}
 		}
-		sig += "} ]"
-		sig += `, "outputs" : [ {`
+		sig.WriteString("} ]")
+		sig.WriteString(`, "outputs" : [ {`)
 		for i, inp := range inputs {
-			sig += fmt.Sprintf(`"name" : "%v", "type" : "%v" `, inp.name, inp.typ)
+			sig.WriteString(fmt.Sprintf(`"name" : "%v", "type" : "%v" `, inp.name, inp.typ))
 			if i+1 < len(inputs) {
-				sig += ","
+				sig.WriteString(",")
 			}
 		}
-		sig += "} ]"
+		sig.WriteString("} ]")
 	}
-	sig += `}]`
+	sig.WriteString(`}]`)
 	//fmt.Printf("sig: %s\n", sig)
-	return JSON(strings.NewReader(sig))
+	return JSON(strings.NewReader(sig.String()))
 }
 
 func fuzzAbi(input []byte) {

--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -167,10 +167,10 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 			fields     []reflect.StructField
 			elems      []*Type
 			names      []string
-			expression string // canonical parameter expression
+			expression strings.Builder // canonical parameter expression
 			used       = make(map[string]bool)
 		)
-		expression += "("
+		expression.WriteString("(")
 		for idx, c := range components {
 			cType, err := NewType(c.Type, c.InternalType, c.Components)
 			if err != nil {
@@ -192,18 +192,18 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 			})
 			elems = append(elems, &cType)
 			names = append(names, c.Name)
-			expression += cType.stringKind
+			expression.WriteString(cType.stringKind)
 			if idx != len(components)-1 {
-				expression += ","
+				expression.WriteString(",")
 			}
 		}
-		expression += ")"
+		expression.WriteString(")")
 
 		typ.TupleType = reflect.StructOf(fields)
 		typ.TupleElems = elems
 		typ.TupleRawNames = names
 		typ.T = TupleTy
-		typ.stringKind = expression
+		typ.stringKind = expression.String()
 
 		const structPrefix = "struct "
 		// After solidity 0.5.10, a new field of abi "internalType"

--- a/accounts/keystore/account_cache.go
+++ b/accounts/keystore/account_cache.go
@@ -52,14 +52,14 @@ type AmbiguousAddrError struct {
 }
 
 func (err *AmbiguousAddrError) Error() string {
-	files := ""
+	var files strings.Builder
 	for i, a := range err.Matches {
-		files += a.URL.Path
+		files.WriteString(a.URL.Path)
 		if i < len(err.Matches)-1 {
-			files += ", "
+			files.WriteString(", ")
 		}
 	}
-	return fmt.Sprintf("multiple keys match address (%s)", files)
+	return fmt.Sprintf("multiple keys match address (%s)", files.String())
 }
 
 // accountCache is a live index of all accounts in the keystore.

--- a/cmd/devp2p/enrcmd.go
+++ b/cmd/devp2p/enrcmd.go
@@ -100,7 +100,7 @@ func dumpNodeURL(out io.Writer, n *enode.Node) {
 
 func dumpRecordKV(kv []interface{}, indent int) string {
 	// Determine the longest key name for alignment.
-	var out string
+	var out strings.Builder
 	var longestKey = 0
 	for i := 0; i < len(kv); i += 2 {
 		key := kv[i].(string)
@@ -113,19 +113,19 @@ func dumpRecordKV(kv []interface{}, indent int) string {
 		key := kv[i].(string)
 		val := kv[i+1].(rlp.RawValue)
 		pad := longestKey - len(key)
-		out += strings.Repeat(" ", indent) + strconv.Quote(key) + strings.Repeat(" ", pad+1)
+		out.WriteString(strings.Repeat(" ", indent) + strconv.Quote(key) + strings.Repeat(" ", pad+1))
 		formatter := attrFormatters[key]
 		if formatter == nil {
 			formatter = formatAttrRaw
 		}
 		fmtval, ok := formatter(val)
 		if ok {
-			out += fmtval + "\n"
+			out.WriteString(fmtval + "\n")
 		} else {
-			out += hex.EncodeToString(val) + " (!)\n"
+			out.WriteString(hex.EncodeToString(val) + " (!)\n")
 		}
 	}
-	return out
+	return out.String()
 }
 
 // parseNode parses a node record and verifies its signature.

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -340,11 +340,12 @@ func confirmAndRemoveDB(paths []string, kind string, ctx *cli.Context, removeFla
 		confirm bool
 		err     error
 	)
-	msg := fmt.Sprintf("Location(s) of '%s': \n", kind)
+	var msg strings.Builder
+	msg.WriteString(fmt.Sprintf("Location(s) of '%s': \n", kind))
 	for _, path := range paths {
-		msg += fmt.Sprintf("\t- %s\n", path)
+		msg.WriteString(fmt.Sprintf("\t- %s\n", path))
 	}
-	fmt.Println(msg)
+	fmt.Println(msg.String())
 	if ctx.IsSet(removeFlagName) {
 		confirm = ctx.Bool(removeFlagName)
 		if confirm {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -26,6 +26,7 @@ import (
 	"runtime"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -3248,11 +3249,11 @@ func (bc *BlockChain) logForkReadiness(block *types.Block) {
 // summarizeBadBlock returns a string summarizing the bad block and other
 // relevant information.
 func summarizeBadBlock(block *types.Block, receipts []*types.Receipt, config *params.ChainConfig, err error) string {
-	var receiptString string
+	var receiptString strings.Builder
 	for i, receipt := range receipts {
-		receiptString += fmt.Sprintf("\n  %d: cumulative: %v gas: %v contract: %v status: %v tx: %v logs: %v bloom: %x state: %x",
+		receiptString.WriteString(fmt.Sprintf("\n  %d: cumulative: %v gas: %v contract: %v status: %v tx: %v logs: %v bloom: %x state: %x",
 			i, receipt.CumulativeGasUsed, receipt.GasUsed, receipt.ContractAddress.Hex(),
-			receipt.Status, receipt.TxHash.Hex(), receipt.Logs, receipt.Bloom, receipt.PostState)
+			receipt.Status, receipt.TxHash.Hex(), receipt.Logs, receipt.Bloom, receipt.PostState))
 	}
 	version, vcs := version.Info()
 	platform := fmt.Sprintf("%s %s %s %s", version, runtime.Version(), runtime.GOARCH, runtime.GOOS)
@@ -3274,7 +3275,7 @@ Platform: %v%v
 Chain config: %#v
 Receipts: %v
 ##############################
-`, block.Number(), block.Hash(), block.Coinbase(), err, platform, vcs, config, receiptString)
+`, block.Number(), block.Hash(), block.Coinbase(), err, platform, vcs, config, receiptString.String())
 }
 
 // InsertHeaderChain attempts to insert the given header chain in to the local

--- a/rlp/rlpgen/gen.go
+++ b/rlp/rlpgen/gen.go
@@ -22,6 +22,7 @@ import (
 	"go/format"
 	"go/types"
 	"sort"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/rlp/internal/rlpstruct"
 )
@@ -570,14 +571,14 @@ func (op structOp) writeOptionalFields(b *bytes.Buffer, ctx *genContext, v strin
 	// Now write the fields.
 	for i, field := range op.optionalFields {
 		selector := v + "." + field.name
-		cond := ""
+		var cond strings.Builder
 		for j := i; j < len(op.optionalFields); j++ {
 			if j > i {
-				cond += " || "
+				cond.WriteString(" || ")
 			}
-			cond += zeroV[j]
+			cond.WriteString(zeroV[j])
 		}
-		fmt.Fprintf(b, "if %s {\n", cond)
+		fmt.Fprintf(b, "if %s {\n", cond.String())
 		fmt.Fprint(b, field.elem.genWrite(ctx, selector))
 		fmt.Fprintf(b, "}\n")
 	}

--- a/trie/node.go
+++ b/trie/node.go
@@ -104,15 +104,16 @@ func (n hashNode) String() string   { return n.fstring("") }
 func (n valueNode) String() string  { return n.fstring("") }
 
 func (n *fullNode) fstring(ind string) string {
-	resp := fmt.Sprintf("[\n%s  ", ind)
+	var resp strings.Builder
+	resp.WriteString(fmt.Sprintf("[\n%s  ", ind))
 	for i, node := range &n.Children {
 		if node == nil {
-			resp += fmt.Sprintf("%s: <nil> ", indices[i])
+			resp.WriteString(fmt.Sprintf("%s: <nil> ", indices[i]))
 		} else {
-			resp += fmt.Sprintf("%s: %v", indices[i], node.fstring(ind+"  "))
+			resp.WriteString(fmt.Sprintf("%s: %v", indices[i], node.fstring(ind+"  ")))
 		}
 	}
-	return resp + fmt.Sprintf("\n%s] ", ind)
+	return resp.String() + fmt.Sprintf("\n%s] ", ind)
 }
 
 func (n *shortNode) fstring(ind string) string {


### PR DESCRIPTION
### Description

strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
