### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -136,8 +136,7 @@ func newTestBackendWithGenerator(blocks int, shanghai bool, cancun bool, generat
 	txconfig := legacypool.DefaultConfig
 	txconfig.Journal = "" // Don't litter the disk with test journals
 
-	storage, _ := os.MkdirTemp("", "blobpool-")
-	defer os.RemoveAll(storage)
+	storage := t.TempDir()
 
 	blobPool := blobpool.New(blobpool.Config{Datadir: storage}, chain, nil)
 	legacyPool := legacypool.New(txconfig, chain)


### PR DESCRIPTION
### Description

TempDir() is a method introduced in Go 1.15 for testing.T. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup. More detail about TempDir https://pkg.go.dev/testing#B.TempDir

The new pr for https://github.com/bnb-chain/bsc/pull/2942

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
