### PR TITLE
release: prepare for release v1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## v1.6.5
+### FEATURE
+[\#3488](https://github.com/bnb-chain/bsc/pull/3488) miner: optional transaction gas limit cap
+
+### IMPROVEMENT
+[\#3483](https://github.com/bnb-chain/bsc/pull/3483) feat: remove the handshake from the bsc protocol
+[\#3486](https://github.com/bnb-chain/bsc/pull/3486) feat: update filtermaps checkpoints
+
 ## v1.6.4
 ### FEATURE
 [\#3466](https://github.com/bnb-chain/bsc/pull/3466) config: update BSC Mainnet hardfork time: Fermi

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1  // Major version component of the current release
 	Minor = 6  // Minor version component of the current release
-	Patch = 4  // Patch version component of the current release
+	Patch = 5  // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
### Description

release: prepare for release v1.6.5

### FEATURE
[\#3488](https://github.com/bnb-chain/bsc/pull/3488) miner: optional transaction gas limit cap

### IMPROVEMENT
[\#3483](https://github.com/bnb-chain/bsc/pull/3483) feat: remove the handshake from the bsc protocol
[\#3486](https://github.com/bnb-chain/bsc/pull/3486) feat: update filtermaps checkpoints
