### PR TITLE
miner: enable more prefetch threads in local mining mode

### DIFF
--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -333,7 +333,7 @@ func (p *statePrefetcher) PrefetchMining(txs TransactionsByPriceAndNonce, header
 					// Convert the transaction into an executable message and pre-cache its sender
 					msg, err := TransactionToMessage(tx, signer, header.BaseFee)
 					if err != nil {
-						return // Also invalid block, bail out
+						continue // Skip invalid tx from txpool
 					}
 					// Disable the nonce check
 					msg.SkipNonceChecks = true

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -227,7 +227,7 @@ type worker struct {
 func newWorker(config *minerconfig.Config, engine consensus.Engine, eth Backend, mux *event.TypeMux) *worker {
 	chainConfig := eth.BlockChain().Config()
 	prefetcher := core.NewStatePrefetcher(chainConfig, eth.BlockChain().HeadChain())
-	if *config.Mev.Enabled {
+	if config.Mev.Enabled != nil && *config.Mev.Enabled {
 		prefetcher.EnableMevMode()
 	}
 	worker := &worker{

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -226,8 +226,12 @@ type worker struct {
 
 func newWorker(config *minerconfig.Config, engine consensus.Engine, eth Backend, mux *event.TypeMux) *worker {
 	chainConfig := eth.BlockChain().Config()
+	prefetcher := core.NewStatePrefetcher(chainConfig, eth.BlockChain().HeadChain())
+	if *config.Mev.Enabled {
+		prefetcher.EnableMevMode()
+	}
 	worker := &worker{
-		prefetcher:         core.NewStatePrefetcher(chainConfig, eth.BlockChain().HeadChain()),
+		prefetcher:         prefetcher,
 		config:             config,
 		chainConfig:        chainConfig,
 		engine:             engine,


### PR DESCRIPTION
### Description
1) Increase PrefetchMining parallelism for local mining when MEV is disabled. Keep MEV mode behavior unchanged .
2)  Replaced return with continue  in PrefetchMining to ensure the prefetch worker goroutine stays alive by skipping invalid transactions instead of terminating on error.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
