### PR TITLE
statedb.go: fix NoTries mode snapshot storage delete

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1289,7 +1289,7 @@ func (s *StateDB) handleDestruction(noStorageWiping bool) (map[common.Hash]*acco
 		// In NoTries mode, prev.Root is always EmptyRootHash (see updateRoot()),
 		// so we cannot rely on it to determine if storage exists.
 		// We must try to delete storage via snapshot regardless.
-		if !s.db.NoTries() && (prev.Root == types.EmptyRootHash || s.db.TrieDB().IsVerkle()) {
+		if (!s.db.NoTries() && prev.Root == types.EmptyRootHash) || s.db.TrieDB().IsVerkle() {
 			continue
 		}
 		if noStorageWiping {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1169,7 +1169,9 @@ func (s *StateDB) fastDeleteStorage(snaps *snapshot.Tree, addrHash common.Hash, 
 	if err := iter.Error(); err != nil { // error might occur during iteration
 		return nil, nil, nil, err
 	}
-	if stack.Hash() != root {
+	// In NoTries mode, root is always EmptyRootHash (see updateRoot()),
+	// so we skip the hash verification. The snapshot is the source of truth.
+	if !s.db.NoTries() && stack.Hash() != root {
 		return nil, nil, nil, fmt.Errorf("snapshot is not matched, exp %x, got %x", root, stack.Hash())
 	}
 	return storages, storageOrigins, nodes, nil
@@ -1284,7 +1286,10 @@ func (s *StateDB) handleDestruction(noStorageWiping bool) (map[common.Hash]*acco
 		deletes[addrHash] = op
 
 		// Short circuit if the origin storage was empty.
-		if prev.Root == types.EmptyRootHash || s.db.TrieDB().IsVerkle() {
+		// In NoTries mode, prev.Root is always EmptyRootHash (see updateRoot()),
+		// so we cannot rely on it to determine if storage exists.
+		// We must try to delete storage via snapshot regardless.
+		if !s.db.NoTries() && (prev.Root == types.EmptyRootHash || s.db.TrieDB().IsVerkle()) {
 			continue
 		}
 		if noStorageWiping {


### PR DESCRIPTION
### Description

In NoTries mode (`--tries-verify-mode none`), storage data is not properly deleted from the snapshot when `handleDestruction` is called during SELFDESTRUCT.

### Rationale

In NoTries mode, `stateObject.updateRoot()` always sets `Root` to `EmptyRootHash` regardless of actual storage content:
```
if s.db.db.NoTries() {
    s.data.Root = types.EmptyRootHash
}
```
This causes two issues in the SELFDESTRUCT flow:

1. `handleDestruction` skips storage deletion: The check `prev.Root == types.EmptyRootHash `incorrectly assumes no storage exists, bypassing `deleteStorage()`.
2. `fastDeleteStorage` hash verification fails: Even if `deleteStorage` is called, the hash check `stack.Hash() != root` fails because `root` is `EmptyRootHash` but the actual storage hash is not.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
