### PR TITLE
release: prepare for release v1.7.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,40 @@
 # Changelog
+## v1.7.0
+v1.7.0-alpha is a preview release for upstream code sync, it catches up with [go-ethereum release [v1.16.7]](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.7) and also include several bug fix and improvements.
+
+### Code Sync
+- [upstream: merge geth-v1.16.2 ～ geth-v1.16.7](https://github.com/bnb-chain/bsc/pull/3505)
+Key changes from the code sync include:
+  - Osaka:
+    - Implement EIP-7823 - Set upper bounds for MODEXP
+    - Implement EIP-7825 - Transaction Gas Limit Cap.
+    - Implement EIP-7883 - ModExp Gas Cost Increase.
+    - Implement EIP-7918 - Blob base fee bounded by execution cost.
+    - Implement EIP-7934 - RLP Execution Block Size Limit.
+    - Implement EIP-7939 - CLZ opcode.
+    - Implement EIP-7951 - Precompile for secp256r1 Curve Support.
+  - eth_sendRawTransactionSync: Synchronous transaction submission
+  - Performance Optimizations: Multiple improvements to enhance overall performance
+  - Code Refactoring: Major cleanup and improvements to components including:
+    - TriePrefetcher prefetch trie nodes in a account in parallel.
+    - Introduced a file-based state journal and refactored state history writes
+
+### FEATURE
+- [internal/ethapi: recover GetDiffAccounts and GetDiffAccountsWithScope](https://github.com/bnb-chain/bsc/pull/3516)
+
+### IMPROVEMENT
+- [miner: enable more prefetch threads in local mining mode](https://github.com/bnb-chain/bsc/pull/3496)
+- [miner/minerconfig: get defaultNoInterruptLeftOver automatically](https://github.com/bnb-chain/bsc/pull/3509)
+
+### BUGFIX
+- core/state: fix handleDestruction for fast node ([#3501](https://github.com/bnb-chain/bsc/pull/3501),[#3517](https://github.com/bnb-chain/bsc/pull/3517),[#3519](https://github.com/bnb-chain/bsc/pull/3519))
+- [fix: add back Contract CodeAddr for superinstruction](https://github.com/bnb-chain/bsc/pull/3502)
+- [fix: fix pruned node init filtermap err](https://github.com/bnb-chain/bsc/pull/3522)
+
+### Others
+- [ci: upgrade github actions to latest versions](https://github.com/bnb-chain/bsc/pull/3515)
+- [ci: ignore nancy failre of quic-go@v0.49.1](https://github.com/bnb-chain/bsc/pull/3512)
+
 ## v1.6.6
 ### BUGFIX
 core/txpool: drop peers on invalid KZG proofs

--- a/version/version.go
+++ b/version/version.go
@@ -18,7 +18,7 @@ package version
 
 const (
 	Major = 1  // Major version component of the current release
-	Minor = 6  // Minor version component of the current release
-	Patch = 6  // Patch version component of the current release
+	Minor = 7  // Minor version component of the current release
+	Patch = 0  // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
### Description

v1.7.0-alpha is a preview release for upstream code sync, it catches up with [go-ethereum release [v1.16.7]](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.7) and also include several bug fix and improvements.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

### Code Sync
- [upstream: merge geth-v1.16.2 ～ geth-v1.16.7](https://github.com/bnb-chain/bsc/pull/3505)
Key changes from the code sync include:
  - Osaka:
    - Implement EIP-7823 - Set upper bounds for MODEXP
    - Implement EIP-7825 - Transaction Gas Limit Cap.
    - Implement EIP-7883 - ModExp Gas Cost Increase.
    - Implement EIP-7918 - Blob base fee bounded by execution cost.
    - Implement EIP-7934 - RLP Execution Block Size Limit.
    - Implement EIP-7939 - CLZ opcode.
    - Implement EIP-7951 - Precompile for secp256r1 Curve Support.
  - eth_sendRawTransactionSync: Synchronous transaction submission
  - Performance Optimizations: Multiple improvements to enhance overall performance
  - Code Refactoring: Major cleanup and improvements to components including:
    - TriePrefetcher prefetch trie nodes in a account in parallel.
    - Introduced a file-based state journal and refactored state history writes

### FEATURE
- [internal/ethapi: recover GetDiffAccounts and GetDiffAccountsWithScope](https://github.com/bnb-chain/bsc/pull/3516)

### IMPROVEMENT
- [miner: enable more prefetch threads in local mining mode](https://github.com/bnb-chain/bsc/pull/3496)
- [miner/minerconfig: get defaultNoInterruptLeftOver automatically](https://github.com/bnb-chain/bsc/pull/3509)

### BUGFIX
- core/state: fix handleDestruction for fast node ([#3501](https://github.com/bnb-chain/bsc/pull/3501),[#3517](https://github.com/bnb-chain/bsc/pull/3517),[#3519](https://github.com/bnb-chain/bsc/pull/3519))
- [fix: add back Contract CodeAddr for superinstruction](https://github.com/bnb-chain/bsc/pull/3502)
- [fix: fix pruned node init filtermap err](https://github.com/bnb-chain/bsc/pull/3522)

### Others
- [ci: upgrade github actions to latest versions](https://github.com/bnb-chain/bsc/pull/3515)
- [ci: ignore nancy failre of quic-go@v0.49.1](https://github.com/bnb-chain/bsc/pull/3512)
