### PR TITLE
feat: support bid block size check for BEP-655

### DIFF
--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -1052,6 +1052,11 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 	// Start executing the transaction
 	r.env.state.SetTxContext(tx.Hash(), r.env.tcount)
 
+	// check EIP 7934 RLP-encoded block size cap
+	if chainConfig.IsOsaka(env.header.Number, env.header.Time) && !env.txFitsSize(tx) {
+		return core.ErrBlockOversized
+	}
+
 	if tx.Type() == types.BlobTxType {
 		sc = types.NewBlobSidecarFromTx(tx)
 		if sc == nil {
@@ -1084,10 +1089,12 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 		env.receipts = append(env.receipts, receipt)
 		env.sidecars = append(env.sidecars, sc)
 		env.blobs += len(sc.Blobs)
+		env.size += tx.WithoutBlobTxSidecar().Size()
 		*env.header.BlobGasUsed += receipt.BlobGasUsed
 	} else {
 		env.txs = append(env.txs, tx)
 		env.receipts = append(env.receipts, receipt)
+		env.size += tx.Size()
 	}
 
 	r.env.tcount++

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -1052,8 +1052,9 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 	// Start executing the transaction
 	r.env.state.SetTxContext(tx.Hash(), r.env.tcount)
 
-	// check EIP 7934 RLP-encoded block size cap
-	if chainConfig.IsOsaka(env.header.Number, env.header.Time) && !env.txFitsSize(tx) {
+	// if inclusion of the transaction would put the block size over the
+	// maximum we allow, don't add any more txs to the payload.
+	if !env.txFitsSize(tx) {
 		return core.ErrBlockOversized
 	}
 


### PR DESCRIPTION
### Description

support  mev bid block size check  [BEP-655: Implement EIP-7934 RLP Execution Block Size Limit](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-655.md)

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
