### PR TITLE
release: prepare for release v1.7.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## v1.7.1
+v1.7.1 is a preview release, which implements BEPs defined in [Osaka/Mendel](https://github.com/allformless/BEPs/blob/mendle-bep-list/BEPs/BEP-658.md).
+
+### FEATURE
+- [feat: support bid block size check for BEP-655](https://github.com/bnb-chain/bsc/pull/3529)
+- [feat: support mev bid gas check of bep 652](https://github.com/bnb-chain/bsc/pull/3528)
+- [eip4844.go: disable eip-7918 for bsc](https://github.com/bnb-chain/bsc/pull/3531)
+- [feat: implement BEP-657 - Limit Blob Transaction Inclusion by Block Number](https://github.com/bnb-chain/bsc/pull/3533)
+
 ## v1.7.0
 v1.7.0-alpha is a preview release for upstream code sync, it catches up with [go-ethereum release [v1.16.7]](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.7) and also include several bug fix and improvements.
 

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1  // Major version component of the current release
 	Minor = 7  // Minor version component of the current release
-	Patch = 0  // Patch version component of the current release
+	Patch = 1  // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
### Description

v1.7.1 is a preview release, which implements BEPs defined in [Osaka/Mendel](https://github.com/allformless/BEPs/blob/mendle-bep-list/BEPs/BEP-658.md).

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

### FEATURE
- [feat: support bid block size check for BEP-655](https://github.com/bnb-chain/bsc/pull/3529)
- [feat: support mev bid gas check of bep 652](https://github.com/bnb-chain/bsc/pull/3528)
- [eip4844.go: disable eip-7918 for bsc](https://github.com/bnb-chain/bsc/pull/3531)
- [feat: implement BEP-657 - Limit Blob Transaction Inclusion by Block Number](https://github.com/bnb-chain/bsc/pull/3533)
