### PR TITLE
tests: update version of spec-tests

### DIFF
--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -1,8 +1,8 @@
 # This file contains sha256 checksums of optional build dependencies.
 
-# version:spec-tests v5.1.0
+# version:spec-tests v5.4.0
 # https://github.com/ethereum/execution-spec-tests/releases
-# https://github.com/ethereum/execution-spec-tests/releases/download/v5.1.0
+# https://github.com/ethereum/execution-spec-tests/releases/download/v5.4.0
 a3192784375acec7eaec492799d5c5d0c47a2909a3cc40178898e4ecd20cc416  fixtures_develop.tar.gz
 
 # version:golang 1.25.1

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -111,7 +111,7 @@ func VerifyEIP4844Header(config *params.ChainConfig, parent, header *types.Heade
 	}
 
 	// BEP-657: non-eligible blocks must have no blob gas used
-	if !IsBlobEligibleBlock(config, header.Number.Uint64(), header.Time) {
+	if config.IsInBSC() && !IsBlobEligibleBlock(config, header.Number.Uint64(), header.Time) {
 		if *header.BlobGasUsed != 0 {
 			return fmt.Errorf("blob transactions not allowed in block %d (N %% %d != 0)", header.Number.Uint64(), params.BlobEligibleBlockInterval)
 		}

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -111,7 +111,7 @@ func VerifyEIP4844Header(config *params.ChainConfig, parent, header *types.Heade
 	}
 
 	// BEP-657: non-eligible blocks must have no blob gas used
-	if config.IsInBSC() && !IsBlobEligibleBlock(config, header.Number.Uint64(), header.Time) {
+	if !IsBlobEligibleBlock(config, header.Number.Uint64(), header.Time) {
 		if *header.BlobGasUsed != 0 {
 			return fmt.Errorf("blob transactions not allowed in block %d (N %% %d != 0)", header.Number.Uint64(), params.BlobEligibleBlockInterval)
 		}

--- a/tests/init.go
+++ b/tests/init.go
@@ -723,15 +723,15 @@ var Forks = map[string]*params.ChainConfig{
 }
 
 var bpo1BlobConfig = &params.BlobConfig{
-	Target:         9,
-	Max:            14,
-	UpdateFraction: 8832827,
+	Target:         10,
+	Max:            15,
+	UpdateFraction: 8346193,
 }
 
 var bpo2BlobConfig = &params.BlobConfig{
 	Target:         14,
 	Max:            21,
-	UpdateFraction: 13739630,
+	UpdateFraction: 11684671,
 }
 
 // AvailableForks returns the set of defined fork names

--- a/tests/run-evm-tests.sh
+++ b/tests/run-evm-tests.sh
@@ -5,7 +5,7 @@ git apply tests/0001-diff-go-ethereum.patch
 git apply tests/0002-diff-go-ethereum.patch
 cd tests
 rm -rf spec-tests && mkdir spec-tests && cd spec-tests
-wget https://github.com/ethereum/execution-spec-tests/releases/download/v5.1.0/fixtures_develop.tar.gz
+wget https://github.com/ethereum/execution-spec-tests/releases/download/v5.4.0/fixtures_develop.tar.gz
 tar xzf fixtures_develop.tar.gz && rm -f fixtures_develop.tar.gz
 cd ..
 go test -run . -v -short >test.log


### PR DESCRIPTION
### Description

tests: update version of spec-tests

[v5.4.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.4.0) is the final Osaka release following the success of the Fusaka upgrade!

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
