### PR TITLE
BEP648: fix race condition in early finalization.

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -265,10 +265,6 @@ type Parlia struct {
 	slashABI                   abi.ABI
 	stakeHubABI                abi.ABI
 
-	// finalizedNotified tracks blocks that have already triggered early finalization notification
-	// to avoid duplicate notifications
-	finalizedNotified *lru.Cache[common.Hash, struct{}]
-
 	// The fields below are for testing only
 	fakeDiff bool // Skip difficulty verifications
 }
@@ -309,7 +305,6 @@ func New(
 		recentSnaps:                lru.NewCache[common.Hash, *Snapshot](inMemorySnapshots),
 		recentHeaders:              lru.NewCache[string, common.Hash](inMemoryHeaders),
 		signatures:                 lru.NewCache[common.Hash, common.Address](inMemorySignatures),
-		finalizedNotified:          lru.NewCache[common.Hash, struct{}](inMemorySnapshots),
 		validatorSetABIBeforeLuban: vABIBeforeLuban,
 		validatorSetABI:            vABI,
 		slashABI:                   sABI,
@@ -2323,26 +2318,18 @@ func (p *Parlia) GetFinalizedHeader(chain consensus.ChainHeaderReader, header *t
 // CheckFinalityAndNotify checks if votes for the target block have reached quorum,
 // and if so, notifies the blockchain of early finalization via the notifyFn callback.
 func (p *Parlia) CheckFinalityAndNotify(chain consensus.ChainHeaderReader, targetBlockHash common.Hash, notifyFn func(finalizedHeader *types.Header)) {
-	// Skip if already notified for this block
-	if _, ok := p.finalizedNotified.Get(targetBlockHash); ok {
+	// Get target block header directly by hash (don't rely on currentHeader which may have moved forward)
+	targetHeader := chain.GetHeaderByHash(targetBlockHash)
+	if targetHeader == nil {
 		return
 	}
 
-	// Get target block header
-	currentHeader := chain.CurrentHeader()
-	if currentHeader == nil || currentHeader.Hash() != targetBlockHash {
-		return
-	}
-
-	finalizedHeader := p.GetFinalizedHeader(chain, currentHeader)
+	finalizedHeader := p.GetFinalizedHeader(chain, targetHeader)
 	if finalizedHeader == nil || finalizedHeader.Number.Uint64() == 0 {
 		return
 	}
 
-	// Mark as notified to avoid duplicate notifications
-	p.finalizedNotified.Add(targetBlockHash, struct{}{})
-
-	// Notify via callback
+	// Notify via callback (NotifyFinalized has its own deduplication logic)
 	notifyFn(finalizedHeader)
 }
 

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -68,6 +68,12 @@ func (bc *BlockChain) CurrentFinalBlock() *types.Header {
 	return nil
 }
 
+// HighestNotifiedFinal retrieves the highest finalized block that has been notified.
+// This is used for deduplication in early finalization checks.
+func (bc *BlockChain) HighestNotifiedFinal() *types.Header {
+	return bc.highestNotifiedFinal.Load()
+}
+
 // CurrentSafeBlock retrieves the current safe block of the canonical
 // chain. The block is retrieved from the blockchain's internal cache.
 func (bc *BlockChain) CurrentSafeBlock() *types.Header {

--- a/core/vote/vote_pool.go
+++ b/core/vote/vote_pool.go
@@ -224,9 +224,10 @@ func (pool *VotePool) putVote(m map[common.Hash]*VoteBox, votesPq *votesPriority
 		localFutureVotesCounter.Inc(1)
 	} else {
 		localCurVotesCounter.Inc(1)
-		// Use goroutine to avoid deadlock: CheckFinalityAndNotify -> GetFinalizedHeader -> FetchVotesByBlockHash
-		// requires RLock, but we're holding Lock here.
-		go pool.engine.CheckFinalityAndNotify(pool.chain, targetHash, pool.chain.NotifyFinalized)
+		// Skip if target block is already finalized and notified
+		if highestNotified := pool.chain.HighestNotifiedFinal(); highestNotified == nil || targetNumber > highestNotified.Number.Uint64()+1 {
+			go pool.engine.CheckFinalityAndNotify(pool.chain, targetHash, pool.chain.NotifyFinalized)
+		}
 	}
 	localReceivedVotesGauge.Update(int64(pool.receivedVotes.Cardinality()))
 }


### PR DESCRIPTION
### Description
It's a fix for #3520
Fix a critical race condition in CheckFinalityAndNotify where the function relied on currentHeader matching targetBlockHash. Since currentHeader is updated later than highestVerifiedBlock in writeBlockAndSetHead, votes entering curVotes (via GetVerifiedBlockByHash check) would trigger CheckFinalityAndNotify before currentHeader was updated, causing the check to fail.

### Rationale

In writeBlockAndSetHead, highestVerifiedBlock is set before currentHeader. When votes arrive and GetVerifiedBlockByHash returns non-nil, they enter curVotes and trigger CheckFinalityAndNotify. However, currentHeader hasn't been updated yet, so the check `currentHeader.Hash() != targetBlockHash` fails, preventing early finalization from working correctly.

### Example

Before fix:
- CheckFinalityAndNotify skipped due to "currentHeader mismatch"
- Early finalization rarely triggered via VotePool

After fix:
- Target header retrieved directly by GetHeaderByHash
- Early finalization works reliably

### Changes

Notable changes:
* CheckFinalityAndNotify: Use GetHeaderByHash(targetBlockHash) instead of 
  checking currentHeader.Hash() == targetBlockHash
* VotePool: Add early filtering using HighestNotifiedFinal() to skip 
  already-finalized blocks
* BlockChain: Add HighestNotifiedFinal() getter for deduplication
* Parlia: Remove finalizedNotified LRU cache