### PR TITLE
eth/downloader, eth/sync: reduce sync stall on BSC's 0.45s block inte…

### DIFF
--- a/eth/downloader/fetchers.go
+++ b/eth/downloader/fetchers.go
@@ -24,6 +24,12 @@ import (
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 )
 
+// masterPeerHeaderTimeout caps the timeout for blocking header requests on the
+// critical sync path (fetchHead, findAncestor, skeleton). With BSC's 0.45s block
+// interval, the dynamic TargetTimeout (10s+) causes excessive lag; this ensures
+// we fail fast and switch peers instead.
+const masterPeerHeaderTimeout = 5 * time.Second
+
 // fetchHeadersByHash is a blocking version of Peer.RequestHeadersByHash which
 // handles all the cancellation, interruption and timeout mechanisms of a data
 // retrieval to allow blocking API calls.
@@ -38,13 +44,18 @@ func (d *Downloader) fetchHeadersByHash(p *peerConnection, hash common.Hash, amo
 	}
 	defer req.Close()
 
-	// Wait until the response arrives, the request is cancelled or times out
+	// Wait until the response arrives, the request is cancelled or times out.
 	ttl := d.peers.rates.TargetTimeout()
-
+	if ttl > masterPeerHeaderTimeout {
+		ttl = masterPeerHeaderTimeout
+	}
 	timeoutTimer := time.NewTimer(ttl)
 	defer timeoutTimer.Stop()
 
 	select {
+	case <-d.cancelCh:
+		return nil, nil, errCanceled
+
 	case <-timeoutTimer.C:
 		// Header retrieval timed out, update the metrics
 		p.log.Debug("Header request timed out", "elapsed", ttl)
@@ -80,9 +91,11 @@ func (d *Downloader) fetchHeadersByNumber(p *peerConnection, number uint64, amou
 	}
 	defer req.Close()
 
-	// Wait until the response arrives, the request is cancelled or times out
+	// Wait until the response arrives, the request is cancelled or times out.
 	ttl := d.peers.rates.TargetTimeout()
-
+	if ttl > masterPeerHeaderTimeout {
+		ttl = masterPeerHeaderTimeout
+	}
 	timeoutTimer := time.NewTimer(ttl)
 	defer timeoutTimer.Stop()
 

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -117,10 +117,16 @@ func (cs *chainSyncer) loop() {
 		select {
 		case <-cs.peerEventCh:
 			// Peer information changed, recheck.
-		case <-cs.doneCh:
+		case err := <-cs.doneCh:
 			cs.doneCh = nil
-			cs.force.Reset(forceSyncCycle)
-			cs.forced = false
+			if err != nil {
+				// Sync failed, keep forced=true so nextSyncOp can immediately
+				// retry with minPeers=1 instead of waiting for the 10s force timer.
+				cs.forced = true
+			} else {
+				cs.force.Reset(forceSyncCycle)
+				cs.forced = false
+			}
 		case <-cs.force.C:
 			cs.forced = true
 
@@ -184,11 +190,17 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 		// 		log.Info("Disable transaction acceptance randomly for the delay exceeding 10 blocks.")
 		// 	}
 	} else if op.td.Cmp(new(big.Int).Add(ourTD, common.Big2)) <= 0 { // common.Big2: difficulty of an in-turn block
-		// On BSC, blocks are produced much faster than on Ethereum.
-		// If the node is only slightly behind (e.g., 1 block), syncing is unnecessary.
-		// It's likely still processing broadcasted blocks(such as including a big tx) or block hash announcements.
-		// In most cases, the node will catch up within 2 seconds.
-		time.Sleep(2 * time.Second)
+		// Only slightly behind (~1 block). Wait briefly for block broadcast to
+		// catch up before starting a full sync. Use non-blocking select to stay
+		// responsive to quit signals and peer events.
+		waitTimer := time.NewTimer(500 * time.Millisecond)
+		defer waitTimer.Stop()
+		select {
+		case <-waitTimer.C:
+		case <-cs.handler.quitSync:
+			return nil
+		case <-cs.peerEventCh:
+		}
 
 		// Re-check local head to see if it has caught up
 		if _, latestTD := cs.modeAndLocalHead(); ourTD.Cmp(latestTD) < 0 {


### PR DESCRIPTION
### Description

Reduce sync stalls on BSC after the block interval was 0.45s. For #3525 #3548
 
1. Cap critical-path header timeout – Introduce masterPeerHeaderTimeout (5s) to bound blocking fetchHeadersByHash / fetchHeadersByNumber. The dynamic TargetTimeout can exceed 10s, stalling the entire pipeline on one slow peer. Also add missing cancelCh handling in fetchHeadersByHash.

2. Preserve forced sync on failure – Keep cs.forced = true on doSync error, so the sync loop retries immediately with minPeers=1 instead of waiting up to 10s.

3. Shorten near-head wait – Replace blocking 2s time.Sleep with a non-blocking 500ms select in nextSyncOp, responsive to quit signals and peer events.

### Rationale

With 0.45s block intervals, the old parameters (designed for 3s/12s cadence) cause compounding delays: a single slow peer triggers a 10s+ timeout, followed by a 10s recovery wait — ~45 blocks of drift total. These changes reduce worst-case sync stall from ~20s to ~5s.

### Changes

* eth/downloader/fetchers.go: Add masterPeerHeaderTimeout = 5s; cap TTL in both header fetch functions; add cancelCh in fetchHeadersByHash
* eth/sync.go: Preserve cs.forced = true on sync failure for immediate retry; replace 2s blocking sleep with 500ms non-blocking select