### PR TITLE
chore: fix comment syntax issues in miner and verkle witness test files

### DIFF
--- a/core/verkle_witness_test.go
+++ b/core/verkle_witness_test.go
@@ -691,7 +691,7 @@ func TestProcessVerkleSelfDestructInSeparateTx(t *testing.T) {
 		account2.Bytes(),
 		[]byte{byte(vm.SELFDESTRUCT)})
 
-	//The goal of this test is to test SELFDESTRUCT that happens in a contract
+	// The goal of this test is to test SELFDESTRUCT that happens in a contract
 	// execution which is created in a previous transaction.
 	selfDestructContract := slices.Concat([]byte{
 		byte(vm.PUSH1), byte(len(runtimeCode)),

--- a/miner/ordering.go
+++ b/miner/ordering.go
@@ -209,7 +209,7 @@ func (t *transactionsByPriceAndNonce) Forward(tx *types.Transaction) {
 	for _, head := range t.heads {
 		if head.tx != nil && head.tx.Resolve() != nil {
 			if tx == head.tx.Tx {
-				//shift t to the position one after tx
+				// Shift t to the position one after tx
 				txTmp := t.PeekWithUnwrap()
 				for txTmp != tx {
 					t.Shift()
@@ -220,13 +220,13 @@ func (t *transactionsByPriceAndNonce) Forward(tx *types.Transaction) {
 			}
 		}
 	}
-	//get the sender address of tx
+	// Get the sender address of tx
 	acc, _ := types.Sender(t.signer, tx)
-	//check whether target tx exists in t.txs
+	// Check whether target tx exists in t.txs
 	if txs, ok := t.txs[acc]; ok {
 		for _, txLazyTmp := range txs {
 			if txLazyTmp != nil && txLazyTmp.Resolve() != nil {
-				//found the same pointer in t.txs as tx and then shift t to the position one after tx
+				// Found the same pointer in t.txs as tx and then shift t to the position one after tx
 				if tx == txLazyTmp.Tx {
 					txTmp := t.PeekWithUnwrap()
 					for txTmp != tx {


### PR DESCRIPTION
### Description

This commit fixes several comment syntax issues by adding proper capitalization at the beginning of comments in miner/ordering.go and core/verkle_witness_test.go. 

The changes improve code documentation consistency and readability without affecting any functional logic.



### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
