### PR TITLE
core/vm: cap CometBFT light client validator count to prevent DoS

### DIFF
--- a/core/vm/lightclient/v2/lightclient.go
+++ b/core/vm/lightclient/v2/lightclient.go
@@ -143,6 +143,9 @@ func DecodeConsensusState(input []byte) (ConsensusState, error) {
 	if inputLen <= minimumLength || (inputLen-minimumLength)%singleValidatorBytesLength != 0 {
 		return ConsensusState{}, fmt.Errorf("expected input size %d+%d*N, actual input size: %d", minimumLength, singleValidatorBytesLength, inputLen)
 	}
+	if inputLen > maxConsensusStateLength {
+		return ConsensusState{}, fmt.Errorf("consensus state too large: %d bytes exceeds maximum %d (max 99 validators)", inputLen, maxConsensusStateLength)
+	}
 
 	pos := uint64(0)
 	chainID := string(bytes.Trim(input[pos:pos+chainIDLength], "\x00"))


### PR DESCRIPTION
### Description

core/vm: cap CometBFT light client validator count to prevent DoS

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
