### PR TITLE
fix:   bypass the gaslimit check for system txn

### DIFF
--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -290,6 +290,9 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		}
 		// Assemble the transaction call message and return if the requested offset
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
+		if !beforeSystemTx {
+			msg.SkipTransactionChecks = true
+		}
 
 		// Not yet the searched for transaction, execute on top of the current state
 		statedb.SetTxContext(tx.Hash(), idx)

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -598,6 +598,9 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 		}
 
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
+		if !beforeSystemTx {
+			msg.SkipTransactionChecks = true
+		}
 		statedb.SetTxContext(tx.Hash(), i)
 		if _, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(msg.GasLimit)); err != nil {
 			log.Warn("Tracing intermediate roots did not complete", "txindex", i, "txhash", tx.Hash(), "err", err)
@@ -800,6 +803,9 @@ txloop:
 
 		// Generate the next state snapshot fast without tracing
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
+		if !beforeSystemTx {
+			msg.SkipTransactionChecks = true
+		}
 		statedb.SetTxContext(tx.Hash(), i)
 		if _, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(msg.GasLimit)); err != nil {
 			failed = err
@@ -905,6 +911,9 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 
 		// Prepare the transaction for un-traced execution
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
+		if !beforeSystemTx {
+			msg.SkipTransactionChecks = true
+		}
 		if txHash != (common.Hash{}) && tx.Hash() != txHash {
 			// Process the tx to update state, but don't trace it.
 			_, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(msg.GasLimit))
@@ -1189,6 +1198,7 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 	// Run the transaction with tracing enabled.
 	if isSystemTx {
 		intrinsicGas, _ = core.IntrinsicGas(message.Data, message.AccessList, message.SetCodeAuthorizations, false, true, true, false)
+		message.SkipTransactionChecks = true
 	}
 
 	// Call Prepare to clear out the statedb access list


### PR DESCRIPTION
### Description

BSC system transactions use math.MaxUint64/2 as gas limit, exceeding the EIP-7825 cap (2^24). During normal block processing Parlia calls evm.Call() directly, bypassing preCheck(). But tracing replays via ApplyMessage which hits the check and fails.

This pr set SkipTransactionChecks = true for system transactions in all tracing/replay paths.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
