### PR TITLE
miner: fix missing tcount increment in commitBlobTransaction

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -735,6 +735,7 @@ func (w *worker) commitBlobTransaction(env *environment, tx *types.Transaction, 
 	env.sidecars = append(env.sidecars, sc)
 	env.blobs += len(sc.Blobs)
 	env.size += txNoBlob.Size()
+	env.tcount++
 	*env.header.BlobGasUsed += receipt.BlobGasUsed
 	return receipt.Logs, nil
 }


### PR DESCRIPTION
### Description

Fix missing `env.tcount` increment in `commitBlobTransaction`, which caused incorrect `Log.TxIndex` in receipts on block-producing validators. The bug was introduced in 2425eea.

### Rationale

`commitTransaction` increments `env.tcount` after a successful commit, but `commitBlobTransaction` does not. Since `env.tcount` is used by `SetTxContext` to set the transaction index, all transactions after a blob tx get a wrong `Log.TxIndex`. This only affects the producing validator because non-producing nodes re-derive log metadata via `Process()`/`DeriveFields`.

### Example

On the producing validator, `eth_getBlockReceipts` returns inconsistent `transactionIndex`:

{
  "transactionIndex": "0x1",
  "logs": [{
    "transactionIndex": "0x0"
  }]
}


### Changes

Notable changes: 
* add each change in a bullet point here
* ...
