### PR TITLE
fix: superinstruction bad block

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -209,7 +209,7 @@ func opTload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 
 // opTstore implements TSTORE opcode
 func opTstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	if interpreter.readOnly {
+	if interpreter.evm.readOnly {
 		return nil, ErrWriteProtection
 	}
 	loc := scope.Stack.pop()

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -112,6 +112,11 @@ type EVM struct {
 	// abort is used to abort the EVM calling operations
 	abort atomic.Bool
 
+	// readOnly is a call-stack property set by STATICCALL and inherited by all
+	// descendants. It must live on EVM (not interpreter) since the EVM may swap
+	// interpreter implementations during execution.
+	readOnly bool
+
 	// callGasTemp holds the gas available for the current call. This is needed because the
 	// available gas is calculated in gasCall* according to the 63/64 rule and later
 	// applied in opCall*.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -112,11 +112,6 @@ type EVM struct {
 	// abort is used to abort the EVM calling operations
 	abort atomic.Bool
 
-	// readOnly is a call-stack property set by STATICCALL and inherited by all
-	// descendants. It must live on EVM (not interpreter) since the EVM may swap
-	// interpreter implementations during execution.
-	readOnly bool
-
 	// callGasTemp holds the gas available for the current call. This is needed because the
 	// available gas is calculated in gasCall* according to the 63/64 rule and later
 	// applied in opCall*.
@@ -127,6 +122,11 @@ type EVM struct {
 
 	// jumpDests stores results of JUMPDEST analysis.
 	jumpDests JumpDestCache
+
+	// readOnly is a call-stack property set by STATICCALL and inherited by all
+	// descendants. It must live on EVM (not interpreter) since the EVM may swap
+	// interpreter implementations during execution.
+	readOnly bool
 
 	// global (to this context) ethereum virtual machine used throughout
 	// the execution of the tx

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -524,7 +524,7 @@ func opSload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 }
 
 func opSstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	if interpreter.readOnly {
+	if interpreter.evm.readOnly {
 		return nil, ErrWriteProtection
 	}
 	loc, val := scope.Stack.pop2()
@@ -658,7 +658,7 @@ func opSwap16(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 }
 
 func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	if interpreter.readOnly {
+	if interpreter.evm.readOnly {
 		return nil, ErrWriteProtection
 	}
 	var (
@@ -701,7 +701,7 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 }
 
 func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	if interpreter.readOnly {
+	if interpreter.evm.readOnly {
 		return nil, ErrWriteProtection
 	}
 	var (
@@ -747,7 +747,7 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	// Get the arguments from the memory.
 	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
 
-	if interpreter.readOnly && !value.IsZero() {
+	if interpreter.evm.readOnly && !value.IsZero() {
 		return nil, ErrWriteProtection
 	}
 	if !value.IsZero() {
@@ -886,7 +886,7 @@ func opStop(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 }
 
 func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	if interpreter.readOnly {
+	if interpreter.evm.readOnly {
 		return nil, ErrWriteProtection
 	}
 	beneficiary := scope.Stack.pop()
@@ -905,7 +905,7 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 }
 
 func opSelfdestruct6780(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	if interpreter.readOnly {
+	if interpreter.evm.readOnly {
 		return nil, ErrWriteProtection
 	}
 	beneficiary := scope.Stack.pop()
@@ -929,7 +929,7 @@ func opSelfdestruct6780(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCon
 // make log instruction function
 func makeLog(size int) executionFunc {
 	return func(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-		if interpreter.readOnly {
+		if interpreter.evm.readOnly {
 			return nil, ErrWriteProtection
 		}
 		topics := make([]common.Hash, size)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -99,7 +99,6 @@ type EVMInterpreter struct {
 	hasher    crypto.KeccakState // Keccak256 hasher instance shared across opcodes
 	hasherBuf common.Hash        // Keccak256 hasher result array shared across opcodes
 
-	readOnly   bool   // Whether to throw on stateful modifications
 	returnData []byte // Last CALL's return data for subsequent reuse
 }
 
@@ -176,9 +175,9 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 
 	// Make sure the readOnly is only set if we aren't in readOnly yet.
 	// This also makes sure that the readOnly flag isn't removed for child calls.
-	if readOnly && !in.readOnly {
-		in.readOnly = true
-		defer func() { in.readOnly = false }()
+	if readOnly && !in.evm.readOnly {
+		in.evm.readOnly = true
+		defer func() { in.evm.readOnly = false }()
 	}
 
 	// Reset the previous call's return data. It's unimportant to preserve the old buffer


### PR DESCRIPTION
### Description

Move the readOnly field from EVMInterpreter to EVM, so that both interpreters share a single source of truth. 

### Rationale

When --vm.opcode.optimize is used, the EVM maintains two interpreter instances (baseInterpreter and optInterpreter) and switches between them per call frame depending on whether the target contract has optimized code. The readOnly flag, which enforces write protection under STATICCALL, was stored as a per-interpreter instance field. When a child call within a STATICCALL context landed on a contract with optimized code, the EVM switched from baseInterpreter (where readOnly=true) to optInterpreter (where readOnly=false by default). Since DelegateCall passes readOnly=false to Run() (relying on inheritance rather than explicit propagation), the new interpreter never picked up the read-only constraint. This allowed state-mutating opcodes like SSTORE to execute inside a STATICCALL context, producing incorrect gas consumption and ultimately a bad block.

### Example
N/A

### Changes

Notable changes: 
* move readOnly field from EVMInterpreter to EVM
