### PR TITLE
params: set Osaka/Mendel time in Chapel testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## v1.7.1
-v1.7.1 is a preview release, which implements BEPs defined in [Osaka/Mendel](https://github.com/allformless/BEPs/blob/mendle-bep-list/BEPs/BEP-658.md).
+v1.7.1 is for BSC Chapel testnet [Osaka/Mendel hardfork](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-658.md),the hard fork time is 2026-03-24 02:30:00 AM UTC
 
 ### FEATURE
 - [feat: support bid block size check for BEP-655](https://github.com/bnb-chain/bsc/pull/3529)

--- a/params/config.go
+++ b/params/config.go
@@ -304,10 +304,10 @@ var (
 		LorentzTime:         newUint64(1744097580), // 2025-04-08 07:33:00 AM UTC
 		MaxwellTime:         newUint64(1748243100), // 2025-05-26 07:05:00 AM UTC
 		FermiTime:           newUint64(1762741500), // 2025-11-10 02:25:00 AM UTC
-		OsakaTime:           nil,
-		MendelTime:          nil,
-		BPO1Time:            nil, // will be skipped in BSC
-		BPO2Time:            nil, // will be skipped in BSC
+		OsakaTime:           newUint64(1774319400), // 2026-03-24 02:30:00 AM UTC
+		MendelTime:          newUint64(1774319400), // 2026-03-24 02:30:00 AM UTC
+		BPO1Time:            nil,                   // will be skipped in BSC
+		BPO2Time:            nil,                   // will be skipped in BSC
 		AmsterdamTime:       nil,
 		PasteurTime:         nil,
 


### PR DESCRIPTION
### Description

params: set Osaka/Mendel time in chapel testnet, 2026-03-24 02:30:00 AM UTC

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
