### PR TITLE
miner: support blob sidecar validation for bids

### DIFF
--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -151,7 +151,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 		return fmt.Errorf("%w: gas tip cap %v, minimum needed %v", ErrTxGasPriceTooLow, tx.GasTipCap(), opts.MinTip)
 	}
 	if tx.Type() == types.BlobTxType {
-		return validateBlobTx(tx, head, opts)
+		return ValidateBlobTx(tx, head, opts)
 	}
 	if tx.Type() == types.SetCodeTxType {
 		if len(tx.SetCodeAuthorizations()) == 0 {
@@ -161,8 +161,9 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	return nil
 }
 
-// validateBlobTx implements the blob-transaction specific validations.
-func validateBlobTx(tx *types.Transaction, head *types.Header, opts *ValidationOptions) error {
+// ValidateBlobTx validates blob-transaction specific fields including sidecar
+// commitment hashes and KZG proofs.
+func ValidateBlobTx(tx *types.Transaction, head *types.Header, opts *ValidationOptions) error {
 	sidecar := tx.BlobTxSidecar()
 	if sidecar == nil {
 		return errors.New("missing sidecar in blob transaction")

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
@@ -1079,6 +1080,19 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 		if sc.Version == types.BlobSidecarVersion1 {
 			return errors.New("cell proof is not supported yet")
 		}
+
+		// Validate blob sidecar commitment hashes and KZG proofs.
+		if sidecar := tx.BlobTxSidecar(); sidecar != nil {
+			if err := sidecar.ValidateBlobCommitmentHashes(tx.BlobHashes()); err != nil {
+				return err
+			}
+			for i := range sidecar.Blobs {
+				if err := kzg4844.VerifyBlobProof(&sidecar.Blobs[i], sidecar.Commitments[i], sidecar.Proofs[i]); err != nil {
+					return fmt.Errorf("invalid blob %d proof: %v", i, err)
+				}
+			}
+		}
+
 		// Checking against blob gas limit: It's kind of ugly to perform this check here, but there
 		// isn't really a better place right now. The blob gas limit is checked at block validation time
 		// and not during execution. This means core.ApplyTransaction will not return an error if the

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
@@ -1082,15 +1081,8 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 		}
 
 		// Validate blob sidecar commitment hashes and KZG proofs.
-		if sidecar := tx.BlobTxSidecar(); sidecar != nil {
-			if err := sidecar.ValidateBlobCommitmentHashes(tx.BlobHashes()); err != nil {
-				return err
-			}
-			for i := range sidecar.Blobs {
-				if err := kzg4844.VerifyBlobProof(&sidecar.Blobs[i], sidecar.Commitments[i], sidecar.Proofs[i]); err != nil {
-					return fmt.Errorf("invalid blob %d proof: %v", i, err)
-				}
-			}
+		if err := txpool.ValidateBlobTx(tx, env.header, nil); err != nil {
+			return err
 		}
 
 		// Checking against blob gas limit: It's kind of ugly to perform this check here, but there


### PR DESCRIPTION
### Description

Add blob sidecar commitment hash and KZG proof validation for builder bids in `commitTransaction`, matching the checks already in `txpool.validateBlobTx`

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
