### PR TITLE
metrics: replace time.Tick with time.NewTicker to prevent resource leaks

### DIFF
--- a/metrics/debug.go
+++ b/metrics/debug.go
@@ -22,7 +22,9 @@ var (
 // CaptureDebugGCStats captures new values for the Go garbage collector statistics
 // exported in debug.GCStats. This is designed to be called as a goroutine.
 func CaptureDebugGCStats(r Registry, d time.Duration) {
-	for range time.Tick(d) {
+	ticker := time.NewTicker(d)
+	defer ticker.Stop()
+	for range ticker.C {
 		CaptureDebugGCStatsOnce(r)
 	}
 }

--- a/metrics/json.go
+++ b/metrics/json.go
@@ -15,7 +15,9 @@ func (r *StandardRegistry) MarshalJSON() ([]byte, error) {
 // WriteJSON writes metrics from the given registry  periodically to the
 // specified io.Writer as JSON.
 func WriteJSON(r Registry, d time.Duration, w io.Writer) {
-	for range time.Tick(d) {
+	ticker := time.NewTicker(d)
+	defer ticker.Stop()
+	for range ticker.C {
 		WriteJSONOnce(r, w)
 	}
 }

--- a/metrics/log.go
+++ b/metrics/log.go
@@ -18,7 +18,9 @@ func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
 	du := float64(scale)
 	duSuffix := scale.String()[1:]
 
-	for range time.Tick(freq) {
+	ticker := time.NewTicker(freq)
+	defer ticker.Stop()
+	for range ticker.C {
 		r.Each(func(name string, i interface{}) {
 			switch metric := i.(type) {
 			case *Counter:

--- a/metrics/opentsdb.go
+++ b/metrics/opentsdb.go
@@ -39,7 +39,9 @@ func OpenTSDB(r Registry, d time.Duration, prefix string, addr *net.TCPAddr) {
 // OpenTSDBWithConfig is a blocking exporter function just like OpenTSDB,
 // but it takes a OpenTSDBConfig instead.
 func OpenTSDBWithConfig(c OpenTSDBConfig) {
-	for range time.Tick(c.FlushInterval) {
+	ticker := time.NewTicker(c.FlushInterval)
+	defer ticker.Stop()
+	for range ticker.C {
 		if err := openTSDB(&c); nil != err {
 			log.Println(err)
 		}

--- a/metrics/syslog.go
+++ b/metrics/syslog.go
@@ -11,7 +11,9 @@ import (
 // Syslog outputs each metric in the given registry to syslog periodically using
 // the given syslogger.
 func Syslog(r Registry, d time.Duration, w *syslog.Writer) {
-	for range time.Tick(d) {
+	ticker := time.NewTicker(d)
+	defer ticker.Stop()
+	for range ticker.C {
 		r.Each(func(name string, i interface{}) {
 			switch metric := i.(type) {
 			case *Counter:

--- a/metrics/writer.go
+++ b/metrics/writer.go
@@ -11,7 +11,9 @@ import (
 // Write sorts writes each metric in the given registry periodically to the
 // given io.Writer.
 func Write(r Registry, d time.Duration, w io.Writer) {
-	for range time.Tick(d) {
+	ticker := time.NewTicker(d)
+	defer ticker.Stop()
+	for range ticker.C {
 		WriteOnce(r, w)
 	}
 }


### PR DESCRIPTION
## Summary

Replace all 6 instances of `time.Tick()` in the `metrics/` package with `time.NewTicker()` + `defer ticker.Stop()`.

`time.Tick()` creates a ticker whose underlying resources can never be released — there is no handle to call `Stop()`. This is flagged by `go vet` (SA1015) and is a recognized Go anti-pattern.

### Changes

| File | Function |
|------|----------|
| `metrics/debug.go` | `CaptureDebugGCStats` |
| `metrics/json.go` | `WriteJSON` |
| `metrics/log.go` | `LogScaled` |
| `metrics/opentsdb.go` | `OpenTSDBWithConfig` |
| `metrics/syslog.go` | `Syslog` |
| `metrics/writer.go` | `Write` |

### Pattern

```diff
-for range time.Tick(d) {
+ticker := time.NewTicker(d)
+defer ticker.Stop()
+for range ticker.C {
```

While these goroutines run for the process lifetime, using `NewTicker` + `defer Stop()` follows Go best practices and enables proper cleanup if these functions are ever modified to have return paths.

Note: this same issue exists in upstream go-ethereum `metrics/` package.