### PR TITLE
handler.go: add peer info in logs

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -91,7 +91,7 @@ type bodyRequesterFn func([]common.Hash, chan *eth.Response) (*eth.Request, erro
 type headerVerifierFn func(header *types.Header) error
 
 // blockBroadcasterFn is a callback type for broadcasting a block to connected peers.
-type blockBroadcasterFn func(block *types.Block, propagate bool)
+type blockBroadcasterFn func(peer string, block *types.Block, propagate bool)
 
 // chainHeightFn is a callback type to retrieve the current chain height.
 type chainHeightFn func() uint64
@@ -912,7 +912,7 @@ func (f *BlockFetcher) importBlocks(op *blockOrHeaderInject) {
 		case nil:
 			// All ok, quickly propagate to our peers
 			blockBroadcastOutTimer.UpdateSince(block.ReceivedAt)
-			go f.broadcastBlock(block, true)
+			go f.broadcastBlock(peer, block, true)
 
 		case consensus.ErrFutureBlock:
 			log.Error("Received future block", "peer", peer, "number", block.Number(), "hash", hash, "err", err)
@@ -935,7 +935,7 @@ func (f *BlockFetcher) importBlocks(op *blockOrHeaderInject) {
 		}
 		// If import succeeded, broadcast the block
 		blockAnnounceOutTimer.UpdateSince(block.ReceivedAt)
-		go f.broadcastBlock(block, false)
+		go f.broadcastBlock(peer, block, false)
 
 		// Invoke the testing hook if needed
 		if f.importedHook != nil {

--- a/eth/fetcher/block_fetcher_test.go
+++ b/eth/fetcher/block_fetcher_test.go
@@ -128,7 +128,7 @@ func (f *fetcherTester) verifyHeader(header *types.Header) error {
 }
 
 // broadcastBlock is a nop placeholder for the block broadcasting.
-func (f *fetcherTester) broadcastBlock(block *types.Block, propagate bool) {
+func (f *fetcherTester) broadcastBlock(peer string, block *types.Block, propagate bool) {
 }
 
 // chainHeight retrieves the current height (block number) of the chain.
@@ -1047,7 +1047,7 @@ func TestBlockFetcherMultiplePeers(t *testing.T) {
 			return nil
 		},
 		// broadcastBlock
-		func(block *types.Block, propagate bool) {},
+		func(peer string, block *types.Block, propagate bool) {},
 		// chainHeight - returns the height of the highest block in the chain
 		func() uint64 {
 			var maxHeight uint64 = 0
@@ -1268,7 +1268,7 @@ func TestQuickBlockFetching(t *testing.T) {
 	fetcher := NewBlockFetcher(
 		blockRetriever.getBlock,
 		func(header *types.Header) error { return nil },
-		func(block *types.Block, propagate bool) {},
+		func(peer string, block *types.Block, propagate bool) {},
 		func() uint64 { return 10 }, // Current height
 		func() uint64 { return 5 },  // Finalized height
 		func(blocks types.Blocks) (int, error) {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -314,15 +314,21 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		return h.chain.InsertChain(blocks)
 	}
 
-	broadcastBlockWithCheck := func(block *types.Block, propagate bool) {
+	broadcastBlockWithCheck := func(peer string, block *types.Block, propagate bool) {
 		if propagate {
 			if !(block.Header().WithdrawalsHash == nil && block.Withdrawals() == nil) &&
 				!(block.Header().EmptyWithdrawalsHash() && block.Withdrawals() != nil && len(block.Withdrawals()) == 0) {
-				log.Error("Propagated block has invalid withdrawals")
+				log.Error("Propagated block has invalid withdrawals", "peer", peer)
 				return
 			}
 			if err := core.IsDataAvailable(h.chain, block); err != nil {
-				log.Error("Propagating block with invalid sidecars", "number", block.Number(), "hash", block.Hash(), "err", err)
+				var peerAddr string
+				if p := h.peers.peer(peer); p != nil {
+					if addr := p.RemoteAddr(); addr != nil {
+						peerAddr = addr.String()
+					}
+				}
+				log.Error("Propagating block with invalid sidecars", "number", block.Number(), "hash", block.Hash(), "peer", peer[:16], "peerAddr", peerAddr, "err", err)
 				return
 			}
 		}


### PR DESCRIPTION
### Description

print peer id when fetch block

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
