### PR TITLE
.github: change dependabot target branch to develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"


### PR DESCRIPTION
### Description

.github: change dependabot target branch to develop

### Rationale

make dependabot creating PR like https://github.com/bnb-chain/bsc/pull/3602
to base develop branch

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
