### PR TITLE
internal/ethapi: fix getDiffAccount api

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1383,6 +1383,7 @@ func (api *BlockChainAPI) replay(ctx context.Context, block *types.Block, accoun
 
 		if posa, ok := api.b.Engine().(consensus.PoSA); ok {
 			if isSystem, _ := posa.IsSystemTransaction(tx, block.Header()); isSystem {
+				msg.SkipTransactionChecks = true
 				balance := statedb.GetBalance(consensus.SystemAddress)
 				if balance.Cmp(common.U2560) > 0 {
 					statedb.SetBalance(consensus.SystemAddress, uint256.NewInt(0), tracing.BalanceChangeUnspecified)


### PR DESCRIPTION
### Description

After the Mendel hardfork, `eth_getDiffAccounts` fails when replaying blocks that contain system transactions. 

EIP-7825 introduced a transaction gas limit cap of 2^24 (16,777,216), but BSC system transactions use `math.MaxInt64` as their gas limit. The `replay()` function in `internal/ethapi/api.go` was not setting `msg.SkipTransactionChecks = true` for system transactions, causing the EIP-7825 check to reject them during replay.

### Rationale
```


curl --location 'https://bsc-testnet-ap.nodereal.io/v1/c90b928c66a145049bc28774b0328b63' \
--header 'Content-Type: application/json' \
--data '{"jsonrpc":"2.0","id":1,"method":"eth_getDiffAccounts","params":["0x5cfe539"]}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"transaction 0x06f7b88ea7d1ba62eea6513eb0bc38900eec6155dbf8193c3e31c081127a82e2 failed: transaction gas limit too high (cap: 16777216, tx: 9223372036854775807)"}}%
```

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
