### PR TITLE
miner: async blob tx validation during bid simulation

### DIFF
--- a/core/txpool/validation_test.go
+++ b/core/txpool/validation_test.go
@@ -18,16 +18,21 @@ package txpool
 
 import (
 	"crypto/ecdsa"
+	"crypto/rand"
 	"errors"
 	"math"
 	"math/big"
 	"testing"
 
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	gokzg4844 "github.com/crate-crypto/go-eth-kzg"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 )
 
 func TestValidateTransactionEIP2681(t *testing.T) {
@@ -112,4 +117,68 @@ func createTestTransaction(key *ecdsa.PrivateKey, nonce uint64) *types.Transacti
 	tx := types.NewTx(txdata)
 	signedTx, _ := types.SignTx(tx, types.HomesteadSigner{}, key)
 	return signedTx
+}
+
+func randFieldElement() [32]byte {
+	bytes := make([]byte, 32)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		panic("failed to get random field element")
+	}
+	var r fr.Element
+	r.SetBytes(bytes)
+	return gokzg4844.SerializeScalar(r)
+}
+
+func randBlob() kzg4844.Blob {
+	var blob kzg4844.Blob
+	for i := 0; i < len(blob); i += gokzg4844.SerializedScalarSize {
+		fieldElementBytes := randFieldElement()
+		copy(blob[i:i+gokzg4844.SerializedScalarSize], fieldElementBytes[:])
+	}
+	return blob
+}
+
+func validBlobSidecar(n int) *types.BlobTxSidecar {
+	blobs := make([]kzg4844.Blob, n)
+	commitments := make([]kzg4844.Commitment, n)
+	proofs := make([]kzg4844.Proof, n)
+	for i := 0; i < n; i++ {
+		blobs[i] = randBlob()
+		c, _ := kzg4844.BlobToCommitment(&blobs[i])
+		commitments[i] = c
+		p, _ := kzg4844.ComputeBlobProof(&blobs[i], c)
+		proofs[i] = p
+	}
+	return types.NewBlobTxSidecar(types.BlobSidecarVersion0, blobs, commitments, proofs)
+}
+
+func signedBlobTx(key *ecdsa.PrivateKey, nonce uint64, sidecar *types.BlobTxSidecar, blobFeeCap uint64) *types.Transaction {
+	blobtx := &types.BlobTx{
+		ChainID:    uint256.MustFromBig(params.MainnetChainConfig.ChainID),
+		Nonce:      nonce,
+		GasTipCap:  uint256.NewInt(1),
+		GasFeeCap:  uint256.NewInt(1000),
+		Gas:        21000,
+		BlobFeeCap: uint256.NewInt(blobFeeCap),
+		BlobHashes: sidecar.BlobHashes(),
+		Value:      uint256.NewInt(0),
+		Sidecar:    sidecar,
+	}
+	tx := types.NewTx(blobtx)
+	signed, _ := types.SignTx(tx, types.NewCancunSigner(params.MainnetChainConfig.ChainID), key)
+	return signed
+}
+
+// TestValidateBlobTx_InvalidProof verifies that ValidateBlobTx rejects a
+// transaction with a tampered KZG proof.
+func TestValidateBlobTx_InvalidProof(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	sidecar := validBlobSidecar(1)
+	sidecar.Proofs[0][0] ^= 0xff
+	tx := signedBlobTx(key, 0, sidecar, 1)
+
+	if err := ValidateBlobTx(tx, nil, nil); err == nil {
+		t.Fatal("ValidateBlobTx should fail with tampered proof")
+	}
 }

--- a/core/types/bid.go
+++ b/core/types/bid.go
@@ -175,6 +175,10 @@ type Bid struct {
 	committed    bool // whether the bid has been committed to simulate or not
 
 	rawBid RawBid
+
+	// BlobValResult carries the result of async blob tx validation (field
+	// checks + KZG proof verification).
+	BlobValResult chan error
 }
 
 func (b *Bid) Commit() {

--- a/core/types/bid.go
+++ b/core/types/bid.go
@@ -176,9 +176,9 @@ type Bid struct {
 
 	rawBid RawBid
 
-	// BlobValResult carries the result of async blob tx validation (field
-	// checks + KZG proof verification).
-	BlobValResult chan error
+	// BlobValResults carries per-tx results of async blob validation (field
+	// checks + KZG proof verification), keyed by transaction hash.
+	BlobValResults map[common.Hash]chan error
 }
 
 func (b *Bid) Commit() {

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -1007,9 +1007,8 @@ type BidRuntime struct {
 	packedBlockReward     *big.Int
 	packedValidatorReward *big.Int
 
-	finished      chan struct{}
-	duration      time.Duration
-	blobValidated bool // true after async blob validation result has been consumed
+	finished chan struct{}
+	duration time.Duration
 }
 
 func newBidRuntime(newBid *types.Bid, validatorCommission uint64) (*BidRuntime, error) {
@@ -1085,15 +1084,14 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 			return errors.New("cell proof is not supported yet")
 		}
 
-		if !r.blobValidated {
-			if r.bid.BlobValResult != nil {
-				if err := <-r.bid.BlobValResult; err != nil {
-					return err
-				}
-			} else if err := txpool.ValidateBlobTx(tx, env.header, nil); err != nil {
+		if ch, ok := r.bid.BlobValResults[tx.Hash()]; ok {
+			if err := <-ch; err != nil {
 				return err
 			}
-			r.blobValidated = true
+		} else {
+			if err := txpool.ValidateBlobTx(tx, env.header, nil); err != nil {
+				return err
+			}
 		}
 
 		// Checking against blob gas limit: It's kind of ugly to perform this check here, but there

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -762,6 +762,10 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 		}
 	}(startTS)
 
+	// Start async blob validation so it runs in parallel with prepareWork and
+	// other setup below.
+	startAsyncBlobValidation(bidRuntime.bid)
+
 	// prepareWork will configure header with a suitable time according to consensus
 	// prepareWork will start trie prefetching
 	if bidRuntime.env, err = b.bidWorker.prepareWork(&generateParams{
@@ -1003,8 +1007,9 @@ type BidRuntime struct {
 	packedBlockReward     *big.Int
 	packedValidatorReward *big.Int
 
-	finished chan struct{}
-	duration time.Duration
+	finished      chan struct{}
+	duration      time.Duration
+	blobValidated bool // true after async blob validation result has been consumed
 }
 
 func newBidRuntime(newBid *types.Bid, validatorCommission uint64) (*BidRuntime, error) {
@@ -1080,9 +1085,15 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 			return errors.New("cell proof is not supported yet")
 		}
 
-		// Validate blob sidecar commitment hashes and KZG proofs.
-		if err := txpool.ValidateBlobTx(tx, env.header, nil); err != nil {
-			return err
+		if !r.blobValidated {
+			if r.bid.BlobValResult != nil {
+				if err := <-r.bid.BlobValResult; err != nil {
+					return err
+				}
+			} else if err := txpool.ValidateBlobTx(tx, env.header, nil); err != nil {
+				return err
+			}
+			r.blobValidated = true
 		}
 
 		// Checking against blob gas limit: It's kind of ugly to perform this check here, but there

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -1085,6 +1085,7 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 		}
 
 		if ch, ok := r.bid.BlobValResults[tx.Hash()]; ok {
+			delete(r.bid.BlobValResults, tx.Hash())
 			if err := <-ch; err != nil {
 				return err
 			}

--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -81,23 +81,19 @@ func (miner *Miner) SendBid(ctx context.Context, bidArgs *types.BidArgs) (common
 	return bid.Hash(), nil
 }
 
-const maxBlobValConcurrency = 3
-
-var blobValSem = make(chan struct{}, maxBlobValConcurrency)
-
 // startAsyncBlobValidation launches one goroutine per blob transaction to
 // validate it in the background (field checks + KZG proof verification).
-// Concurrency is throttled by blobValSem. Results are stored per-tx in
-// bid.BlobValResults keyed by tx hash.
+// Results are stored per-tx in bid.BlobValResults keyed by tx hash.
 func startAsyncBlobValidation(bid *types.Bid) {
 	bid.BlobValResults = make(map[common.Hash]chan error)
 	for _, tx := range bid.Txs {
 		if tx.Type() == types.BlobTxType {
+			if _, dup := bid.BlobValResults[tx.Hash()]; dup {
+				continue
+			}
 			ch := make(chan error, 1)
 			bid.BlobValResults[tx.Hash()] = ch
 			go func() {
-				blobValSem <- struct{}{}
-				defer func() { <-blobValSem }()
 				ch <- txpool.ValidateBlobTx(tx, nil, nil)
 			}()
 		}

--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/internal/version"
 	"github.com/ethereum/go-ethereum/log"
-	"golang.org/x/sync/errgroup"
 )
 
 // MevRunning return true if mev is running.
@@ -84,29 +83,25 @@ func (miner *Miner) SendBid(ctx context.Context, bidArgs *types.BidArgs) (common
 
 const maxBlobValConcurrency = 3
 
-// startAsyncBlobValidation launches a single background goroutine that validates
-// all blob transactions in the bid (field checks + KZG proof verification).
+var blobValSem = make(chan struct{}, maxBlobValConcurrency)
+
+// startAsyncBlobValidation launches one goroutine per blob transaction to
+// validate it in the background (field checks + KZG proof verification).
+// Concurrency is throttled by blobValSem. Results are stored per-tx in
+// bid.BlobValResults keyed by tx hash.
 func startAsyncBlobValidation(bid *types.Bid) {
-	var blobTxs []*types.Transaction
+	bid.BlobValResults = make(map[common.Hash]chan error)
 	for _, tx := range bid.Txs {
 		if tx.Type() == types.BlobTxType {
-			blobTxs = append(blobTxs, tx)
+			ch := make(chan error, 1)
+			bid.BlobValResults[tx.Hash()] = ch
+			go func() {
+				blobValSem <- struct{}{}
+				defer func() { <-blobValSem }()
+				ch <- txpool.ValidateBlobTx(tx, nil, nil)
+			}()
 		}
 	}
-	if len(blobTxs) == 0 {
-		return
-	}
-	bid.BlobValResult = make(chan error, 1)
-	go func() {
-		var g errgroup.Group
-		g.SetLimit(maxBlobValConcurrency)
-		for _, tx := range blobTxs {
-			g.Go(func() error {
-				return txpool.ValidateBlobTx(tx, nil, nil)
-			})
-		}
-		bid.BlobValResult <- g.Wait()
-	}()
 }
 
 func (miner *Miner) MevParams() *types.MevParams {

--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -7,9 +7,11 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/internal/version"
 	"github.com/ethereum/go-ethereum/log"
+	"golang.org/x/sync/errgroup"
 )
 
 // MevRunning return true if mev is running.
@@ -78,6 +80,33 @@ func (miner *Miner) SendBid(ctx context.Context, bidArgs *types.BidArgs) (common
 	}
 
 	return bid.Hash(), nil
+}
+
+const maxBlobValConcurrency = 3
+
+// startAsyncBlobValidation launches a single background goroutine that validates
+// all blob transactions in the bid (field checks + KZG proof verification).
+func startAsyncBlobValidation(bid *types.Bid) {
+	var blobTxs []*types.Transaction
+	for _, tx := range bid.Txs {
+		if tx.Type() == types.BlobTxType {
+			blobTxs = append(blobTxs, tx)
+		}
+	}
+	if len(blobTxs) == 0 {
+		return
+	}
+	bid.BlobValResult = make(chan error, 1)
+	go func() {
+		var g errgroup.Group
+		g.SetLimit(maxBlobValConcurrency)
+		for _, tx := range blobTxs {
+			g.Go(func() error {
+				return txpool.ValidateBlobTx(tx, nil, nil)
+			})
+		}
+		bid.BlobValResult <- g.Wait()
+	}()
 }
 
 func (miner *Miner) MevParams() *types.MevParams {

--- a/miner/miner_mev_test.go
+++ b/miner/miner_mev_test.go
@@ -1,0 +1,87 @@
+package miner
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	gokzg4844 "github.com/crate-crypto/go-eth-kzg"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+func randFieldElement() [32]byte {
+	bytes := make([]byte, 32)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		panic("failed to get random field element")
+	}
+	var r fr.Element
+	r.SetBytes(bytes)
+	return gokzg4844.SerializeScalar(r)
+}
+
+func randBlob() kzg4844.Blob {
+	var blob kzg4844.Blob
+	for i := 0; i < len(blob); i += gokzg4844.SerializedScalarSize {
+		fieldElementBytes := randFieldElement()
+		copy(blob[i:i+gokzg4844.SerializedScalarSize], fieldElementBytes[:])
+	}
+	return blob
+}
+
+func makeSignedBlobTx(nonce uint64, sidecar *types.BlobTxSidecar) *types.Transaction {
+	key, _ := crypto.GenerateKey()
+	blobtx := &types.BlobTx{
+		ChainID:    uint256.MustFromBig(params.MainnetChainConfig.ChainID),
+		Nonce:      nonce,
+		GasTipCap:  uint256.NewInt(1),
+		GasFeeCap:  uint256.NewInt(1000),
+		Gas:        21000,
+		BlobFeeCap: uint256.NewInt(1),
+		BlobHashes: sidecar.BlobHashes(),
+		Value:      uint256.NewInt(0),
+		Sidecar:    sidecar,
+	}
+	tx := types.NewTx(blobtx)
+	signed, _ := types.SignTx(tx, types.NewCancunSigner(params.MainnetChainConfig.ChainID), key)
+	return signed
+}
+
+func validBlobSidecar(n int) *types.BlobTxSidecar {
+	blobs := make([]kzg4844.Blob, n)
+	commitments := make([]kzg4844.Commitment, n)
+	proofs := make([]kzg4844.Proof, n)
+	for i := 0; i < n; i++ {
+		blobs[i] = randBlob()
+		c, _ := kzg4844.BlobToCommitment(&blobs[i])
+		commitments[i] = c
+		p, _ := kzg4844.ComputeBlobProof(&blobs[i], c)
+		proofs[i] = p
+	}
+	return types.NewBlobTxSidecar(types.BlobSidecarVersion0, blobs, commitments, proofs)
+}
+
+// TestStartAsyncBlobValidation_InvalidProof verifies that the async blob
+// validation goroutine correctly detects a tampered blob proof.
+func TestStartAsyncBlobValidation_InvalidProof(t *testing.T) {
+	sidecar := validBlobSidecar(1)
+	sidecar.Proofs[0][0] ^= 0xff
+
+	tx := makeSignedBlobTx(0, sidecar)
+	bid := &types.Bid{
+		Txs: types.Transactions{tx},
+	}
+	startAsyncBlobValidation(bid)
+
+	ch, ok := bid.BlobValResults[tx.Hash()]
+	if !ok {
+		t.Fatal("expected BlobValResults to contain the blob tx")
+	}
+	if err := <-ch; err == nil {
+		t.Fatal("expected error for invalid KZG proof")
+	}
+}


### PR DESCRIPTION
### Description

Async blob validation is launched at the beginning of simBid, right before prepareWork. The validation result is consumed lazily in commitTransaction when the first blob tx is encountered.

If a bid contains N transactions and the first blob tx is at position K, the effective parallel window equals the prepareWork setup time plus the execution time of the preceding K-1 non-blob transactions. With a typical simBid duration of ~14ms and KZG proof verification at ~1.8ms per blob, the parallel window is usually sufficient to fully absorb the verification cost — especially since blob transactions are unlikely to appear at the very beginning of a bid.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
