### PR TITLE
workflows: use GITHUB_TOKEN instead of PACKAGE_TOKEN

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -19,6 +19,9 @@ jobs:
           - os: ubuntu-24.04-arm
             platform_pair: linux-arm64
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
     steps:
 
       - name: Checkout
@@ -51,7 +54,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.PACKAGE_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         id: build
@@ -76,6 +79,9 @@ jobs:
           retention-days: 1
   merge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs:
       - build
     steps:
@@ -91,7 +97,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.PACKAGE_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
### Description

workflows: use GITHUB_TOKEN instead of PACKAGE_TOKEN

### Rationale
PACKAGE_TOKEN expired

v1.6.8 with this PR has succeed
https://github.com/bnb-chain/bsc/actions/runs/23184031781

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
