### PR TITLE
core/vm: continue after super-instruction fallback

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -211,6 +211,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		res       []byte // result of the opcode execution function
 		debug     = in.evm.Config.Tracer != nil
 		isEIP4762 = in.evm.chainRules.IsEIP4762
+		fallback  []OpCode
 	)
 	// Don't move this deferred function, it's placed before the OnOpcode-deferred method,
 	// so that it gets executed _after_: the OnOpcode needs the stacks before
@@ -258,7 +259,11 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 
 		// Get the operation from the jump table and validate the stack to ensure there are
 		// enough stack items available to perform the operation.
-		op = contract.GetOp(pc)
+		if len(fallback) > 0 {
+			op = fallback[0]
+		} else {
+			op = contract.GetOp(pc)
+		}
 		operation := jumpTable[op]
 		cost = operation.constantGas // For tracing
 		// Validate stack
@@ -269,9 +274,11 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		}
 		// for tracing: this gas consumption event is emitted below in the debug section.
 		if contract.Gas < cost {
-			if seq, isSuper := DecomposeSuperInstruction(op); isSuper {
-				err = in.tryFallbackForSuperInstruction(&pc, seq, contract, stack, mem, callContext)
-				return nil, err
+			if len(fallback) == 0 {
+				if seq, isSuper := DecomposeSuperInstruction(op); isSuper {
+					fallback = seq
+					continue
+				}
 			}
 			return nil, ErrOutOfGas
 		} else {
@@ -310,9 +317,11 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			if contract.Gas < dynamicCost {
 				contract.Gas += operation.constantGas // restore deducted constant gas first
 				mem.lastGasCost = memLastGasCost
-				if seq, isSuper := DecomposeSuperInstruction(op); isSuper {
-					err = in.tryFallbackForSuperInstruction(&pc, seq, contract, stack, mem, callContext)
-					return nil, err
+				if len(fallback) == 0 {
+					if seq, isSuper := DecomposeSuperInstruction(op); isSuper {
+						fallback = seq
+						continue
+					}
 				}
 				return nil, ErrOutOfGas
 			} else {
@@ -340,6 +349,9 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			break
 		}
 		pc++
+		if len(fallback) > 0 {
+			fallback = fallback[1:]
+		}
 	}
 
 	if err == errStopToken {

--- a/core/vm/interpreter_si.go
+++ b/core/vm/interpreter_si.go
@@ -1,12 +1,6 @@
 package vm
 
-import (
-	"fmt"
-	"strings"
-
-	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/log"
-)
+import "strings"
 
 // superInstructionMap maps super-instruction opcodes to the slice of ordinary opcodes
 // they were fused from.  The mapping comes from the fusion patterns implemented in
@@ -59,60 +53,4 @@ func DecomposeSuperInstruction(op OpCode) ([]OpCode, bool) {
 func DecomposeSuperInstructionByName(name string) ([]OpCode, bool) {
 	op := StringToOp(strings.ToUpper(name))
 	return DecomposeSuperInstruction(op)
-}
-
-func (in *EVMInterpreter) executeSingleOpcode(pc *uint64, op OpCode, contract *Contract, stack *Stack, mem *Memory, callCtx *ScopeContext) error {
-	operation := in.table[op]
-	if operation == nil {
-		return fmt.Errorf("unknown opcode %02x", op)
-	}
-
-	// -------- check static gas --------
-	if contract.Gas < operation.constantGas {
-		return ErrOutOfGas
-	}
-	contract.Gas -= operation.constantGas
-
-	// -------- check dynamic gas  --------
-	var memorySize uint64
-	if operation.memorySize != nil {
-		memSize, overflow := operation.memorySize(stack)
-		if overflow {
-			return ErrGasUintOverflow
-		}
-		if memorySize, overflow = math.SafeMul(toWordSize(memSize), 32); overflow {
-			return ErrGasUintOverflow
-		}
-	}
-
-	if operation.dynamicGas != nil {
-		dyn, err := operation.dynamicGas(in.evm, contract, stack, mem, memorySize)
-		if err != nil {
-			return err
-		}
-		if contract.Gas < dyn {
-			return ErrOutOfGas
-		}
-		contract.Gas -= dyn
-	}
-
-	if memorySize > 0 {
-		mem.Resize(memorySize)
-	}
-
-	// -------- execute --------
-	_, err := operation.execute(pc, in, callCtx)
-	return err
-}
-
-// tryFallbackForSuperInstruction break down superinstruction to normal opcode and execute in sequence, until gas deplete or succeed
-// return nil show successful execution of si or OOG in the middle (and updated pc/gas), shall continue in main loop
-func (in *EVMInterpreter) tryFallbackForSuperInstruction(pc *uint64, seq []OpCode, contract *Contract, stack *Stack, mem *Memory, callCtx *ScopeContext) error {
-	for _, sub := range seq {
-		if err := in.executeSingleOpcode(pc, sub, contract, stack, mem, callCtx); err != nil {
-			log.Debug("[FALLBACK-EXEC]", "op", sub.String(), "err", err, "gasLeft", contract.Gas)
-			return err // OutOfGas or other errors, will let upper level handle
-		}
-	}
-	return nil
 }

--- a/core/vm/interpreter_test.go
+++ b/core/vm/interpreter_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 )
 
 var loopInterruptTests = []string{
@@ -93,4 +94,89 @@ func BenchmarkInterpreter(b *testing.B) {
 	for b.Loop() {
 		gasSStoreEIP3529(evm, contract, stack, mem, 1234)
 	}
+}
+
+func TestSuperInstructionFallbackContinuesExecution(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	evm := NewEVM(BlockContext{BlockNumber: big.NewInt(1), Time: 1, Random: &common.Hash{}}, statedb, params.MergedTestChainConfig, Config{})
+	interpreter := NewEVMInterpreter(evm)
+	interpreter.CopyAndInstallSuperInstruction()
+	interpreter.table[Push1Push1].constantGas = 10_000
+
+	contract := GetContract(common.Address{}, common.Address{}, uint256.NewInt(0), 100, nil)
+	contract.Code = []byte{
+		byte(Push1Push1), 0x01, byte(Nop), 0x02,
+		byte(ADD),
+		byte(PUSH1), 0x00,
+		byte(MSTORE),
+		byte(PUSH1), 0x20,
+		byte(PUSH1), 0x00,
+		byte(RETURN),
+	}
+	contract.SetOptimizedForTest()
+
+	ret, err := interpreter.Run(contract, nil, false)
+	require.NoError(t, err)
+	require.Equal(t, common.LeftPadBytes([]byte{0x03}, 32), ret)
+}
+
+func TestSuperInstructionFallbackContinuesTracing(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	var traced []OpCode
+	evm := NewEVM(BlockContext{BlockNumber: big.NewInt(1), Time: 1, Random: &common.Hash{}}, statedb, params.MergedTestChainConfig, Config{
+		Tracer: &tracing.Hooks{
+			OnOpcode: func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+				traced = append(traced, OpCode(op))
+			},
+		},
+	})
+	interpreter := NewEVMInterpreter(evm)
+	interpreter.CopyAndInstallSuperInstruction()
+	interpreter.table[Push1Push1].constantGas = 10_000
+
+	contract := GetContract(common.Address{}, common.Address{}, uint256.NewInt(0), 100, nil)
+	contract.Code = []byte{byte(Push1Push1), 0x01, byte(Nop), 0x02, byte(STOP)}
+	contract.SetOptimizedForTest()
+
+	_, err := interpreter.Run(contract, nil, false)
+	require.NoError(t, err)
+	require.Equal(t, []OpCode{PUSH1, PUSH1, STOP}, traced)
+}
+
+func TestSuperInstructionFallbackChargesVerkleCodeChunks(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	chainConfig := *params.MergedTestChainConfig
+	chainConfig.PragueTime = nil
+	chainConfig.OsakaTime = nil
+	verkleTime := uint64(0)
+	chainConfig.VerkleTime = &verkleTime
+
+	evm := NewEVM(BlockContext{BlockNumber: big.NewInt(1), Time: 1, Random: &common.Hash{}}, statedb, &chainConfig, Config{})
+	evm.SetTxContext(TxContext{})
+
+	interpreter := NewEVMInterpreter(evm)
+	interpreter.CopyAndInstallSuperInstruction()
+	interpreter.table[Push2Jump].constantGas = 10_000
+
+	code := make([]byte, 33)
+	code[0] = byte(JUMPDEST)
+	code[1] = byte(PUSH1)
+	code[2] = 0x1b
+	code[3] = byte(JUMP)
+	code[4] = byte(JUMPDEST)
+	code[5] = byte(STOP)
+	code[27] = byte(JUMPDEST)
+	code[28] = byte(Push2Jump)
+	code[29] = 0x00
+	code[30] = 0x04
+	code[31] = byte(Nop)
+	code[32] = byte(STOP)
+
+	contract := GetContract(common.Address{}, common.Address{}, uint256.NewInt(0), 5_000, nil)
+	contract.Code = code
+	contract.SetOptimizedForTest()
+
+	_, err := interpreter.Run(contract, nil, false)
+	require.NoError(t, err)
+	require.Len(t, evm.TxContext.AccessEvents.Keys(), 2)
 }


### PR DESCRIPTION
## Summary
  - Keep super-instruction fallback inside the main interpreter loop instead of executing decomposed opcodes through a side helper.
  - Preserve normal per-opcode behavior during fallback, including tracing and EIP-4762 code-chunk charging.
  - Add regression coverage for fallback execution, opcode tracing, and Verkle code-chunk accounting.

  ## Motivation
  When a fused opcode falls back to its raw opcode sequence, the interpreter should continue execution exactly as if the unfused opcodes had been stepped normally.

  The previous fallback path executed decomposed opcodes outside the main loop. That made control flow continue, but it bypassed main-loop behavior that is consensus- and tooling-relevant:
  - `OnOpcode` tracing for fallback-executed opcodes
  - EIP-4762 code-chunk charging/access-event updates on each stepped opcode

  This change routes fallback through the existing interpreter loop so raw opcodes inherit the same gas, tracing, and PC progression semantics as normal execution.

  ## Implementation
  - Add a `fallback []OpCode` queue in the interpreter loop.
  - When a fused opcode cannot pay its fused gas cost, decompose it and continue the loop in fallback mode.
  - Step decomposed opcodes through the normal opcode path, then drain the fallback queue as each opcode completes.
  - Remove the old helper that executed fallback opcodes out-of-band.