### PR TITLE
cmd/utils: disabled transaction unindexing for archive node by default

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2212,9 +2212,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 
 	if ctx.String(GCModeFlag.Name) == "archive" {
-		if cfg.TransactionHistory != 0 {
+		if cfg.TransactionHistory == ethconfig.Defaults.TransactionHistory {
 			cfg.TransactionHistory = 0
-			log.Warn("Disabled transaction unindexing for archive node")
 		}
 	}
 	if ctx.IsSet(LogHistoryFlag.Name) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2214,6 +2214,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.String(GCModeFlag.Name) == "archive" {
 		if cfg.TransactionHistory == ethconfig.Defaults.TransactionHistory {
 			cfg.TransactionHistory = 0
+			log.Warn("Disabled transaction unindexing for archive node")
 		}
 	}
 	if ctx.IsSet(LogHistoryFlag.Name) {

--- a/interfaces.go
+++ b/interfaces.go
@@ -148,10 +148,7 @@ func (prog SyncProgress) Done() bool {
 	if prog.CurrentBlock < prog.HighestBlock {
 		return false
 	}
-	// Transaction indexing is a background process that may take a long time
-	// (e.g. archive nodes indexing the entire chain from a snapshot) and should
-	// not block the sync status. Its progress is still reported in the response.
-	return prog.StateIndexRemaining == 0
+	return prog.TxIndexRemainingBlocks == 0 && prog.StateIndexRemaining == 0
 }
 
 // ChainSyncReader wraps access to the node's current sync status. If there's no

--- a/interfaces.go
+++ b/interfaces.go
@@ -148,7 +148,10 @@ func (prog SyncProgress) Done() bool {
 	if prog.CurrentBlock < prog.HighestBlock {
 		return false
 	}
-	return prog.TxIndexRemainingBlocks == 0 && prog.StateIndexRemaining == 0
+	// Transaction indexing is a background process that may take a long time
+	// (e.g. archive nodes indexing the entire chain from a snapshot) and should
+	// not block the sync status. Its progress is still reported in the response.
+	return prog.StateIndexRemaining == 0
 }
 
 // ChainSyncReader wraps access to the node's current sync status. If there's no


### PR DESCRIPTION
### Description

Exclude background transaction indexing from the `SyncProgress.Done()` check so that `eth.syncing` returns `false` once block sync and state indexing are complete, without waiting for the full transaction index to be built.


### Rationale

When running a node with `--gcmode=archive`, the flag handler forces `TransactionHistory=0` (index entire chain). For a node bootstrapped from a snapshot (e.g. at block ~88M on BSC), the tx indexer must index ~86 million historical blocks — a process that can take days or weeks.

During this time, `SyncProgress.Done()` returns `false` because it requires `TxIndexRemainingBlocks == 0`, so `eth.syncing` never returns `false` even though block sync completed long ago and the node can fully serve current data.

Transaction indexing is a background maintenance task, not part of the initial chain sync. State indexing (`StateIndexRemaining`) is kept in the check because it is bounded by `--history.state` and finishes in reasonable time.

**Note**: upstream `go-ethereum` [PR #32103](https://github.com/ethereum/go-ethereum/pull/32103) attempted to fix this by removing the archive mode `TransactionHistory` override in `flags.go`, but was rejected because transaction unindexing is very slow and causes significant I/O load. This fix takes a different approach by only changing the sync completion criteria.


### Example

Before (archive node started from snapshot, block sync done):
```
> eth.syncing
{
  currentBlock: 88673649,
  highestBlock: 88634931,
  stateIndexRemaining: 0,
  txIndexFinishedBlocks: 2541198,
  txIndexRemainingBlocks: 86132452,
  ...
}
```
After:
```
> eth.syncing
false
```

### Changes


Notable changes:
* Remove `TxIndexRemainingBlocks == 0` from `SyncProgress.Done()` in `interfaces.go`
* `StateIndexRemaining == 0` check is preserved — state indexing is bounded and completes in reasonable time
* `txIndexFinishedBlocks` and `txIndexRemainingBlocks` fields are still included in the `eth_syncing` response for monitoring
* Internal tx lookup readiness (`BlockChain.TxIndexDone()`) uses a separate `TxIndexProgress.Done()` method and is unaffected

### Flow
```
eth.syncing (RPC call)
  → EthereumAPI.Syncing()                          [internal/ethapi/api.go]
    → api.b.SyncProgress()                          [eth/api_backend.go]
      → Downloader.Progress()                        (block sync: CurrentBlock, HighestBlock)
      → BlockChain.TxIndexProgress()                 (tx index: Indexed, Remaining)
      → BlockChain.StateIndexProgress()              (state index: Remaining)
    → progress.Done()                                [interfaces.go]  ← THE FIX
      ✓ CurrentBlock >= HighestBlock                 (block sync complete?)
      ✓ StateIndexRemaining == 0                     (state index complete?)
      ✗ TxIndexRemainingBlocks == 0                  (REMOVED — no longer blocks)
    → if Done(): return false                        (not syncing)
    → else: return { currentBlock, ..., txIndexRemainingBlocks, ... }
```

### Flow with step
1. **Line 158**: `api.b.SyncProgress(ctx)` fetches the progress (which merges block sync + tx index + state index data)
2. **Line 161**: `progress.Done()` -- this calls our changed method in interfaces.go
3. **Line 162**: If `Done()` returns true --> returns false (meaning "not syncing")
4. **Lines 165-184**: If `Done()` returns false --> returns the full progress map (the object the issue reporter sees with all those fields like `txIndexRemainingBlocks: 86132452`)

-> this is use config in #3621
```
currentBlock: 88673649
highestBlock: 88634931
stateIndexRemaining: 0
txIndexRemainingBlocks: 86132452
```

Fixes #3621
