### PR TITLE
eth: tune timing parameters and broadcast queue for 450ms block

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -34,10 +34,10 @@ import (
 
 const (
 	lightTimeout        = time.Millisecond       // Time allowance before an announced header is explicitly requested
-	arriveTimeout       = 500 * time.Millisecond // Time allowance before an announced block/transaction is explicitly requested
-	gatherSlack         = 100 * time.Millisecond // Interval used to collate almost-expired announces with fetches
+	arriveTimeout       = 200 * time.Millisecond // Time allowance before an announced block/transaction is explicitly requested
+	gatherSlack         = 50 * time.Millisecond  // Interval used to collate almost-expired announces with fetches
 	fetchTimeout        = 5 * time.Second        // Maximum allotted time to return an explicitly requested block/transaction
-	reQueueBlockTimeout = 500 * time.Millisecond // Time allowance before blocks are requeued for import
+	reQueueBlockTimeout = 200 * time.Millisecond // Time allowance before blocks are requeued for import
 
 )
 

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -64,11 +64,11 @@ const (
 
 	// txArriveTimeout is the time allowance before an announced transaction is
 	// explicitly requested.
-	txArriveTimeout = 500 * time.Millisecond
+	txArriveTimeout = 200 * time.Millisecond
 
 	// txGatherSlack is the interval used to collate almost-expired announces
 	// with network fetches.
-	txGatherSlack = 100 * time.Millisecond
+	txGatherSlack = 50 * time.Millisecond
 
 	// addTxsBatchSize it the max number of transactions to add in a single batch from a peer.
 	addTxsBatchSize = 128

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -51,14 +51,13 @@ const (
 	maxQueuedTxAnns = 4096
 
 	// maxQueuedBlocks is the maximum number of block propagations to queue up before
-	// dropping broadcasts. There's not much point in queueing stale blocks, so a few
-	// that might cover uncles should be enough.
-	maxQueuedBlocks = 4
+	// dropping broadcasts. With 450ms block interval, a 1.5s slow block can cause 3-4
+	// blocks to queue up, so we need a larger buffer to avoid dropping broadcasts.
+	maxQueuedBlocks = 16
 
 	// maxQueuedBlockAnns is the maximum number of block announcements to queue up before
-	// dropping broadcasts. Similarly to block propagations, there's no point to queue
-	// above some healthy uncle limit, so use that.
-	maxQueuedBlockAnns = 4
+	// dropping broadcasts. Increased to match maxQueuedBlocks for 450ms block interval.
+	maxQueuedBlockAnns = 16
 )
 
 // Peer is a collection of relevant information we have about a `eth` peer.


### PR DESCRIPTION
### Description

eth: tune timing parameters and broadcast queue for 450ms block

### Rationale

- Reduce block/tx fetcher arrive timeouts from 500ms to 200ms and gather slack from 100ms to 50ms, so the effective fetch trigger (150ms) stays well within the 450ms block interval. The previous 400ms trigger could
cause announce-path blocks to arrive after the next block was already due, leading to cascading propagation delays.                                                                                         
- Increase per-peer block broadcast queue from 4 to 16 to absorb bursts when occasional slow blocks (e.g. 1.5s execution) temporarily stall  consumption, preventing dropped block broadcasts that force slower recovery via announce+fetch or sync. 

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
