### PR TITLE
miner: use worker pool for async blob validation

### DIFF
--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -762,8 +762,6 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 		}
 	}(startTS)
 
-	// Start async blob validation so it runs in parallel with prepareWork and
-	// other setup below.
 	startAsyncBlobValidation(bidRuntime.bid)
 
 	// prepareWork will configure header with a suitable time according to consensus

--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+const maxBlobValConcurrency = 3
+
 // MevRunning return true if mev is running.
 func (miner *Miner) MevRunning() bool {
 	return miner.bidSimulator.isRunning() && miner.bidSimulator.receivingBid()
@@ -81,11 +83,18 @@ func (miner *Miner) SendBid(ctx context.Context, bidArgs *types.BidArgs) (common
 	return bid.Hash(), nil
 }
 
-// startAsyncBlobValidation launches one goroutine per blob transaction to
-// validate it in the background (field checks + KZG proof verification).
+// startAsyncBlobValidation uses a fixed-size worker pool to validate blob
+// transactions in the background (field checks + KZG proof verification).
 // Results are stored per-tx in bid.BlobValResults keyed by tx hash.
 func startAsyncBlobValidation(bid *types.Bid) {
+	type blobJob struct {
+		tx *types.Transaction
+		ch chan error
+	}
+
 	bid.BlobValResults = make(map[common.Hash]chan error)
+	jobs := make([]blobJob, 0, maxBlobValConcurrency)
+
 	for _, tx := range bid.Txs {
 		if tx.Type() == types.BlobTxType {
 			if _, dup := bid.BlobValResults[tx.Hash()]; dup {
@@ -93,10 +102,26 @@ func startAsyncBlobValidation(bid *types.Bid) {
 			}
 			ch := make(chan error, 1)
 			bid.BlobValResults[tx.Hash()] = ch
-			go func() {
-				ch <- txpool.ValidateBlobTx(tx, nil, nil)
-			}()
+			jobs = append(jobs, blobJob{tx: tx, ch: ch})
 		}
+	}
+
+	jobCh := make(chan blobJob, len(jobs))
+	for _, j := range jobs {
+		jobCh <- j
+	}
+	close(jobCh)
+
+	workers := len(jobs)
+	if workers > maxBlobValConcurrency {
+		workers = maxBlobValConcurrency
+	}
+	for i := 0; i < workers; i++ {
+		go func() {
+			for j := range jobCh {
+				j.ch <- txpool.ValidateBlobTx(j.tx, nil, nil)
+			}
+		}()
 	}
 }
 

--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -13,7 +13,10 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-const maxBlobValConcurrency = 3
+const (
+	maxBlobValConcurrency = 3
+	maxBlobTxPerBlock     = 6
+)
 
 // MevRunning return true if mev is running.
 func (miner *Miner) MevRunning() bool {
@@ -93,7 +96,7 @@ func startAsyncBlobValidation(bid *types.Bid) {
 	}
 
 	bid.BlobValResults = make(map[common.Hash]chan error)
-	jobs := make([]blobJob, 0, maxBlobValConcurrency)
+	jobs := make([]blobJob, 0, maxBlobTxPerBlock)
 
 	for _, tx := range bid.Txs {
 		if tx.Type() == types.BlobTxType {
@@ -103,6 +106,9 @@ func startAsyncBlobValidation(bid *types.Bid) {
 			ch := make(chan error, 1)
 			bid.BlobValResults[tx.Hash()] = ch
 			jobs = append(jobs, blobJob{tx: tx, ch: ch})
+			if len(jobs) >= maxBlobTxPerBlock {
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description

use worker pool to limit the cpu resource for  async blob validation

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
