### PR TITLE
core/rawdb: increase SlowFreezerBatchLimit from 100 to 200

### DIFF
--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -40,9 +40,9 @@ const (
 	// storage.
 	freezerRecheckInterval = time.Minute
 
-	// TODO(galaio): For BSC, the 0.75 interval and freezing of 30,000 blocks will seriously affect performance.
-	// It is temporarily adjusted to 100, and improves the freezing performance later.
-	SlowFreezerBatchLimit = 100
+	// For BSC, freezing 30,000 blocks at once will seriously affect performance near the chain head.
+	// Set to 200 to keep up with 450ms block interval (~133 blocks/min) while limiting I/O impact.
+	SlowFreezerBatchLimit = 200
 	SlowdownFreezeWindow  = 24 * time.Hour
 )
 


### PR DESCRIPTION
### Description

With 450ms block interval, the chain produces ~133 blocks/min, but the freezer only processes 100 blocks/min at the old limit, causing old blocks to accumulate in LevelDB indefinitely. Bump to 200 to keep up with chain growth.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
