### PR TITLE
eth/ethconfig: set default value to 576000 for history.logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ Download latest chaindata snapshot from [here](https://github.com/bnb-chain/bsc-
 #### 4. Start a full node
 ```shell
 ## It will run with Path-Base Storage Scheme by default and enable inline state prune, keeping the latest 600000 blocks' history state.
-./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --history.transactions 0 --history.logs 576000
+./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --history.transactions 0
 
 ## It is recommend to run fullnode with `--tries-verify-mode none` if you want high performance and care little about state consistency.
-./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --history.transactions 0 --history.logs 576000 --tries-verify-mode none
+./geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --history.transactions 0 --tries-verify-mode none
 ```
 
 #### 5. Monitor node status

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -58,6 +58,7 @@ var Defaults = Config{
 	NetworkId:              0, // enable auto configuration of networkID == chainID
 	TxLookupLimit:          2350000,
 	TransactionHistory:     2350000,
+	LogHistory:             576000,
 	BlockHistory:           0,
 	StateHistory:           params.FullImmutabilityThreshold,
 	DatabaseCache:          512,


### PR DESCRIPTION
### Description

eth/ethconfig: set default value to 576000 for history.logs

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
