### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2849,11 +2849,11 @@ func (bc *BlockChain) insertSideChain(block *types.Block, it *insertIterator, ma
 		blocks []*types.Block
 		memory uint64
 	)
-	for i := len(hashes) - 1; i >= 0; i-- {
+	for i, v := range slices.Backward(hashes) {
 		// Append the next block to our batch
-		block := bc.GetBlock(hashes[i], numbers[i])
+		block := bc.GetBlock(v, numbers[i])
 		if block == nil {
-			log.Crit("Importing heavy sidechain block is nil", "hash", hashes[i], "number", numbers[i])
+			log.Crit("Importing heavy sidechain block is nil", "hash", v, "number", numbers[i])
 		}
 		blocks = append(blocks, block)
 		memory += block.Size()
@@ -2914,7 +2914,7 @@ func (bc *BlockChain) recoverAncestors(block *types.Block, makeWitness bool) (co
 		return common.Hash{}, errors.New("missing parent")
 	}
 	// Import all the pruned blocks to make the state available
-	for i := len(hashes) - 1; i >= 0; i-- {
+	for i, v := range slices.Backward(hashes) {
 		// If the chain is terminating, stop processing blocks
 		if bc.insertStopped() {
 			log.Debug("Abort during blocks processing")
@@ -2924,7 +2924,7 @@ func (bc *BlockChain) recoverAncestors(block *types.Block, makeWitness bool) (co
 		if i == 0 {
 			b = block
 		} else {
-			b = bc.GetBlock(hashes[i], numbers[i])
+			b = bc.GetBlock(v, numbers[i])
 		}
 		if _, _, err := bc.insertChain(types.Blocks{b}, false, makeWitness && i == 0); err != nil {
 			return b.ParentHash(), err
@@ -3057,8 +3057,8 @@ func (bc *BlockChain) reorg(oldHead *types.Header, newHead *types.Header) error 
 	//
 	// TODO(karalabe): This should be nuked out, no idea how, deprecate some APIs?
 	{
-		for i := len(oldChain) - 1; i >= 0; i-- {
-			block := bc.GetBlock(oldChain[i].Hash(), oldChain[i].Number.Uint64())
+		for _, v := range slices.Backward(oldChain) {
+			block := bc.GetBlock(v.Hash(), v.Number.Uint64())
 			if block == nil {
 				return errInvalidOldChain // Corrupt database, mostly here to avoid weird panics
 			}

--- a/core/rawdb/accessors_history.go
+++ b/core/rawdb/accessors_history.go
@@ -19,6 +19,7 @@ package rawdb
 import (
 	"bytes"
 	"errors"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -215,9 +216,9 @@ func DeleteTrienodeHistoryIndexBlock(db ethdb.KeyValueWriter, addressHash common
 // increaseKey increase the input key by one bit. Return nil if the entire
 // addition operation overflows.
 func increaseKey(key []byte) []byte {
-	for i := len(key) - 1; i >= 0; i-- {
-		key[i]++
-		if key[i] != 0x0 {
+	for _, v := range slices.Backward(key) {
+		v++
+		if v != 0x0 {
 			return key
 		}
 	}

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -17,6 +17,8 @@
 package rawdb
 
 import (
+	"slices"
+
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 
@@ -189,10 +191,10 @@ func (t *table) Compact(start []byte, limit []byte) error {
 	// as the limit
 	if limit == nil {
 		limit = []byte(t.prefix)
-		for i := len(limit) - 1; i >= 0; i-- {
+		for i, v := range slices.Backward(limit) {
 			// Bump the current character, stopping if it doesn't overflow
-			limit[i]++
-			if limit[i] > 0 {
+			v++
+			if v > 0 {
 				break
 			}
 			// Character overflown, proceed to the next or nil if the last

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/VictoriaMetrics/fastcache"
@@ -709,9 +710,9 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 // increaseKey increase the input key by one bit. Return nil if the entire
 // addition operation overflows.
 func increaseKey(key []byte) []byte {
-	for i := len(key) - 1; i >= 0; i-- {
-		key[i]++
-		if key[i] != 0x0 {
+	for _, v := range slices.Backward(key) {
+		v++
+		if v != 0x0 {
 			return key
 		}
 	}

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -19,6 +19,7 @@ package snapshot
 import (
 	"fmt"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -855,9 +856,9 @@ func testGenerateWithIncompleteStorage(t *testing.T, scheme string) {
 }
 
 func incKey(key []byte) []byte {
-	for i := len(key) - 1; i >= 0; i-- {
-		key[i]++
-		if key[i] != 0x0 {
+	for _, v := range slices.Backward(key) {
+		v++
+		if v != 0x0 {
 			break
 		}
 	}
@@ -865,9 +866,9 @@ func incKey(key []byte) []byte {
 }
 
 func decKey(key []byte) []byte {
-	for i := len(key) - 1; i >= 0; i-- {
-		key[i]--
-		if key[i] != 0xff {
+	for _, v := range slices.Backward(key) {
+		v--
+		if v != 0xff {
 			break
 		}
 	}


### PR DESCRIPTION
### Description

There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899


### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
