### PR TITLE
core: use now for DA check instead of chasingHead.time

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -62,9 +62,6 @@ type ChainHeaderReader interface {
 
 	// GetVerifiedBlockByHash retrieves the highest verified block.
 	GetVerifiedBlockByHash(hash common.Hash) *types.Header
-
-	// ChasingHead return the best chain head of peers.
-	ChasingHead() *types.Header
 }
 
 type VotePool interface {

--- a/consensus/parlia/finality_test.go
+++ b/consensus/parlia/finality_test.go
@@ -73,10 +73,6 @@ func (c *finalizedHeaderChain) GetVerifiedBlockByHash(hash common.Hash) *types.H
 	return c.byHash[hash]
 }
 
-func (c *finalizedHeaderChain) ChasingHead() *types.Header {
-	return c.current
-}
-
 type fixedVotePool struct {
 	n int
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -386,7 +386,6 @@ type BlockChain struct {
 	currentSnapBlock      atomic.Pointer[types.Header] // Current head of snap-sync
 	currentFinalBlock     atomic.Pointer[types.Header] // Latest (consensus) finalized block
 	highestNotifiedFinal  atomic.Pointer[types.Header] // Highest finalized block that has been notified (for deduplication)
-	chasingHead           atomic.Pointer[types.Header]
 	historyPrunePoint     atomic.Pointer[history.PrunePoint]
 
 	bodyCache       *lru.Cache[common.Hash, *types.Body]
@@ -521,7 +520,6 @@ func NewBlockChain(db ethdb.Database, genesis *Genesis, engine consensus.Engine,
 	bc.highestVerifiedBlock.Store(nil)
 	bc.currentBlock.Store(nil)
 	bc.currentSnapBlock.Store(nil)
-	bc.chasingHead.Store(nil)
 
 	// Update chain info data metrics
 	chainInfoGauge.Update(metrics.GaugeInfoValue{"chain_id": bc.chainConfig.ChainID.String()})
@@ -1392,20 +1390,6 @@ func (bc *BlockChain) SnapSyncCommitHead(hash common.Hash) error {
 	}
 	log.Info("Committed new head block", "number", block.Number(), "hash", hash)
 	return nil
-}
-
-// UpdateChasingHead update remote best chain head, used by DA check now.
-func (bc *BlockChain) UpdateChasingHead(head *types.Header) {
-	if head.Time > uint64(time.Now().Unix()) {
-		log.Warn("Ignoring future chasing head", "number", head.Number, "time", head.Time)
-		return
-	}
-	bc.chasingHead.Store(types.CopyHeader(head))
-}
-
-// ChasingHead return the best chain head of peers.
-func (bc *BlockChain) ChasingHead() *types.Header {
-	return bc.chasingHead.Load()
 }
 
 // Reset purges the entire blockchain, restoring it to its genesis state.

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -796,7 +796,3 @@ func (cm *chainMaker) GetHighestVerifiedHeader() *types.Header {
 func (cm *chainMaker) GetVerifiedBlockByHash(hash common.Hash) *types.Header {
 	return cm.GetHeaderByHash(hash)
 }
-
-func (cm *chainMaker) ChasingHead() *types.Header {
-	panic("not supported")
-}

--- a/core/data_availability.go
+++ b/core/data_availability.go
@@ -66,18 +66,8 @@ func IsDataAvailable(chain consensus.ChainHeaderReader, block *types.Block) (err
 		return nil
 	}
 
-	// Only trusted heads may decide whether recent blob data can be discarded.
-	// ChasingHead is populated from remote peer sync state, so future values must
-	// never be allowed to suppress DA checks.
-	highest := chain.ChasingHead()
-	current := chain.CurrentHeader()
 	now := uint64(time.Now().Unix())
-	if highest == nil || highest.Number == nil || highest.Time > now {
-		highest = current
-	} else if current != nil && current.Number != nil && highest.Number.Cmp(current.Number) < 0 {
-		highest = current
-	}
-	if block.Time()+params.MinTimeDurationForBlobRequests < highest.Time {
+	if block.Time()+params.MinTimeDurationForBlobRequests < now {
 		// if we needn't check DA of this block, just clean it
 		block.CleanSidecars()
 		return nil

--- a/core/data_availability_test.go
+++ b/core/data_availability_test.go
@@ -24,16 +24,16 @@ var (
 
 func TestIsDataAvailable(t *testing.T) {
 	hr := NewMockDAHeaderReader(params.ParliaTestChainConfig)
+	now := uint64(time.Now().Unix())
 	tests := []struct {
-		block             *types.Block
-		chasingHeadNumber uint64
-		chasingHeadTime   uint64
-		withSidecar       bool
-		err               bool
+		block       *types.Block
+		withSidecar bool
+		err         bool
 	}{
 		{
 			block: types.NewBlockWithHeader(&types.Header{
 				Number: big.NewInt(1),
+				Time:   now,
 			}).WithBody(types.Body{Transactions: types.Transactions{
 				createMockDATx(hr.Config(), nil),
 				createMockDATx(hr.Config(), &types.BlobTxSidecar{
@@ -42,26 +42,24 @@ func TestIsDataAvailable(t *testing.T) {
 					Proofs:      []kzg4844.Proof{emptyBlobProof},
 				}),
 			}}),
-			chasingHeadNumber: 1,
-			chasingHeadTime:   params.MinTimeDurationForBlobRequests - 1,
-			withSidecar:       true,
-			err:               false,
+			withSidecar: true,
+			err:         false,
 		},
 		{
 			block: types.NewBlockWithHeader(&types.Header{
 				Number: big.NewInt(1),
+				Time:   now,
 			}).WithBody(types.Body{Transactions: types.Transactions{
 				createMockDATx(hr.Config(), nil),
 				createMockDATx(hr.Config(), nil),
 			}}),
-			chasingHeadNumber: 1,
-			chasingHeadTime:   params.MinTimeDurationForBlobRequests - 1,
-			withSidecar:       true,
-			err:               false,
+			withSidecar: true,
+			err:         false,
 		},
 		{
 			block: types.NewBlockWithHeader(&types.Header{
 				Number: big.NewInt(1),
+				Time:   now,
 			}).WithBody(types.Body{Transactions: types.Transactions{
 				createMockDATx(hr.Config(), nil),
 				createMockDATx(hr.Config(), &types.BlobTxSidecar{
@@ -70,14 +68,13 @@ func TestIsDataAvailable(t *testing.T) {
 					Proofs:      []kzg4844.Proof{emptyBlobProof},
 				}),
 			}}),
-			chasingHeadNumber: 1,
-			chasingHeadTime:   params.MinTimeDurationForBlobRequests - 1,
-			withSidecar:       false,
-			err:               true,
+			withSidecar: false,
+			err:         true,
 		},
 		{
 			block: types.NewBlockWithHeader(&types.Header{
 				Number: big.NewInt(1),
+				Time:   now,
 			}).WithBody(types.Body{Transactions: types.Transactions{
 				createMockDATx(hr.Config(), nil),
 				createMockDATx(hr.Config(), &types.BlobTxSidecar{
@@ -91,15 +88,13 @@ func TestIsDataAvailable(t *testing.T) {
 					Proofs:      []kzg4844.Proof{emptyBlobProof, emptyBlobProof},
 				}),
 			}}),
-			chasingHeadNumber: 1,
-			chasingHeadTime:   params.MinTimeDurationForBlobRequests - 1,
-			withSidecar:       true,
-			err:               false,
+			withSidecar: true,
+			err:         false,
 		},
-
 		{
 			block: types.NewBlockWithHeader(&types.Header{
 				Number: big.NewInt(1),
+				Time:   now,
 			}).WithBody(types.Body{Transactions: types.Transactions{
 				createMockDATx(hr.Config(), nil),
 				createMockDATx(hr.Config(), &types.BlobTxSidecar{
@@ -113,14 +108,14 @@ func TestIsDataAvailable(t *testing.T) {
 					Proofs:      []kzg4844.Proof{emptyBlobProof, emptyBlobProof, emptyBlobProof, emptyBlobProof},
 				}),
 			}}),
-			chasingHeadNumber: params.MinBlocksForBlobRequests + 1,
-			chasingHeadTime:   params.MinTimeDurationForBlobRequests,
-			withSidecar:       true,
-			err:               true,
+			withSidecar: true,
+			err:         true,
 		},
+		// Old block outside the retention window: DA check is skipped, sidecars cleaned, no error.
 		{
 			block: types.NewBlockWithHeader(&types.Header{
 				Number: big.NewInt(1),
+				Time:   0,
 			}).WithBody(types.Body{Transactions: types.Transactions{
 				createMockDATx(hr.Config(), nil),
 				createMockDATx(hr.Config(), &types.BlobTxSidecar{
@@ -129,10 +124,8 @@ func TestIsDataAvailable(t *testing.T) {
 					Proofs:      []kzg4844.Proof{emptyBlobProof},
 				}),
 			}}),
-			chasingHeadNumber: params.MinBlocksForBlobRequests + 1,
-			chasingHeadTime:   params.MinTimeDurationForBlobRequests + 1,
-			withSidecar:       false,
-			err:               false,
+			withSidecar: false,
+			err:         false,
 		},
 	}
 
@@ -140,7 +133,6 @@ func TestIsDataAvailable(t *testing.T) {
 		if item.withSidecar {
 			item.block = item.block.WithSidecars(collectBlobsFromTxs(item.block.Header(), item.block.Transactions()))
 		}
-		hr.setChasingHead(item.chasingHeadNumber, item.chasingHeadTime)
 		err := IsDataAvailable(hr, item.block)
 		if item.err {
 			require.Error(t, err, i)
@@ -151,43 +143,45 @@ func TestIsDataAvailable(t *testing.T) {
 	}
 }
 
-func TestIsDataAvailableRejectsFutureChasingHead(t *testing.T) {
-	blockTime := uint64(time.Now().Unix())
-	cfg := params.ParliaTestChainConfig
+// TestIsDataAvailableSkipsOldBlocks verifies that the time-based retention window
+// is enforced using wall-clock time: old blocks bypass DA and get sidecars cleaned,
+// while recent blocks are always fully validated.
+func TestIsDataAvailableSkipsOldBlocks(t *testing.T) {
+	hr := NewMockDAHeaderReader(params.ParliaTestChainConfig)
 
-	badBlob := emptyBlob
-	badBlob[0] = 0x01
-	badSidecar := &types.BlobTxSidecar{
-		Blobs:       []kzg4844.Blob{badBlob},
-		Commitments: []kzg4844.Commitment{emptyBlobCommit},
-		Proofs:      []kzg4844.Proof{emptyBlobProof},
-	}
-	makeBlock := func() *types.Block {
-		block := types.NewBlockWithHeader(&types.Header{
-			Number: big.NewInt(1),
-			Time:   blockTime,
-		}).WithBody(types.Body{Transactions: types.Transactions{
-			createMockDATx(cfg, badSidecar),
-		}})
-		return block.WithSidecars(collectBlobsFromTxs(block.Header(), block.Transactions()))
-	}
+	// A block outside the retention window must have sidecars cleaned without error.
+	oldBlock := types.NewBlockWithHeader(&types.Header{
+		Number: big.NewInt(1),
+		Time:   0, // far outside MinTimeDurationForBlobRequests window
+	}).WithBody(types.Body{Transactions: types.Transactions{
+		createMockDATx(hr.Config(), &types.BlobTxSidecar{
+			Blobs:       []kzg4844.Blob{emptyBlob},
+			Commitments: []kzg4844.Commitment{emptyBlobCommit},
+			Proofs:      []kzg4844.Proof{emptyBlobProof},
+		}),
+	}})
+	oldBlock = oldBlock.WithSidecars(collectBlobsFromTxs(oldBlock.Header(), oldBlock.Transactions()))
+	require.NotEmpty(t, oldBlock.Sidecars())
+	require.NoError(t, IsDataAvailable(hr, oldBlock))
+	require.Empty(t, oldBlock.Sidecars(), "sidecars must be cleaned for blocks outside the retention window")
 
-	block := makeBlock()
-	reader := &mockSplitDAHeaderReader{
-		config:      cfg,
-		currentNum:  1,
-		currentTime: blockTime,
-		chasingNum:  100000,
-		chasingTime: blockTime + 30*86400,
-	}
-
-	err := IsDataAvailable(reader, block)
-	require.Error(t, err)
-	require.NotEmpty(t, block.Sidecars())
+	// A recent block with an invalid sidecar must not be silently skipped.
+	recentBlock := types.NewBlockWithHeader(&types.Header{
+		Number: big.NewInt(1),
+		Time:   uint64(time.Now().Unix()),
+	}).WithBody(types.Body{Transactions: types.Transactions{
+		createMockDATx(hr.Config(), &types.BlobTxSidecar{
+			Blobs:       []kzg4844.Blob{emptyBlob, emptyBlob, emptyBlob},
+			Commitments: []kzg4844.Commitment{emptyBlobCommit, emptyBlobCommit, emptyBlobCommit},
+			Proofs:      []kzg4844.Proof{emptyBlobProof}, // mismatched proof count
+		}),
+	}})
+	require.Error(t, IsDataAvailable(hr, recentBlock), "recent blocks with invalid sidecars must fail DA check")
 }
 
 func TestCheckDataAvailableInBatch(t *testing.T) {
 	hr := NewMockDAHeaderReader(params.ParliaTestChainConfig)
+	now := uint64(time.Now().Unix())
 	tests := []struct {
 		chain types.Blocks
 		err   bool
@@ -197,6 +191,7 @@ func TestCheckDataAvailableInBatch(t *testing.T) {
 			chain: types.Blocks{
 				types.NewBlockWithHeader(&types.Header{
 					Number: big.NewInt(1),
+					Time:   now,
 				}).WithBody(types.Body{Transactions: types.Transactions{
 					createMockDATx(hr.Config(), nil),
 					createMockDATx(hr.Config(), &types.BlobTxSidecar{
@@ -212,6 +207,7 @@ func TestCheckDataAvailableInBatch(t *testing.T) {
 				}}),
 				types.NewBlockWithHeader(&types.Header{
 					Number: big.NewInt(2),
+					Time:   now,
 				}).WithBody(types.Body{Transactions: types.Transactions{
 					createMockDATx(hr.Config(), &types.BlobTxSidecar{
 						Blobs:       []kzg4844.Blob{emptyBlob, emptyBlob},
@@ -226,6 +222,7 @@ func TestCheckDataAvailableInBatch(t *testing.T) {
 			chain: types.Blocks{
 				types.NewBlockWithHeader(&types.Header{
 					Number: big.NewInt(1),
+					Time:   now,
 				}).WithBody(types.Body{Transactions: types.Transactions{
 					createMockDATx(hr.Config(), &types.BlobTxSidecar{
 						Blobs:       []kzg4844.Blob{emptyBlob},
@@ -235,6 +232,7 @@ func TestCheckDataAvailableInBatch(t *testing.T) {
 				}}),
 				types.NewBlockWithHeader(&types.Header{
 					Number: big.NewInt(2),
+					Time:   now,
 				}).WithBody(types.Body{Transactions: types.Transactions{
 					createMockDATx(hr.Config(), &types.BlobTxSidecar{
 						Blobs:       []kzg4844.Blob{emptyBlob, emptyBlob, emptyBlob},
@@ -244,6 +242,7 @@ func TestCheckDataAvailableInBatch(t *testing.T) {
 				}}),
 				types.NewBlockWithHeader(&types.Header{
 					Number: big.NewInt(3),
+					Time:   now,
 				}).WithBody(types.Body{Transactions: types.Transactions{
 					createMockDATx(hr.Config(), &types.BlobTxSidecar{
 						Blobs:       []kzg4844.Blob{emptyBlob},
@@ -259,6 +258,7 @@ func TestCheckDataAvailableInBatch(t *testing.T) {
 			chain: types.Blocks{
 				types.NewBlockWithHeader(&types.Header{
 					Number: big.NewInt(1),
+					Time:   now,
 				}).WithBody(types.Body{Transactions: types.Transactions{
 					createMockDATx(hr.Config(), nil),
 					createMockDATx(hr.Config(), &types.BlobTxSidecar{
@@ -297,6 +297,7 @@ func BenchmarkEmptySidecarDAChecking(b *testing.B) {
 	hr := NewMockDAHeaderReader(params.ParliaTestChainConfig)
 	block := types.NewBlockWithHeader(&types.Header{
 		Number: big.NewInt(1),
+		Time:   uint64(time.Now().Unix()),
 	}).WithBody(types.Body{Transactions: types.Transactions{
 		createMockDATx(hr.Config(), emptySidecar()),
 		createMockDATx(hr.Config(), emptySidecar()),
@@ -319,6 +320,7 @@ func BenchmarkRandomSidecarDAChecking(b *testing.B) {
 	for i := 0; i < len(blocks); i++ {
 		block := types.NewBlockWithHeader(&types.Header{
 			Number: big.NewInt(1),
+			Time:   uint64(time.Now().Unix()),
 		}).WithBody(types.Body{Transactions: types.Transactions{
 			createMockDATx(hr.Config(), randomSidecar()),
 			createMockDATx(hr.Config(), randomSidecar()),
@@ -353,28 +355,11 @@ func collectBlobsFromTxs(header *types.Header, txs types.Transactions) types.Blo
 }
 
 type mockDAHeaderReader struct {
-	config            *params.ChainConfig
-	chasingHeadNumber uint64
-	chasingHeadTime   uint64
-}
-
-type mockSplitDAHeaderReader struct {
-	config      *params.ChainConfig
-	currentNum  uint64
-	currentTime uint64
-	chasingNum  uint64
-	chasingTime uint64
+	config *params.ChainConfig
 }
 
 func NewMockDAHeaderReader(config *params.ChainConfig) *mockDAHeaderReader {
-	return &mockDAHeaderReader{
-		config: config,
-	}
-}
-
-func (r *mockDAHeaderReader) setChasingHead(number, time uint64) {
-	r.chasingHeadNumber = number
-	r.chasingHeadTime = time
+	return &mockDAHeaderReader{config: config}
 }
 
 func (r *mockDAHeaderReader) Config() *params.ChainConfig {
@@ -382,17 +367,7 @@ func (r *mockDAHeaderReader) Config() *params.ChainConfig {
 }
 
 func (r *mockDAHeaderReader) CurrentHeader() *types.Header {
-	return &types.Header{
-		Number: new(big.Int).SetUint64(r.chasingHeadNumber),
-		Time:   r.chasingHeadTime,
-	}
-}
-
-func (r *mockDAHeaderReader) ChasingHead() *types.Header {
-	return &types.Header{
-		Number: new(big.Int).SetUint64(r.chasingHeadNumber),
-		Time:   r.chasingHeadTime,
-	}
+	return &types.Header{}
 }
 
 func (r *mockDAHeaderReader) GenesisHeader() *types.Header {
@@ -421,81 +396,6 @@ func (r *mockDAHeaderReader) GetHighestVerifiedHeader() *types.Header {
 
 func (r *mockDAHeaderReader) GetVerifiedBlockByHash(hash common.Hash) *types.Header {
 	panic("not supported")
-}
-
-func (r *mockSplitDAHeaderReader) Config() *params.ChainConfig {
-	return r.config
-}
-
-func (r *mockSplitDAHeaderReader) CurrentHeader() *types.Header {
-	return &types.Header{
-		Number: new(big.Int).SetUint64(r.currentNum),
-		Time:   r.currentTime,
-	}
-}
-
-func (r *mockSplitDAHeaderReader) ChasingHead() *types.Header {
-	if r.chasingNum == 0 && r.chasingTime == 0 {
-		return nil
-	}
-	return &types.Header{
-		Number: new(big.Int).SetUint64(r.chasingNum),
-		Time:   r.chasingTime,
-	}
-}
-
-func (r *mockSplitDAHeaderReader) GenesisHeader() *types.Header {
-	panic("not supported")
-}
-
-func (r *mockSplitDAHeaderReader) GetHeader(hash common.Hash, number uint64) *types.Header {
-	panic("not supported")
-}
-
-func (r *mockSplitDAHeaderReader) GetHeaderByNumber(number uint64) *types.Header {
-	panic("not supported")
-}
-
-func (r *mockSplitDAHeaderReader) GetHeaderByHash(hash common.Hash) *types.Header {
-	panic("not supported")
-}
-
-func (r *mockSplitDAHeaderReader) GetTd(hash common.Hash, number uint64) *big.Int {
-	panic("not supported")
-}
-
-func (r *mockSplitDAHeaderReader) GetHighestVerifiedHeader() *types.Header {
-	panic("not supported")
-}
-
-func (r *mockSplitDAHeaderReader) GetVerifiedBlockByHash(hash common.Hash) *types.Header {
-	panic("not supported")
-}
-
-func TestUpdateChasingHeadRejectsFutureHeader(t *testing.T) {
-	now := uint64(time.Now().Unix())
-	bc := &BlockChain{hc: &HeaderChain{}}
-	bc.hc.SetCurrentHeader(&types.Header{
-		Number: big.NewInt(100),
-		Time:   now,
-	})
-
-	valid := &types.Header{
-		Number: big.NewInt(101),
-		Time:   now,
-	}
-	bc.UpdateChasingHead(valid)
-	require.NotNil(t, bc.ChasingHead())
-	require.Equal(t, valid.Number.Uint64(), bc.ChasingHead().Number.Uint64())
-	require.Equal(t, valid.Time, bc.ChasingHead().Time)
-
-	future := &types.Header{
-		Number: big.NewInt(102),
-		Time:   now + uint64(time.Hour/time.Second),
-	}
-	bc.UpdateChasingHead(future)
-	require.Equal(t, valid.Number.Uint64(), bc.ChasingHead().Number.Uint64())
-	require.Equal(t, valid.Time, bc.ChasingHead().Time)
 }
 
 func createMockDATx(config *params.ChainConfig, sidecar *types.BlobTxSidecar) *types.Transaction {

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -426,10 +426,6 @@ func (hc *HeaderChain) GetVerifiedBlockByHash(hash common.Hash) *types.Header {
 	return hc.GetHeaderByHash(hash)
 }
 
-func (hc *HeaderChain) ChasingHead() *types.Header {
-	return nil
-}
-
 // GetAncestor retrieves the Nth ancestor of a given block. It assumes that either the given block or
 // a close ancestor of it is canonical. maxNonCanonical points to a downwards counter limiting the
 // number of blocks to be individually checked before we reach the canonical chain.

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -226,9 +226,6 @@ type BlockChain interface {
 	// with trie nodes.
 	TrieDB() *triedb.Database
 
-	// UpdateChasingHead update remote best chain head, used by DA check now.
-	UpdateChasingHead(head *types.Header)
-
 	// AncientTail retrieves the tail the ancients blocks
 	AncientTail() (uint64, error)
 
@@ -648,8 +645,6 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 			return d.checkStalling(td, beaconMode)
 		})
 	}
-	// update the chasing head
-	d.blockchain.UpdateChasingHead(remoteHeader)
 	return d.spawnSync(fetchers)
 }
 

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -125,10 +125,6 @@ func (m *simChainHeadReader) CurrentHeader() *types.Header {
 	return m.Backend.CurrentHeader()
 }
 
-func (m *simChainHeadReader) ChasingHead() *types.Header {
-	return m.Backend.Chain().ChasingHead()
-}
-
 func (m *simChainHeadReader) GetHeader(hash common.Hash, number uint64) *types.Header {
 	header, err := m.Backend.HeaderByNumber(m.Context, rpc.BlockNumber(number))
 	if err != nil || header == nil {


### PR DESCRIPTION
### Description

core: use now for DA check instead of chasingHead.time

### Rationale

this PR will replace [core: reject future chasing heads for DA checks](https://github.com/bnb-chain/bsc/pull/3601)

The previous DA skip condition compared block time against `ChasingHead.Time` — a
best-known remote head populated from peer sync state via the downloader. This introduced
two problems:

1. **Security risk**: a malicious peer could advertise a far-future head timestamp to
   suppress DA validation on recent blocks, bypassing blob sidecar checks. A future-time
   guard was added as a mitigation, but it only partially addressed the issue.

2. **Unnecessary complexity**: `ChasingHead` was the *only* consumer of this
   peer-provided head state. The blob retention window (`MinTimeDurationForBlobRequests =
   18.2 days`) is defined in wall-clock time, so the correct reference point is
   `time.Now()`, not a peer-derived value.



### Example

add an example CLI or API response...

### Changes

Replace the skip condition:

```go
// before
if block.Time()+MinTimeDurationForBlobRequests < chasingHead.Time { ... }

// after
if block.Time()+MinTimeDurationForBlobRequests < time.Now().Unix() { ... }

