### PR TITLE
Revert ".github: change dependabot target branch to develop (#3606)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: "develop"


### PR DESCRIPTION
This reverts commit 7b8fbeeb419a1807dd9f3100cf452e326c1db6fd.

### Description

## Background

PR #3606 added `.github/dependabot.yml` with the intent of making
Dependabot security updates target the `develop` branch instead of `master`.

## Why revert

After investigation, the `target-branch` field in `dependabot.yml` only
applies to **Dependabot version updates**, not security updates.

Dependabot security updates always target the repository's **default branch**,
regardless of the `target-branch` configuration. This is a GitHub platform
limitation with no workaround via config file.

The only way to redirect security updates to `develop` would be to change
the repository's default branch from `master` to `develop`, which is a
broader change that requires separate discussion.

Since the added `dependabot.yml` did not achieve its original goal
(and introduces unintended weekly version-bump PRs targeting `develop`),
this PR reverts it.

## Changes

- Removes `.github/dependabot.yml` introduced in #3606


### Rationale

the file `dependabot.yml` will trigger for deps update PR even it's not a security fix

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
