### PR TITLE
miner: shrink greedy merge buffer

### DIFF
--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -905,7 +905,7 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 	// if enable greedy merge, fill bid env with transactions from mempool
 	greedyMergeElapsed := time.Duration(0)
 	if *b.config.GreedyMergeTx {
-		endingBidsExtra := 20 * time.Millisecond // Add a buffer to ensure ending bids before `delayLeftOver`
+		endingBidsExtra := 10 * time.Millisecond // Add a buffer to ensure ending bids before `delayLeftOver`
 		minTimeLeftForEndingBids := b.delayLeftOver + endingBidsExtra
 		delay := b.engine.Delay(b.chain, bidRuntime.env.header, &minTimeLeftForEndingBids)
 		if delay != nil && *delay > 0 {

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -42,6 +42,9 @@ var (
 	simulateSpeedGauge = metrics.NewRegisteredGauge("bid/sim/simulateSpeed", nil) // mgasps
 
 	bidSimTimeoutCounter = metrics.NewRegisteredCounter("bid/sim/simTimeout", nil)
+
+	// greedyMergeOnchainCounter counts bids that went through greedy merge and were finally chosen as BUILDER BLOCK.
+	greedyMergeOnchainCounter = metrics.NewRegisteredCounter("bid/greedyMerge/onchain", nil)
 )
 
 var (
@@ -910,6 +913,9 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 		delay := b.engine.Delay(b.chain, bidRuntime.env.header, &minTimeLeftForEndingBids)
 		if delay != nil && *delay > 0 {
 			greedyMergeStartTs := time.Now()
+			rewardBefore := new(big.Int).Set(bidRuntime.packedBlockReward)
+			tcountBefore := bidRuntime.env.tcount
+			bidRuntime.greedyMerged = true
 			bidTxsSet := mapset.NewThreadUnsafeSetWithSize[common.Hash](len(bidRuntime.bid.Txs))
 			for _, tx := range bidRuntime.bid.Txs {
 				bidTxsSet.Add(tx.Hash())
@@ -921,9 +927,12 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 			// recalculate the packed reward
 			bidRuntime.packReward(*b.config.ValidatorCommission)
 			greedyMergeElapsed = time.Since(greedyMergeStartTs)
+			addedTx := bidRuntime.env.tcount - tcountBefore
+			rewardDelta := new(big.Int).Sub(bidRuntime.packedBlockReward, rewardBefore)
 
 			log.Debug("BidSimulator: greedy merge stopped", "block", bidRuntime.env.header.Number,
-				"builder", bidRuntime.bid.Builder, "tx count", bidRuntime.env.tcount-bidTxLen+1, "err", fillErr, "greedyMergeElapsed", greedyMergeElapsed)
+				"builder", bidRuntime.bid.Builder, "addedTx", addedTx, "rewardDelta", weiToEtherStringF6(rewardDelta),
+				"budget", *delay, "elapsed", greedyMergeElapsed, "err", fillErr)
 		}
 	}
 
@@ -1007,6 +1016,8 @@ type BidRuntime struct {
 
 	finished chan struct{}
 	duration time.Duration
+
+	greedyMerged bool
 }
 
 func newBidRuntime(newBid *types.Bid, validatorCommission uint64) (*BidRuntime, error) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1442,6 +1442,9 @@ LOOP:
 			// blockReward(benefits delegators) and validatorReward(benefits the validator) are both optimal
 			if localValidatorReward.CmpBig(bestBid.packedValidatorReward) < 0 {
 				bidWinGauge.Inc(1)
+				if bestBid.greedyMerged {
+					greedyMergeOnchainCounter.Inc(1)
+				}
 
 				bestWork = bestBid.env
 


### PR DESCRIPTION
### Description
BSC block time has dropped from 3s to sub-second (~450ms today). The 20ms endingBidsExtra was calibrated for slower blocks and is now too conservative: competitive bids arrive late and their simBid finishes within 25–35ms of block.time, just inside the skip region, so most winning bids miss greedy merge.

### Rationale

Log analysis on ~25 recent mainnet blocks shows 4 of the 9 blocks whose on-chain bid didn't trigger greedy merge had their BID RESULT within 25–35ms of block.time. Lowering endingBidsExtra to 10ms captures exactly these cases and roughly doubles the share of builder blocks that go through greedy merge (~36% → ~64%). delayLeftOver itself is unchanged, so the sealing safety budget stays the same.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
