### PR TITLE
release: prepare metainfo for release v1.7.3

### DIFF
--- a/.github/generate_change_log.sh
+++ b/.github/generate_change_log.sh
@@ -6,7 +6,9 @@ change_log_file="./CHANGELOG.md"
 version="## $@"
 version_prefix="## v"
 start=0
+in_meta=0
 CHANGE_LOG=""
+META_INFO=""
 while read line; do
     if [[ $line == *"$version"* ]]; then
         start=1
@@ -16,7 +18,18 @@ while read line; do
         break;
     fi
     if [ $start == 1 ]; then
-        CHANGE_LOG+="$line\n"
+        if [[ $line == "## MetaInfo"* ]]; then
+            in_meta=1
+            continue
+        fi
+        if [[ $line == "## "* ]] && [ $in_meta == 1 ]; then
+            in_meta=0
+        fi
+        if [ $in_meta == 1 ]; then
+            META_INFO+="$line\n"
+        else
+            CHANGE_LOG+="$line\n"
+        fi
     fi
 done < ${change_log_file}
 MAINNET_ZIP_SUM="$(checksum ./mainnet.zip)"
@@ -26,6 +39,8 @@ MAC_BIN_SUM="$(checksum ./macos/geth)"
 WINDOWS_BIN_SUM="$(checksum ./windows/geth.exe)"
 ARM64_BIN_SUM="$(checksum ./arm64/geth-linux-arm64)"
 OUTPUT=$(cat <<-END
+## MetaInfo\n
+${META_INFO}\n
 ## Changelog\n
 ${CHANGE_LOG}\n
 ## Assets\n

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 ## v1.7.3
+v1.7.3 is a maintenance release, which mainly fixes kvdb abnormal continuous growth, pls refer change log for detail.
+
+### BUGFIX
+- [\#3633](https://github.com/bnb-chain/bsc/pull/3633) core/rawdb: increase SlowFreezerBatchLimit from 100 to 200, fixing kvdb abnormal continuous growth
+- [\#3631](https://github.com/bnb-chain/bsc/pull/3631) core/vote: fix deadlock in votepool when stop client
+- [\#3627](https://github.com/bnb-chain/bsc/pull/3627) core/vm: fix super-instruction LT comparison after swap1
 
 ### FEATURE
 - [\#3624](https://github.com/bnb-chain/bsc/pull/3624) cmd/utils: disabled transaction unindexing for archive node by default; when running in archive mode, the `--history.transactions` flag is now respected to specify transaction history range instead of being forced to index all history
@@ -8,16 +14,21 @@
 ### IMPROVEMENT
 - [\#3626](https://github.com/bnb-chain/bsc/pull/3626) eth: tune timing parameters and broadcast queue for 450ms block
 - [\#3618](https://github.com/bnb-chain/bsc/pull/3618) [\#3629](https://github.com/bnb-chain/bsc/pull/3629) miner: async blob tx validation during bid simulation with worker pool
-
-### BUGFIX
-- [\#3633](https://github.com/bnb-chain/bsc/pull/3633) core/rawdb: increase SlowFreezerBatchLimit from 100 to 200, fixing kvdb abnormal continuous growth
-- [\#3631](https://github.com/bnb-chain/bsc/pull/3631) core/vote: fix deadlock in votepool when stop client
-- [\#3627](https://github.com/bnb-chain/bsc/pull/3627) core/vm: fix super-instruction LT comparison after swap1
+- [\#3650](https://github.com/bnb-chain/bsc/pull/3650) miner: shrink greedy merge buffer
+- [\#3645](https://github.com/bnb-chain/bsc/pull/3645) core: use now for DA check instead of chasingHead.time
 
 ### Others
 - [\#3639](https://github.com/bnb-chain/bsc/pull/3639) go.mod: use go1.25.0 and update otel
+- [\#3637](https://github.com/bnb-chain/bsc/pull/3637) build(deps): bump go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp from 1.34.0 to 1.43.0
 - [\#3617](https://github.com/bnb-chain/bsc/pull/3617) build(deps): bump github.com/mattn/go-colorable from 0.1.13 to 0.1.14
 - [\#3616](https://github.com/bnb-chain/bsc/pull/3616) build(deps): bump github.com/gorilla/mux from 1.8.0 to 1.8.1
+- [\#3648](https://github.com/bnb-chain/bsc/pull/3648) Revert ".github: change dependabot target branch to develop"
+
+## MetaInfo
+Mandatory Update Required: No
+Target Audience: all BSC Mainnet/Testnet users
+Procedure: simply binary replacement should be good from v1.7.x, ensure no 'JournalFileEnabled' field in config file if from v1.6.x
+Schedule(Timeline): no scheduled upgrade timeline
 
 ## v1.7.2
 v1.7.2 is for BSC Mainnet [Osaka/Mendel hardfork](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-658.md),the hard fork time is 2026-04-28 02:30:00 AM UTC


### PR DESCRIPTION
### Description

release: prepare metainfo for release v1.7.3

### Rationale

support generate 'MetaInfo' in release note

format follow https://github.com/allformless/bsc/releases/tag/v1.7.3

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
