### PR TITLE
eth/handler.go: add verify bal

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -358,7 +358,9 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		for i, item := range res {
 			block := types.NewBlockWithHeader(item.Header).WithBody(types.Body{Transactions: item.Txs, Uncles: item.Uncles})
 			block = block.WithSidecars(item.Sidecars)
-			block = block.WithBAL(item.BAL)
+			if item.BAL != nil && h.chain.Engine().VerifyBAL(block, item.BAL) == nil {
+				block = block.WithBAL(item.BAL)
+			}
 			block.ReceivedAt = time.Now()
 			block.ReceivedFrom = p.ID()
 			if err := block.SanityCheck(); err != nil {


### PR DESCRIPTION
### Description

The fetchRangeBlocks callback attached peer-supplied BAL directly via WithBAL without calling VerifyBAL, while the NewBlock broadcast path in handler_eth.go gates BAL attachment on VerifyBAL returning nil. Align the quick-fetch path with the same discipline: only attach BAL if it is non-nil and passes VerifyBAL, ensuring the BAL is signed by the block's coinbase before it flows into the prefetcher or is persisted

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
