### PR TITLE
miner: reduce local mining time for last block in one turn

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1667,6 +1667,15 @@ func (p *Parlia) Authorize(val common.Address, signFn SignerFn, signTxFn SignerT
 	p.signTxFn = signTxFn
 }
 
+// IsLastBlockInTurn reports whether header is the last block in the current validator's turn.
+func (p *Parlia) IsLastBlockInTurn(chain consensus.ChainReader, header *types.Header) bool {
+	snap, err := p.snapshot(chain, header.Number.Uint64()-1, header.ParentHash, nil)
+	if err != nil {
+		return false
+	}
+	return snap.lastBlockInOneTurn(header.Number.Uint64())
+}
+
 // Argument leftOver is the time reserved for block finalize(calculate root, distribute income...)
 func (p *Parlia) Delay(chain consensus.ChainReader, header *types.Header, leftOver *time.Duration) *time.Duration {
 	snap, err := p.snapshot(chain, header.Number.Uint64()-1, header.ParentHash, nil)
@@ -1675,11 +1684,7 @@ func (p *Parlia) Delay(chain consensus.ChainReader, header *types.Header, leftOv
 	}
 
 	delay := p.delayForRamanujanFork(snap, header)
-	// The blocking time should be no more than half of period when snap.TurnLength == 1
-	timeForMining := time.Duration(snap.BlockInterval) * time.Millisecond / 2
-	if !snap.lastBlockInOneTurn(header.Number.Uint64()) {
-		timeForMining = time.Duration(snap.BlockInterval) * time.Millisecond
-	}
+	timeForMining := time.Duration(snap.BlockInterval) * time.Millisecond
 	if delay > timeForMining {
 		delay = timeForMining
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1208,6 +1208,26 @@ func (w *worker) generateWork(genParam *generateParams, witness bool) *newPayloa
 	}
 }
 
+// delay returns the time budget for local block building.
+// For the last block in a validator's turn it caps the budget to BlockInterval/4,
+// giving the next validator enough lead time to avoid producing an empty block.
+// (post-Fermi: 450ms interval, ~120ms one-way p2p delay)
+func (w *worker) delay(header *types.Header, leftOver *time.Duration) *time.Duration {
+	d := w.engine.Delay(w.chain, header, leftOver)
+	if d == nil {
+		return nil
+	}
+	if p, ok := w.engine.(*parlia.Parlia); ok && p.IsLastBlockInTurn(w.chain, header) {
+		blockInterval, err := p.BlockInterval(w.chain, header)
+		if err == nil {
+			if cap := time.Duration(blockInterval) * time.Millisecond / 4; *d > cap {
+				return &cap
+			}
+		}
+	}
+	return d
+}
+
 // commitWork generates several new sealing tasks based on the parent block
 // and submit them to the sealer.
 func (w *worker) commitWork(interruptCh chan int32, timestamp int64) {
@@ -1265,7 +1285,7 @@ LOOP:
 		prevWork = work
 		workList = append(workList, work)
 
-		delay := w.engine.Delay(w.chain, work.header, w.config.DelayLeftOver)
+		delay := w.delay(work.header, w.config.DelayLeftOver)
 		if delay == nil {
 			log.Warn("commitWork delay is nil, something is wrong")
 			stopTimer = nil
@@ -1348,7 +1368,7 @@ LOOP:
 				log.Debug("commitWork interruptCh closed, new block imported or resubmit triggered")
 				return
 			case ev := <-txsCh:
-				delay := w.engine.Delay(w.chain, work.header, w.config.DelayLeftOver)
+				delay := w.delay(work.header, w.config.DelayLeftOver)
 				log.Debug("commitWork txsCh arrived", "fillDuration", fillDuration.String(),
 					"delay", delay.String(), "work.tcount", work.tcount,
 					"newTxsNum", newTxsNum, "len(ev.Txs)", len(ev.Txs))


### PR DESCRIPTION
### Description

miner: reduce local mining time for last block in one turn

### Rationale

This PR fixes two issues:

1. **Empty first block in a validator's turn (local mining)**: When a validator takes
the full `BlockInterval` to mine the last block of its turn, the next validator receives
it too late and has little time left to build a non-empty block. The fix caps the
last-in-turn block's local mining time to `BlockInterval/4`, giving the next validator
sufficient lead time.

2. **Insufficient bid simulation window for the last block in a turn**: Previously the
mining time cap (`BlockInterval/2`) was applied uniformly inside `Delay()`, which also
shortened the bid simulation window for the last block. The fix moves the cap into a
local-mining-only wrapper in `worker.go`, so bid simulators always get the full
`BlockInterval` window regardless of turn position.


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
