### PR TITLE
eth/protocols/bsc: cap GetBlocksByRange response size

### DIFF
--- a/eth/protocols/bsc/handler.go
+++ b/eth/protocols/bsc/handler.go
@@ -13,9 +13,20 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
-const MaxRequestRangeBlocksCount = 64
+const (
+	// MaxRequestRangeBlocksCount is the maximum number of blocks to serve per
+	// GetBlocksByRange request. Mostly there to bound disk lookups; with BSC's
+	// typical block size, the practical limit will always be softResponseLimit.
+	MaxRequestRangeBlocksCount = 64
+
+	// softResponseLimit is the target maximum size of replies. The hard cap on
+	// the wire is maxMessageSize (10MB); 8MB leaves headroom for outer RLP/p2p
+	// framing. Each entry's measured size includes sidecars and BAL.
+	softResponseLimit = 8 * 1024 * 1024
+)
 
 // Handler is a callback to invoke from an outside runner after the boilerplate
 // exchanges have passed.
@@ -168,7 +179,7 @@ func handleGetBlocksByRange(backend Backend, msg Decoder, peer *Peer) error {
 	}
 
 	// Get requested blocks
-	blocks := make([]*BlockData, 0, req.Count)
+	blocks := make([]rlp.RawValue, 0, req.Count)
 	var block *types.Block
 	// Prioritize blockHash query, get block & sidecars from db
 	if req.StartBlockHash != (common.Hash{}) {
@@ -179,19 +190,28 @@ func handleGetBlocksByRange(backend Backend, msg Decoder, peer *Peer) error {
 	if block == nil {
 		return fmt.Errorf("msg %v, cannot get start block: %v, %v", GetBlocksByRangeMsg, req.StartBlockHeight, req.StartBlockHash)
 	}
-	blocks = append(blocks, NewBlockData(block))
-	balSize := block.BALSize()
-	for i := uint64(1); i < req.Count; i++ {
-		block = backend.Chain().GetBlockByHash(block.ParentHash())
-		if block == nil {
+	responseSize := 0
+	for i := uint64(0); i < req.Count; i++ {
+		if i > 0 {
+			block = backend.Chain().GetBlockByHash(block.ParentHash())
+			if block == nil {
+				break
+			}
+		}
+		enc, err := rlp.EncodeToBytes(NewBlockData(block))
+		if err != nil {
+			log.Error("failed to encode BlockData", "hash", block.Hash(), "err", err)
 			break
 		}
-		balSize += block.BALSize()
-		blocks = append(blocks, NewBlockData(block))
+		if len(blocks) > 0 && responseSize+len(enc) > softResponseLimit {
+			break // already have at least one block; next entry would overflow
+		}
+		blocks = append(blocks, enc)
+		responseSize += len(enc)
 	}
 
-	log.Debug("reply GetBlocksByRange msg", "from", peer.id, "req", req.Count, "blocks", len(blocks), "balSize", balSize)
-	return p2p.Send(peer.rw, BlocksByRangeMsg, &BlocksByRangePacket{
+	log.Debug("reply GetBlocksByRange msg", "from", peer.id, "req", req.Count, "blocks", len(blocks), "responseSize", responseSize)
+	return p2p.Send(peer.rw, BlocksByRangeMsg, &BlocksByRangeRLPPacket{
 		RequestId: req.RequestId,
 		Blocks:    blocks,
 	})

--- a/eth/protocols/bsc/protocol.go
+++ b/eth/protocols/bsc/protocol.go
@@ -107,3 +107,11 @@ type BlocksByRangePacket struct {
 
 func (*BlocksByRangePacket) Name() string { return "BlocksByRange" }
 func (*BlocksByRangePacket) Kind() byte   { return BlocksByRangeMsg }
+
+// BlocksByRangeRLPPacket mirrors BlocksByRangePacket on the wire but carries
+// pre-encoded entries, letting the server reuse RLP bytes already produced for
+// size accounting and avoid a redundant encode pass in p2p.Send.
+type BlocksByRangeRLPPacket struct {
+	RequestId uint64
+	Blocks    []rlp.RawValue
+}


### PR DESCRIPTION
### Description
Cap `GetBlocksByRange` response size and reuse RLP bytes on the send path.

### Rationale
Today the handler accumulates only `block.Size() + block.BALSize()` and never bounds the total against the 10MB `maxMessageSize` hard cap. Sidecars are not counted at all, so a batch of 64 BAL/blob-rich blocks can overflow the limit and drop the peer — after the server has already paid the full encode cost.

This change mirrors eth/66's body-serve pattern: measure each entry's exact RLP size (sidecars and BAL included), stop before `softResponseLimit` (8MB) would overflow, and send `[]rlp.RawValue` to avoid a second encode pass in `p2p.Send`. Wire format is unchanged.

### Changes
- `handleGetBlocksByRange`: measure exact size via `rlp.EncodeToBytes`; break before `softResponseLimit` (8MB) would overflow; always include the start block, even when it alone exceeds the soft limit.
- Hoist `MaxRequestRangeBlocksCount` and `softResponseLimit` into a single `const (...)` block at the top of `handler.go`.
- Add `BlocksByRangeRLPPacket` (`Blocks []rlp.RawValue`) and use it on the send path. Wire bytes are identical to `BlocksByRangePacket`; receivers are unchanged.