### PR TITLE
eth/protocols/bsc: rate-limit incoming votes by vote count

### DIFF
--- a/eth/handler_bsc.go
+++ b/eth/handler_bsc.go
@@ -48,11 +48,9 @@ func (h *bscHandler) Handle(peer *bsc.Peer, packet bsc.Packet) error {
 }
 
 // handleVotesBroadcast is invoked from a peer's message handler when it transmits a
-// votes broadcast for the local node to process.
+// votes broadcast for the local node to process. Per-peer rate limiting happens
+// upstream in bsc.handleVotes via IsOverLimitAfterReceivingVotes.
 func (h *bscHandler) handleVotesBroadcast(peer *bsc.Peer, votes []*types.VoteEnvelope) error {
-	if peer.IsOverLimitAfterReceiving() {
-		return nil
-	}
 	// Here we only put the first vote, to avoid ddos attack by sending a large batch of votes.
 	// This won't abandon any valid vote, because one vote is sent every time referring to func voteBroadcastLoop
 	if len(votes) > 0 {

--- a/eth/protocols/bsc/handler.go
+++ b/eth/protocols/bsc/handler.go
@@ -150,6 +150,11 @@ func handleVotes(backend Backend, msg Decoder, peer *Peer) error {
 	if err := msg.Decode(ann); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
+	// Charge limiter by vote count, not packet count, to match the documented
+	// intent of receiveRateLimitPerSecond (see peer.go:23-27).
+	if peer.IsOverLimitAfterReceivingVotes(uint(len(ann.Votes))) {
+		return nil
+	}
 	// Schedule all the unknown hashes for retrieval
 	peer.markVotes(ann.Votes)
 	return backend.Handle(peer, ann)

--- a/eth/protocols/bsc/peer.go
+++ b/eth/protocols/bsc/peer.go
@@ -124,9 +124,10 @@ func (p *Peer) AsyncSendVotes(votes []*types.VoteEnvelope) {
 	}
 }
 
-// Step into the next period when secondsPerPeriod seconds passed,
-// Otherwise, check whether the number of received votes extra (secondsPerPeriod * receiveRateLimitPerSecond)
-func (p *Peer) IsOverLimitAfterReceiving() bool {
+// IsOverLimitAfterReceivingVotes increments the per-period vote counter by n
+// and reports whether the rolling 30s budget has been exceeded.
+// The budget is `secondsPerPeriod * receiveRateLimitPerSecond` votes per peer.
+func (p *Peer) IsOverLimitAfterReceivingVotes(n uint) bool {
 	if timeInterval := time.Since(p.periodBegin).Seconds(); timeInterval >= secondsPerPeriod {
 		if p.periodCounter > uint(secondsPerPeriod*receiveRateLimitPerSecond) {
 			p.Log().Debug("sending votes too much", "secondsPerPeriod", secondsPerPeriod, "count ", p.periodCounter)
@@ -135,7 +136,7 @@ func (p *Peer) IsOverLimitAfterReceiving() bool {
 		p.periodCounter = 0
 		return false
 	}
-	p.periodCounter += 1
+	p.periodCounter += n
 	return p.periodCounter > uint(secondsPerPeriod*receiveRateLimitPerSecond)
 }
 


### PR DESCRIPTION
### Description
Rate-limit incoming votes by vote count, not packet count.

### Rationale
The receive limiter charges `periodCounter += 1` per `VotesPacket`, but the documented budget (`receiveRateLimitPerSecond = 68`, sized as 21 votes/block ÷ 0.45s) is reasoned in votes/sec. A peer batching 21 votes per packet legitimately costs 21× more than one sending single votes, yet both spend the same against the limiter.

Charge by `len(ann.Votes)` so the budget reflects actual votes/sec regardless of batching. Move the check to `bsc.handleVotes` — the earliest point with the decoded count — and drop the now-redundant check in `handleVotesBroadcast` so there is a single charge site.

### Changes
- `peer.go`: rename `IsOverLimitAfterReceiving()` to `IsOverLimitAfterReceivingVotes(n uint)`; increment the counter by `n`.
- `handler.go`: charge the limiter in `handleVotes` by vote count; drop rate-limited packets before `markVotes` and `backend.Handle`.
- `handler_bsc.go`: remove the redundant rate-limit check from `handleVotesBroadcast`; rate limiting now lives upstream.