### PR TITLE
miner: remove optional transaction gas limit cap

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/params"
-
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/cmd/utils"
@@ -465,20 +463,6 @@ func startNode(ctx *cli.Context, stack *node.Node, backend ethapi.Backend, isCon
 
 	// Start auxiliary services if enabled
 	ethBackend, ok := backend.(*eth.EthAPIBackend)
-	gasCeil := ethBackend.Miner().GasCeil()
-	maxTxGas := uint64(0)
-	if gasCeil > params.SystemTxsGasSoftLimit {
-		maxTxGas = gasCeil - params.SystemTxsGasSoftLimit
-	}
-	if txGasLimit := ethBackend.Miner().TxGasLimit(); txGasLimit > 0 {
-		if maxTxGas == 0 || txGasLimit < maxTxGas {
-			maxTxGas = txGasLimit
-		}
-	}
-	if maxTxGas > 0 {
-		ethBackend.TxPool().SetMaxGas(maxTxGas)
-	}
-
 	if ctx.Bool(utils.MiningEnabledFlag.Name) {
 		// Mining only makes sense if a full Ethereum node is running
 		if ctx.String(utils.SyncModeFlag.Name) == "light" {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -584,11 +584,6 @@ var (
 		Value:    ethconfig.Defaults.TxPool.ReannounceTime,
 		Category: flags.TxPoolCategory,
 	}
-	MinerTxGasLimitFlag = &cli.Uint64Flag{
-		Name:     "miner.txgaslimit",
-		Usage:    fmt.Sprintf("Maximum gas allowed per transaction (default = 0, disabled; min = %d)", params.MaxTxGas),
-		Category: flags.MinerCategory,
-	}
 	// Blob transaction pool settings
 	BlobPoolDataDirFlag = &cli.StringFlag{
 		Name:     "blobpool.datadir",
@@ -2044,11 +2039,7 @@ func setMiner(ctx *cli.Context, cfg *minerconfig.Config) {
 		cfg.DisableVoteAttestation = true
 	}
 	if ctx.IsSet(MinerTxGasLimitFlag.Name) {
-		limit := ctx.Uint64(MinerTxGasLimitFlag.Name)
-		if limit != 0 && limit < params.MaxTxGas {
-			Fatalf("Invalid --miner.txgaslimit: %d (must be >= %d or 0)", limit, params.MaxTxGas)
-		}
-		cfg.TxGasLimit = limit
+		log.Warn("The flag --miner.txgaslimit is deprecated and has no effect; per-transaction gas limit is now enforced by EIP-7825")
 	}
 }
 

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -140,6 +140,13 @@ var (
 		Value:    true,
 		Category: flags.DeprecatedCategory,
 	}
+	// Deprecated: tx gas limit is now enforced at protocol level by EIP-7825.
+	MinerTxGasLimitFlag = &cli.Uint64Flag{
+		Name:     "miner.txgaslimit",
+		Hidden:   true,
+		Usage:    "Deprecated: per-transaction gas limit is now enforced by EIP-7825; this flag has no effect",
+		Category: flags.DeprecatedCategory,
+	}
 )
 
 // showDeprecated displays deprecated flags that will be soon removed from the codebase.

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -344,7 +344,6 @@ type BlobPool struct {
 	head   atomic.Pointer[types.Header] // Current head of the chain
 	state  *state.StateDB               // Current state at the head of the chain
 	gasTip atomic.Pointer[uint256.Int]  // Currently accepted minimum gas tip
-	maxGas atomic.Uint64                // Currently accepted max gas, it will be modified by MinerAPI
 
 	lookup *lookup                          // Lookup table mapping blobs to txs and txs to billy entries
 	index  map[common.Address][]*blobTxMeta // Blob transactions grouped by accounts, sorted by nonce
@@ -1335,7 +1334,6 @@ func (p *BlobPool) ValidateTxBasics(tx *types.Transaction) error {
 		MaxSize:      txMaxSize,
 		MinTip:       p.gasTip.Load().ToBig(),
 		MaxBlobCount: maxBlobsPerTx,
-		MaxGas:       p.GetMaxGas(),
 	}
 	return txpool.ValidateTransaction(tx, p.head.Load(), p.signer, opts)
 }
@@ -2157,14 +2155,6 @@ func (p *BlobPool) Status(hash common.Hash) txpool.TxStatus {
 		return txpool.TxStatusPending
 	}
 	return txpool.TxStatusUnknown
-}
-
-func (p *BlobPool) SetMaxGas(maxGas uint64) {
-	p.maxGas.Store(maxGas)
-}
-
-func (p *BlobPool) GetMaxGas() uint64 {
-	return p.maxGas.Load()
 }
 
 // Clear implements txpool.SubPool, removing all tracked transactions

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -247,7 +247,6 @@ type LegacyPool struct {
 	scope        event.SubscriptionScope
 	signer       types.Signer
 	mu           sync.RWMutex
-	maxGas       atomic.Uint64 // Currently accepted max gas, it will be modified by MinerAPI
 
 	currentHead   atomic.Pointer[types.Header] // Current head of the blockchain
 	currentState  *state.StateDB               // Current state in the blockchain head
@@ -623,7 +622,6 @@ func (pool *LegacyPool) ValidateTxBasics(tx *types.Transaction) error {
 			1<<types.SetCodeTxType,
 		MaxSize: txMaxSize,
 		MinTip:  pool.gasTip.Load().ToBig(),
-		MaxGas:  pool.GetMaxGas(),
 	}
 	return txpool.ValidateTransaction(tx, pool.currentHead.Load(), pool.signer, opts)
 }
@@ -1682,14 +1680,6 @@ func (pool *LegacyPool) demoteUnexecutables() {
 			}
 		}
 	}
-}
-
-func (pool *LegacyPool) GetMaxGas() uint64 {
-	return pool.maxGas.Load()
-}
-
-func (pool *LegacyPool) SetMaxGas(maxGas uint64) {
-	pool.maxGas.Store(maxGas)
 }
 
 // accountSet is simply a set of addresses to check for existence, and a signer

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -182,9 +182,6 @@ type SubPool interface {
 	// identified by their hashes.
 	Status(hash common.Hash) TxStatus
 
-	// SetMaxGas limit max acceptable tx gas when mine is enabled
-	SetMaxGas(maxGas uint64)
-
 	// Clear removes all tracked transactions from the pool
 	Clear()
 }

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -263,12 +263,6 @@ func (p *TxPool) SetGasTip(tip *big.Int) {
 	}
 }
 
-func (p *TxPool) SetMaxGas(gas uint64) {
-	for _, subpool := range p.subpools {
-		subpool.SetMaxGas(gas)
-	}
-}
-
 // Has returns an indicator whether the pool has a transaction cached with the
 // given hash.
 func (p *TxPool) Has(hash common.Hash) bool {

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -45,7 +45,6 @@ type ValidationOptions struct {
 	MaxSize      uint64   // Maximum size of a transaction that the caller can meaningfully handle
 	MinTip       *big.Int // Minimum gas tip needed to allow a transaction into the caller pool
 	MaxBlobCount int      // Maximum number of blobs allowed per transaction
-	MaxGas       uint64   // Max acceptable transaction gas in the txpool
 }
 
 // ValidationFunction is an method type which the pools use to perform the tx-validations which do not
@@ -101,11 +100,6 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	// Ensure the transaction doesn't exceed the current block limit gas
 	if head.GasLimit < tx.Gas() {
 		return ErrGasLimit
-	}
-
-	// Ensure the transaction doesn't exceed the current miner max acceptable limit gas
-	if opts.MaxGas > 0 && tx.Gas() > opts.MaxGas {
-		return fmt.Errorf("%w (cap: %d, tx: %d)", core.ErrGasLimitTooHigh, opts.MaxGas, tx.Gas())
 	}
 
 	// Sanity check for extremely large numbers (supported by RLP or RPC)

--- a/eth/api_miner.go
+++ b/eth/api_miner.go
@@ -20,8 +20,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/ethereum/go-ethereum/params"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
@@ -67,15 +65,6 @@ func (api *MinerAPI) SetGasPrice(gasPrice hexutil.Big) bool {
 
 	api.e.txPool.SetGasTip((*big.Int)(&gasPrice))
 	api.e.Miner().SetGasTip((*big.Int)(&gasPrice))
-	return true
-}
-
-// SetGasLimit sets the gaslimit to target towards during mining.
-func (api *MinerAPI) SetGasLimit(gasLimit hexutil.Uint64) bool {
-	api.e.Miner().SetGasCeil(uint64(gasLimit))
-	if uint64(gasLimit) > params.SystemTxsGasSoftLimit {
-		api.e.TxPool().SetMaxGas(uint64(gasLimit) - params.SystemTxsGasSoftLimit)
-	}
 	return true
 }
 

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -673,12 +673,6 @@ web3._extend({
 			inputFormatter: [web3._extend.utils.fromDecimal]
 		}),
 		new web3._extend.Method({
-			name: 'setGasLimit',
-			call: 'miner_setGasLimit',
-			params: 1,
-			inputFormatter: [web3._extend.utils.fromDecimal]
-		}),
-		new web3._extend.Method({
 			name: 'setRecommitInterval',
 			call: 'miner_setRecommitInterval',
 			params: 1,

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -96,7 +96,6 @@ type bidSimulator struct {
 	config        *minerconfig.MevConfig
 	delayLeftOver time.Duration
 	minGasPrice   *big.Int
-	txMaxGas      uint64 // Maximum gas for per transaction(will be removed after Mendel hardfork)
 	chain         *core.BlockChain
 	txpool        *txpool.TxPool
 	chainConfig   *params.ChainConfig
@@ -139,7 +138,6 @@ func newBidSimulator(
 	config *minerconfig.MevConfig,
 	delayLeftOver *time.Duration,
 	minGasPrice *big.Int,
-	txMaxGas uint64,
 	eth Backend,
 	chainConfig *params.ChainConfig,
 	engine consensus.Engine,
@@ -148,7 +146,6 @@ func newBidSimulator(
 	b := &bidSimulator{
 		config:        config,
 		minGasPrice:   minGasPrice,
-		txMaxGas:      txMaxGas,
 		chain:         eth.BlockChain(),
 		txpool:        eth.TxPool(),
 		chainConfig:   chainConfig,
@@ -436,6 +433,8 @@ func (b *bidSimulator) newBidLoop() {
 				continue
 			}
 
+			// Pre-check before simulation for fast feedback to the builder;
+			// simulation would reject these txs anyway via state_transition preCheck.
 			if errCap := b.checkIfBidExceedsTxGasLimit(newBid.bid); errCap != nil {
 				if newBid.feedback != nil {
 					newBid.feedback <- errCap
@@ -535,29 +534,20 @@ func (b *bidSimulator) getBlockInterval(parentHeader *types.Header) uint64 {
 
 // checkIfBidExceedsTxGasLimit checks whether any transaction in the bid exceeds the max txn gas.
 func (b *bidSimulator) checkIfBidExceedsTxGasLimit(bid *types.Bid) error {
-	var gasLimitCap uint64
 	currentHeader := b.chain.CurrentBlock()
-	if b.chainConfig.IsOsaka(currentHeader.Number, currentHeader.Time) {
-		gasLimitCap = params.MaxTxGas
-	} else {
-		if b.txMaxGas == 0 {
-			return nil
-		}
-		gasLimitCap = b.txMaxGas
+	if !b.chainConfig.IsOsaka(currentHeader.Number, currentHeader.Time) {
+		return nil
 	}
-
-	// Scan all txs in the bid to check if any transaction exceeds the gas limit cap
 	for _, tx := range bid.Txs {
-		if tx.Gas() > gasLimitCap {
+		if tx.Gas() > params.MaxTxGas {
 			log.Debug("discard bid due to per-tx gas limit",
 				"block", bid.BlockNumber,
 				"bidHash", bid.Hash().TerminalString(),
 				"txHash", tx.Hash().TerminalString(),
 				"txGas", tx.Gas(),
-				"txGasLimit", gasLimitCap,
+				"txGasLimit", params.MaxTxGas,
 			)
-
-			return fmt.Errorf("bid rejected: %w (cap: %d, tx: %d)", core.ErrGasLimitTooHigh, gasLimitCap, tx.Gas())
+			return fmt.Errorf("bid rejected: %w (cap: %d, tx: %d)", core.ErrGasLimitTooHigh, params.MaxTxGas, tx.Gas())
 		}
 	}
 	return nil

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -70,7 +70,7 @@ func New(eth Backend, config *minerconfig.Config, mux *event.TypeMux, engine con
 		worker:  newWorker(config, engine, eth, mux),
 	}
 
-	miner.bidSimulator = newBidSimulator(&config.Mev, config.DelayLeftOver, config.GasPrice, config.TxGasLimit, eth, eth.BlockChain().Config(), engine, miner.worker)
+	miner.bidSimulator = newBidSimulator(&config.Mev, config.DelayLeftOver, config.GasPrice, eth, eth.BlockChain().Config(), engine, miner.worker)
 	miner.worker.setBestBidFetcher(miner.bidSimulator)
 
 	miner.wg.Add(1)
@@ -234,8 +234,4 @@ func (miner *Miner) BuildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 
 func (miner *Miner) GasCeil() uint64 {
 	return miner.worker.getGasCeil()
-}
-
-func (miner *Miner) TxGasLimit() uint64 {
-	return miner.worker.getTxGasLimit()
 }

--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -68,7 +68,6 @@ type Config struct {
 	VoteEnable             bool           // Whether to vote when mining
 	MaxWaitProposalInSecs  *uint64        `toml:",omitempty"` // The maximum time to wait for the proposal to be done, it's aimed to prevent validator being slashed when restarting
 	DisableVoteAttestation bool           // Whether to skip assembling vote attestation
-	TxGasLimit             uint64         // Maximum gas for per transaction(will be removed after Mendel hardfork)
 
 	Mev MevConfig // Mev configuration
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -315,12 +315,6 @@ func (w *worker) getGasCeil() uint64 {
 	return w.config.GasCeil
 }
 
-func (w *worker) getTxGasLimit() uint64 {
-	w.confMu.RLock()
-	defer w.confMu.RUnlock()
-	return w.config.TxGasLimit
-}
-
 // setExtra sets the content used to initialize the block extra field.
 func (w *worker) setExtra(extra []byte) {
 	w.confMu.Lock()
@@ -1052,10 +1046,6 @@ func (w *worker) fillTransactions(interruptCh chan int32, env *environment, stop
 	}
 	if env.header.ExcessBlobGas != nil {
 		filter.BlobFee = uint256.MustFromBig(eip4844.CalcBlobFee(w.chainConfig, env.header))
-	}
-
-	if cap := w.getTxGasLimit(); cap > 0 {
-		filter.GasLimitCap = cap
 	}
 
 	if w.chainConfig.IsOsaka(env.header.Number, env.header.Time) {


### PR DESCRIPTION
### Description

miner: remove optional transaction gas limit cap

### Rationale

EIP-7825 has been enabled on bsc,
so remove optional transaction gas limit cap,
along side remove useless 'SetMaxGas'

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
