### PR TITLE
core: fix txLookupLock mutex leak on error returns in reorg() (#34039)

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -3024,6 +3024,7 @@ func (bc *BlockChain) reorg(oldHead *types.Header, newHead *types.Header) error 
 	// as the txlookups should be changed atomically, and all subsequent
 	// reads should be blocked until the mutation is complete.
 	bc.txLookupLock.Lock()
+	defer bc.txLookupLock.Unlock()
 
 	// Reorg can be executed, start reducing the chain's old blocks and appending
 	// the new blocks
@@ -3129,9 +3130,6 @@ func (bc *BlockChain) reorg(oldHead *types.Header, newHead *types.Header) error 
 	}
 	// Reset the tx lookup cache to clear stale txlookup cache.
 	bc.txLookupCache.Purge()
-
-	// Release the tx-lookup lock after mutation.
-	bc.txLookupLock.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
### Description

core: fix txLookupLock mutex leak on error returns in reorg() (#34039)

### Rationale

upstream commit: https://github.com/ethereum/go-ethereum/commit/b6115e9a3

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
