### PR TITLE
core, internal/ethapi: fix incorrect max-initcode RPC error mapping

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -68,10 +68,6 @@ var (
 	// have enough funds for transfer(topmost call only).
 	ErrInsufficientFundsForTransfer = errors.New("insufficient funds for transfer")
 
-	// ErrMaxInitCodeSizeExceeded is returned if creation transaction provides the init code bigger
-	// than init code size limit.
-	ErrMaxInitCodeSizeExceeded = errors.New("max initcode size exceeded")
-
 	// ErrInsufficientBalanceWitness is returned if the transaction sender has enough
 	// funds to cover the transfer, but not enough to pay for witness access/modification
 	// costs for the transaction

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -496,7 +496,7 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 
 	// Check whether the init code size has been exceeded.
 	if rules.IsShanghai && contractCreation && len(msg.Data) > params.MaxInitCodeSize {
-		return nil, fmt.Errorf("%w: code size %v limit %v", ErrMaxInitCodeSizeExceeded, len(msg.Data), params.MaxInitCodeSize)
+		return nil, fmt.Errorf("%w: code size %v limit %v", vm.ErrMaxInitCodeSizeExceeded, len(msg.Data), params.MaxInitCodeSize)
 	}
 
 	// Execute the preparatory steps for state transition which includes:

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -87,7 +88,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	}
 	// Check whether the init code size has been exceeded
 	if rules.IsShanghai && tx.To() == nil && len(tx.Data()) > params.MaxInitCodeSize {
-		return fmt.Errorf("%w: code size %v, limit %v", core.ErrMaxInitCodeSizeExceeded, len(tx.Data()), params.MaxInitCodeSize)
+		return fmt.Errorf("%w: code size %v, limit %v", vm.ErrMaxInitCodeSizeExceeded, len(tx.Data()), params.MaxInitCodeSize)
 	}
 	if rules.IsOsaka && tx.Gas() > params.MaxTxGas {
 		return fmt.Errorf("%w (cap: %d, tx: %d)", core.ErrGasLimitTooHigh, params.MaxTxGas, tx.Gas())

--- a/internal/ethapi/errors.go
+++ b/internal/ethapi/errors.go
@@ -146,7 +146,7 @@ func txValidationError(err error) *invalidTxError {
 		return &invalidTxError{Message: err.Error(), Code: errCodeIntrinsicGas}
 	case errors.Is(err, core.ErrInsufficientFundsForTransfer):
 		return &invalidTxError{Message: err.Error(), Code: errCodeInsufficientFunds}
-	case errors.Is(err, core.ErrMaxInitCodeSizeExceeded):
+	case errors.Is(err, vm.ErrMaxInitCodeSizeExceeded):
 		return &invalidTxError{Message: err.Error(), Code: errCodeMaxInitCodeSizeExceeded}
 	}
 	return &invalidTxError{


### PR DESCRIPTION
## Description

core, internal/ethapi: fix incorrect max-initcode RPC error mapping

### Rationale

upstream commit: https://github.com/ethereum/go-ethereum/commit/a61e5ccb1

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
