### PR TITLE
eth/filters: rangeLogs should error on invalid block range (#33763)

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -389,7 +389,7 @@ func (f *Filter) rangeLogs(ctx context.Context, firstBlock, lastBlock uint64) ([
 	}
 
 	if firstBlock > lastBlock {
-		return nil, nil
+		return nil, errInvalidBlockRange
 	}
 	mb := f.sys.backend.NewMatcherBackend()
 	defer mb.Close()

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -360,7 +360,8 @@ func testFilters(t *testing.T, history uint64, noHistory bool) {
 				want: `[{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0x53e3675800c6908424b61b35a44e51ca4c73ca603e58a65b32c67968b4f42200","transactionIndex":"0x0","blockHash":"0x2e4620a2b426b0612ec6cad9603f466723edaed87f98c9137405dd4f7a2409ff","logIndex":"0x0","removed":false}]`,
 			},
 			{
-				f: sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.FinalizedBlockNumber), nil, nil),
+				f:   sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.FinalizedBlockNumber), nil, nil, false),
+				err: errInvalidBlockRange.Error(),
 			},
 			{
 				f:   sys.NewRangeFilter(int64(rpc.SafeBlockNumber), int64(rpc.LatestBlockNumber), nil, nil),
@@ -375,18 +376,6 @@ func testFilters(t *testing.T, history uint64, noHistory bool) {
 				err: "safe header not found",
 			},
 		*/
-		{
-			f:   sys.NewRangeFilter(int64(rpc.SafeBlockNumber), int64(rpc.LatestBlockNumber), nil, nil, false),
-			err: "safe header not found",
-		},
-		{
-			f:   sys.NewRangeFilter(int64(rpc.SafeBlockNumber), int64(rpc.SafeBlockNumber), nil, nil, false),
-			err: "safe header not found",
-		},
-		{
-			f:   sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.SafeBlockNumber), nil, nil, false),
-			err: "safe header not found",
-		},
 		{
 			f:   sys.NewRangeFilter(int64(rpc.PendingBlockNumber), int64(rpc.PendingBlockNumber), nil, nil, false),
 			err: errPendingLogsUnsupported.Error(),

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -376,6 +376,18 @@ func testFilters(t *testing.T, history uint64, noHistory bool) {
 			},
 		*/
 		{
+			f:   sys.NewRangeFilter(int64(rpc.SafeBlockNumber), int64(rpc.LatestBlockNumber), nil, nil, false),
+			err: "safe header not found",
+		},
+		{
+			f:   sys.NewRangeFilter(int64(rpc.SafeBlockNumber), int64(rpc.SafeBlockNumber), nil, nil, false),
+			err: "safe header not found",
+		},
+		{
+			f:   sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.SafeBlockNumber), nil, nil, false),
+			err: "safe header not found",
+		},
+		{
 			f:   sys.NewRangeFilter(int64(rpc.PendingBlockNumber), int64(rpc.PendingBlockNumber), nil, nil, false),
 			err: errPendingLogsUnsupported.Error(),
 		},


### PR DESCRIPTION
### Description

eth/filters: rangeLogs should error on invalid block range (#33763)

### Rationale

upstream commit: https://github.com/ethereum/go-ethereum/commit/3341d8ace

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
