### PR TITLE
eth/filters: fix source leak when New Filters

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -219,6 +219,7 @@ func (api *FilterAPI) NewVotesFilter() rpc.ID {
 	api.filtersMu.Unlock()
 
 	gopool.Submit(func() {
+		defer voteSub.Unsubscribe()
 		for {
 			select {
 			case vote := <-votes:
@@ -341,6 +342,7 @@ func (api *FilterAPI) NewFinalizedHeaderFilter() rpc.ID {
 	api.filtersMu.Unlock()
 
 	gopool.Submit(func() {
+		defer headerSub.Unsubscribe()
 		for {
 			select {
 			case h := <-headers:


### PR DESCRIPTION
### Description

eth/filters: fix source leak when New Filters

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
