### PR TITLE
eth, ethapi: implement eth_baseFee RPC method

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/consensus/parlia"
 	"github.com/ethereum/go-ethereum/core"
@@ -455,6 +456,15 @@ func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastB
 
 func (b *EthAPIBackend) Chain() *core.BlockChain {
 	return b.eth.BlockChain()
+}
+
+func (b *EthAPIBackend) BaseFee(ctx context.Context) *big.Int {
+	head := b.CurrentHeader()
+	nextBlock := new(big.Int).Add(head.Number, common.Big1)
+	if b.ChainConfig().IsLondon(nextBlock) {
+		return eip1559.CalcBaseFee(b.ChainConfig(), head)
+	}
+	return nil
 }
 
 func (b *EthAPIBackend) BlobBaseFee(ctx context.Context) *big.Int {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -142,6 +142,11 @@ func (api *EthereumAPI) FeeHistory(ctx context.Context, blockCount math.HexOrDec
 	return results, nil
 }
 
+// BaseFee returns the base fee of the next block, or nil if base fee is not activated.
+func (api *EthereumAPI) BaseFee(ctx context.Context) *hexutil.Big {
+	return (*hexutil.Big)(api.b.BaseFee(ctx))
+}
+
 // BlobBaseFee returns the base fee for blob gas at the current head.
 func (api *EthereumAPI) BlobBaseFee(ctx context.Context) *hexutil.Big {
 	return (*hexutil.Big)(api.b.BlobBaseFee(ctx))

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -500,6 +500,7 @@ func (b testBackend) Chain() *core.BlockChain {
 func (b testBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error) {
 	return nil, nil, nil, nil, nil, nil, nil
 }
+func (b testBackend) BaseFee(ctx context.Context) *big.Int     { return new(big.Int) }
 func (b testBackend) BlobBaseFee(ctx context.Context) *big.Int { return new(big.Int) }
 func (b testBackend) ChainDb() ethdb.Database                  { return b.db }
 func (b testBackend) AccountManager() *accounts.Manager        { return b.accman }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -47,6 +47,7 @@ type Backend interface {
 
 	Chain() *core.BlockChain
 	FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error)
+	BaseFee(ctx context.Context) *big.Int
 	BlobBaseFee(ctx context.Context) *big.Int
 	ChainDb() ethdb.Database
 	AccountManager() *accounts.Manager

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -317,6 +317,7 @@ func (b *backendMock) setFork(fork string) error {
 func (b *backendMock) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(42), nil
 }
+func (b *backendMock) BaseFee(ctx context.Context) *big.Int     { return big.NewInt(0) }
 func (b *backendMock) BlobBaseFee(ctx context.Context) *big.Int { return big.NewInt(42) }
 
 func (b *backendMock) CurrentHeader() *types.Header     { return b.current }


### PR DESCRIPTION
### Description

Implements [`eth_baseFee`](https://github.com/ethereum/execution-apis/pull/795), which returns the calculated base fee of the next block.

### Rationale

This method is useful for custom gas pricing strategies.
It provides a lightweight way to get this information.
It is analogous to `eth_blobBaseFee`.

### Example

```json
{
    "id": 1,
    "jsonrpc": "2.0",
    "method": "eth_baseFee",
    "params": []
}
```

### Changes

* add `eth_baseFee` method to jsonrpc