### PR TITLE
core/txpool/blobpool: continue on proof error in GetBlobs (#34891)

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1609,7 +1609,8 @@ func (p *BlobPool) GetBlobs(vhashes []common.Hash, version byte, convert bool) (
 				} else {
 					proof, err := kzg4844.ComputeBlobProof(&sidecar.Blobs[i], sidecar.Commitments[i])
 					if err != nil {
-						return nil, nil, nil, err
+						log.Error("Failed to compute blob proof", "id", txID, "err", err)
+						continue
 					}
 					pf = []kzg4844.Proof{proof}
 				}
@@ -1617,13 +1618,15 @@ func (p *BlobPool) GetBlobs(vhashes []common.Hash, version byte, convert bool) (
 				if sidecar.Version == types.BlobSidecarVersion0 {
 					cellProofs, err := kzg4844.ComputeCellProofs(&sidecar.Blobs[i])
 					if err != nil {
-						return nil, nil, nil, err
+						log.Error("Failed to compute cell proofs", "id", txID, "err", err)
+						continue
 					}
 					pf = cellProofs
 				} else {
 					cellProofs, err := sidecar.CellProofsAt(i)
 					if err != nil {
-						return nil, nil, nil, err
+						log.Error("Failed to get cell proofs", "id", txID, "err", err)
+						continue
 					}
 					pf = cellProofs
 				}


### PR DESCRIPTION
## Summary

Cherry-pick of go-ethereum [`0ad890e3a`](https://github.com/ethereum/go-ethereum/commit/0ad890e3a) (upstream PR #34891).

\`GetBlobs\` returned early when proof computation reported corrupted / out-of-bounds proofs, dropping every blob already collected and aborting the remaining hashes — a single bad sidecar killed the whole batch. Replaced the three \`return nil, nil, nil, err\` paths with \`log.Error + continue\` so the failed slot stays \`nil\` per the sparse-array contract, matching the store/RLP/nil-sidecar branches a few lines above.

## BSC reachability — IMPORTANT

> ⚠️ **Originally classified P0 by \`docs/v1.17.3_upstream_release_check.md\` finding #2 on the assumption that the Engine API \`engine_getBlobs\` path is live in BSC. That assumption is wrong.**

The only callers of \`BlobPool.GetBlobs\` are \`GetBlobsV1\` / \`GetBlobsV2\` in \`eth/catalyst/api.go\` (the Engine API package). On BSC:

- \`catalyst.RegisterSimulatedBeaconAPIs\` is gated behind \`--dev\` (\`cmd/geth/config.go:343-349\`) and is *not* registered on mainnet / Chapel testnet.
- BSC's Parlia consensus runs in-process; there is no external consensus client invoking \`engine_getBlobs\`.
- \`GetBlobsV1\` is additionally gated behind the \`Cancun\` fork check, \`GetBlobsV2\` behind \`Osaka\`.
- No BSC-specific caller exists in the tree (verified with \`grep\`).

**Effective severity on BSC: N/A / hardening.** The patch is still worth carrying as defense-in-depth and to stay faithful to upstream — if BSC ever exposes Engine API in production, the bug would matter then. The code change itself is trivial and risk-free.

## BSC-specific notes

Upstream only patched the \`CellProofsAt\` path. BSC's \`GetBlobs\` additionally supports v0↔v1 sidecar conversion via \`ComputeBlobProof\` and \`ComputeCellProofs\`, so all **three** error paths receive the same treatment:

- \`ComputeBlobProof\` (v0 proof from v1 sidecar) — \`blobpool.go:1610\`
- \`ComputeCellProofs\` (v1 proofs from v0 sidecar) — \`blobpool.go:1619\`
- \`CellProofsAt\` (v1 proofs from v1 sidecar) — \`blobpool.go:1626\`

Callers (\`eth/catalyst/api.go:512\` GetBlobsV1, \`eth/catalyst/api.go:573\` GetBlobsV2) already check nil slots before dereferencing, so the behavior change is safe.

## Test plan

- [x] \`go build ./core/txpool/blobpool/\` — clean
- [x] \`go test -timeout 120s ./core/txpool/blobpool/\` — all pass (14.3s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)