### PR TITLE
crypto: add hash length check in nocgo VerifySignature (#33839)

### DIFF
--- a/crypto/signature_nocgo.go
+++ b/crypto/signature_nocgo.go
@@ -99,7 +99,7 @@ func Sign(hash []byte, prv *ecdsa.PrivateKey) ([]byte, error) {
 // The public key should be in compressed (33 bytes) or uncompressed (65 bytes) format.
 // The signature should have the 64 byte [R || S] format.
 func VerifySignature(pubkey, hash, signature []byte) bool {
-	if len(signature) != 64 {
+	if len(signature) != 64 || len(hash) != DigestLength {
 		return false
 	}
 	var r, s secp256k1.ModNScalar


### PR DESCRIPTION
## Summary

Cherry-pick of go-ethereum [`8581125a2`](https://github.com/ethereum/go-ethereum/commit/8581125a2) (upstream PR #33839).

The cgo path in \`secp256k1/secp256.go\` already rejects non-32-byte hashes, but the nocgo (pure-Go) path did not. Upstream PR #33104 had added the check to \`Sign\` and \`sigToPub\` but missed \`VerifySignature\`. Without it, a wrong-length hash gets passed to decred's \`Verify\` and silently gives a bogus result — a truncated hash may match a different signature, an extended hash silently ignores extra bytes.

## Impact

Severity: **MEDIUM / P2** per \`docs/v1.17.3_upstream_release_check.md\` finding #1.

BSC validators / RPC nodes built with \`CGO_ENABLED=1\` (production default) are not affected, because the CGO path uses libsecp256k1 which internally validates hash length. The nocgo path is a fallback for edge-case builds (Docker alpine, cross-compilation, some CI). All hot-path callers (block validation, tx verification) pass a 32-byte Keccak hash, so an attacker cannot easily control hash length through normal protocol interaction — but the defensive check is still warranted.

## Test plan

- [x] \`CGO_ENABLED=0 go build ./crypto/\` — clean
- [x] \`CGO_ENABLED=0 go test ./crypto/\` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)