### PR TITLE
p2p/discover: copy buffer before sending read errors to unhandled (#34888)

### DIFF
--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -570,8 +570,9 @@ func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
 		if err := t.handlePacket(from, buf[:nbytes]); err != nil && unhandled == nil {
 			t.log.Debug("Bad discv4 packet", "addr", from, "err", err)
 		} else if err != nil && unhandled != nil {
+			p := ReadPacket{bytes.Clone(buf[:nbytes]), from}
 			select {
-			case unhandled <- ReadPacket{buf[:nbytes], from}:
+			case unhandled <- p:
 			default:
 			}
 		}


### PR DESCRIPTION
## Summary

Cherry-pick of go-ethereum [`e1e3eaa38`](https://github.com/ethereum/go-ethereum/commit/e1e3eaa38) (upstream PR #34888).

The discv4 read loop allocates \`buf\` once and reuses it for every \`ReadFromUDPAddrPort\` call. When a packet fails \`handlePacket\`, the raw buffer \`buf[:nbytes]\` was sent by reference to the \`unhandled\` channel — by the time the consumer (discv5 in mixed-mode operation) processed it, the next \`ReadFromUDPAddrPort\` had overwritten the buffer contents with a new packet.

\`bytes.Clone\` the slice before sending so the consumer owns an independent copy.

## Impact

Severity: **LOW / P2** per \`docs/v1.17.3_upstream_release_check.md\` finding #4. Corruption only affects packets already rejected by discv4 being forwarded to discv5. No security-critical data is at risk, but mixed-mode discovery may misclassify packets due to the corrupted bytes.

## Test plan

- [x] \`go build ./p2p/discover/\` — clean
- [x] \`go test -timeout 180s -run TestUDPv4_ ./p2p/discover/\` — all pass (11.050s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)