### PR TITLE
p2p/discover: fix timeout loop early exit when removing expired matchers (#34743)

### DIFF
--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -448,7 +448,8 @@ func (t *UDPv4) loop(isBootNode bool) {
 		}
 		// Start the timer so it fires when the next pending reply has expired.
 		now := time.Now()
-		for el := plist.Front(); el != nil; el = el.Next() {
+		for el := plist.Front(); el != nil; {
+			next := el.Next()
 			nextTimeout = el.Value.(*replyMatcher)
 			if dist := nextTimeout.deadline.Sub(now); dist < 2*respTimeout {
 				timeout.Reset(dist)
@@ -459,6 +460,7 @@ func (t *UDPv4) loop(isBootNode bool) {
 			// backwards after the deadline was assigned.
 			nextTimeout.errc <- errClockWarp
 			plist.Remove(el)
+			el = next
 		}
 		nextTimeout = nil
 		timeout.Stop()

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -486,7 +486,8 @@ func (t *UDPv4) loop(isBootNode bool) {
 
 		case r := <-t.gotreply:
 			var matched bool // whether any replyMatcher considered the reply acceptable.
-			for el := plist.Front(); el != nil; el = el.Next() {
+			for el := plist.Front(); el != nil; {
+				next := el.Next()
 				p := el.Value.(*replyMatcher)
 				if p.from == r.from && p.ptype == r.data.Kind() && p.ip == r.ip {
 					ok, requestDone := p.callback(r.data)
@@ -500,6 +501,7 @@ func (t *UDPv4) loop(isBootNode bool) {
 					// Reset the continuous timeout counter (time drift detection)
 					contTimeouts = 0
 				}
+				el = next
 			}
 			r.matched <- matched
 
@@ -507,13 +509,15 @@ func (t *UDPv4) loop(isBootNode bool) {
 			nextTimeout = nil
 
 			// Notify and remove callbacks whose deadline is in the past.
-			for el := plist.Front(); el != nil; el = el.Next() {
+			for el := plist.Front(); el != nil; {
+				next := el.Next()
 				p := el.Value.(*replyMatcher)
 				if now.After(p.deadline) || now.Equal(p.deadline) {
 					p.errc <- errTimeout
 					plist.Remove(el)
 					contTimeouts++
 				}
+				el = next
 			}
 			// If we've accumulated too many timeouts, do an NTP time sync check
 			if contTimeouts > ntpFailureThreshold {


### PR DESCRIPTION
## Summary

Cherry-pick of go-ethereum [`51c97216c`](https://github.com/ethereum/go-ethereum/commit/51c97216c) (upstream PR #34743), adapted minimally for BSC.

In two of the \`UDPv4.loop()\` event handlers (\`gotreply\` and \`timeout.C\`), \`plist.Remove(el)\` is called inside a \`for el := plist.Front(); el != nil; el = el.Next()\` loop. Go's \`container/list.Remove\` clears the removed element's links, so the subsequent \`el.Next()\` returns nil and the loop exits after removing only the **first** expired / done matcher. Remaining entries leak.

Save \`el.Next()\` into a local before calling \`Remove\` so the iteration continues through every entry.

## Adaptation notes

Upstream's commit also refactored these loops to use a new \`iterList\` helper. That refactor itself introduced a regression (stale \`nextTimeout\` tracking) which upstream fixed in a follow-up (\`60db25b07\`). To avoid carrying both the refactor *and* its follow-up, BSC keeps the original manual iteration and just saves \`el.Next()\` before \`Remove\` — same correctness, smaller surface.

This matches the analysis in \`docs/v1.17.3_upstream_release_check.md\` finding #5 (and the explicit \`DROPPED\` rationale for finding #6).

## Impact

Severity: **LOW / P2** per the release-check report. Resource leak — expired \`replyMatcher\` entries accumulate, consuming memory and creating stale peer-tracking state on long-running nodes.

## Test plan

- [x] \`go build ./p2p/discover/\` — clean
- [x] \`go test -count=1 -timeout 180s -run TestUDPv4_ ./p2p/discover/\` — all pass (34.866s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)