### PR TITLE
core/stateless: fix parsing an empty witness (#34683)

### DIFF
--- a/core/stateless/encoding.go
+++ b/core/stateless/encoding.go
@@ -17,6 +17,7 @@
 package stateless
 
 import (
+	"errors"
 	"io"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -42,6 +43,9 @@ func (w *Witness) ToExtWitness() *ExtWitness {
 
 // fromExtWitness converts the consensus witness format into our internal one.
 func (w *Witness) fromExtWitness(ext *ExtWitness) error {
+	if len(ext.Headers) == 0 {
+		return errors.New("witness must contain at least one header")
+	}
 	w.Headers = ext.Headers
 
 	w.Codes = make(map[string]struct{}, len(ext.Codes))


### PR DESCRIPTION
## Summary

Cherry-pick of go-ethereum [`68c7058a8`](https://github.com/ethereum/go-ethereum/commit/68c7058a8) (upstream PR #34683).

\`fromExtWitness\` did not validate that \`ext.Headers\` was non-empty. Downstream code accesses \`Headers[0]\` unconditionally and panics on an empty witness. Returns a sentinel error on empty Headers instead.

## BSC reachability

\`core/stateless\` is imported by:
- \`core/blockchain.go\`
- \`miner/worker.go\`
- \`eth/catalyst/witness.go\`

The empty-witness path is reached by submitting a crafted witness through \`debug_executionWitness\` (requires \`--http.api=debug\`, non-default) or through a malformed consensus-client response.

## Impact

Severity: **LOW / P2** per \`docs/v1.17.3_upstream_release_check.md\` finding #20. Panics the node process if the empty-witness path is reachable.

## Test plan

- [x] \`go build ./core/stateless/\` — clean
- [x] \`go test -count=1 -timeout 60s ./core/stateless/\` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)