### PR TITLE
eth/protocols/eth: stop serving on unavailable responses (#34787)

### DIFF
--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -429,16 +429,20 @@ func testGetBlockBodies(t *testing.T, protocol uint) {
 		{0, []common.Hash{backend.chain.CurrentBlock().Hash()}, []bool{true}, 1}, // The chains head block should be retrievable
 		{0, []common.Hash{{}}, []bool{false}, 0},                                 // A non existent block should not be returned
 
-		// Existing and non-existing blocks interleaved should not cause problems
+		// Existing blocks followed by a non-existing one should stop at the gap
+		{0, []common.Hash{
+			backend.chain.GetBlockByNumber(1).Hash(),
+			backend.chain.GetBlockByNumber(10).Hash(),
+			backend.chain.GetBlockByNumber(100).Hash(),
+			{},
+		}, []bool{true, true, true, false}, 3},
+
+		// A non-existing block at the start should return nothing
 		{0, []common.Hash{
 			{},
 			backend.chain.GetBlockByNumber(1).Hash(),
-			{},
 			backend.chain.GetBlockByNumber(10).Hash(),
-			{},
-			backend.chain.GetBlockByNumber(100).Hash(),
-			{},
-		}, []bool{false, true, false, true, false, true, false}, 3},
+		}, []bool{false, true, true}, 0},
 	}
 	// Run each of the tests and verify the results against the chain
 	for i, tt := range tests {

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -240,7 +240,7 @@ func ServiceGetBlockBodiesQuery(chain *core.BlockChain, query GetBlockBodiesRequ
 		}
 		body := chain.GetBody(hash)
 		if body == nil {
-			continue
+			break // If we don't have this block's body, stop serving.
 		}
 		sidecars := chain.GetSidecarsByHash(hash)
 		bodyWithSidecars := &struct {
@@ -257,7 +257,7 @@ func ServiceGetBlockBodiesQuery(chain *core.BlockChain, query GetBlockBodiesRequ
 		enc, err := rlp.EncodeToBytes(bodyWithSidecars)
 		if err != nil {
 			log.Error("block body encode err", "hash", hash, "err", err)
-			continue
+			break
 		}
 		bodies = append(bodies, enc)
 		bytes += len(enc)
@@ -301,19 +301,20 @@ func ServiceGetReceiptsQuery68(chain *core.BlockChain, query GetReceiptsRequest)
 		// Retrieve the requested block's receipts
 		results := chain.GetReceiptsRLP(hash)
 		if results == nil {
+			// If we don't have this block (or it isn't an empty-receipts block), stop serving.
 			if header := chain.GetHeaderByHash(hash); header == nil || header.ReceiptHash != types.EmptyRootHash {
-				continue
+				break
 			}
 		} else {
 			body := chain.GetBodyRLP(hash)
 			if body == nil {
-				continue
+				break // The block body is missing, stop serving.
 			}
 			var err error
 			results, err = blockReceiptsToNetwork68(results, body)
 			if err != nil {
 				log.Error("Error in block receipts conversion", "hash", hash, "err", err)
-				continue
+				break
 			}
 		}
 		receipts = append(receipts, results)
@@ -338,19 +339,20 @@ func serviceGetReceiptsQuery69(chain *core.BlockChain, query GetReceiptsRequest)
 		// Retrieve the requested block's receipts
 		results := chain.GetReceiptsRLP(hash)
 		if results == nil {
+			// If we don't have this block (or it isn't an empty-receipts block), stop serving.
 			if header := chain.GetHeaderByHash(hash); header == nil || header.ReceiptHash != types.EmptyRootHash {
-				continue
+				break
 			}
 		} else {
 			body := chain.GetBodyRLP(hash)
 			if body == nil {
-				continue
+				break // The block body is missing, stop serving.
 			}
 			var err error
 			results, err = blockReceiptsToNetwork69(results, body)
 			if err != nil {
 				log.Error("Error in block receipts conversion", "hash", hash, "err", err)
-				continue
+				break
 			}
 		}
 		receipts = append(receipts, results)


### PR DESCRIPTION
## Summary

Cherry-pick of go-ethereum [`ea1cf7bf5`](https://github.com/ethereum/go-ethereum/commit/ea1cf7bf5) (upstream PR #34787).

When serving \`GetBlockBodies\` / \`GetReceipts\`, if a requested item is unavailable locally, stop serving instead of silently dropping it. Requests for unavailable items are typically a sign that the peer is following a different fork; replying with a sparse list is misleading because dropped slots are elided. Halting at the first gap gives the requester a clearer signal and saves the server work.

## BSC adaptation

- \`ServiceGetBlockBodiesQuery\` — BSC variant carries sidecars; same break-on-nil/error semantics applied.
- \`ServiceGetReceiptsQuery68\` and \`serviceGetReceiptsQuery69\` — BSC keeps the empty-receipts-root branch (header present, \`ReceiptHash == EmptyRootHash\` → serve empty receipts). We \`break\` only when the block is truly absent or the body / encode call fails, matching upstream intent.
- Test \`testGetBlockBodies\` updated to two new sub-cases that match the new "stop at gap" semantics.

## Impact

Severity: **LOW / P2** (hardening) per \`docs/v1.17.3_upstream_release_check.md\` finding #8. Defensive change against peers requesting many unavailable bodies/receipts to waste server cycles.

## Test plan

- [x] \`go build ./eth/protocols/eth/\` — clean
- [x] \`go test -run TestGetBlockBodies68 ./eth/protocols/eth/\` — PASS
- [x] \`go test -run TestGetBlockReceipts68 ./eth/protocols/eth/\` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)