### PR TITLE
triedb/pathdb: fix lookup sentinel collision with zero disk layer root (#34680)

### DIFF
--- a/triedb/pathdb/layertree.go
+++ b/triedb/pathdb/layertree.go
@@ -315,8 +315,8 @@ func (tree *layerTree) lookupAccount(accountHash common.Hash, state common.Hash)
 	tree.lock.RLock()
 	defer tree.lock.RUnlock()
 
-	tip := tree.lookup.accountTip(accountHash, state, tree.base.root)
-	if tip == (common.Hash{}) {
+	tip, ok := tree.lookup.accountTip(accountHash, state, tree.base.root)
+	if !ok {
 		return nil, fmt.Errorf("[%#x] %w", state, errSnapshotStale)
 	}
 	l := tree.layers[tip]
@@ -333,8 +333,8 @@ func (tree *layerTree) lookupStorage(accountHash common.Hash, slotHash common.Ha
 	tree.lock.RLock()
 	defer tree.lock.RUnlock()
 
-	tip := tree.lookup.storageTip(accountHash, slotHash, state, tree.base.root)
-	if tip == (common.Hash{}) {
+	tip, ok := tree.lookup.storageTip(accountHash, slotHash, state, tree.base.root)
+	if !ok {
 		return nil, fmt.Errorf("[%#x] %w", state, errSnapshotStale)
 	}
 	l := tree.layers[tip]

--- a/triedb/pathdb/lookup.go
+++ b/triedb/pathdb/lookup.go
@@ -85,12 +85,16 @@ func newLookup(head layer, descendant func(state common.Hash, ancestor common.Ha
 // stateID or is a descendant of it.
 //
 // If found, the account data corresponding to the supplied stateID resides
-// in that layer. Otherwise, two scenarios are possible:
+// in the layer identified by the returned hash (ok=true). Otherwise,
+// (common.Hash{}, false) is returned to signal that the supplied stateID is
+// stale.
 //
-// (a) the account remains unmodified from the current disk layer up to the state
-// layer specified by the stateID: fallback to the disk layer for data retrieval,
-// (b) or the layer specified by the stateID is stale: reject the data retrieval.
-func (l *lookup) accountTip(accountHash common.Hash, stateID common.Hash, base common.Hash) common.Hash {
+// Note the returned hash may itself be common.Hash{} when the disk layer's
+// root is zero — as is the case for a fresh verkle/bintrie database whose
+// empty trie hashes to EmptyVerkleHash. Callers must therefore consult the
+// boolean rather than comparing the returned hash against common.Hash{}
+// directly.
+func (l *lookup) accountTip(accountHash common.Hash, stateID common.Hash, base common.Hash) (common.Hash, bool) {
 	// Traverse the mutation history from latest to oldest one. Several
 	// scenarios are possible:
 	//
@@ -116,31 +120,26 @@ func (l *lookup) accountTip(accountHash common.Hash, stateID common.Hash, base c
 		// containing the modified data. Otherwise, the current state may be ahead
 		// of the requested one or belong to a different branch.
 		if list[i] == stateID || l.descendant(stateID, list[i]) {
-			return list[i]
+			return list[i], true
 		}
 	}
 	// No layer matching the stateID or its descendants was found. Use the
 	// current disk layer as a fallback.
 	if base == stateID || l.descendant(stateID, base) {
-		return base
+		return base, true
 	}
 	// The layer associated with 'stateID' is not the descendant of the current
 	// disk layer, it's already stale, return nothing.
-	return common.Hash{}
+	return common.Hash{}, false
 }
 
 // storageTip traverses the layer list associated with the given account and
 // slot hash in reverse order to locate the first entry that either matches
 // the specified stateID or is a descendant of it.
 //
-// If found, the storage data corresponding to the supplied stateID resides
-// in that layer. Otherwise, two scenarios are possible:
-//
-// (a) the storage slot remains unmodified from the current disk layer up to
-// the state layer specified by the stateID: fallback to the disk layer for
-// data retrieval, (b) or the layer specified by the stateID is stale: reject
-// the data retrieval.
-func (l *lookup) storageTip(accountHash common.Hash, slotHash common.Hash, stateID common.Hash, base common.Hash) common.Hash {
+// See accountTip for the returned-hash / ok convention — the same
+// bintrie-zero-root caveat applies here.
+func (l *lookup) storageTip(accountHash common.Hash, slotHash common.Hash, stateID common.Hash, base common.Hash) (common.Hash, bool) {
 	list := l.storages[storageKey(accountHash, slotHash)]
 	for i := len(list) - 1; i >= 0; i-- {
 		// If the current state matches the stateID, or the requested state is a
@@ -148,17 +147,17 @@ func (l *lookup) storageTip(accountHash common.Hash, slotHash common.Hash, state
 		// containing the modified data. Otherwise, the current state may be ahead
 		// of the requested one or belong to a different branch.
 		if list[i] == stateID || l.descendant(stateID, list[i]) {
-			return list[i]
+			return list[i], true
 		}
 	}
 	// No layer matching the stateID or its descendants was found. Use the
 	// current disk layer as a fallback.
 	if base == stateID || l.descendant(stateID, base) {
-		return base
+		return base, true
 	}
 	// The layer associated with 'stateID' is not the descendant of the current
 	// disk layer, it's already stale, return nothing.
-	return common.Hash{}
+	return common.Hash{}, false
 }
 
 // addLayer traverses the state data retained in the specified diff layer and


### PR DESCRIPTION
## Summary

Cherry-pick of go-ethereum [`3772bb536`](https://github.com/ethereum/go-ethereum/commit/3772bb536) (upstream PR #34680).

\`accountTip\` and \`storageTip\` both returned \`common.Hash{}\` as the "not found" sentinel. That collides with a legitimate disk-layer fallback when the disk layer's root is itself the zero hash — as is the case for a fresh verkle/bintrie database whose empty trie hashes to \`EmptyVerkleHash\`.

Switch to a \`(hash, ok)\` return signature so callers can distinguish stale state from a zero-root disk-layer fallback. Update \`lookupAccount\`/\`lookupStorage\` call sites in \`layertree.go\`.

## BSC adaptation

The upstream regression test \`TestLookupZeroBaseRootFallback\` depends on test helpers not present in BSC's \`layertree_test.go\` and was omitted. The existing pathdb test suite still exercises the happy path:

- \`go test -count=1 -timeout 300s ./triedb/pathdb/\` — PASS (18.469s)

## Impact

Severity: **LOW / P3** (hardening) per \`docs/v1.17.3_upstream_release_check.md\` finding #10. BSC does not activate verkle in production today, so the zero-root collision is theoretical. Recommended as prerequisite for any future verkle/bintrie adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)