### PR TITLE
eth/tracers: forward OnSystemCall hooks through mux (#34862)

### DIFF
--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -71,6 +71,8 @@ func newMuxTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *params
 			OnStorageChange:           t.OnStorageChange,
 			OnLog:                     t.OnLog,
 			OnSystemTxFixIntrinsicGas: t.OnSystemTxFixIntrinsicGas,
+			OnSystemCallStartV2:       t.OnSystemCallStart,
+			OnSystemCallEnd:           t.OnSystemCallEnd,
 		},
 		GetResult: t.GetResult,
 		Stop:      t.Stop,
@@ -177,6 +179,24 @@ func (t *muxTracer) OnSystemTxFixIntrinsicGas(intrinsicGas uint64) {
 	for _, t := range t.tracers {
 		if t.OnSystemTxFixIntrinsicGas != nil {
 			t.OnSystemTxFixIntrinsicGas(intrinsicGas)
+		}
+	}
+}
+
+func (t *muxTracer) OnSystemCallStart(vm *tracing.VMContext) {
+	for _, t := range t.tracers {
+		if t.OnSystemCallStartV2 != nil {
+			t.OnSystemCallStartV2(vm)
+		} else if t.OnSystemCallStart != nil {
+			t.OnSystemCallStart()
+		}
+	}
+}
+
+func (t *muxTracer) OnSystemCallEnd() {
+	for _, t := range t.tracers {
+		if t.OnSystemCallEnd != nil {
+			t.OnSystemCallEnd()
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Cherry-pick of go-ethereum [`b9c5fe6d2`](https://github.com/ethereum/go-ethereum/commit/b9c5fe6d2) (upstream PR #34862).

The mux tracer fanned out every standard hook to its children but never forwarded \`OnSystemCallStart\` / \`OnSystemCallEnd\`. Tracers that rely on these (e.g. \`logger.jsonLogger\`, which uses the start hook to silence its opcode hook for the duration of a system call) never got the signal when wrapped behind a mux. Combining \`--trace\` with \`--opcode-count\` in \`evm t8n\` produces that wrapping, and the first system call (e.g. \`ProcessBeaconBlockRoot\`) crashes t8n on a nil env deref.

Forward \`OnSystemCallStartV2\` (with V1 fallback per child) and \`OnSystemCallEnd\` through the mux. Same precedence as \`core/state_processor.go\`.

## Impact

Severity: **LOW / P3** (hardening) per \`docs/v1.17.3_upstream_release_check.md\` finding #11. t8n is a development/testing tool, not a production code path. Still worth carrying so that anyone debugging BSC system-call behavior via \`evm t8n\` doesn't hit a confusing nil panic.

## Test plan

- [x] \`go build ./eth/tracers/native/\` — clean
- [x] \`go test -count=1 -timeout 60s ./eth/tracers/native/\` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)