### PR TITLE
eth/downloader: drop invalid peers + fix deliver index (#34745, #34870)

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -116,6 +116,7 @@ func (dl *downloadTester) newPeer(id string, version uint, blocks []*types.Block
 		id:              id,
 		chain:           newTestBlockchain(blocks),
 		withholdHeaders: make(map[common.Hash]struct{}),
+		dropped:         make(chan error, 1),
 	}
 	dl.peers[id] = peer
 
@@ -144,6 +145,9 @@ type downloadTesterPeer struct {
 	chain *core.BlockChain
 
 	withholdHeaders map[common.Hash]struct{}
+	corruptBodies   bool // if set, the peer serves incorrect bodies
+
+	dropped chan error // signaled when res.Done receives an error
 }
 
 func (dlp *downloadTesterPeer) MarkLagging() {
@@ -279,6 +283,11 @@ func (dlp *downloadTesterPeer) RequestBodies(hashes []common.Hash, sink chan *et
 		txsHashes[i] = types.DeriveSha(types.Transactions(body.Transactions), hasher)
 		uncleHashes[i] = types.CalcUncleHash(body.Uncles)
 	}
+	if dlp.corruptBodies {
+		for i := range txsHashes {
+			txsHashes[i] = common.Hash{0xff}
+		}
+	}
 	req := &eth.Request{
 		Peer: dlp.id,
 	}
@@ -291,10 +300,16 @@ func (dlp *downloadTesterPeer) RequestBodies(hashes []common.Hash, sink chan *et
 			WithdrawalRoots:  withdrawalHashes,
 		},
 		Time: 1,
-		Done: make(chan error, 1), // Ignore the returned status
+		Done: make(chan error),
 	}
 	go func() {
 		sink <- res
+		if err := <-res.Done; err != nil {
+			select {
+			case dlp.dropped <- err:
+			default:
+			}
+		}
 	}()
 	return req, nil
 }
@@ -1261,5 +1276,23 @@ func TestRemoteHeaderRequestSpan(t *testing.T) {
 			t.Logf("exp: %v\n", exp)
 			t.Errorf("test %d: wrong values", i)
 		}
+	}
+}
+
+// TestInvalidBodyPeerDrop verifies that a peer serving corrupted block bodies
+// is signalled through res.Done so the eth protocol handler can drop it.
+func TestInvalidBodyPeerDrop(t *testing.T) {
+	tester := newTester(t)
+	defer tester.terminate()
+
+	chain := testChainBase.shorten(blockCacheMaxItems - 15)
+	peer := tester.newPeer("corrupt", eth.ETH68, chain.blocks[1:])
+	peer.corruptBodies = true
+
+	go tester.sync("corrupt", nil, FullSync)
+	select {
+	case <-peer.dropped:
+	case <-time.After(1 * time.Minute):
+		t.Fatal("peer was not dropped")
 	}
 }

--- a/eth/downloader/fetchers_concurrent.go
+++ b/eth/downloader/fetchers_concurrent.go
@@ -357,25 +357,32 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 			delete(pending, res.Req.Peer)
 			delete(stales, res.Req.Peer)
 
-			// Signal the dispatcher that the round trip is done. We'll drop the
-			// peer if the data turns out to be junk.
-			res.Done <- nil
-			res.Req.Close()
-
 			// If the peer was previously banned and failed to deliver its pack
 			// in a reasonable time frame, ignore its message.
-			if peer := d.peers.Peer(res.Req.Peer); peer != nil {
-				// Deliver the received chunk of data and check chain validity
-				accepted, err := queue.deliver(peer, res)
-				if errors.Is(err, errInvalidChain) {
-					return err
-				}
-				// Unless a peer delivered something completely else than requested (usually
-				// caused by a timed out request which came through in the end), set it to
-				// idle. If the delivery's stale, the peer should have already been idled.
-				if !errors.Is(err, errStaleDelivery) {
-					queue.updateCapacity(peer, accepted, res.Time)
-				}
+			peer := d.peers.Peer(res.Req.Peer)
+			if peer == nil {
+				res.Done <- nil
+				res.Req.Close()
+				continue
+			}
+			// Deliver the received chunk of data and check chain validity
+			accepted, err := queue.deliver(peer, res)
+			// Unless a peer delivered something completely else than requested (usually
+			// caused by a timed out request which came through in the end), set it to
+			// idle. If the delivery's stale, the peer should have already been idled.
+			if !errors.Is(err, errStaleDelivery) {
+				queue.updateCapacity(peer, accepted, res.Time)
+			}
+			res.Done <- validityErrorOfRequest(err)
+			res.Req.Close()
+
+			if errors.Is(err, errInvalidChain) {
+				// errInvalidChain is the signal that processing of items failed internally,
+				// even though the items were validly encoded.
+				//
+				// This can be due to invalid blocks, or a database error.
+				// The sync cycle should be aborted for such errors, so we return it here.
+				return err
 			}
 
 		case cont := <-queue.waker():
@@ -385,4 +392,12 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 			}
 		}
 	}
+}
+
+// validityErrorOfRequest returns err if it is related to block validity, and nil otherwise.
+func validityErrorOfRequest(err error) error {
+	if errors.Is(err, errInvalidBody) || errors.Is(err, errInvalidReceipt) {
+		return err
+	}
+	return nil
 }

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -918,10 +918,10 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 	}
 	// Assemble each of the results with their headers and retrieved data parts
 	var (
-		accepted int
-		failure  error
-		i        int
-		hashes   []common.Hash
+		accepted   int
+		failure    error
+		i          int
+		foundStale bool
 	)
 	for _, header := range request.Headers {
 		// Short circuit assembly if no more fetch results are found
@@ -933,42 +933,41 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 			failure = err
 			break
 		}
-		hashes = append(hashes, header.Hash())
 		i++
 	}
 
 	for _, header := range request.Headers[:i] {
 		if res, stale, err := q.resultCache.GetDeliverySlot(header.Number.Uint64()); err == nil && !stale {
 			reconstruct(accepted, res)
+			accepted++
 		} else {
-			// else: between here and above, some other peer filled this result,
+			// Between here and above, some other peer filled this result,
 			// or it was indeed a no-op. This should not happen, but if it does it's
 			// not something to panic about
 			log.Error("Delivery stale", "stale", stale, "number", header.Number.Uint64(), "err", err)
-			failure = errStaleDelivery
+			foundStale = true
 		}
 		// Clean up a successful fetch
-		delete(taskPool, hashes[accepted])
-		accepted++
+		delete(taskPool, header.Hash())
 	}
 	resDropMeter.Mark(int64(results - accepted))
 
 	// Return all failed or missing fetches to the queue
-	for _, header := range request.Headers[accepted:] {
+	for _, header := range request.Headers[i:] {
 		taskQueue.Push(header, -int64(header.Number.Uint64()))
 	}
 	// Wake up Results
 	if accepted > 0 {
 		q.active.Signal()
 	}
-	if failure == nil {
-		return accepted, nil
+	if failure != nil {
+		return accepted, failure
 	}
 	// If none of the data was good, it's a stale delivery
-	if accepted > 0 {
-		return accepted, fmt.Errorf("partial failure: %v", failure)
+	if foundStale {
+		return accepted, errStaleDelivery
 	}
-	return accepted, fmt.Errorf("%w: %v", failure, errStaleDelivery)
+	return accepted, nil
 }
 
 // Prepare configures the result cache to allow accepting and caching inbound

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -936,9 +936,9 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 		i++
 	}
 
-	for _, header := range request.Headers[:i] {
+	for k, header := range request.Headers[:i] {
 		if res, stale, err := q.resultCache.GetDeliverySlot(header.Number.Uint64()); err == nil && !stale {
-			reconstruct(accepted, res)
+			reconstruct(k, res)
 			accepted++
 		} else {
 			// Between here and above, some other peer filled this result,


### PR DESCRIPTION
Cherry-pick of go-ethereum [`75a64ee34`](https://github.com/ethereum/go-ethereum/commit/75a64ee34) (PR #34745) + [`5b837e578`](https://github.com/ethereum/go-ethereum/commit/5b837e578) (PR #34870). Both touch `eth/downloader/queue.go` and are intertwined, so they're bundled into one PR.

## What this fixes

1. **Invalid peers were not dropped (#34745, P1)** — `concurrentFetch` sent `res.Done <- nil` before `queue.deliver` validated the response, so `errInvalidBody` / `errInvalidReceipt` never reached the eth dispatcher and the misbehaving peer stayed connected. `queue.deliver` itself wrapped real validation errors under `errStaleDelivery`, further hiding them.

2. **Wrong reconstruct index on stale slot (#34870, P3)** — after the fix in (1), `accepted` only increments on successful slots, but `reconstruct(accepted, res)` is supposed to index into the parallel response slices. Whenever an earlier header in the same batch hits a stale slot, the next successful slot reads from the wrong slice element. Switch to the loop's range index `k`.

## Files changed

- `eth/downloader/fetchers_concurrent.go` — move `res.Done` after `queue.deliver`, add `validityErrorOfRequest` whitelist (only invalidBody / invalidReceipt trigger the dispatcher to drop the peer)
- `eth/downloader/queue.go` — separate `foundStale` bool from `failure`, fix the `accepted`/`taskPool` bookkeeping, use range index `k` in reconstruct
- `eth/downloader/downloader_test.go` — `corruptBodies` peer + `dropped` channel + `TestInvalidBodyPeerDrop`

## Test plan

- [x] `go build ./eth/downloader/` — clean
- [x] `go test -run TestInvalidBodyPeerDrop -v ./eth/downloader/` — PASS
- [x] `go test -count=1 -timeout 600s ./eth/downloader/` — all pass

Supersedes #3699 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)