### PR TITLE
core/state: fix StateDB Reader error discarded after Commit

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1464,7 +1464,7 @@ func (s *StateDB) commitAndFlush(block uint64, deleteEmptyObjects bool, noStorag
 			s.TrieDBCommits += time.Since(start)
 		}
 	}
-	s.reader, _ = s.db.Reader(s.originalRoot)
+	s.reader, err = s.db.Reader(s.originalRoot)
 	return ret, err
 }
 


### PR DESCRIPTION
## Description

Cherry-pick of go-ethereum upstream commit [`e71098ba4`](https://github.com/ethereum/go-ethereum/commit/e71098ba4) (v1.17.3 security release).

In `StateDB.commitAndFlush`, the error returned by `s.db.Reader(s.originalRoot)` was discarded with the blank identifier:

```go
s.reader, _ = s.db.Reader(s.originalRoot)
```

If reconstructing the reader fails after a commit, the error is swallowed and `s.reader` may be left `nil` / stale. Subsequent reads against the `StateDB` then proceed without surfacing the failure, which can mask state-access errors after a commit.

The fix propagates the error through the function's named `err` return value:

```go
s.reader, err = s.db.Reader(s.originalRoot)
return ret, err
```

## Note on prior triage

This commit was initially triaged as "already patched in BSC" during the v1.17.3 upstream review (`docs/v1.17.3_pick_decisions.md` #13). That was a misread — BSC still had the `_` discard, so the bug was present. This PR applies the actual fix.

## Rationale

- **Severity:** MEDIUM. Error from reader reconstruction was silently dropped after `Commit`.
- **Scope:** single-line change in `core/state/statedb.go`, faithful to upstream.

## Changes

- `core/state/statedb.go`: capture the `Reader` error into the returned `err` instead of discarding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)