### PR TITLE
p2p/discover: decouple nodeFeed from Table mutex in waitForNodes

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -764,6 +764,41 @@ func (tab *Table) deleteNode(n *enode.Node) {
 
 // waitForNodes blocks until the table contains at least n nodes.
 func (tab *Table) waitForNodes(ctx context.Context, n int) error {
+	// Wrap ctx so the forwarder goroutine exits when waitForNodes returns,
+	// regardless of whether the caller's ctx is canceled.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Set up a notification channel that gets unblocked when there was any activity on
+	// the table. Ultimately this reads from the table's nodeFeed, but can't use the feed
+	// directly on the same goroutine that takes Table.mutex, it would deadlock.
+	var notify chan struct{}
+	var notifyErr error
+	initsub := func() event.Subscription {
+		notify = make(chan struct{}, 1)
+		newnode := make(chan *enode.Node, 1)
+		sub := tab.nodeFeed.Subscribe(newnode)
+		go func() {
+			defer close(notify)
+			for {
+				select {
+				case <-newnode:
+					select {
+					case notify <- struct{}{}:
+					default:
+					}
+				case <-ctx.Done():
+					notifyErr = ctx.Err()
+					return
+				case <-tab.closeReq:
+					notifyErr = errClosed
+					return
+				}
+			}
+		}()
+		return sub
+	}
+
 	getlength := func() (count int) {
 		for _, b := range &tab.buckets {
 			count += len(b.entries)
@@ -771,28 +806,24 @@ func (tab *Table) waitForNodes(ctx context.Context, n int) error {
 		return count
 	}
 
-	var ch chan *enode.Node
 	for {
 		tab.mutex.Lock()
 		if getlength() >= n {
 			tab.mutex.Unlock()
 			return nil
 		}
-		if ch == nil {
-			// Init subscription.
-			ch = make(chan *enode.Node)
-			sub := tab.nodeFeed.Subscribe(ch)
+		if notify == nil {
+			// Lazily init the subscription. Do this while holding the
+			// lock so we don't miss any events that change the node count.
+			sub := initsub()
 			defer sub.Unsubscribe()
 		}
 		tab.mutex.Unlock()
 
-		// Wait for a node add event.
-		select {
-		case <-ch:
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-tab.closeReq:
-			return errClosed
+		// Wait for table event.
+		if _, ok := <-notify; !ok {
+			break
 		}
 	}
+	return notifyErr
 }

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -17,6 +17,7 @@
 package discover
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"fmt"
 	"math/rand"
@@ -526,6 +527,45 @@ func quickcfg() *quick.Config {
 	return &quick.Config{
 		MaxCount: 5000,
 		Rand:     rand.New(rand.NewSource(time.Now().Unix())),
+	}
+}
+
+// This test checks that waitForNodes does not block addFoundNode.
+// See https://github.com/ethereum/go-ethereum/issues/34881.
+func TestTable_waitForNodesLocking(t *testing.T) {
+	transport := newPingRecorder()
+	tab, db := newTestTable(transport, Config{})
+	defer db.Close()
+	defer tab.close()
+	<-tab.initDone
+
+	// waitForNodes will never reach this count, so it stays subscribed
+	// to nodeFeed and looping for the duration of the test.
+	waitCtx, cancelWait := context.WithCancel(context.Background())
+	defer cancelWait()
+	waitDone := make(chan struct{})
+	go func() {
+		defer close(waitDone)
+		tab.waitForNodes(waitCtx, 1<<20)
+	}()
+
+	// Call addFoundNode in loop to send to the feed.
+	addDone := make(chan struct{})
+	go func() {
+		defer close(addDone)
+		for i := range 10000 {
+			d := 240 + (i % 17)
+			n := nodeAtDistance(tab.self().ID(), d, intIP(i))
+			tab.addFoundNode(n, true)
+		}
+	}()
+
+	select {
+	case <-addDone:
+		cancelWait()
+		<-waitDone
+	case <-time.After(10 * time.Second):
+		t.Fatal("deadlock detected: add loop did not finish within 10s")
 	}
 }
 


### PR DESCRIPTION
## Description

Cherry-pick of go-ethereum upstream commit [`281dc4c2`](https://github.com/ethereum/go-ethereum/commit/281dc4c2091400ea1388b030300e5adc7672ffa0) (PR [#34898](https://github.com/ethereum/go-ethereum/pull/34898), fixes ethereum/go-ethereum#34881), part of the v1.17.3 security release.

Fixes a deadlock between `Table.waitForNodes` and `Table.nodeAdded` in p2p discovery.

### The deadlock (present in BSC before this PR)

- `nodeAdded` calls `tab.nodeFeed.Send(n.Node)` **synchronously while holding `tab.mutex`** (`handleAddNode` locks `tab.mutex` at `table.go:566`, then calls `nodeAdded` → `nodeFeed.Send` at `table.go:629`).
- `waitForNodes` subscribes to `nodeFeed` on an **unbuffered** channel and reads from it on the **same goroutine** that re-acquires `tab.mutex` each loop iteration.

This produces a classic lock-ordering deadlock:
1. `waitForNodes` loops back and blocks on `tab.mutex.Lock()` (held by the adder).
2. The adder holds `tab.mutex` and blocks in `nodeFeed.Send`, waiting for `waitForNodes` to receive on the unbuffered channel.
3. Neither can proceed.

### The fix

Move the feed receive onto a dedicated forwarder goroutine that publishes to a buffered `notify` channel, decoupling the feed receive from `tab.mutex`. The synchronous feed send in `nodeAdded` is preserved (per upstream's design intent).

## Note on prior triage

This commit was initially triaged as "already patched in BSC" in the v1.17.3 upstream review (`docs/v1.17.3_pick_decisions.md` #14). That was a misread: the doc's justification — "BSC unlocks `tab.mutex` before blocking in `waitForNodes`" — describes the **pre-fix** vulnerable code (which already unlocked before the `select`). BSC's `waitForNodes` was byte-for-byte the upstream pre-fix version, so the deadlock was present. This PR applies the actual fix.

## Changes

- `p2p/discover/table.go`: `waitForNodes` now uses a forwarder goroutine + buffered `notify` channel.
- `p2p/discover/table_test.go`: add `TestTable_waitForNodesLocking` (regression test; fails by 10s timeout on the buggy code). The unrelated `TestSetFallbackNodes_DNSHostname` that appeared as diff context was intentionally not pulled in — it is not part of this commit and not present on BSC.

## Testing

```
go test ./p2p/discover/ -run TestTable_waitForNodesLocking -v   # PASS
go build ./p2p/discover/ && go vet ./p2p/discover/              # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)