### PR TITLE
core/rawdb: fix file descriptor leak in freezer error paths

### DIFF
--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -167,6 +167,7 @@ func newTable(path string, name string, readMeter, writeMeter *metrics.Meter, si
 		// the initialization.
 		meta, err = openFreezerFileForAppend(filepath.Join(path, fmt.Sprintf("%s.meta", name)))
 		if err != nil {
+			index.Close()
 			return nil, err
 		}
 	} else {
@@ -176,6 +177,7 @@ func newTable(path string, name string, readMeter, writeMeter *metrics.Meter, si
 		}
 		meta, err = openFreezerFileForAppend(filepath.Join(path, fmt.Sprintf("%s.meta", name)))
 		if err != nil {
+			index.Close()
 			return nil, err
 		}
 	}
@@ -183,6 +185,8 @@ func newTable(path string, name string, readMeter, writeMeter *metrics.Meter, si
 	// is detected.
 	metadata, err := newMetadata(meta)
 	if err != nil {
+		meta.Close()
+		index.Close()
 		return nil, err
 	}
 	// Create the table and repair any past inconsistency

--- a/core/rawdb/freezer_utils.go
+++ b/core/rawdb/freezer_utils.go
@@ -87,6 +87,7 @@ func openFreezerFileForAppend(filename string) (*os.File, error) {
 	}
 	// Seek to end for append
 	if _, err = file.Seek(0, io.SeekEnd); err != nil {
+		file.Close()
 		return nil, err
 	}
 	return file, nil


### PR DESCRIPTION
## Description

Cherry-pick of go-ethereum upstream commit [`5af5510b1`](https://github.com/ethereum/go-ethereum/commit/5af5510b1) (PR [#34735](https://github.com/ethereum/go-ethereum/pull/34735)), part of the v1.17.3 security release.

Fixes file-descriptor leaks on freezer-table open error paths. BSC's code was byte-for-byte the upstream pre-fix version, so the leaks were present:

1. **`openFreezerFileForAppend`** (`freezer_utils.go`): if `Seek` fails after the file is opened, the file handle is not closed.
2. **`newTable`** (`freezer_table.go`): if opening the `.meta` file fails, the already-opened `index` file is leaked (both the readonly and read-write branches).
3. **`newTable`**: if `newMetadata` fails, both `index` and `meta` are leaked.

Under repeated error conditions (e.g. a corrupted filesystem) these descriptors accumulate and can exhaust the OS fd limit, causing cascading failures.

## Note on prior triage

This commit was initially triaged as "already patched in BSC" in the v1.17.3 upstream review (`docs/v1.17.3_pick_decisions.md` #15). That was a misread — the cited `openFile` caching does not close the handle on these error paths. This PR applies the actual fix.

## Changes

- `core/rawdb/freezer_utils.go`: `file.Close()` before returning on `Seek` failure.
- `core/rawdb/freezer_table.go`: `index.Close()` on meta-open failure (both branches); `meta.Close()` + `index.Close()` on `newMetadata` failure.

Faithful pick, identical to upstream.

## Testing

```
go test ./core/rawdb/ -run 'Freezer|Table'   # ok
go build ./core/rawdb/ && go vet ./core/rawdb/  # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)