### PR TITLE
core/rawdb: fsync temp file before rename in copyFrom

### DIFF
--- a/core/rawdb/freezer_utils.go
+++ b/core/rawdb/freezer_utils.go
@@ -69,6 +69,11 @@ func copyFrom(srcPath, destPath string, offset uint64, before func(f *os.File) e
 	// we do the final move.
 	src.Close()
 
+	// Permanently persist the content into disk
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
 	if err := f.Close(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Cherry-pick of go-ethereum upstream commit [`573d94013`](https://github.com/ethereum/go-ethereum/commit/573d94013) (PR [#34728](https://github.com/ethereum/go-ethereum/pull/34728)), part of the v1.17.3 security release.

Fixes incorrect fsync ordering when the freezer truncates its tail. `copyFrom` (used by `truncateTail` to drop a prefix of the index/data files) rewrites the file by copying into a temp file and renaming it over the destination — but it never `fsync`'d the temp file's contents before the rename. The rename's directory-entry update can be persisted while the file's data blocks are still in the page cache, so a crash right after a tail-truncation can leave a corrupted or zero-length index/data file.

The fix adds `f.Sync()` after the copy completes and before `f.Close()` + `os.Rename()`.

## Note on prior triage

This commit was initially triaged as "already patched in BSC" in the v1.17.3 upstream review (`docs/v1.17.3_pick_decisions.md` #16). That was a misread — the cited `Sync()`/`Close()` ordering in `freezer_table.go` (`truncateHead`'s in-place `truncateFreezerFile` path) is an unrelated code path. The actual buggy function is `copyFrom` in `freezer_utils.go`, which had no `Sync()` at all. This PR applies the real fix.

## Changes

- `core/rawdb/freezer_utils.go`: `f.Sync()` before `f.Close()`/`os.Rename()` in `copyFrom`.

Faithful pick, identical to upstream.

## Testing

```
go test ./core/rawdb/   # ok
go build ./core/rawdb/ && go vet ./core/rawdb/  # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)