### PR TITLE
fix: guard slice access in processSnapSyncContent pivot-stale block

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1521,6 +1521,12 @@ func (d *Downloader) processSnapSyncContent() error {
 				return errCanceled
 			default:
 			}
+			// Nothing to process this iteration; wait for the next batch.
+			// Skips the pre-commit pivot-stale block below, which would
+			// otherwise dereference results[len(results)-1].
+			if oldPivot == nil {
+				continue
+			}
 		}
 		if d.chainInsertHook != nil {
 			d.chainInsertHook(results, nil)
@@ -1546,7 +1552,7 @@ func (d *Downloader) processSnapSyncContent() error {
 			results = append(append([]*fetchResult{oldPivot}, oldTail...), results...)
 		}
 		// Split around the pivot block and process the two sides via snap/full sync
-		if !d.committed.Load() {
+		if !d.committed.Load() && len(results) > 0 {
 			latest := results[len(results)-1].Header
 			// If the height is above the pivot block by 2 sets, it means the pivot
 			// became stale in the network, and it was garbage collected, move to a
@@ -1556,6 +1562,12 @@ func (d *Downloader) processSnapSyncContent() error {
 			// need to be taken into account, otherwise we're detecting the pivot move
 			// late and will drop peers due to unavailable state!!!
 			if height := latest.Number.Uint64(); height >= pivot.Number.Uint64()+2*uint64(fsMinFullBlocks)-uint64(reorgProtHeaderDelay) {
+				// The second index requires len(results) >= fsMinFullBlocks - reorgProtHeaderDelay + 1.
+				// In normal operation the height guard above implies enough accumulated results,
+				// but guard explicitly to avoid panic if invariants ever drift.
+				if len(results) < fsMinFullBlocks-reorgProtHeaderDelay+1 {
+					continue
+				}
 				log.Warn("Pivot became stale, moving", "old", pivot.Number.Uint64(), "new", height-uint64(fsMinFullBlocks)+uint64(reorgProtHeaderDelay))
 				pivot = results[len(results)-1-fsMinFullBlocks+reorgProtHeaderDelay].Header // must exist as lower old pivot is uncommitted
 


### PR DESCRIPTION
The BSC-specific stale-pivot detection block in `eth/downloader/downloader.go` indexes into `results[len(results)-1]` without first checking that the slice is non-empty. The empty-results handler at the top of the loop only returns early when `committed` is set or `cancelCh` is closed; otherwise control falls through to the unguarded index, which can panic on `index out of range [-1]`.

In current code the trigger is not remotely reachable — `snap.Syncer.Sync` only returns `nil` or `ErrCancelled`, so `closeOnErr` cannot be driven by adversarial peer data, and `Results(true)` cannot be coerced into an empty slice this way. The unguarded access is still a real hardening gap that future refactors to `Sync()`'s error contract or local disk/DB error paths could expose.

Adds three narrow length guards:
1. `continue` the loop when `results` is empty and `oldPivot == nil`.
2. Wrap the pivot-stale block in `len(results) > 0`.
3. Bound the second index `results[len(results)-1-fsMinFullBlocks+reorgProtHeaderDelay]` inside the height-conditional branch.

No storage layout / interface change. Refs: SRC-2026-782.