### PR TITLE
fix: nocgo sigToPub hash check + pathdb zero-base regression test

### DIFF
--- a/crypto/signature_nocgo.go
+++ b/crypto/signature_nocgo.go
@@ -39,6 +39,9 @@ func Ecrecover(hash, sig []byte) ([]byte, error) {
 }
 
 func sigToPub(hash, sig []byte) (*secp256k1.PublicKey, error) {
+	if len(hash) != DigestLength {
+		return nil, fmt.Errorf("hash is required to be exactly %d bytes (%d)", DigestLength, len(hash))
+	}
 	if len(sig) != SignatureLength {
 		return nil, errors.New("invalid signature")
 	}

--- a/triedb/pathdb/layertree_test.go
+++ b/triedb/pathdb/layertree_test.go
@@ -882,3 +882,64 @@ func TestStorageLookup(t *testing.T) {
 		}
 	}
 }
+
+// TestLookupZeroBaseRootFallback regresses the sentinel collision in
+// accountTip/storageTip when the disk layer root is itself common.Hash{}
+// (a fresh verkle/bintrie database whose empty trie hashes to zero).
+// Returning only common.Hash conflated the disk-layer fallback with the
+// "stale" sentinel, so lookupAccount/Storage reported errSnapshotStale
+// for a valid fall-through.
+func TestLookupZeroBaseRootFallback(t *testing.T) {
+	db := New(rawdb.NewMemoryDatabase(), nil, false)
+	base := newDiskLayer(common.Hash{}, 0, db, nil, nil, newBuffer(0, nil, nil, 0), nil)
+	tr := newLayerTree(base)
+
+	if err := tr.add(common.Hash{0x2}, common.Hash{}, 1,
+		NewNodeSetWithOrigin(nil, nil),
+		NewStateSetWithOrigin(randomAccountSet("0xa"),
+			randomStorageSet([]string{"0xa"}, [][]string{{"0x1"}}, nil),
+			nil, nil, false)); err != nil {
+		t.Fatalf("add first diff layer: %v", err)
+	}
+	if err := tr.add(common.Hash{0x3}, common.Hash{0x2}, 2,
+		NewNodeSetWithOrigin(nil, nil),
+		NewStateSetWithOrigin(randomAccountSet("0xb"), nil, nil, nil, false)); err != nil {
+		t.Fatalf("add second diff layer: %v", err)
+	}
+
+	// Unknown account at HEAD: must fall through to the zero-rooted disk layer.
+	l, err := tr.lookupAccount(common.HexToHash("0xdead"), common.Hash{0x3})
+	if err != nil {
+		t.Fatalf("lookupAccount fallback: unexpected error %v", err)
+	}
+	if l.rootHash() != (common.Hash{}) {
+		t.Errorf("lookupAccount fallback: want disk root 0, got %x", l.rootHash())
+	}
+
+	// Symmetric storage case.
+	l, err = tr.lookupStorage(common.HexToHash("0xdead"), common.HexToHash("0x99"), common.Hash{0x3})
+	if err != nil {
+		t.Fatalf("lookupStorage fallback: unexpected error %v", err)
+	}
+	if l.rootHash() != (common.Hash{}) {
+		t.Errorf("lookupStorage fallback: want disk root 0, got %x", l.rootHash())
+	}
+
+	// Happy path still works: account 0xa was written in diff 0x2.
+	l, err = tr.lookupAccount(common.HexToHash("0xa"), common.Hash{0x3})
+	if err != nil {
+		t.Fatalf("lookupAccount(known): %v", err)
+	}
+	if l.rootHash() != (common.Hash{0x2}) {
+		t.Errorf("lookupAccount(known): want %x, got %x", common.Hash{0x2}, l.rootHash())
+	}
+
+	// Truly stale state root must still surface errSnapshotStale,
+	// pinning the other half of the contract.
+	if _, err := tr.lookupAccount(common.HexToHash("0xa"), common.HexToHash("0xdeadbeef")); !errors.Is(err, errSnapshotStale) {
+		t.Errorf("lookupAccount(stale): want errSnapshotStale, got %v", err)
+	}
+	if _, err := tr.lookupStorage(common.HexToHash("0xa"), common.HexToHash("0x1"), common.HexToHash("0xdeadbeef")); !errors.Is(err, errSnapshotStale) {
+		t.Errorf("lookupStorage(stale): want errSnapshotStale, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Two small follow-ups to recently merged v1.17.3 backports, surfaced by a HashDit security review:

- **crypto/signature_nocgo.go** — #3700 ported the upstream hash-length guard to `VerifySignature` but not to `sigToPub`. Upstream PR [33839](https://github.com/ethereum/go-ethereum/pull/33839) adds the check to both. Mirror it so callers like `Ecrecover` reject malformed hash inputs with a clear error.
- **triedb/pathdb/layertree_test.go** — #3706 ported the `(common.Hash, bool)` signature change and caller updates but not the regression test from upstream PR [34680](https://github.com/ethereum/go-ethereum/pull/34680). Add `TestLookupZeroBaseRootFallback` to pin both halves of the contract: the disk-layer fallback when the disk root is `common.Hash{}` (verkle/bintrie empty trie), and the still-errSnapshotStale guarantee for truly unknown state roots.

## Test plan

- [x] `go test ./crypto/ -count=1`
- [x] `go test ./triedb/pathdb/ -run TestLookupZeroBaseRootFallback -count=1`
- [x] `go build ./crypto/... ./triedb/pathdb/...`