### PR TITLE
core/rawdb: cheanup bep-592 bal key related

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -579,7 +579,6 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		tds                stat
 		numHashPairings    stat
 		blobSidecars       stat
-		bals               stat
 		hashNumPairings    stat
 		legacyTries        stat
 		stateLookups       stat
@@ -719,8 +718,6 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			// bsc speicial
 			case bytes.HasPrefix(key, BlockBlobSidecarsPrefix):
 				blobSidecars.add(size)
-			case bytes.HasPrefix(key, BlockBALPrefix):
-				bals.add(size)
 			case bytes.HasPrefix(key, ParliaSnapshotPrefix) && len(key) == 7+common.HashLength:
 				parliaSnaps.add(size)
 
@@ -807,7 +804,6 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Singleton metadata", metadata.sizeString(), metadata.countString()},
 		// bsc special
 		{"Key-Value store", "BlobSidecars", blobSidecars.sizeString(), blobSidecars.countString()},
-		{"Key-Value store", "Block access list", bals.sizeString(), bals.countString()},
 		{"Key-Value store", "Parlia snapshots", parliaSnaps.sizeString(), parliaSnaps.countString()},
 	}
 

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -149,8 +149,6 @@ var (
 
 	BlockBlobSidecarsPrefix = []byte("blobs")
 
-	BlockBALPrefix = []byte("bal") // blockBALPrefix + blockNumber (uint64 big endian) + blockHash -> block access list
-
 	// new log index
 	filterMapsPrefix         = "fm-"
 	filterMapsRangeKey       = []byte(filterMapsPrefix + "R")
@@ -222,13 +220,6 @@ func blockReceiptsKey(number uint64, hash common.Hash) []byte {
 // blockBlobSidecarsKey = BlockBlobSidecarsPrefix + blockNumber (uint64 big endian) + blockHash
 func blockBlobSidecarsKey(number uint64, hash common.Hash) []byte {
 	return append(append(BlockBlobSidecarsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
-}
-
-// blockBALKey = blockBALPrefix + blockNumber (uint64 big endian) + blockHash
-//
-//nolint:unused
-func blockBALKey(number uint64, hash common.Hash) []byte {
-	return append(append(BlockBALPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
 }
 
 // txLookupKey = txLookupPrefix + hash


### PR DESCRIPTION
### Description

core/rawdb: cheanup bep-592 bal key related

### Rationale

upstream defined other bal key now, conflict with this, so remove it

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
