### PR TITLE
feat: implement BEP-696 compatibility 

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -628,10 +628,9 @@ func (p *Parlia) VerifyUnsealedHeader(chain consensus.ChainHeaderReader, header 
 		}
 	}
 
-	// Ensure that the block doesn't contain any uncles which are meaningless in PoA.
-	// From Pasteur (BEP-696), UncleHash is repurposed to carry producer metadata and may
-	// hold any value; the empty-uncle-list guarantee is enforced by VerifyUncles on the
-	// block body instead.
+	// Before Pasteur, Parlia headers must commit to an empty uncle list. After
+	// Pasteur, UncleHash may carry producer metadata; VerifyUncles still rejects
+	// actual uncle bodies.
 	pasteur := chain.Config().IsPasteur(header.Number, header.Time)
 	if !pasteur && header.UncleHash != types.EmptyUncleHash {
 		return errInvalidUncleHash
@@ -647,8 +646,7 @@ func (p *Parlia) VerifyUnsealedHeader(chain consensus.ChainHeaderReader, header 
 			return fmt.Errorf("invalid parentBeaconRoot, have %#x, expected zero hash", header.ParentBeaconRoot)
 		}
 	} else {
-		// From Pasteur (BEP-696), ParentBeaconRoot is repurposed to carry producer
-		// metadata. It must still be present, but may hold any value.
+		// After Pasteur, ParentBeaconRoot is mandatory but may carry producer metadata.
 		if header.ParentBeaconRoot == nil {
 			return fmt.Errorf("invalid parentBeaconRoot, have %#x, expected non-nil", header.ParentBeaconRoot)
 		}
@@ -1849,7 +1847,7 @@ func calcDifficulty(snap *Snapshot, signer common.Address) *big.Int {
 }
 
 func encodeSigHeaderWithoutVoteAttestation(w io.Writer, header *types.Header, chainId *big.Int) {
-	toEncode := []interface{}{
+	err := rlp.Encode(w, []interface{}{
 		chainId,
 		header.ParentHash,
 		header.UncleHash,
@@ -1866,24 +1864,7 @@ func encodeSigHeaderWithoutVoteAttestation(w io.Writer, header *types.Header, ch
 		header.Extra[:extraVanity], // this will panic if extra is too short, should check before calling encodeSigHeaderWithoutVoteAttestation
 		header.MixDigest,
 		header.Nonce,
-	}
-	// Cover the same post-Cancun fields as types.SealHash so that this sealing-task id stays
-	// unique when the header carries them. In particular, from Pasteur (BEP-696) ParentBeaconRoot
-	// may hold producer metadata, and two block works differing only in it must not collide.
-	// The vote attestation is deliberately left out (Extra is truncated to the vanity) because it
-	// is inserted during Seal, after the task id has been computed.
-	if header.ParentBeaconRoot != nil {
-		toEncode = append(toEncode, header.BaseFee,
-			header.WithdrawalsHash,
-			header.BlobGasUsed,
-			header.ExcessBlobGas,
-			header.ParentBeaconRoot)
-
-		if header.RequestsHash != nil {
-			toEncode = append(toEncode, header.RequestsHash)
-		}
-	}
-	err := rlp.Encode(w, toEncode)
+	})
 	if err != nil {
 		panic("can't encode: " + err.Error())
 	}

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -634,13 +634,20 @@ func (p *Parlia) VerifyUnsealedHeader(chain consensus.ChainHeaderReader, header 
 	}
 
 	bohr := chain.Config().IsBohr(header.Number, header.Time)
+	pasteur := chain.Config().IsPasteur(header.Number, header.Time)
 	if !bohr {
 		if header.ParentBeaconRoot != nil {
 			return fmt.Errorf("invalid parentBeaconRoot, have %#x, expected nil", header.ParentBeaconRoot)
 		}
-	} else {
+	} else if !pasteur {
 		if header.ParentBeaconRoot == nil || *header.ParentBeaconRoot != (common.Hash{}) {
 			return fmt.Errorf("invalid parentBeaconRoot, have %#x, expected zero hash", header.ParentBeaconRoot)
+		}
+	} else {
+		// From Pasteur (BEP-696), ParentBeaconRoot is repurposed to carry producer
+		// metadata. It must still be present, but may hold any value.
+		if header.ParentBeaconRoot == nil {
+			return fmt.Errorf("invalid parentBeaconRoot, have %#x, expected non-nil", header.ParentBeaconRoot)
 		}
 	}
 
@@ -1839,7 +1846,7 @@ func calcDifficulty(snap *Snapshot, signer common.Address) *big.Int {
 }
 
 func encodeSigHeaderWithoutVoteAttestation(w io.Writer, header *types.Header, chainId *big.Int) {
-	err := rlp.Encode(w, []interface{}{
+	toEncode := []interface{}{
 		chainId,
 		header.ParentHash,
 		header.UncleHash,
@@ -1856,7 +1863,24 @@ func encodeSigHeaderWithoutVoteAttestation(w io.Writer, header *types.Header, ch
 		header.Extra[:extraVanity], // this will panic if extra is too short, should check before calling encodeSigHeaderWithoutVoteAttestation
 		header.MixDigest,
 		header.Nonce,
-	})
+	}
+	// Cover the same post-Cancun fields as types.SealHash so that this sealing-task id stays
+	// unique when the header carries them. In particular, from Pasteur (BEP-696) ParentBeaconRoot
+	// may hold producer metadata, and two block works differing only in it must not collide.
+	// The vote attestation is deliberately left out (Extra is truncated to the vanity) because it
+	// is inserted during Seal, after the task id has been computed.
+	if header.ParentBeaconRoot != nil {
+		toEncode = append(toEncode, header.BaseFee,
+			header.WithdrawalsHash,
+			header.BlobGasUsed,
+			header.ExcessBlobGas,
+			header.ParentBeaconRoot)
+
+		if header.RequestsHash != nil {
+			toEncode = append(toEncode, header.RequestsHash)
+		}
+	}
+	err := rlp.Encode(w, toEncode)
 	if err != nil {
 		panic("can't encode: " + err.Error())
 	}

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -628,13 +628,16 @@ func (p *Parlia) VerifyUnsealedHeader(chain consensus.ChainHeaderReader, header 
 		}
 	}
 
-	// Ensure that the block doesn't contain any uncles which are meaningless in PoA
-	if header.UncleHash != types.EmptyUncleHash {
+	// Ensure that the block doesn't contain any uncles which are meaningless in PoA.
+	// From Pasteur (BEP-696), UncleHash is repurposed to carry producer metadata and may
+	// hold any value; the empty-uncle-list guarantee is enforced by VerifyUncles on the
+	// block body instead.
+	pasteur := chain.Config().IsPasteur(header.Number, header.Time)
+	if !pasteur && header.UncleHash != types.EmptyUncleHash {
 		return errInvalidUncleHash
 	}
 
 	bohr := chain.Config().IsBohr(header.Number, header.Time)
-	pasteur := chain.Config().IsPasteur(header.Number, header.Time)
 	if !bohr {
 		if header.ParentBeaconRoot != nil {
 			return fmt.Errorf("invalid parentBeaconRoot, have %#x, expected nil", header.ParentBeaconRoot)

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -64,9 +64,8 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	if err := v.bc.engine.VerifyUncles(v.bc, block); err != nil {
 		return err
 	}
-	// From Pasteur (BEP-696), UncleHash is repurposed to carry producer metadata and no
-	// longer commits to the uncle list. VerifyUncles above already guarantees the body
-	// carries no uncles, so the uncle-root match is only enforced before Pasteur.
+	// After Pasteur, UncleHash no longer commits to the body; VerifyUncles still
+	// guarantees the body has no uncles.
 	if !v.config.IsPasteur(block.Number(), block.Time()) {
 		if hash := types.CalcUncleHash(block.Uncles()); hash != header.UncleHash {
 			return fmt.Errorf("uncle root hash mismatch (header value %x, calculated %x)", header.UncleHash, hash)

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -64,8 +64,13 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	if err := v.bc.engine.VerifyUncles(v.bc, block); err != nil {
 		return err
 	}
-	if hash := types.CalcUncleHash(block.Uncles()); hash != header.UncleHash {
-		return fmt.Errorf("uncle root hash mismatch (header value %x, calculated %x)", header.UncleHash, hash)
+	// From Pasteur (BEP-696), UncleHash is repurposed to carry producer metadata and no
+	// longer commits to the uncle list. VerifyUncles above already guarantees the body
+	// carries no uncles, so the uncle-root match is only enforced before Pasteur.
+	if !v.config.IsPasteur(block.Number(), block.Time()) {
+		if hash := types.CalcUncleHash(block.Uncles()); hash != header.UncleHash {
+			return fmt.Errorf("uncle root hash mismatch (header value %x, calculated %x)", header.UncleHash, hash)
+		}
 	}
 
 	validateFuns := []func() error{

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -291,11 +291,11 @@ func ApplyTransaction(evm *vm.EVM, gp *GasPool, statedb *state.StateDB, header *
 // ProcessBeaconBlockRoot applies the EIP-4788 system call to the beacon block root
 // contract. This method is exported to be used in tests.
 func ProcessBeaconBlockRoot(beaconRoot common.Hash, evm *vm.EVM) {
-	// Return immediately if beaconRoot equals the zero hash when using the Parlia engine.
-	if beaconRoot == (common.Hash{}) {
-		if chainConfig := evm.ChainConfig(); chainConfig != nil && chainConfig.IsInBSC() {
-			return
-		}
+	// BSC has no consensus-layer beacon chain, so the EIP-4788 system call is never
+	// executed. Before Pasteur the field is always the zero hash; from Pasteur (BEP-696)
+	// it may carry producer metadata. In either case the system call must be skipped.
+	if chainConfig := evm.ChainConfig(); chainConfig != nil && chainConfig.IsInBSC() {
+		return
 	}
 	if tracer := evm.Config.Tracer; tracer != nil {
 		onSystemCallStart(tracer, evm.GetVMContext())

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -291,9 +291,7 @@ func ApplyTransaction(evm *vm.EVM, gp *GasPool, statedb *state.StateDB, header *
 // ProcessBeaconBlockRoot applies the EIP-4788 system call to the beacon block root
 // contract. This method is exported to be used in tests.
 func ProcessBeaconBlockRoot(beaconRoot common.Hash, evm *vm.EVM) {
-	// BSC has no consensus-layer beacon chain, so the EIP-4788 system call is never
-	// executed. Before Pasteur the field is always the zero hash; from Pasteur (BEP-696)
-	// it may carry producer metadata. In either case the system call must be skipped.
+	// BSC has no consensus-layer beacon chain; ParentBeaconRoot is not an EIP-4788 input.
 	if chainConfig := evm.ChainConfig(); chainConfig != nil && chainConfig.IsInBSC() {
 		return
 	}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -179,6 +179,9 @@ type BlockChain interface {
 	// CurrentHeader retrieves the head header from the local chain.
 	CurrentHeader() *types.Header
 
+	// Config retrieves the chain's fork configuration.
+	Config() *params.ChainConfig
+
 	// GetTd returns the total difficulty of a local block.
 	GetTd(common.Hash, uint64) *big.Int
 
@@ -242,7 +245,7 @@ func New(stateDb ethdb.Database, mux *event.TypeMux, chain BlockChain, dropPeer 
 	dl := &Downloader{
 		stateDB:           stateDb,
 		mux:               mux,
-		queue:             newQueue(blockCacheMaxItems, blockCacheInitialItems),
+		queue:             newQueue(blockCacheMaxItems, blockCacheInitialItems, chain.Config()),
 		peers:             newPeerSet(),
 		blockchain:        chain,
 		chainCutoffNumber: cutoffNumber,

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -806,10 +806,13 @@ func (q *queue) DeliverBodies(id string, hashes eth.BlockBodyHashes, bodies []et
 		if hashes.TransactionRoots[index] != header.TxHash {
 			return errInvalidBody
 		}
-		// From Pasteur (BEP-696), UncleHash carries producer metadata and no longer commits
-		// to the uncle list, so the delivered body is matched on the transaction root alone;
-		// BSC bodies never carry uncles, which header verification continues to enforce.
-		if q.config == nil || !q.config.IsPasteur(header.Number, header.Time) {
+		// After Pasteur, UncleHash is metadata; block bodies must still have no
+		// uncles. Before Pasteur, it remains the uncle-list commitment.
+		if q.config != nil && q.config.IsPasteur(header.Number, header.Time) {
+			if hashes.UncleHashes[index] != types.EmptyUncleHash {
+				return errInvalidBody
+			}
+		} else {
 			if hashes.UncleHashes[index] != header.UncleHash {
 				return errInvalidBody
 			}

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -134,6 +135,8 @@ func (f *fetchResult) Done(kind uint) bool {
 type queue struct {
 	mode SyncMode // Synchronisation mode to decide on the block parts to schedule for fetching
 
+	config *params.ChainConfig // Chain configuration, used for fork-gated body validation
+
 	// Headers are "special", they download in batches, supported by a skeleton chain
 	headerHead      common.Hash                    // Hash of the last queued header to verify order
 	headerTaskPool  map[uint64]*types.Header       // Pending header retrieval tasks, mapping starting indexes to skeleton headers
@@ -168,9 +171,10 @@ type queue struct {
 }
 
 // newQueue creates a new download queue for scheduling block retrieval.
-func newQueue(blockCacheLimit int, thresholdInitialSize int) *queue {
+func newQueue(blockCacheLimit int, thresholdInitialSize int, config *params.ChainConfig) *queue {
 	lock := new(sync.RWMutex)
 	q := &queue{
+		config:           config,
 		headerContCh:     make(chan bool, 1),
 		blockTaskQueue:   prque.New[int64, *types.Header](nil),
 		blockWakeCh:      make(chan bool, 1),
@@ -802,8 +806,13 @@ func (q *queue) DeliverBodies(id string, hashes eth.BlockBodyHashes, bodies []et
 		if hashes.TransactionRoots[index] != header.TxHash {
 			return errInvalidBody
 		}
-		if hashes.UncleHashes[index] != header.UncleHash {
-			return errInvalidBody
+		// From Pasteur (BEP-696), UncleHash carries producer metadata and no longer commits
+		// to the uncle list, so the delivered body is matched on the transaction root alone;
+		// BSC bodies never carry uncles, which header verification continues to enforce.
+		if q.config == nil || !q.config.IsPasteur(header.Number, header.Time) {
+			if hashes.UncleHashes[index] != header.UncleHash {
+				return errInvalidBody
+			}
 		}
 		if header.WithdrawalsHash == nil {
 			// nil hash means that withdrawals should not be present in body

--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -99,7 +99,7 @@ func TestBasics(t *testing.T) {
 	numOfBlocks := len(emptyChain.blocks)
 	numOfReceipts := len(emptyChain.blocks) / 2
 
-	q := newQueue(10, 10)
+	q := newQueue(10, 10, params.TestChainConfig)
 	if !q.Idle() {
 		t.Errorf("new queue should be idle")
 	}
@@ -198,7 +198,7 @@ func TestBasics(t *testing.T) {
 func TestEmptyBlocks(t *testing.T) {
 	numOfBlocks := len(emptyChain.blocks)
 
-	q := newQueue(10, 10)
+	q := newQueue(10, 10, params.TestChainConfig)
 
 	q.Prepare(1, SnapSync)
 
@@ -277,7 +277,7 @@ func XTestDelivery(t *testing.T) {
 	if false {
 		log.SetDefault(log.NewLogger(slog.NewTextHandler(os.Stdout, nil)))
 	}
-	q := newQueue(10, 10)
+	q := newQueue(10, 10, params.TestChainConfig)
 	var wg sync.WaitGroup
 	q.Prepare(1, SnapSync)
 	wg.Add(1)

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -750,16 +750,17 @@ func (f *BlockFetcher) loop() {
 						if f.queued[hash] != nil || announce.origin != task.peer {
 							continue
 						}
-						// From Pasteur (BEP-696), UncleHash carries producer metadata and no longer
-						// commits to the uncle list, so match the body on the transaction root alone;
-						// BSC bodies never carry uncles, which block import continues to enforce.
-						if f.chainConfig == nil || !f.chainConfig.IsPasteur(announce.header.Number, announce.header.Time) {
-							if uncleHash == (common.Hash{}) {
-								uncleHash = types.CalcUncleHash(task.uncles[i])
-							}
-							if uncleHash != announce.header.UncleHash {
+						if uncleHash == (common.Hash{}) {
+							uncleHash = types.CalcUncleHash(task.uncles[i])
+						}
+						// After Pasteur, UncleHash is metadata; block bodies must still have no
+						// uncles. Before Pasteur, it remains the uncle-list commitment.
+						if f.chainConfig != nil && f.chainConfig.IsPasteur(announce.header.Number, announce.header.Time) {
+							if uncleHash != types.EmptyUncleHash {
 								continue
 							}
+						} else if uncleHash != announce.header.UncleHash {
+							continue
 						}
 						if txnHash == (common.Hash{}) {
 							txnHash = types.DeriveSha(types.Transactions(task.transactions[i]), trie.NewStackTrie(nil))

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 )
 
@@ -209,6 +210,8 @@ type BlockFetcher struct {
 	dropPeer             peerDropFn             // Drops a peer for misbehaving
 	fetchRangeBlocks     fetchRangeBlocksFn     // Fetches a range of blocks from a peer
 
+	chainConfig *params.ChainConfig // Chain configuration, used for fork-gated body matching
+
 	// Testing hooks
 	announceChangeHook func(common.Hash, bool)           // Method to call upon adding or deleting a hash from the blockAnnounce list
 	queueChangeHook    func(common.Hash, bool)           // Method to call upon adding or deleting a block from the import queue
@@ -220,7 +223,7 @@ type BlockFetcher struct {
 // NewBlockFetcher creates a block fetcher to retrieve blocks based on hash announcements.
 func NewBlockFetcher(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, broadcastBlock blockBroadcasterFn,
 	chainHeight chainHeightFn, chainFinalizedHeight chainFinalizedHeightFn, insertChain chainInsertFn, dropPeer peerDropFn,
-	fetchRangeBlocks fetchRangeBlocksFn) *BlockFetcher {
+	fetchRangeBlocks fetchRangeBlocksFn, chainConfig *params.ChainConfig) *BlockFetcher {
 	return &BlockFetcher{
 		notify:               make(chan *blockAnnounce),
 		inject:               make(chan *blockOrHeaderInject),
@@ -246,6 +249,7 @@ func NewBlockFetcher(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, b
 		insertChain:          insertChain,
 		dropPeer:             dropPeer,
 		fetchRangeBlocks:     fetchRangeBlocks,
+		chainConfig:          chainConfig,
 	}
 }
 
@@ -746,11 +750,16 @@ func (f *BlockFetcher) loop() {
 						if f.queued[hash] != nil || announce.origin != task.peer {
 							continue
 						}
-						if uncleHash == (common.Hash{}) {
-							uncleHash = types.CalcUncleHash(task.uncles[i])
-						}
-						if uncleHash != announce.header.UncleHash {
-							continue
+						// From Pasteur (BEP-696), UncleHash carries producer metadata and no longer
+						// commits to the uncle list, so match the body on the transaction root alone;
+						// BSC bodies never carry uncles, which block import continues to enforce.
+						if f.chainConfig == nil || !f.chainConfig.IsPasteur(announce.header.Number, announce.header.Time) {
+							if uncleHash == (common.Hash{}) {
+								uncleHash = types.CalcUncleHash(task.uncles[i])
+							}
+							if uncleHash != announce.header.UncleHash {
+								continue
+							}
 						}
 						if txnHash == (common.Hash{}) {
 							txnHash = types.DeriveSha(types.Transactions(task.transactions[i]), trie.NewStackTrie(nil))

--- a/eth/fetcher/block_fetcher_test.go
+++ b/eth/fetcher/block_fetcher_test.go
@@ -131,7 +131,7 @@ func newTester() *fetcherTester {
 		tester.chainHeight, tester.chainFinalizedHeight, tester.insertChain, tester.dropPeer,
 		func(peer string, startHeight uint64, startHash common.Hash, count uint64) ([]*types.Block, error) {
 			return nil, errors.New("not implemented")
-		})
+		}, params.TestChainConfig)
 	tester.fetcher.Start()
 
 	return tester
@@ -1091,6 +1091,7 @@ func TestBlockFetcherMultiplePeers(t *testing.T) {
 		func(peer string, startHeight uint64, startHash common.Hash, count uint64) ([]*types.Block, error) {
 			return nil, errors.New("not implemented")
 		},
+		params.TestChainConfig,
 	)
 
 	// Start fetcher
@@ -1299,6 +1300,7 @@ func TestQuickBlockFetching(t *testing.T) {
 			// Return requested block
 			return []*types.Block{block}, nil
 		},
+		params.TestChainConfig,
 	)
 
 	// Start fetcher

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -377,7 +377,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 	}
 
 	h.blockFetcher = fetcher.NewBlockFetcher(h.chain.GetBlockByHash, validator, broadcastBlockWithCheck,
-		heighter, finalizeHeighter, inserter, h.removePeer, fetchRangeBlocks)
+		heighter, finalizeHeighter, inserter, h.removePeer, fetchRangeBlocks, h.chain.Config())
 
 	fetchTx := func(peer string, hashes []common.Hash) error {
 		p := h.peers.peer(peer)

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -387,10 +387,14 @@ func handleNewBlock(backend Backend, msg Decoder, peer *Peer) error {
 		return err
 	}
 
-	// From Pasteur (BEP-696), UncleHash carries producer metadata and no longer commits to
-	// the uncle list, so skip the uncle-root match for such blocks; the empty-uncle-list
-	// guarantee is enforced during block import.
-	if !backend.Chain().Config().IsPasteur(ann.Block.Number(), ann.Block.Time()) {
+	// After Pasteur, UncleHash is metadata; block bodies must still have no
+	// uncles. Before Pasteur, it remains the uncle-list commitment.
+	if backend.Chain().Config().IsPasteur(ann.Block.Number(), ann.Block.Time()) {
+		if len(ann.Block.Uncles()) > 0 {
+			log.Warn("Propagated block has uncles after Pasteur", "count", len(ann.Block.Uncles()))
+			return nil // TODO(karalabe): return error eventually, but wait a few releases
+		}
+	} else {
 		if hash := types.CalcUncleHash(ann.Block.Uncles()); hash != ann.Block.UncleHash() {
 			log.Warn("Propagated block has invalid uncles", "have", hash, "exp", ann.Block.UncleHash())
 			return nil // TODO(karalabe): return error eventually, but wait a few releases

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -387,9 +387,14 @@ func handleNewBlock(backend Backend, msg Decoder, peer *Peer) error {
 		return err
 	}
 
-	if hash := types.CalcUncleHash(ann.Block.Uncles()); hash != ann.Block.UncleHash() {
-		log.Warn("Propagated block has invalid uncles", "have", hash, "exp", ann.Block.UncleHash())
-		return nil // TODO(karalabe): return error eventually, but wait a few releases
+	// From Pasteur (BEP-696), UncleHash carries producer metadata and no longer commits to
+	// the uncle list, so skip the uncle-root match for such blocks; the empty-uncle-list
+	// guarantee is enforced during block import.
+	if !backend.Chain().Config().IsPasteur(ann.Block.Number(), ann.Block.Time()) {
+		if hash := types.CalcUncleHash(ann.Block.Uncles()); hash != ann.Block.UncleHash() {
+			log.Warn("Propagated block has invalid uncles", "have", hash, "exp", ann.Block.UncleHash())
+			return nil // TODO(karalabe): return error eventually, but wait a few releases
+		}
 	}
 	if hash := types.DeriveSha(ann.Block.Transactions(), trie.NewStackTrie(nil)); hash != ann.Block.TxHash() {
 		log.Warn("Propagated block has invalid body", "have", hash, "exp", ann.Block.TxHash())

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -199,9 +199,7 @@ func (ec *Client) getBlock(ctx context.Context, method string, args ...interface
 	if head.UncleHash == types.EmptyUncleHash && len(body.UncleHashes) > 0 {
 		return nil, errors.New("server returned non-empty uncle list but block header indicates no uncles")
 	}
-	// A non-empty UncleHash no longer implies the block has uncles: on BSC, from the Pasteur
-	// hard fork (BEP-696), UncleHash may carry producer metadata while the block has none, so
-	// the body's uncle list is authoritative and a missing list is not treated as an error.
+	// On BSC after Pasteur, a non-empty UncleHash may be producer metadata, not an uncle list.
 	if head.TxHash == types.EmptyTxsHash && len(body.Transactions) > 0 {
 		return nil, errors.New("server returned non-empty transaction list but block header indicates no transactions")
 	}

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -199,9 +199,9 @@ func (ec *Client) getBlock(ctx context.Context, method string, args ...interface
 	if head.UncleHash == types.EmptyUncleHash && len(body.UncleHashes) > 0 {
 		return nil, errors.New("server returned non-empty uncle list but block header indicates no uncles")
 	}
-	if head.UncleHash != types.EmptyUncleHash && len(body.UncleHashes) == 0 {
-		return nil, errors.New("server returned empty uncle list but block header indicates uncles")
-	}
+	// A non-empty UncleHash no longer implies the block has uncles: on BSC, from the Pasteur
+	// hard fork (BEP-696), UncleHash may carry producer metadata while the block has none, so
+	// the body's uncle list is authoritative and a missing list is not treated as an error.
 	if head.TxHash == types.EmptyTxsHash && len(body.Transactions) > 0 {
 		return nil, errors.New("server returned non-empty transaction list but block header indicates no transactions")
 	}


### PR DESCRIPTION
### Description

Implement [BEP-696](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-696.md) compatibility for repurposing ParentBeaconRoot and UncleHash as optional producer metadata after Pasteur.

Allow post-Pasteur ParentBeaconRoot to carry non-zero metadata while still requiring it to be present.
Skip BSC EIP-4788 beacon-root system calls because ParentBeaconRoot is not a consensus-layer beacon root.
Allow post-Pasteur UncleHash to carry producer metadata instead of committing to the uncle body.
Keep actual block bodies uncle-free across downloader, fetcher, broadcast, and import validation paths.
Preserve pre-Pasteur validation semantics for both fields.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
