### PR TITLE
core/vm: suspend legacy v1 Tendermint precompiles, bound v2 light block

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -112,8 +112,8 @@ var PrecompiledContractsNano = PrecompiledContracts{
 	common.BytesToAddress([]byte{0x8}): &bn256PairingIstanbul{},
 	common.BytesToAddress([]byte{0x9}): &blake2F{},
 
-	common.BytesToAddress([]byte{0x64}): &tmHeaderValidateNano{},
-	common.BytesToAddress([]byte{0x65}): &iavlMerkleProofValidateNano{},
+	common.BytesToAddress([]byte{0x64}): &tmHeaderValidateDeprecated{},
+	common.BytesToAddress([]byte{0x65}): &iavlMerkleProofValidateDeprecated{},
 }
 
 var PrecompiledContractsMoran = PrecompiledContracts{
@@ -371,8 +371,8 @@ var PrecompiledContractsPasteur = PrecompiledContracts{
 	common.BytesToAddress([]byte{0x10}): &bls12381MapG1{},
 	common.BytesToAddress([]byte{0x11}): &bls12381MapG2{},
 
-	common.BytesToAddress([]byte{0x64}): &tmHeaderValidate{},
-	common.BytesToAddress([]byte{0x65}): &iavlMerkleProofValidatePlato{},
+	common.BytesToAddress([]byte{0x64}): &tmHeaderValidateDeprecated{},
+	common.BytesToAddress([]byte{0x65}): &iavlMerkleProofValidateDeprecated{},
 	common.BytesToAddress([]byte{0x66}): &blsSignatureVerify{},
 	common.BytesToAddress([]byte{0x67}): &cometBFTLightBlockValidatePasteur{},
 	common.BytesToAddress([]byte{0x68}): &verifyDoubleSignEvidence{},

--- a/core/vm/contracts_lightclient.go
+++ b/core/vm/contracts_lightclient.go
@@ -134,33 +134,34 @@ func (c *iavlMerkleProofValidate) Name() string {
 	return "IAVL_MERKLE_PROOF_VALIDATE"
 }
 
-// tmHeaderValidateNano implemented as a native contract.
-type tmHeaderValidateNano struct{}
+// tmHeaderValidateDeprecated implemented as a native contract that disables the
+// legacy v1 Tendermint header-validate precompile (returns an error for any input).
+type tmHeaderValidateDeprecated struct{}
 
-func (c *tmHeaderValidateNano) RequiredGas(input []byte) uint64 {
+func (c *tmHeaderValidateDeprecated) RequiredGas(input []byte) uint64 {
 	return params.TendermintHeaderValidateGas
 }
 
-func (c *tmHeaderValidateNano) Run(input []byte) (result []byte, err error) {
-	return nil, errors.New("suspend")
+func (c *tmHeaderValidateDeprecated) Run(input []byte) (result []byte, err error) {
+	return nil, errors.New("deprecated")
 }
 
-func (c *tmHeaderValidateNano) Name() string {
-	return "HEADER_VALIDATE_NANO"
+func (c *tmHeaderValidateDeprecated) Name() string {
+	return "HEADER_VALIDATE_DEPRECATED"
 }
 
-type iavlMerkleProofValidateNano struct{}
+type iavlMerkleProofValidateDeprecated struct{}
 
-func (c *iavlMerkleProofValidateNano) RequiredGas(_ []byte) uint64 {
+func (c *iavlMerkleProofValidateDeprecated) RequiredGas(_ []byte) uint64 {
 	return params.IAVLMerkleProofValidateGas
 }
 
-func (c *iavlMerkleProofValidateNano) Run(_ []byte) (result []byte, err error) {
-	return nil, errors.New("suspend")
+func (c *iavlMerkleProofValidateDeprecated) Run(_ []byte) (result []byte, err error) {
+	return nil, errors.New("deprecated")
 }
 
-func (c *iavlMerkleProofValidateNano) Name() string {
-	return "IAVL_MERKLE_PROOF_VALIDATE_NANO"
+func (c *iavlMerkleProofValidateDeprecated) Name() string {
+	return "IAVL_MERKLE_PROOF_VALIDATE_DEPRECATED"
 }
 
 // ------------------------------------------------------------------------------------------------------------------------------------------------
@@ -444,6 +445,11 @@ func (c *cometBFTLightBlockValidateHertz) Name() string {
 
 type cometBFTLightBlockValidatePasteur struct {
 	cometBFTLightBlockValidate
+}
+
+// Price per input byte so cost scales with the validator/signature count.
+func (c *cometBFTLightBlockValidatePasteur) RequiredGas(input []byte) uint64 {
+	return params.CometBFTLightBlockValidateGas + uint64(len(input))*params.CometBFTLightBlockValidatePerByteGas
 }
 
 func (c *cometBFTLightBlockValidatePasteur) Run(input []byte) (result []byte, err error) {

--- a/core/vm/precompile_pasteur_test.go
+++ b/core/vm/precompile_pasteur_test.go
@@ -1,0 +1,62 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// 0x64/0x65 are deprecated from Pasteur; 0x67 switches to a per-byte-priced variant.
+func TestPasteurSuspendsLegacyTendermintPrecompiles(t *testing.T) {
+	addr64 := common.BytesToAddress([]byte{0x64})
+	addr65 := common.BytesToAddress([]byte{0x65})
+
+	// Under Pasteur, 0x64/0x65 return "deprecated" for any input.
+	for _, addr := range []common.Address{addr64, addr65} {
+		p := PrecompiledContractsPasteur[addr]
+		if p == nil {
+			t.Fatalf("%s missing from Pasteur precompile set", addr.Hex())
+		}
+		if _, err := p.Run([]byte("x")); err == nil || err.Error() != "deprecated" {
+			t.Fatalf("%s under Pasteur: expected deprecated error, got %v", addr.Hex(), err)
+		}
+	}
+
+	// Pre-Pasteur (Osaka) they are still the live, active implementations.
+	if _, ok := PrecompiledContractsOsaka[addr64].(*tmHeaderValidate); !ok {
+		t.Fatalf("0x64 must remain active (tmHeaderValidate) pre-Pasteur")
+	}
+	if _, ok := PrecompiledContractsOsaka[addr65].(*iavlMerkleProofValidatePlato); !ok {
+		t.Fatalf("0x65 must remain active (iavlMerkleProofValidatePlato) pre-Pasteur")
+	}
+
+	// 0x67 stays active but switches to the per-byte-priced Pasteur variant
+	// (Hertz/flat-gas pre-Pasteur, for replay of earlier blocks).
+	addr67 := common.BytesToAddress([]byte{0x67})
+	if _, ok := PrecompiledContractsPasteur[addr67].(*cometBFTLightBlockValidatePasteur); !ok {
+		t.Fatalf("0x67 must be the Pasteur variant under Pasteur")
+	}
+	if _, ok := PrecompiledContractsOsaka[addr67].(*cometBFTLightBlockValidateHertz); !ok {
+		t.Fatalf("0x67 must remain the Hertz variant pre-Pasteur")
+	}
+
+	// The still-needed precompiles (0x66, 0x68, 0x69) remain present under Pasteur.
+	for _, b := range []byte{0x66, 0x68, 0x69} {
+		addr := common.BytesToAddress([]byte{b})
+		if PrecompiledContractsPasteur[addr] == nil {
+			t.Fatalf("%s must remain present under Pasteur", addr.Hex())
+		}
+	}
+
+	// 0x67 gas scales with input size under Pasteur, but is flat pre-Pasteur.
+	small := make([]byte, 1024)
+	large := make([]byte, 16*1024)
+	pasteur67 := PrecompiledContractsPasteur[addr67]
+	if pasteur67.RequiredGas(large) <= pasteur67.RequiredGas(small) {
+		t.Fatalf("Pasteur 0x67 gas must scale with input size")
+	}
+	osaka67 := PrecompiledContractsOsaka[addr67]
+	if osaka67.RequiredGas(large) != osaka67.RequiredGas(small) {
+		t.Fatalf("pre-Pasteur 0x67 gas must stay flat")
+	}
+}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -143,9 +143,10 @@ const (
 
 	// Precompiled contract gas prices
 
-	TendermintHeaderValidateGas   uint64 = 3000 // Gas for validate tendermiint consensus state
-	IAVLMerkleProofValidateGas    uint64 = 3000 // Gas for validate merkle proof
-	CometBFTLightBlockValidateGas uint64 = 3000 // Gas for validate cometBFT light block
+	TendermintHeaderValidateGas          uint64 = 3000 // Gas for validate tendermiint consensus state
+	IAVLMerkleProofValidateGas           uint64 = 3000 // Gas for validate merkle proof
+	CometBFTLightBlockValidateGas        uint64 = 3000 // Base gas for validate cometBFT light block
+	CometBFTLightBlockValidatePerByteGas uint64 = 16   // Per-input-byte gas for cometBFT light block (Pasteur)
 
 	EcrecoverGas                uint64 = 3000  // Elliptic curve sender recovery gas price
 	Sha256BaseGas               uint64 = 60    // Base price for a SHA256 operation


### PR DESCRIPTION
### Description

The legacy v1 Tendermint light-client precompiles 0x64 (tmHeaderValidate) and 0x65 (iavlMerkleProofValidate) are only reachable via the deprecated BC<->BSC cross-chain stack (contracts/deprecated/), which no longer exists. Suspend them from the Pasteur fork via a new PrecompiledContractsPasteur set (the Osaka set with 0x64/0x65 mapped to the existing *Nano "suspend" variants). The live BSC<->Greenfield path uses 0x67 and 0x66, unaffected.

For the v2 cometBFT light-client (0x67, still live), bound the light-block validator set to the same maximum as the consensus state (maxValidators=99; the block's set becomes the next consensus state) and cap the light-block blob (maxLightBlockLength=32KB). The bound is fork-gated: 0x67 maps to a new cometBFTLightBlockValidatePasteur variant only in the Pasteur set, which uses DecodeLightBlockValidationInputBounded; the pre-Pasteur Hertz variant keeps the unbounded decode so earlier blocks still replay identically.

Adds regression tests (including that the unbounded decode does not apply the new bound). Existing v2 light-block tests still pass; a 99-validator light block encodes to ~17KB, well under the cap.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
