### PR TITLE
core/systemcontracts: point Pasteur CommitUrl to genesis-contract v1.2.6

### DIFF
--- a/core/systemcontracts/upgrade.go
+++ b/core/systemcontracts/upgrade.go
@@ -1064,12 +1064,12 @@ func init() {
 		Configs: []*UpgradeConfig{
 			{
 				ContractAddr: common.HexToAddress(StakeHubContract),
-				CommitUrl:    "https://github.com/bnb-chain/bsc-genesis-contract/commit/3f02a2e834308eb989ea230cd3b90ea8c47e6699",
+				CommitUrl:    "https://github.com/bnb-chain/bsc-genesis-contract/commit/041881a02475638b19f3d840871b7621cdebd8f8",
 				Code:         pasteur.MainnetStakeHubContract,
 			},
 			{
 				ContractAddr: common.HexToAddress(GovernorContract),
-				CommitUrl:    "https://github.com/bnb-chain/bsc-genesis-contract/commit/3f02a2e834308eb989ea230cd3b90ea8c47e6699",
+				CommitUrl:    "https://github.com/bnb-chain/bsc-genesis-contract/commit/041881a02475638b19f3d840871b7621cdebd8f8",
 				Code:         pasteur.MainnetGovernorContract,
 			},
 		},
@@ -1080,12 +1080,12 @@ func init() {
 		Configs: []*UpgradeConfig{
 			{
 				ContractAddr: common.HexToAddress(StakeHubContract),
-				CommitUrl:    "https://github.com/bnb-chain/bsc-genesis-contract/commit/3f02a2e834308eb989ea230cd3b90ea8c47e6699",
+				CommitUrl:    "https://github.com/bnb-chain/bsc-genesis-contract/commit/041881a02475638b19f3d840871b7621cdebd8f8",
 				Code:         pasteur.ChapelStakeHubContract,
 			},
 			{
 				ContractAddr: common.HexToAddress(GovernorContract),
-				CommitUrl:    "https://github.com/bnb-chain/bsc-genesis-contract/commit/3f02a2e834308eb989ea230cd3b90ea8c47e6699",
+				CommitUrl:    "https://github.com/bnb-chain/bsc-genesis-contract/commit/041881a02475638b19f3d840871b7621cdebd8f8",
 				Code:         pasteur.ChapelGovernorContract,
 			},
 		},
@@ -1096,12 +1096,12 @@ func init() {
 		Configs: []*UpgradeConfig{
 			{
 				ContractAddr: common.HexToAddress(StakeHubContract),
-				CommitUrl:    "https://github.com/bnb-chain/bsc-genesis-contract/commit/3f02a2e834308eb989ea230cd3b90ea8c47e6699",
+				CommitUrl:    "https://github.com/bnb-chain/bsc-genesis-contract/commit/041881a02475638b19f3d840871b7621cdebd8f8",
 				Code:         pasteur.RialtoStakeHubContract,
 			},
 			{
 				ContractAddr: common.HexToAddress(GovernorContract),
-				CommitUrl:    "https://github.com/bnb-chain/bsc-genesis-contract/commit/3f02a2e834308eb989ea230cd3b90ea8c47e6699",
+				CommitUrl:    "https://github.com/bnb-chain/bsc-genesis-contract/commit/041881a02475638b19f3d840871b7621cdebd8f8",
 				Code:         pasteur.RialtoGovernorContract,
 			},
 		},


### PR DESCRIPTION
## Description

Update the Pasteur system-contract upgrade `CommitUrl` for **StakeHub (0x2002)** and **BSCGovernor (0x2004)** from the interim commit `3f02a2e` to the tagged release **[v1.2.6](https://github.com/bnb-chain/bsc-genesis-contract/releases/tag/v1.2.6)** (commit `041881a02475638b19f3d840871b7621cdebd8f8`).

## Rationale

The Pasteur bytecode was originally wired with an interim genesis-contract commit before the release was tagged. Now that `bsc-genesis-contract` has cut **v1.2.6**, point the provenance at the official tag.

The embedded bytecode itself is **unchanged** — verified the StakeHub/BSCGovernor runtime code for Mainnet/Chapel/Rialto matches the v1.2.6 genesis byte-for-byte, so this PR only corrects the reference.

## Changes

- `core/systemcontracts/upgrade.go`: 6× `CommitUrl` (StakeHub + BSCGovernor across Mainnet/Chapel/Rialto) → v1.2.6 commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)