### PR TITLE
miner: add BidBlock verify metrics

### DIFF
--- a/miner/bid_block.go
+++ b/miner/bid_block.go
@@ -122,6 +122,9 @@ func (w *worker) prepareBidBlockTask(
 	decoded *types.DecodedBidBlock,
 	start time.Time,
 ) (*task, error) {
+	prepareStart := time.Now()
+	defer bidBlockPrepareTimer.UpdateSince(prepareStart)
+
 	if !w.isRunning() {
 		return nil, errors.New("worker is not running")
 	}
@@ -270,7 +273,10 @@ func (w *worker) handleBidBlockResult(block *types.Block, task *task) {
 	//   - Tx precheck failures (nonce, balance, signature, intrinsic gas, ...)
 	//   - System tx value / params (e.g. deposit value vs. SystemAddress balance)
 	//   - Blob sidecar checks (KZG proofs, blob hashes)
-	if _, err := w.chain.InsertChain(types.Blocks{block}); err != nil {
+	verifyStart := time.Now()
+	_, insertErr := w.chain.InsertChain(types.Blocks{block})
+	bidBlockVerifyTimer.UpdateSince(verifyStart)
+	if insertErr != nil {
 		log.Error("[BID BLOCK VERIFY FAILED]",
 			"number", block.Number(),
 			"hash", hash,
@@ -281,8 +287,9 @@ func (w *worker) handleBidBlockResult(block *types.Block, task *task) {
 			"stateRoot", block.Root(),
 			"receiptHash", block.ReceiptHash(),
 			"builder", task.bidBlockInfo.builder,
-			"err", err)
-		w.revokeBidBlockBuilder(task.bidBlockInfo.builder, fmt.Sprintf("InsertChain err: %v", err), hash, block.NumberU64())
+			"err", insertErr)
+		bidBlockVerifyFailedGauge.Inc(1)
+		w.revokeBidBlockBuilder(task.bidBlockInfo.builder, fmt.Sprintf("InsertChain err: %v", insertErr), hash, block.NumberU64())
 		return
 	}
 	// Check the post-import average gas price excluding system transactions; only future BidBlock permission is revoked.

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -59,6 +59,15 @@ var (
 
 	// bidBlockPreSealVerifyTimer measures only preSealVerifyBidBlock duration.
 	bidBlockPreSealVerifyTimer = metrics.NewRegisteredTimer("bidblock/sendBidBlock/preSealVerify", nil)
+
+	// bidBlockPrepareTimer measures prepareBidBlockTask: the selected BidBlock's
+	// blob KZG validation + system-tx bind-signing + TxHash recompute, on the
+	// critical path between selection and seal (fires on success and failure).
+	bidBlockPrepareTimer = metrics.NewRegisteredTimer("bidblock/prepare/duration", nil)
+
+	// bidBlockVerifyTimer times the sealed-BidBlock InsertChain verify; fires on
+	// success+failure, so _count = total verifies (verified = _count - bidBlockVerifyFailed).
+	bidBlockVerifyTimer = metrics.NewRegisteredTimer("bidblock/verify/duration", nil)
 )
 
 var (

--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -84,6 +84,15 @@ func (miner *Miner) SendBidBlock(ctx context.Context, args *types.BidBlockArgs) 
 		return common.Hash{}, types.NewInvalidBidError(fmt.Sprintf("invalid signature: bidHash=%s, err=%v", bidHash, err))
 	}
 
+	// Receive marker for the mev-sentry -> validator hop: correlate this bidHash with
+	// the send-side log for latency. Logged before the gates so rejected arrivals count too.
+	log.Debug("[BID BLOCK RECEIVED]",
+		"bidHash", bidHash,
+		"builder", builder,
+		"number", bb.Header.Number,
+		"parentHash", bb.Header.ParentHash,
+		"txs", len(bb.Transactions))
+
 	if !miner.bidSimulator.ExistBuilder(builder) {
 		return common.Hash{}, types.NewInvalidBidError(fmt.Sprintf("builder is not registered: builder=%s, bidHash=%s", builder, bidHash))
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -78,9 +78,12 @@ var (
 	bestBidGasUsedGauge  = metrics.NewRegisteredGauge("worker/bestBidGasUsed", nil)  // MGas
 	bestWorkGasUsedGauge = metrics.NewRegisteredGauge("worker/bestWorkGasUsed", nil) // MGas
 	bidBlockExistGauge   = metrics.NewRegisteredGauge("worker/bidBlockExist", nil)
+	bidBlockWinGauge     = metrics.NewRegisteredGauge("worker/bidBlockWin", nil)
 	bidBlockCommitGauge  = metrics.NewRegisteredGauge("worker/bidBlockCommit", nil)
 	bidBlockGasUsedGauge = metrics.NewRegisteredGauge("worker/bidBlockGasUsed", nil) // MGas
 	bidBlockRevokeGauge  = metrics.NewRegisteredGauge("worker/bidBlockRevoke", nil)  // cumulative revoke count
+	// bidBlockVerifyFailedGauge counts sealed BidBlocks that failed async InsertChain verification (cumulative).
+	bidBlockVerifyFailedGauge = metrics.NewRegisteredGauge("worker/bidBlockVerifyFailed", nil)
 	// bidBlockRevokedBuildersGauge snapshots how many builders are revoked, taken at each revoke.
 	bidBlockRevokedBuildersGauge = metrics.NewRegisteredGauge("worker/bidBlockRevokedBuilders", nil)
 
@@ -1473,6 +1476,7 @@ LOOP:
 	}
 
 	if bestBidBlock != nil && w.selectBidBlock(bestBidBlock, simBidBlockReward, simBidValidatorReward, bestReward) {
+		bidBlockWinGauge.Inc(1)
 		task, err := w.prepareBidBlockTask(bestBidBlock, start)
 		if err != nil {
 			log.Error("Failed to prepare bid block, fallback",


### PR DESCRIPTION
### Description

Metrics added by this PR (miner: add BidBlock verify metrics):

1. worker/bidBlockWin (Gauge, cumulative) — number of times a BidBlock wins the auction (beats both simBid and the local block); bidBlockWin − bidBlockCommit is the count of wins that then failed prepare and fell back.
2.worker/bidBlockVerifyFailed (Gauge, cumulative) — number of sealed BidBlocks that fail async InsertChain verification (i.e. a bad block was broadcast); the key alert signal.
3.bidblock/prepare/duration (Timer) — duration of prepareBidBlockTask: blob KZG validation + system-tx bind-signing + TxHash recompute for the selected BidBlock; the pre-seal critical path.
4.bidblock/verify/duration (Timer) — duration of the sealed BidBlock's InsertChain verification (recorded on both success and failure); _count = total verifications, so verified = _count − bidBlockVerifyFailed.




### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
