### PR TITLE
 miner: disable BidBlock on hard-fork activation blocks

### DIFF
--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -109,8 +109,15 @@ func (miner *Miner) SendBidBlock(ctx context.Context, args *buildertypes.BidBloc
 	}
 	blockNumber := bb.Header.Number.Uint64()
 	parentHash := bb.Header.ParentHash
-	if miner.bidSimulator.chain.GetHeaderByHash(parentHash) == nil {
+	parent := miner.bidSimulator.chain.GetHeaderByHash(parentHash)
+	if parent == nil {
 		return common.Hash{}, buildertypes.NewInvalidBidError(fmt.Sprintf("parent not found: %s, bidHash=%s", parentHash.Hex(), bidHash))
+	}
+
+	// Security: validators must self-produce hard-fork activation blocks.
+	if miner.worker.chainConfig.IsOnPasteur(bb.Header.Number, parent.Time, bb.Header.Time) {
+		return common.Hash{}, buildertypes.NewInvalidBidError(fmt.Sprintf(
+			"BidBlock disabled on hard-fork activation block %d, fallback to SendBid", blockNumber))
 	}
 	if err := miner.bidSimulator.CheckPending(blockNumber, builder, bidHash); err != nil {
 		return common.Hash{}, err


### PR DESCRIPTION
### Description

improve bep-675 security

Hard-fork activation blocks carry mandatory system txs / contract upgrades that the BidBlock shape check (expectedSystemTxShape) cannot validate, so a builder-proposed block for them is unsafe. This adds a guard in Miner.SendBidBlock that rejects BidBlocks on the fork activation block (currently Pasteur) with a fallback-to-mev_sendBid error, forcing the validator to self-produce it.
.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
