### PR TITLE
miner: optimize BidBlock signing hash

### DIFF
--- a/core/types/builder/bid.go
+++ b/core/types/builder/bid.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -263,12 +264,16 @@ type BidBlock struct {
 	hash atomic.Value
 }
 
-// Hash returns rlpHash over all BidBlock fields. This is what the builder signs.
+// Hash returns the BidBlock signing hash. The header carries TxHash, and the
+// validator checks TxHash against Transactions before blind-signing.
 func (b *BidBlock) Hash() common.Hash {
 	if hash := b.hash.Load(); hash != nil {
 		return hash.(common.Hash)
 	}
-	h := rlpHash(b)
+	start := time.Now()
+	h := rlpHash(b.Header)
+	log.Debug("BidBlock Hash() computed", "number", b.Header.Number, "elapsed", time.Since(start),
+		"txs", len(b.Transactions), "sidecars", len(b.Sidecars))
 	b.hash.Store(h)
 	return h
 }

--- a/core/types/builder/bid.go
+++ b/core/types/builder/bid.go
@@ -271,7 +271,7 @@ func (b *BidBlock) Hash() common.Hash {
 		return hash.(common.Hash)
 	}
 	start := time.Now()
-	h := rlpHash(b.Header)
+	h := b.Header.Hash()
 	log.Debug("BidBlock Hash() computed", "number", b.Header.Number, "elapsed", time.Since(start),
 		"txs", len(b.Transactions), "sidecars", len(b.Sidecars))
 	b.hash.Store(h)

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/miner/minerconfig"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/trie"
 )
 
 const prefetchTxNumber = 50
@@ -736,6 +737,9 @@ func (b *bidSimulator) preSealVerifyBidBlock(decoded *buildertypes.DecodedBidBlo
 	}
 	if err := parliaEngine.BlockTimeUpperCheck(b.chain, header); err != nil {
 		return fmt.Errorf("invalid header: %v", err)
+	}
+	if txHash := types.DeriveSha(decoded.Txs, trie.NewStackTrie(nil)); header.TxHash != txHash {
+		return fmt.Errorf("invalid tx root: got %s, want %s", header.TxHash, txHash)
 	}
 
 	decoded.SystemTxStart, decoded.GasFee = parliaEngine.ExtractBidBlockDepositValue(decoded.Txs)


### PR DESCRIPTION
### Description

This narrows the BidBlock signing hash to the header, using header.TxHash as the commitment to the submitted transactions. The validator now verifies header.TxHash == DeriveSha(decoded.Txs) before blind-signing and verify the blob txn in prepareBidBlock, so transaction integrity is preserved while avoiding hashing the full BidBlock payload during signature recovery.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
