### PR TITLE
miner, core: fix mining prefetch rate-limiting broken by shadowing

### DIFF
--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -132,7 +132,7 @@ func (p *statePrefetcher) Prefetch(transactions types.Transactions, header *type
 // PrefetchMining processes the state changes according to the Ethereum rules by running
 // the transaction messages using the statedb, but any changes are discarded. The
 // only goal is to warm the state caches. Only used for mining stage.
-func (p *statePrefetcher) PrefetchMining(txs TransactionsByPriceAndNonce, header *types.Header, gasLimit uint64, statedb *state.StateDB, cfg vm.Config, interruptCh <-chan struct{}, txCurr **types.Transaction) {
+func (p *statePrefetcher) PrefetchMining(txs TransactionsByPriceAndNonce, header *types.Header, gasLimit uint64, statedb *state.StateDB, cfg vm.Config, interruptCh <-chan struct{}, txCurr *atomic.Pointer[types.Transaction]) {
 	if statedb == nil {
 		return
 	}
@@ -206,7 +206,9 @@ func (p *statePrefetcher) PrefetchMining(txs TransactionsByPriceAndNonce, header
 				return
 			default:
 				if count++; count%checkInterval == 0 {
-					txset.Forward(*txCurr)
+					if curr := txCurr.Load(); curr != nil {
+						txset.Forward(curr)
+					}
 				}
 				tx := txset.PeekWithUnwrap()
 				if tx == nil {

--- a/core/types.go
+++ b/core/types.go
@@ -48,7 +48,7 @@ type Prefetcher interface {
 	// only goal is to warm the state caches.
 	Prefetch(transactions types.Transactions, header *types.Header, gasLimit uint64, statedb *state.StateDB, cfg vm.Config, interrupt *atomic.Bool)
 	// PrefetchMining used for pre-caching transaction signatures and state trie nodes. Only used for mining stage.
-	PrefetchMining(txs TransactionsByPriceAndNonce, header *types.Header, gasLimit uint64, statedb *state.StateDB, cfg vm.Config, interruptCh <-chan struct{}, txCurr **types.Transaction)
+	PrefetchMining(txs TransactionsByPriceAndNonce, header *types.Header, gasLimit uint64, statedb *state.StateDB, cfg vm.Config, interruptCh <-chan struct{}, txCurr *atomic.Pointer[types.Transaction])
 }
 
 // Processor is an interface for processing blocks using a given initial state.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -797,10 +797,12 @@ func (w *worker) commitTransactions(env *environment, plainTxs, blobTxs *transac
 	defer close(stopPrefetchCh)
 	// prefetch plainTxs txs, don't bother to prefetch a few blobTxs
 	txsPrefetch := plainTxs.Copy()
-	tx := txsPrefetch.PeekWithUnwrap()
-	if tx != nil {
-		txCurr := &tx
-		w.prefetcher.PrefetchMining(txsPrefetch, env.header, env.gasPool.Gas(), env.state.StateForPrefetch(), *w.chain.GetVMConfig(), stopPrefetchCh, txCurr)
+	// prefetchCurr marks the tx the main loop is on; the prefetch feeder reads
+	// it to rate-limit itself (see Forward).
+	var prefetchCurr atomic.Pointer[types.Transaction]
+	if prefetchHead := txsPrefetch.PeekWithUnwrap(); prefetchHead != nil {
+		prefetchCurr.Store(prefetchHead)
+		w.prefetcher.PrefetchMining(txsPrefetch, env.header, env.gasPool.Gas(), env.state.StateForPrefetch(), *w.chain.GetVMConfig(), stopPrefetchCh, &prefetchCurr)
 	}
 
 	signal := commitInterruptNone
@@ -897,6 +899,7 @@ LOOP:
 			txs.Pop()
 			continue
 		}
+		prefetchCurr.Store(tx)
 
 		// if inclusion of the transaction would put the block size over the
 		// maximum we allow, don't add any more txs to the payload.


### PR DESCRIPTION
### Description

Fixes #3740 — the mining prefetch feeder's rate-limiting has been a no-op since v1.3.0; restore it with a race-free progress marker. Performance only, no consensus impact.

### Rationale

The v1.12.2 merge brought upstream's `tx := ltx.Resolve()` into `commitTransactions`, shadowing the outer `tx` that `txCurr` points to. The pointer stays frozen at the first transaction, so the feeder's `Forward(*txCurr)` never advances and prefetch runs unbounded ahead of the sealing loop, warming transactions the block will never include (wasted CPU/cache, worst when sealing is cut short by the block-interval timer).

The fix uses a dedicated `atomic.Pointer[types.Transaction]` instead of resurrecting the shadowed variable:
* upstream-shared lines stay byte-identical (no recurring merge conflict / silent regression);
* the marker is stored after the nil check and the feeder nil-guards its `Load` — `Forward(nil)` would clear the prefetch set and kill prefetching for the rest of the block;
* atomics make the now-live cross-goroutine handoff pass `-race` (the old double-pointer design was only race-free because the write was frozen).

### Example

```
go build ./miner/... ./core/...
go test -race ./miner/ -run 'TestBuildPayload|TestCommit|TestPrefetch' -count=1  # ok
```

### Changes

* `miner/worker.go`: track sealing progress in `prefetchCurr atomic.Pointer[types.Transaction]`, stored per committed tx after the nil check
* `core/state_prefetcher.go`: `PrefetchMining` takes `*atomic.Pointer[types.Transaction]`; feeder does nil-guarded `Load` before `Forward`
* `core/types.go`: `Prefetcher` interface signature updated to match