### PR TITLE
core/txpool, eth: remove local transaction reannounce mechanism

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -95,7 +95,6 @@ var (
 		utils.TxPoolGlobalQueueFlag,
 		utils.TxPoolOverflowPoolSlotsFlag, // deprecated
 		utils.TxPoolLifetimeFlag,
-		utils.TxPoolReannounceTimeFlag,
 		utils.MinerTxGasLimitFlag,
 		utils.EnableBALFlag,
 		utils.BlobPoolDataDirFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -580,12 +580,6 @@ var (
 		Value:    ethconfig.Defaults.TxPool.Lifetime,
 		Category: flags.TxPoolCategory,
 	}
-	TxPoolReannounceTimeFlag = &cli.DurationFlag{
-		Name:     "txpool.reannouncetime",
-		Usage:    "Duration for announcing local pending transactions again (default = 10 years, minimum = 1 minute)",
-		Value:    ethconfig.Defaults.TxPool.ReannounceTime,
-		Category: flags.TxPoolCategory,
-	}
 	// Blob transaction pool settings
 	BlobPoolDataDirFlag = &cli.StringFlag{
 		Name:     "blobpool.datadir",
@@ -2072,9 +2066,6 @@ func setTxPool(ctx *cli.Context, cfg *legacypool.Config) {
 	}
 	if ctx.IsSet(TxPoolLifetimeFlag.Name) {
 		cfg.Lifetime = ctx.Duration(TxPoolLifetimeFlag.Name)
-	}
-	if ctx.IsSet(TxPoolReannounceTimeFlag.Name) {
-		cfg.ReannounceTime = ctx.Duration(TxPoolReannounceTimeFlag.Name)
 	}
 }
 

--- a/core/events.go
+++ b/core/events.go
@@ -26,9 +26,6 @@ import (
 // NewTxsEvent is posted when a batch of transactions enters the transaction pool.
 type NewTxsEvent struct{ Txs []*types.Transaction }
 
-// ReannoTxsEvent is posted when a batch of local pending transactions exceed a specified duration.
-type ReannoTxsEvent struct{ Txs []*types.Transaction }
-
 // NewSealedBlockEvent is posted when a block has been sealed.
 type NewSealedBlockEvent struct{ Block *types.Block }
 

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -384,8 +384,6 @@ type BlobPool struct {
 
 	discoverFeed event.Feed // Event feed to send out new tx events on pool discovery (reorg excluded)
 	insertFeed   event.Feed // Event feed to send out new tx events on pool inclusion (reorg included)
-	reannoTxFeed event.Feed // Event feed for announcing transactions again
-	scope        event.SubscriptionScope
 
 	lock sync.RWMutex // Mutex protecting the pool during reorg handling
 }
@@ -2046,12 +2044,6 @@ func (p *BlobPool) SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool
 	} else {
 		return p.discoverFeed.Subscribe(ch)
 	}
-}
-
-// SubscribeReannoTxsEvent registers a subscription of ReannoTxsEvent and
-// starts sending event to the given channel.
-func (p *BlobPool) SubscribeReannoTxsEvent(ch chan<- core.ReannoTxsEvent) event.Subscription {
-	return p.scope.Track(p.reannoTxFeed.Subscribe(ch))
 }
 
 // Nonce returns the next nonce of an account, with all transactions executable

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -54,9 +54,6 @@ const (
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
 	txMaxSize = 4 * txSlotSize // 128KB
-
-	// txReannoMaxNum is the maximum number of transactions a reannounce action can include.
-	txReannoMaxNum = 1024
 )
 
 var (
@@ -81,7 +78,6 @@ var (
 var (
 	evictionInterval    = time.Minute     // Time interval to check for evictable transactions
 	statsReportInterval = 8 * time.Second // Time interval to report transaction pool stats
-	reannounceInterval  = time.Minute     // Time interval to check for reannounce transactions
 )
 
 var (
@@ -158,8 +154,7 @@ type Config struct {
 	AccountQueue uint64 // Maximum number of non-executable transaction slots permitted per account
 	GlobalQueue  uint64 // Maximum number of non-executable transaction slots for all accounts
 
-	Lifetime       time.Duration // // Maximum amount of time an account can remain stale in the non-executable pool
-	ReannounceTime time.Duration // Duration for announcing local pending transactions again
+	Lifetime time.Duration // Maximum amount of time an account can remain stale in the non-executable pool
 }
 
 // DefaultConfig contains the default configurations for the transaction pool.
@@ -175,8 +170,7 @@ var DefaultConfig = Config{
 	AccountQueue: 200,
 	GlobalQueue:  4000,
 
-	Lifetime:       3 * time.Hour,
-	ReannounceTime: 10 * 365 * 24 * time.Hour,
+	Lifetime: 3 * time.Hour,
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -211,10 +205,6 @@ func (config *Config) sanitize() Config {
 		log.Warn("Sanitizing invalid txpool lifetime", "provided", conf.Lifetime, "updated", DefaultConfig.Lifetime)
 		conf.Lifetime = DefaultConfig.Lifetime
 	}
-	if conf.ReannounceTime < time.Minute {
-		log.Warn("Sanitizing invalid txpool reannounce time", "provided", conf.ReannounceTime, "updated", time.Minute)
-		conf.ReannounceTime = time.Minute
-	}
 	return conf
 }
 
@@ -240,15 +230,13 @@ func (config *Config) sanitize() Config {
 // will reject new transactions with delegations from that account with standard in-flight
 // transactions.
 type LegacyPool struct {
-	config       Config
-	chainconfig  *params.ChainConfig
-	chain        BlockChain
-	gasTip       atomic.Pointer[uint256.Int]
-	txFeed       event.Feed
-	reannoTxFeed event.Feed // Event feed for announcing transactions again
-	scope        event.SubscriptionScope
-	signer       types.Signer
-	mu           sync.RWMutex
+	config      Config
+	chainconfig *params.ChainConfig
+	chain       BlockChain
+	gasTip      atomic.Pointer[uint256.Int]
+	txFeed      event.Feed
+	signer      types.Signer
+	mu          sync.RWMutex
 
 	currentHead   atomic.Pointer[types.Header] // Current head of the blockchain
 	currentState  *state.StateDB               // Current state in the blockchain head
@@ -361,13 +349,11 @@ func (pool *LegacyPool) loop() {
 		prevPending, prevQueued, prevStales int
 
 		// Start the stats reporting and transaction eviction tickers
-		report     = time.NewTicker(statsReportInterval)
-		evict      = time.NewTicker(evictionInterval)
-		reannounce = time.NewTicker(reannounceInterval)
+		report = time.NewTicker(statsReportInterval)
+		evict  = time.NewTicker(evictionInterval)
 	)
 	defer report.Stop()
 	defer evict.Stop()
-	defer reannounce.Stop()
 
 	// Notify tests that the init phase is done
 	close(pool.initDoneCh)
@@ -396,29 +382,6 @@ func (pool *LegacyPool) loop() {
 				pool.removeTx(hash, true, true)
 			}
 			pool.mu.Unlock()
-
-		case <-reannounce.C:
-			pool.mu.RLock()
-			reannoTxs := func() []*types.Transaction {
-				txs := make([]*types.Transaction, 0)
-				for _, list := range pool.pending {
-					for _, tx := range list.Flatten() {
-						// Default ReannounceTime is 10 years, won't announce by default.
-						if time.Since(tx.Time()) < pool.config.ReannounceTime {
-							break
-						}
-						txs = append(txs, tx)
-						if len(txs) >= txReannoMaxNum {
-							return txs
-						}
-					}
-				}
-				return txs
-			}()
-			pool.mu.RUnlock()
-			if len(reannoTxs) > 0 {
-				pool.reannoTxFeed.Send(core.ReannoTxsEvent{Txs: reannoTxs})
-			}
 		}
 	}
 }
@@ -448,12 +411,6 @@ func (pool *LegacyPool) SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs
 	// is because the new txs are added to the queue, resurrected ones too and
 	// reorgs run lazily, so separating the two would need a marker.
 	return pool.txFeed.Subscribe(ch)
-}
-
-// SubscribeReannoTxsEvent registers a subscription of ReannoTxsEvent and
-// starts sending event to the given channel.
-func (pool *LegacyPool) SubscribeReannoTxsEvent(ch chan<- core.ReannoTxsEvent) event.Subscription {
-	return pool.scope.Track(pool.reannoTxFeed.Subscribe(ch))
 }
 
 // SetGasTip updates the minimum gas tip required by the transaction pool for a

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -2274,48 +2274,6 @@ func TestSlotCount(t *testing.T) {
 	}
 }
 
-// Tests the local pending transaction announced again correctly.
-func TestTransactionPendingReannouce(t *testing.T) {
-	t.Parallel()
-
-	// Create the pool to test the limit enforcement with
-	statedb, _ := state.New(common.Hash{}, state.NewDatabaseForTesting())
-	blockchain := newTestBlockChain(params.TestChainConfig, 1000000, statedb, new(event.Feed))
-
-	config := testTxPoolConfig
-	// This ReannounceTime will be modified to time.Minute when creating tx_pool.
-	config.ReannounceTime = time.Second
-	reannounceInterval = time.Second
-
-	pool := New(config, blockchain)
-	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), newReserver())
-	// Modify ReannounceTime to trigger quicker.
-	pool.config.ReannounceTime = time.Second
-	defer pool.Close()
-
-	key, _ := crypto.GenerateKey()
-	account := crypto.PubkeyToAddress(key.PublicKey)
-	pool.currentState.AddBalance(account, uint256.NewInt(1000000), tracing.BalanceChangeUnspecified)
-
-	events := make(chan core.ReannoTxsEvent, testTxPoolConfig.AccountQueue)
-	sub := pool.reannoTxFeed.Subscribe(events)
-	defer sub.Unsubscribe()
-
-	// Generate a batch of transactions and add to tx_pool locally.
-	txs := make([]*types.Transaction, 0, testTxPoolConfig.AccountQueue)
-	for i := uint64(0); i < testTxPoolConfig.AccountQueue; i++ {
-		txs = append(txs, transaction(i, 100000, key))
-	}
-	pool.Add(txs, true)
-
-	select {
-	case ev := <-events:
-		t.Logf("received reannouce event, txs length: %d", len(ev.Txs))
-	case <-time.After(5 * time.Second):
-		t.Errorf("reannouce event not fired")
-	}
-}
-
 // TestSetCodeTransactions tests a few scenarios regarding the EIP-7702
 // SetCodeTx.
 func TestSetCodeTransactions(t *testing.T) {

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -161,10 +161,6 @@ type SubPool interface {
 	// or also for reorged out ones.
 	SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool) event.Subscription
 
-	// SubscribeReannoTxsEvent should return an event subscription of
-	// ReannoTxsEvent and send events to the given channel.
-	SubscribeReannoTxsEvent(chan<- core.ReannoTxsEvent) event.Subscription
-
 	// Nonce returns the next nonce of an account, with all transactions executable
 	// by the pool already applied on top.
 	Nonce(addr common.Address) uint64

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -389,19 +389,6 @@ func (p *TxPool) SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool) 
 	return p.subs.Track(event.JoinSubscriptions(subs...))
 }
 
-// SubscribeReannoTxsEvent registers a subscription of ReannoTxsEvent and starts sending
-// events to the given channel.
-func (p *TxPool) SubscribeReannoTxsEvent(ch chan<- core.ReannoTxsEvent) event.Subscription {
-	subs := make([]event.Subscription, 0, len(p.subpools))
-	for _, subpool := range p.subpools {
-		sub := subpool.SubscribeReannoTxsEvent(ch)
-		if sub != nil { // sub will be nil when subpool have been shut down
-			subs = append(subs, sub)
-		}
-	}
-	return p.subs.Track(event.JoinSubscriptions(subs...))
-}
-
 // PoolNonce returns the next nonce of an account, with all transactions executable
 // by the pool already applied on top.
 func (p *TxPool) PoolNonce(addr common.Address) uint64 {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -109,10 +109,6 @@ type txPool interface {
 	// or also for reorged out ones.
 	SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool) event.Subscription
 
-	// SubscribeReannoTxsEvent should return an event subscription of
-	// ReannoTxsEvent and send events to the given channel.
-	SubscribeReannoTxsEvent(chan<- core.ReannoTxsEvent) event.Subscription
-
 	// FilterType returns whether the given tx type is supported by the txPool.
 	FilterType(kind byte) bool
 }
@@ -198,8 +194,6 @@ type handler struct {
 	handlerStartCh chan struct{}
 	handlerDoneCh  chan struct{}
 
-	reannoTxsCh    chan core.ReannoTxsEvent
-	reannoTxsSub   event.Subscription
 	minedBlockSub  *event.TypeMuxSubscription
 	voteCh         chan core.NewVoteEvent
 	votesSub       event.Subscription
@@ -725,12 +719,6 @@ func (h *handler) Start(maxPeers int, maxPeersPerIP int) {
 		}
 	}
 
-	// announce local pending transactions again
-	h.wg.Add(1)
-	h.reannoTxsCh = make(chan core.ReannoTxsEvent, txChanSize)
-	h.reannoTxsSub = h.txpool.SubscribeReannoTxsEvent(h.reannoTxsCh)
-	go h.txReannounceLoop()
-
 	// broadcast mined blocks
 	h.wg.Add(1)
 	h.minedBlockSub = h.eventMux.Subscribe(core.NewMinedBlockEvent{}, core.NewSealedBlockEvent{})
@@ -770,7 +758,6 @@ func (h *handler) startMaliciousVoteMonitor() {
 func (h *handler) Stop() {
 	h.txsSub.Unsubscribe() // quits txBroadcastLoop
 	h.blockRange.stop()
-	h.reannoTxsSub.Unsubscribe()  // quits txReannounceLoop
 	h.minedBlockSub.Unsubscribe() // quits blockBroadcastLoop
 	if h.votepool != nil {
 		h.votesSub.Unsubscribe() // quits voteBroadcastLoop
@@ -988,24 +975,6 @@ func (h *handler) BroadcastTransactions(txs types.Transactions) {
 		"bcastpeers", len(txset), "bcastcount", directCount, "annpeers", len(annos), "anncount", annCount)
 }
 
-// ReannounceTransactions will announce a batch of local pending transactions
-// to a square root of all peers.
-func (h *handler) ReannounceTransactions(txs types.Transactions) {
-	hashes := make([]common.Hash, 0, txs.Len())
-	for _, tx := range txs {
-		hashes = append(hashes, tx.Hash())
-	}
-
-	// Announce transactions hash to a batch of peers
-	peersCount := uint(math.Sqrt(float64(h.peers.len())))
-	peers := h.peers.headPeers(peersCount)
-	for _, peer := range peers {
-		peer.AsyncSendPooledTransactionHashes(hashes)
-	}
-	log.Debug("Transaction reannounce", "txs", len(txs),
-		"announce packs", peersCount, "announced hashes", peersCount*uint(len(hashes)))
-}
-
 // BroadcastVote will propagate a batch of votes to all peers
 // which are not known to already have the given vote.
 func (h *handler) BroadcastVote(vote *types.VoteEnvelope) {
@@ -1073,21 +1042,6 @@ func (h *handler) txBroadcastLoop() {
 		case event := <-h.txsCh:
 			h.BroadcastTransactions(event.Txs)
 		case <-h.txsSub.Err():
-			return
-		case <-h.stopCh:
-			return
-		}
-	}
-}
-
-// txReannounceLoop announces local pending transactions to connected peers again.
-func (h *handler) txReannounceLoop() {
-	defer h.wg.Done()
-	for {
-		select {
-		case event := <-h.reannoTxsCh:
-			h.ReannounceTransactions(event.Txs)
-		case <-h.reannoTxsSub.Err():
 			return
 		case <-h.stopCh:
 			return

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -528,59 +528,6 @@ func testTransactionPropagation(t *testing.T, protocol uint) {
 	}
 }
 
-// Tests that local pending transactions get propagated to peers.
-func TestTransactionPendingReannounce(t *testing.T) {
-	t.Parallel()
-
-	// Create a source handler to announce transactions from and a sink handler
-	// to receive them.
-	source := newTestHandler(ethconfig.FullSync)
-	defer source.close()
-
-	sink := newTestHandler(ethconfig.FullSync)
-	defer sink.close()
-	sink.handler.acceptTxs.Store(true) // mark synced to accept transactions
-
-	sourcePipe, sinkPipe := p2p.MsgPipe()
-	defer sourcePipe.Close()
-	defer sinkPipe.Close()
-
-	sourcePeer := eth.NewPeer(eth.ETH68, p2p.NewPeer(enode.ID{0}, "", nil), sourcePipe, source.txpool, source.chain.Config())
-	sinkPeer := eth.NewPeer(eth.ETH68, p2p.NewPeer(enode.ID{0}, "", nil), sinkPipe, sink.txpool, sink.chain.Config())
-	defer sourcePeer.Close()
-	defer sinkPeer.Close()
-
-	go source.handler.runEthPeer(sourcePeer, func(peer *eth.Peer) error {
-		return eth.Handle((*ethHandler)(source.handler), peer)
-	})
-	go sink.handler.runEthPeer(sinkPeer, func(peer *eth.Peer) error {
-		return eth.Handle((*ethHandler)(sink.handler), peer)
-	})
-
-	// Subscribe transaction pools
-	txCh := make(chan core.NewTxsEvent, 1024)
-	sub := sink.txpool.SubscribeTransactions(txCh, false)
-	defer sub.Unsubscribe()
-
-	txs := make([]*types.Transaction, 64)
-	for nonce := range txs {
-		tx := types.NewTransaction(uint64(nonce), common.Address{}, big.NewInt(0), 100000, big.NewInt(0), nil)
-		tx, _ = types.SignTx(tx, types.HomesteadSigner{}, testKey)
-
-		txs[nonce] = tx
-	}
-	source.txpool.ReannouceTransactions(txs)
-
-	for arrived := 0; arrived < len(txs); {
-		select {
-		case event := <-txCh:
-			arrived += len(event.Txs)
-		case <-time.NewTimer(time.Second).C:
-			t.Errorf("sink: transaction propagation timed out: have %d, want %d", arrived, len(txs))
-		}
-	}
-}
-
 // Tests that blocks are broadcast to a sqrt number of peers only.
 func TestBroadcastBlock1Peer(t *testing.T)    { testBroadcastBlock(t, 1, 1) }
 func TestBroadcastBlock2Peers(t *testing.T)   { testBroadcastBlock(t, 2, 1) }

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -64,9 +64,8 @@ var (
 type testTxPool struct {
 	pool map[common.Hash]*types.Transaction // Hash map of collected transactions
 
-	txFeed       event.Feed   // Notification feed to allow waiting for inclusion
-	reannoTxFeed event.Feed   // Notification feed to trigger reannouce
-	lock         sync.RWMutex // Protects the transaction pool
+	txFeed event.Feed   // Notification feed to allow waiting for inclusion
+	lock   sync.RWMutex // Protects the transaction pool
 }
 
 // newTestTxPool creates a mock transaction pool.
@@ -136,18 +135,6 @@ func (p *testTxPool) Add(txs []*types.Transaction, sync bool) []error {
 	return make([]error, len(txs))
 }
 
-// ReannouceTransactions announce the transactions to some peers.
-func (p *testTxPool) ReannouceTransactions(txs []*types.Transaction) []error {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	for _, tx := range txs {
-		p.pool[tx.Hash()] = tx
-	}
-	p.reannoTxFeed.Send(core.ReannoTxsEvent{Txs: txs})
-	return make([]error, len(txs))
-}
-
 // Pending returns all the transactions known to the pool
 func (p *testTxPool) Pending(filter txpool.PendingFilter) (map[common.Address][]*txpool.LazyTransaction, int) {
 	p.lock.RLock()
@@ -184,12 +171,6 @@ func (p *testTxPool) Pending(filter txpool.PendingFilter) (map[common.Address][]
 // send events to the given channel.
 func (p *testTxPool) SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool) event.Subscription {
 	return p.txFeed.Subscribe(ch)
-}
-
-// SubscribeReannoTxsEvent should return an event subscription of ReannoTxsEvent and
-// send events to the given channel.
-func (p *testTxPool) SubscribeReannoTxsEvent(ch chan<- core.ReannoTxsEvent) event.Subscription {
-	return p.reannoTxFeed.Subscribe(ch)
 }
 
 // FilterType should check whether the pool supports the given type of transactions.

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -410,25 +410,6 @@ func (ps *peerSet) isProxyedValidator(validator common.Address, proxyedAddressMa
 	return true
 }
 
-// headPeers retrieves a specified number list of peers.
-func (ps *peerSet) headPeers(num uint) []*ethPeer {
-	ps.lock.RLock()
-	defer ps.lock.RUnlock()
-
-	if num > uint(len(ps.peers)) {
-		num = uint(len(ps.peers))
-	}
-
-	list := make([]*ethPeer, 0, num)
-	for _, p := range ps.peers {
-		if len(list) > int(num) {
-			break
-		}
-		list = append(list, p)
-	}
-	return list
-}
-
 // peersWithoutBlock retrieves a list of peers that do not have a given block in
 // their set of known hashes, so it might be propagated to them.
 func (ps *peerSet) peersWithoutBlock(hash common.Hash) []*ethPeer {


### PR DESCRIPTION
## Description

This PR completely removes the local pending transaction "reannounce" mechanism that was introduced ~5 years ago in #570 — the background reannounce loop, its event-feed plumbing, the CLI flag, the config field, and all associated tests.

## Motivation

The feature periodically re-broadcast a node's own local pending transactions to a `sqrt(peers)` subset, gated by a `ReannounceTime` interval. Its **default value is 10 years** (`10 * 365 * 24h`), i.e. the feature has been effectively disabled out of the box for its entire lifetime.

In exchange for a capability almost nobody enables, it carries permanent cost and complexity across the codebase:

- A dedicated `time.Ticker` (`reannounceInterval`, fires every minute) plus a full pending-pool scan on every tick inside the legacy pool's hot `loop()`.
- A separate `event.Feed` (`reannoTxFeed`) and its `Subscribe`/`Send` plumbing threaded through the `SubPool` interface, `TxPool`, `LegacyPool`, and `BlobPool`.
- A `ReannoTxsEvent` type, a `txReannounceLoop` goroutine and dedicated subscription in the eth `handler`, plus the `ReannounceTransactions` broadcast path.
- A CLI flag (`--txpool.reannouncetime`) and a `Config.ReannounceTime` field with its own sanitization branch.

Under modern transaction propagation (announce/retrieve), periodic self-reannounce provides no meaningful benefit; a stuck local tx is better served by fee bumping / replacement than by the node re-shouting hashes. Removing it simplifies the txpool and the eth handler and eliminates a recurring scan of the pending set.

## Changes

- **core/txpool/legacypool**: remove the `reannounce` ticker and its case in `loop()`, the `reannoTxFeed` field, `SubscribeReannoTxsEvent`, the `ReannounceTime` config field (+ default + sanitization), and the `txReannoMaxNum` / `reannounceInterval` constants.
- **core/txpool/blobpool**: remove the `reannoTxFeed` field and `SubscribeReannoTxsEvent`.
- **core/txpool** (`txpool.go`, `subpool.go`): remove `SubscribeReannoTxsEvent` from the aggregate pool and from the `SubPool` interface.
- **core/events.go**: remove the `ReannoTxsEvent` type.
- **eth/handler.go**: remove `SubscribeReannoTxsEvent` from the `txPool` interface, the `reannoTxsCh`/`reannoTxsSub` fields, the subscription setup in `Start`, the unsubscribe in `Stop`, the `txReannounceLoop` goroutine, and the `ReannounceTransactions` method.
- **eth/peerset.go**: remove `headPeers`, which was added by #570 and whose only caller was `ReannounceTransactions` (now dead code).
- **cmd/utils/flags.go, cmd/geth/main.go**: remove the `--txpool.reannouncetime` flag and its wiring in `setTxPool`.
- **Tests**: remove `TestTransactionPendingReannouce` (legacypool), `TestTransactionPendingReannounce` (eth handler), and the reannounce plumbing in the eth `testTxPool` mock.

Net effect: 12 files, ~272 lines removed.

## Backward compatibility

This is a small, intentional breaking change for the removed knobs:

- Passing `--txpool.reannouncetime=...` will now fail at startup with an unknown flag error.
- A `config.toml` that still contains `ReannounceTime` under `[Eth.TxPool]` (e.g. one produced by an older `geth dumpconfig`) will fail to load, since unknown TOML fields are rejected.

Because the feature shipped disabled by default (10-year interval), we expect effectively no production node to have deliberately set either knob. Operators with an auto-generated `config.toml` should drop the stale `ReannounceTime` line.

## Testing

- `go build ./...` passes.
- `go vet ./core/txpool/... ./eth/ ./cmd/...` passes.
- `go test ./core/txpool/legacypool/` and `go test ./eth/` pass (neighbouring transaction-propagation and broadcast tests included).
- `gofmt` clean; a repo-wide grep for `reanno` / `headPeers` shows no remaining references.
