### PR TITLE
miner, core/vm: fix MEV bid gas accounting and EVM stack-arena double-release

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -19,6 +19,7 @@ package vm
 import (
 	"errors"
 	"math/big"
+	"sync"
 	"sync/atomic"
 
 	"github.com/holiman/uint256"
@@ -129,7 +130,8 @@ type EVM struct {
 	readOnly   bool   // Whether to throw on stateful modifications
 	returnData []byte // Last CALL's return data for subsequent reuse
 
-	arena *stackArena
+	arena       *stackArena
+	releaseOnce sync.Once // guards returning the arena to the pool exactly once
 }
 
 // NewEVM constructs an EVM instance with the supplied block context, state
@@ -227,10 +229,22 @@ func (evm *EVM) Cancel() {
 	evm.abort.Store(true)
 }
 
-// Release returns some memory allocated by the EVM, should be called after the EVM was used
-// for the last time. Not necessary, but an improvement.
+// Release returns the EVM's stack arena to the shared pool. It is optional (GC
+// reclaims the arena otherwise) but enables reuse; the EVM must not be used
+// afterwards.
+//
+// It is idempotent and goroutine-safe: sync.Once returns the arena once and
+// clears it, so a double Release can't hand the same arena to the pool twice
+// (which would let two later EVMs draw and race on it). Defense-in-depth, not
+// a license for aliased ownership.
 func (evm *EVM) Release() {
-	returnStack(evm.arena)
+	evm.releaseOnce.Do(func() {
+		if evm.arena == nil {
+			return
+		}
+		returnStack(evm.arena)
+		evm.arena = nil
+	})
 }
 
 // Cancelled returns true if Cancel has been called

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -1022,6 +1022,11 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 	}, false); err != nil {
 		return
 	}
+	// Mark this env as simulator-owned: it is retained in bidsToSim and
+	// discarded only by clearLoop, so the worker must not discard it when this
+	// bid wins and its env becomes w.current. AddBidToSim below is what makes
+	// clearLoop the sole owner; the two must stay paired.
+	bidRuntime.env.fromBid = true
 	b.AddBidToSim(bidRuntime)
 
 	// if the left time is not enough to do simulation, return

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -1032,12 +1032,12 @@ func (b *bidSimulator) simBid(interruptCh chan int32, bidRuntime *BidRuntime) {
 	}
 
 	gasLimit := bidRuntime.env.header.GasLimit
-	if bidRuntime.env.gasPool == nil {
-		bidRuntime.env.gasPool = core.NewGasPool(gasLimit)
-		if p, ok := b.engine.(*parlia.Parlia); ok {
-			bidRuntime.env.gasPool.SubGas(p.EstimateGasReservedForSystemTxs(b.chain, bidRuntime.env.header))
-		}
-		bidRuntime.env.gasPool.SubGas(params.PayBidTxGasLimit)
+
+	// Reserve gas for the payBidTx appended at the end of the block so the
+	// admission check and greedy merge leave room for it; returned right before
+	// it is committed.
+	if err = bidRuntime.env.gasPool.SubGas(params.PayBidTxGasLimit); err != nil {
+		return
 	}
 
 	// error log:
@@ -1366,6 +1366,7 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 	} else if unRevertible && receipt.Status == types.ReceiptStatusFailed {
 		return errors.New("no revertible transaction failed")
 	}
+	env.header.GasUsed = env.gasPool.Used()
 
 	if tx.Type() == types.BlobTxType {
 		sc.TxIndex = uint64(len(env.txs))

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -126,6 +126,11 @@ type environment struct {
 	witness *stateless.Witness
 
 	committed bool
+
+	// fromBid marks an env owned by the bid simulator (retained in bidsToSim,
+	// discarded by its clearLoop). The worker must not discard it even when a
+	// winning bid's env becomes w.current, or the EVM arena is released twice.
+	fromBid bool
 }
 
 // discard terminates the background prefetcher go-routine. It should
@@ -137,6 +142,7 @@ func (env *environment) discard() {
 	}
 	if env.evm != nil {
 		env.evm.Release()
+		env.evm = nil
 	}
 }
 
@@ -501,7 +507,7 @@ func (w *worker) mainLoop() {
 	defer w.wg.Done()
 	defer w.chainHeadSub.Unsubscribe()
 	defer func() {
-		if w.current != nil {
+		if w.current != nil && !w.current.fromBid {
 			w.current.discard()
 		}
 	}()
@@ -1522,10 +1528,10 @@ LOOP:
 	}
 
 	if bidBlockCommitted {
-		if w.current != nil {
+		if w.current != nil && !w.current.fromBid {
 			w.current.discard()
-			w.current = nil
 		}
+		w.current = nil
 		return
 	}
 
@@ -1559,7 +1565,7 @@ LOOP:
 
 	// Swap out the old work with the new one, terminating any leftover
 	// prefetcher processes in the mean time and starting a new one.
-	if w.current != nil {
+	if w.current != nil && !w.current.fromBid {
 		w.current.discard()
 	}
 	w.current = bestWork


### PR DESCRIPTION
### Description

Two independent regressions from the v1.17.3 merge in the MEV path, one fix per commit:

1. **Bid gas accounting** — winning bids sealed a wrong `header.GasUsed` and were rejected on import.
2. **EVM stack-arena double-release** — a winning bid's EVM was released twice, corrupting the shared arena pool and causing sporadic interpreter panics.

### Rationale

#### 1. Bid gas accounting (`e66f8082`)

The merge dropped the `usedGas` param from `core.ApplyTransaction` and made `makeEnv` build the gas pool eagerly, breaking the `simBid` path two ways:

- `BidRuntime.commitTransaction` stopped updating `env.header.GasUsed`, so a winning bid sealed a `header.GasUsed` of `0` (or short by payBidTx) → **every winning MEV block failed import with `invalid gas used`**. Fix: set `env.header.GasUsed = env.gasPool.Used()` after each committed tx, as `worker.applyTransaction` does, so the sealed value matches what `StateProcessor` recomputes.
- The eager pool left the `gasPool == nil` branch dead, dropping the payBidTx gas reservation. Fix: reserve it with `SubGas(PayBidTxGasLimit)` before the admission check; the existing `AddGas(PayBidTxGasLimit)` before committing payBidTx returns it, so the pair nets to zero on `Used()`.

Net: `header.GasUsed = Σ(user txs + payBidTx)`, identical to the non-MEV path — no double count, no residue.

#### 2. EVM stack-arena double-release (`590e4ea0`)

The stack arena (new in v1.17.3) is pooled and must be returned via `EVM.Release()` exactly once. But a MEV env's EVM had two owners — the simulator (env kept in `bidsToSim`, released by its `clearLoop`) and the worker (released on discard once the winning bid's env becomes `w.current`). So its arena was returned to the pool twice; two later EVMs then drew the same arena and raced on its `top` index → sporadic `index out of range` panic.

Fix — one owner per EVM:

- **bid EVM → simulator only.** Envs carry a `fromBid` marker; the worker skips `discard()` for them, so `clearLoop` is the sole owner.
- **worker EVM → worker only.** Local envs discard as before, and `env.evm` is cleared after `Release()` so they can't be released twice either.
- **Defense in depth:** `EVM.Release()` is now idempotent (`sync.Once` + nil check), turning any stray double release into a no-op.

### Changes

* `miner/bid_simulator.go`: write `header.GasUsed` from the gas pool after each committed tx; reserve `PayBidTxGasLimit` before the admission check; mark bid-owned envs with `fromBid`.
* `miner/worker.go`: add `environment.fromBid`; the worker discards only non-`fromBid` envs; clear `env.evm` after `Release()`.
* `core/vm/evm.go`: make `EVM.Release()` idempotent and goroutine-safe.
