### PR TITLE
miner: fix stack arena double release of MEV bid envs

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -2156,6 +2156,7 @@ func (p *Parlia) applyTransaction(
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
 	evm := vm.NewEVM(context, state, p.chainConfig, vm.Config{Tracer: tracer})
+	defer evm.Release()
 	evm.SetTxContext(core.NewEVMTxContext(msg))
 
 	// Tracing receipt will be set if there is no error and will be used to trace the transaction

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -628,20 +628,27 @@ func (b *bidSimulator) clearLoop() {
 			}
 		}
 		for blockNumber, bidList := range b.bidsToSim {
-			if blockNumber <= clearThreshold {
-				for _, bid := range bidList {
-					if bid.env == nil || bid.envAdopted.Load() {
-						continue
-					}
-					select {
-					case <-bid.finished:
-						// envs for simulating only discard here
-						bid.env.discard()
-					default:
-						// simulation still running; leave the env to the GC
-						// rather than releasing an arena that is still in use
-					}
+			if blockNumber > clearThreshold {
+				continue
+			}
+			var pending []*BidRuntime
+			for _, bid := range bidList {
+				if bid.env == nil || bid.envAdopted.Load() {
+					continue
 				}
+				select {
+				case <-bid.finished:
+					// envs for simulating only discard here
+					bid.env.discard()
+				default:
+					// simulation still running; keep it and retry on the next
+					// chain head rather than releasing an arena still in use
+					pending = append(pending, bid)
+				}
+			}
+			if len(pending) > 0 {
+				b.bidsToSim[blockNumber] = pending
+			} else {
 				delete(b.bidsToSim, blockNumber)
 			}
 		}

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -630,7 +630,7 @@ func (b *bidSimulator) clearLoop() {
 		for blockNumber, bidList := range b.bidsToSim {
 			if blockNumber <= clearThreshold {
 				for _, bid := range bidList {
-					if bid.env != nil {
+					if bid.env != nil && !bid.envAdopted.Load() {
 						// envs for simulating only discard here
 						bid.env.discard()
 					}
@@ -1254,6 +1254,11 @@ type BidRuntime struct {
 	bid *types.Bid
 
 	env *environment
+	// envAdopted marks that env's ownership has been transferred to the worker
+	// (committed as sealing work), which then must discard it exactly once;
+	// the simulator must no longer discard it, otherwise the EVM stack arena
+	// is double-released into the global pool and gets shared by two EVMs.
+	envAdopted atomic.Bool
 
 	expectedBlockReward     *big.Int
 	expectedValidatorReward *big.Int

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -630,9 +630,16 @@ func (b *bidSimulator) clearLoop() {
 		for blockNumber, bidList := range b.bidsToSim {
 			if blockNumber <= clearThreshold {
 				for _, bid := range bidList {
-					if bid.env != nil && !bid.envAdopted.Load() {
+					if bid.env == nil || bid.envAdopted.Load() {
+						continue
+					}
+					select {
+					case <-bid.finished:
 						// envs for simulating only discard here
 						bid.env.discard()
+					default:
+						// simulation still running; leave the env to the GC
+						// rather than releasing an arena that is still in use
 					}
 				}
 				delete(b.bidsToSim, blockNumber)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1531,7 +1531,11 @@ LOOP:
 
 	// simBid fallback. Re-runs the legacy dual-threshold gate against simBid
 	// whenever no BidBlock is being committed.
-	if bestBid != nil {
+	// bestBid outlives its env: once the env was adopted and later discarded
+	// (it is no longer w.current), re-adopting it would discard it a second
+	// time and double-release its stack arena. Adoption while it is still
+	// w.current stays allowed and is harmless (commit no-ops via committed).
+	if bestBid != nil && (bestBid.env == w.current || !bestBid.envAdopted.Load()) {
 		if bestReward.Cmp(simBidBlockReward) < 0 &&
 			localValidatorReward.Cmp(simBidValidatorReward) < 0 {
 			bidWinGauge.Inc(1)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1539,6 +1539,7 @@ LOOP:
 				greedyMergeOnchainCounter.Inc(1)
 			}
 			bestWork = bestBid.env
+			bestBid.envAdopted.Store(true)
 			// Record MEV v1 (bid path) source and builder address.
 			setBidMevInfo(bestWork.header, bestBid.bid.Builder, false)
 			logMsg := "[BUILDER BLOCK]"

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1560,7 +1560,10 @@ LOOP:
 
 	// Swap out the old work with the new one, terminating any leftover
 	// prefetcher processes in the mean time and starting a new one.
-	if w.current != nil {
+	// bestWork may alias w.current when the same winning bid env is adopted
+	// again (e.g. a second newWorkReq at the same height); discarding it then
+	// would release an env that stays in use as w.current.
+	if w.current != nil && w.current != bestWork {
 		w.current.discard()
 	}
 	w.current = bestWork


### PR DESCRIPTION
### Description

Fix a validator crash introduced by the v1.17.3 upstream merge:

```
panic: runtime error: index out of range [-1]
core/vm.(*Stack).pop / opSstore / EVM.Run / ProcessParentBlockHash / worker.prepareWork
```

Upstream's stack arena (ethereum/go-ethereum#33960) makes each `vm.EVM` borrow a `stackArena` from a global `sync.Pool`, returned via `evm.Release()` in `environment.discard()`. The new contract is that discard must run **exactly once per env** — but the MEV bid path discards the winning bid's env twice: once by the worker after adopting it as `w.current`, and again by the bid simulator's `clearFn`, which sweeps every env recorded in `bidsToSim` ~`TriesInMemory` blocks later. The double `Put` hands the same arena to two live EVMs; they race on `arena.top` while stack-depth validation only checks the per-frame view's `size`, so `pop` underflows in an unrelated block ~128 blocks after the actual bug.

### Rationale

The arena turned a previously harmless double `discard()` (it only stopped the prefetcher) into silent memory corruption of a global pool. All fixes are call-site ownership rules — no runtime belt-and-braces — so each known double-release path is closed explicitly:

* adopted envs are marked (`envAdopted`) and skipped by `clearFn`;
* `commitWork` no longer discards `w.current` when it aliases the newly chosen `bestWork`;
* a bid env that was adopted and already discarded (no longer `w.current`) is never re-adopted;
* `clearFn` keeps still-simulating envs for the next sweep instead of releasing an arena in use (or leaking it).

### Example

N/A (validator-side crash fix; no CLI/API change)

### Changes

Notable changes:
* miner: mark adopted bid envs so the bid simulator's `clearFn` never discards an env owned by the worker
* miner: guard the `w.current` swap against aliasing the newly chosen `bestWork`
* miner: never re-adopt a bid env the worker has already discarded
* miner: `clearFn` retries still-running simulations on the next chain head instead of dropping them
* consensus/parlia: `defer evm.Release()` for the per-system-tx EVM (returns one ~32KB arena per system tx to the pool; pure perf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)