### PR TITLE
core/txpool: fall back to an empty state when head state is unavailable

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -445,7 +445,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 	// fully synced).
 	state, err := p.chain.StateAt(head)
 	if err != nil {
-		state, err = p.chain.StateAt(p.chain.Genesis().Header())
+		state, err = p.chain.StateAt(&types.Header{Number: head.Number, Time: head.Time, Root: types.EmptyRootHash})
 	}
 	if err != nil {
 		return err

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -334,7 +334,7 @@ func (pool *LegacyPool) Init(gasTip uint64, head *types.Header, reserver txpool.
 	// fully synced).
 	statedb, err := pool.chain.StateAt(head)
 	if err != nil {
-		statedb, err = pool.chain.StateAt(pool.chain.Genesis().Header())
+		statedb, err = pool.chain.StateAt(&types.Header{Number: head.Number, Time: head.Time, Root: types.EmptyRootHash})
 	}
 	if err != nil {
 		return err

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -93,7 +93,7 @@ func New(gasTip uint64, chain BlockChain, subpools []SubPool) (*TxPool, error) {
 	// fully synced).
 	statedb, err := chain.StateAt(head)
 	if err != nil {
-		statedb, err = chain.StateAt(chain.Genesis().Header())
+		statedb, err = chain.StateAt(&types.Header{Number: head.Number, Time: head.Time, Root: types.EmptyRootHash})
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

Restore the empty-state fallback in the tx/blob/legacy pool constructors when the chain head state is unavailable, so a node restarted in the middle of an initial snap sync (path scheme) can start up and resume syncing instead of aborting.

## Rationale

On the path scheme, during an initial snap sync the trie database is in wait-sync mode and the disk layer sits at the empty root, so neither the head (genesis) state nor the genesis state is materialized yet. The current fallback reads `chain.Genesis().Header()`, which fails too, and the node aborts at startup:

```
Fatal: Failed to register the Ethereum service: missing trie node <root> (path ) state <root> is not available
```

Upstream go-ethereum #34700 changed this fallback from `types.EmptyRootHash` to `chain.Genesis().Header()` while reworking `StateAt` to take a header; the comment above still reads "fallback to empty one", indicating the change was unintentional. The empty root is always resolvable (it is the disk layer during snap sync), and the pool is reset to the real head state once the chain head advances.

## Example

1. Path scheme (default) + `--syncmode snap` on a fresh datadir.
2. Stop the node while it is in `state download in progress` (before the pivot state completes).
3. Restart.

Before: node aborts with the fatal above.
After: node logs `Genesis state is missing, wait state sync` → `Enabled snap sync` and resumes.

## Changes

- `core/txpool/txpool.go`
- `core/txpool/legacypool/legacypool.go`
- `core/txpool/blobpool/blobpool.go`

Each constructor now falls back to an empty state at the head's height (preserving number/time so the correct trie flavor is selected) instead of the genesis state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)