### PR TITLE
eth/downloader: fix legacy snap sync regressions from the v1.17.3 merge

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -385,7 +385,7 @@ func (d *Downloader) LegacySync(id string, head common.Hash, name string, td *bi
 // synchronise will select the peer and use it for synchronising. If an empty string is given
 // it will use the best peer possible and synchronize if its TD is higher than our own. If any of the
 // checks fail an error will be returned. This method is synchronous
-func (d *Downloader) synchronise(id string, hash common.Hash, td, ttd *big.Int, mode SyncMode, beaconMode bool, beaconPing chan struct{}) error {
+func (d *Downloader) synchronise(id string, hash common.Hash, td, ttd *big.Int, mode SyncMode, beaconMode bool, beaconPing chan struct{}) (err error) {
 	// The beacon header syncer is async. It will start this synchronization and
 	// will continue doing other tasks. However, if synchronization needs to be
 	// cancelled, the syncer needs to know if we reached the startup point (and
@@ -418,7 +418,7 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td, ttd *big.Int, 
 	// Obtain the synchronized used in this cycle
 	mode = d.moder.get(true)
 	defer func() {
-		if mode == ethconfig.SnapSync {
+		if err == nil && mode == ethconfig.SnapSync {
 			d.moder.disableSnap()
 			log.Info("Disabled snap-sync after the initial sync cycle")
 		}
@@ -1574,6 +1574,29 @@ func (d *Downloader) processSnapSyncContent() error {
 			}
 		} else { // results already piled up, consume before handling pivot move
 			results = append(append([]*fetchResult{oldPivot}, oldTail...), results...)
+		}
+		// Split around the pivot block and process the two sides via snap/full sync
+		if !d.committed.Load() {
+			latest := results[len(results)-1].Header
+			// If the height is above the pivot block by 2 sets, it means the pivot
+			// became stale in the network, and it was garbage collected, move to a
+			// new pivot.
+			//
+			// Note, we have `reorgProtHeaderDelay` number of blocks withheld, Those
+			// need to be taken into account, otherwise we're detecting the pivot move
+			// late and will drop peers due to unavailable state!!!
+			if height := latest.Number.Uint64(); height >= pivot.Number.Uint64()+2*uint64(fsMinFullBlocks)-uint64(reorgProtHeaderDelay) {
+				log.Warn("Pivot became stale, moving", "old", pivot.Number.Uint64(), "new", height-uint64(fsMinFullBlocks)+uint64(reorgProtHeaderDelay))
+				pivot = results[len(results)-1-fsMinFullBlocks+reorgProtHeaderDelay].Header // must exist as lower old pivot is uncommitted
+
+				d.pivotLock.Lock()
+				d.pivotHeader = pivot
+				d.pivotLock.Unlock()
+
+				// Write out the pivot into the database so a rollback beyond it will
+				// reenable snap sync
+				rawdb.WriteLastPivotNumber(d.stateDB, pivot.Number.Uint64())
+			}
 		}
 		P, beforeP, afterP := splitAroundPivot(pivot.Number.Uint64(), results)
 		if err := d.commitSnapSyncData(beforeP, sync); err != nil {

--- a/eth/downloader/syncmode.go
+++ b/eth/downloader/syncmode.go
@@ -100,7 +100,10 @@ func (m *syncModer) get(report bool) ethconfig.SyncMode {
 	// We are in a full sync, but the associated head state is missing. To complete
 	// the head state, forcefully rerun the snap sync. Note it doesn't mean the
 	// persistent state is corrupted, just mismatch with the head block.
-	if !m.chain.HasState(head.Root) {
+	// Note: NoTries (fast node, --tries-verify-mode none) chains must never
+	// auto-switch to snap sync, mirroring the guard in eth/sync.go modeAndLocalHead
+	// and newSyncModer above; otherwise SnapSyncStart would wipe the fastnode state.
+	if !m.chain.NoTries() && !m.chain.HasState(head.Root) {
 		logger("Reenabled snap-sync as chain is stateless")
 		return ethconfig.SnapSync
 	}


### PR DESCRIPTION
### Description

Restore three load-bearing pieces of BSC's legacy snap-sync path that the v1.17.3 merge silently dropped when it adopted upstream go-ethereum's beacon-only sync code.

### Rationale

BSC keeps its legacy `chainSyncer` / `LegacySync` driver, but the v1.17.3 merge (grafted with no common ancestor) let git silently adopt upstream's beacon-only versions of code the legacy driver still depends on — with no conflict markers. The three dropped pieces:

**1. Pivot mover → silent snap-sync deadlock.** `processSnapSyncContent` lost its "Pivot became stale, moving" block (upstream removed it in ethereum/go-ethereum#33150 since beacon sync advances the pivot elsewhere). It was the legacy driver's *only* runtime pivot mover: once the header skeleton completes the pivot freezes, its state root goes stale, and snap sync deadlocks with no error. Restored from BSC master.

**2. `disableSnap` guard → silent full sync from genesis.** The `err == nil` guard on `moder.disableSnap()` was dropped, so any transient failure of the first snap cycle (peer race, `fetchHead` timeout, lock contention) permanently downgrades the node to full sync from genesis. Restored via a named return, matching upstream.

**3. `NoTries` guard → fastnode snapshot wipe.** `moder.get()` lost the `!NoTries()` guard that `newSyncModer` and `eth/sync.go` already carry (#2367), so a `--tries-verify-mode none` fastnode with a transiently-missing snapshot could be forced into snap sync, wiping its state via `SnapSyncStart`.

### Changes

* `eth/downloader/downloader.go` — restore the stale-pivot detect/advance block in `processSnapSyncContent` (verbatim from BSC master).
* `eth/downloader/downloader.go` — `synchronise` uses a named return and restores `if err == nil && mode == SnapSync` before `moder.disableSnap()`.
* `eth/downloader/syncmode.go` — add `!m.chain.NoTries()` to `moder.get()`'s stateless re-enable.

### Verification

* `go build ./... && go vet ./eth/downloader/`; `go test ./eth/downloader/ -run 'Snap|Sync'` passes.
* Devnet (chapel): pivot resumes moving (`Pivot became stale, moving`), state download progresses, and sync reaches `Committed new head block`. A red/green test reproducing the deadlock was used during development, kept out to keep the diff minimal.
