### PR TITLE
eth: fix peerSet lock deadlock in waitSnapExtension

### DIFF
--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -187,8 +187,13 @@ func (ps *peerSet) waitSnapExtension(peer *eth.Peer) (*snap.Peer, error) {
 		ps.lock.Unlock()
 		return snap, nil
 	}
-	// Otherwise wait for `snap` to connect concurrently
-	wait := make(chan *snap.Peer)
+	// Otherwise wait for `snap` to connect concurrently. The channel is given a
+	// capacity of 1 so that registerSnapExtension's delivery below can never
+	// block while holding ps.lock: registerSnapExtension deletes this entry
+	// from snapWait before sending, under the same lock, so at most one value
+	// is ever sent here, and the buffer absorbs it even if nobody is left to
+	// receive (e.g. this call already timed out or the peerset is closing).
+	wait := make(chan *snap.Peer, 1)
 	ps.snapWait[id] = wait
 	ps.lock.Unlock()
 


### PR DESCRIPTION
### Description

Fixes a deadlock between `registerSnapExtension` and `waitSnapExtension` on the global `peerSet.lock`. `registerSnapExtension` holds ps.lock while sending on the unbuffered snapWait channel; if the corresponding `waitSnapExtension` call times out (or the peerset is closing) at the same moment and tries to grab `ps.lock` itself before receiving, both sides block on each other forever. Gives the snapWait channel a buffer of 1 so the delivery in `registerSnapExtension` can never block while holding the lock.

### Rationale

NA

### Example

NA

### Changes

Notable changes: 
NA
