### PR TITLE
eth: cap NewBlockHashesPacket length

### DIFF
--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -912,6 +912,48 @@ func TestHandleNewBlock(t *testing.T) {
 	}
 }
 
+func TestHandleNewBlockhashes(t *testing.T) {
+	t.Parallel()
+
+	backend := newTestBackendWithGenerator(1, false, false, nil)
+	defer backend.close()
+
+	localEth := NewPeer(ETH68, p2p.NewPeer(enode.ID{1}, "peer", nil), nil, nil, backend.chain.Config())
+
+	newPacket := func(n int) NewBlockHashesPacket {
+		ann := make(NewBlockHashesPacket, n)
+		for i := range ann {
+			ann[i].Hash = common.Hash{byte(i), byte(i >> 8)}
+			ann[i].Number = uint64(i)
+		}
+		return ann
+	}
+	msgFor := func(ann NewBlockHashesPacket) p2p.Msg {
+		size, r, _ := rlp.EncodeToReader(ann)
+		return p2p.Msg{Code: NewBlockHashesMsg, Size: uint32(size), Payload: r}
+	}
+
+	testCases := []struct {
+		name    string
+		count   int
+		wantErr bool
+	}{
+		{"at limit", maxNewBlockHashes, false},
+		{"over limit", maxNewBlockHashes + 1, true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := handleNewBlockhashes(backend, msgFor(newPacket(tc.count)), localEth)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %d announcements, got nil", tc.count)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for %d announcements: %v", tc.count, err)
+			}
+		})
+	}
+}
+
 func makeBlkBlobs(n, nPerTx int) []*types.BlobTxSidecar {
 	if n <= 0 {
 		return nil

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -374,6 +374,9 @@ func handleNewBlockhashes(backend Backend, msg Decoder, peer *Peer) error {
 	if err := msg.Decode(ann); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
+	if len(*ann) > maxNewBlockHashes {
+		return fmt.Errorf("too many block announcements: %d > %d", len(*ann), maxNewBlockHashes)
+	}
 	// Mark the hashes as present at the remote node
 	for _, block := range *ann {
 		peer.markBlock(block.Hash)

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -52,6 +52,12 @@ const maxMessageSize = 10 * 1024 * 1024
 // This is the maximum number of transactions in a Transactions message.
 const maxTransactionAnnouncements = 5000
 
+// This is the maximum number of block hash announcements in a NewBlockHashes
+// message. Honest peers announce freshly mined blocks one (rarely a handful)
+// at a time, so this is only there to cap the amount of work a malicious peer
+// can trigger downstream (e.g. per-hash lookups) with a single message.
+const maxNewBlockHashes = 1024
+
 const (
 	StatusMsg                     = 0x00
 	NewBlockHashesMsg             = 0x01


### PR DESCRIPTION
### Description

`handleNewBlockhashes` (the handler for the eth protocol's `NewBlockHashes` message) only rejected an empty announcement list. The number of block hashes a single message can carry was otherwise unbounded except for the 10MB devp2p message size limit, which permits roughly 250k entries per message. This adds an explicit `maxNewBlockHashes = 1024` cap, checked right after decoding and before any per-hash work is done.

### Rationale

Downstream of this handler, handleBlockAnnounces unconditionally calls GetBlockStats for every hash in the packet — not just the ones the node hasn't seen before — in the peer's own message-handling goroutine. This loop runs outside of the shared block fetcher's own per-peer throttle (hashLimit = 256 in eth/fetcher/block_fetcher.go), so it's never gated by the fetcher's existing guardrails.

Any unauthenticated peer could therefore send one ~10MB NewBlockHashes message packed with ~250k hashes and force this node to do ~250k stats lookups (LRU churn, CPU, allocations) before the fetcher's own limits ever get a chance to apply — a cheap, remote, no-auth-required amplification vector. Announcing new blocks one at a time (rarely a handful) is the only legitimate use of this message, so capping the packet at the entry point closes the gap without needing to touch the downstream loop itself, and without affecting any real client behavior.

### Example

NA

### Changes

Notable changes: 
NA
