### PR TITLE
consensus/parlia: add metrics for assembleVoteAttestation outcomes

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -93,13 +93,15 @@ var (
 	diffInTurn = big.NewInt(2) // Block difficulty for in-turn signatures
 	diffNoTurn = big.NewInt(1) // Block difficulty for out-of-turn signatures
 	// 100 native token
-	maxSystemBalance                  = new(uint256.Int).Mul(uint256.NewInt(100), uint256.NewInt(params.Ether))
-	verifyVoteAttestationErrorCounter = metrics.NewRegisteredCounter("parlia/verifyVoteAttestation/error", nil)
-	updateAttestationErrorCounter     = metrics.NewRegisteredCounter("parlia/updateAttestation/error", nil)
-	validVotesfromSelfCounter         = metrics.NewRegisteredCounter("parlia/VerifyVote/self", nil)
-	doubleSignCounter                 = metrics.NewRegisteredCounter("parlia/doublesign", nil)
-	intentionalDelayMiningCounter     = metrics.NewRegisteredCounter("parlia/intentionalDelayMining", nil)
-	attestationVoteCountGauge         = metrics.NewRegisteredGauge("parlia/attestation/voteCount", nil)
+	maxSystemBalance                    = new(uint256.Int).Mul(uint256.NewInt(100), uint256.NewInt(params.Ether))
+	verifyVoteAttestationErrorCounter   = metrics.NewRegisteredCounter("parlia/verifyVoteAttestation/error", nil)
+	updateAttestationErrorCounter       = metrics.NewRegisteredCounter("parlia/updateAttestation/error", nil)
+	assembleVoteAttestationErrorCounter = metrics.NewRegisteredCounter("parlia/assembleVoteAttestation/error", nil)
+	assembleVoteAttestationSkipCounter  = metrics.NewRegisteredCounter("parlia/assembleVoteAttestation/skip", nil)
+	validVotesfromSelfCounter           = metrics.NewRegisteredCounter("parlia/VerifyVote/self", nil)
+	doubleSignCounter                   = metrics.NewRegisteredCounter("parlia/doublesign", nil)
+	intentionalDelayMiningCounter       = metrics.NewRegisteredCounter("parlia/intentionalDelayMining", nil)
+	attestationVoteCountGauge           = metrics.NewRegisteredGauge("parlia/attestation/voteCount", nil)
 
 	systemContracts = map[common.Address]bool{
 		common.HexToAddress(systemcontracts.ValidatorContract):          true,
@@ -1080,6 +1082,11 @@ func (p *Parlia) assembleVoteAttestation(chain consensus.ChainHeaderReader, head
 		}
 	}
 	if targetHeaderParentSnap == nil {
+		// Not an error: quorum votes for a recent enough target simply haven't
+		// arrived yet by sealing time. Counted separately from real assemble
+		// errors so operators can distinguish "still catching up on votes"
+		// from an actual, persistent assembly failure.
+		assembleVoteAttestationSkipCounter.Inc(1)
 		return nil
 	}
 
@@ -1762,8 +1769,13 @@ func (p *Parlia) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 		err := p.assembleVoteAttestation(chain, header)
 		if err != nil {
 			/* If the vote attestation can't be assembled successfully, the blockchain won't get
-			   fast finalized, but it can be tolerated, so just report this error here. */
-			log.Debug("Assemble vote attestation failed when sealing", "err", err)
+			   fast finalized, but it can be tolerated, so just report this error here. This is a
+			   genuine assemble failure (not the routine "quorum votes not in yet" case, which
+			   returns nil and is tracked separately via assembleVoteAttestationSkipCounter), so
+			   it's worth surfacing above Debug and counting for alerting, symmetric to
+			   verifyVoteAttestationErrorCounter on the import side. */
+			assembleVoteAttestationErrorCounter.Inc(1)
+			log.Warn("Assemble vote attestation failed when sealing", "err", err)
 		}
 
 		// Sign all the things!


### PR DESCRIPTION
### Description

Adds two Prometheus counters and bumps a log level in consensus/parlia/parlia.go so that `assembleVoteAttestation` failures during Seal are observable, without changing any control flow: block sealing still proceeds exactly as before regardless of whether the vote attestation could be assembled.

### Rationale

NA

### Example

NA

### Changes

Notable changes: 
NA
