### PR TITLE
internal/ethapi, eth/filters: fix eth_simulateV1 multi-block and getLogs latest range-limit regressions

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -145,8 +145,22 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 	if err != nil {
 		return nil, err
 	}
-	if f.rangeLimit != 0 && (end-begin) > f.rangeLimit {
-		return nil, invalidParamsErr("exceed maximum block range %d", f.rangeLimit)
+	if f.rangeLimit != 0 {
+		// "latest"/"pending" resolve to MaxUint64 here and are only translated to
+		// the real head inside rangeLogs, so clamp them to the current head before
+		// measuring the range, otherwise any query up to head is falsely rejected.
+		lo, hi := begin, end
+		if head := f.sys.backend.CurrentHeader(); head != nil {
+			if lo == math.MaxUint64 {
+				lo = head.Number.Uint64()
+			}
+			if hi == math.MaxUint64 {
+				hi = head.Number.Uint64()
+			}
+		}
+		if hi >= lo && hi-lo > f.rangeLimit {
+			return nil, invalidParamsErr("exceed maximum block range %d", f.rangeLimit)
+		}
 	}
 	return f.rangeLogs(ctx, begin, end)
 }

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -444,7 +444,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	chainHeadReader := &simChainHeadReader{ctx, sim.b}
 
 	// Assemble the block
-	b, _, err := core.AssembleBlock(sim.b.Engine(), chainHeadReader, header, sim.state, blockBody, receipts)
+	b, err := sim.FinalizeAndAssemble(chainHeadReader, header, sim.state, blockBody, receipts)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
### Description

Fix two `eth_`-namespace RPC regressions introduced by the geth v1.17.3 upstream merge:
`eth_simulateV1` failing every multi-block call with `parent not found`, and
`eth_getLogs`/`eth_getFilterLogs` wrongly rejecting `toBlock: latest` queries under the block-range limit.

### Rationale

- **eth_simulateV1**: the merge switched synthetic-block assembly to `core.AssembleBlock(sim.b.Engine(), …)`, which on BSC routes into Parlia's `finalizeAndAssemble`. That resolves the parent via `chain.GetHeaderByHash` and walks the snapshot, but the simulate chain reader only serves the canonical chain — so from the 2nd virtual block onward (parent = a just-simulated block) the lookup returns nil → `parent not found`. Running consensus finalize (slash / system-tx injection) on hypothetical blocks is also semantically wrong.
- **range limit**: the `(end - begin) > rangeLimit` check runs before the `latest`/`pending` sentinel (`math.MaxUint64`) is translated to the real head, so any query with `toBlock: latest` (or omitted, which defaults to latest) sees `end - begin ≈ MaxUint64` and trips `exceed maximum block range` even for a 1-block span. This defect exists in upstream go-ethereum too; it is dormant there only because the upstream default limit is `0` (unlimited).

### Example

```
# 2-block eth_simulateV1 — was: {"error":{"code":-32000,"message":"parent not found"}}
curl -s $RPC -d '{"jsonrpc":"2.0","id":1,"method":"eth_simulateV1","params":[{"blockStateCalls":[{"calls":[]},{"calls":[]}]},"latest"]}'

# eth_getLogs to latest within the 5000-block cap — was: "exceed maximum block range 5000"
curl -s $RPC -d '{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{"fromBlock":"0x1","toBlock":"latest"}]}'
```

`go test ./internal/ethapi/ -run Simulate` and `go test ./eth/filters/` pass.

### Changes

* `internal/ethapi/simulate.go`: assemble simulated blocks via the engine-free `sim.FinalizeAndAssemble` instead of `core.AssembleBlock`, restoring the pre-merge behavior and keeping Parlia's consensus finalize out of the simulate path.
* `eth/filters/filter.go`: clamp the `MaxUint64` (latest) sentinel to the current head before the range-limit check, so the check measures the real query span.
