### PR TITLE
core/rawdb, core: revert all-prunable chain tables, re-enable cutoff test

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -4510,15 +4510,11 @@ func testChainReorgSnapSync(t *testing.T, ancientLimit uint64) {
 	}
 }
 
-// TODO(sysvm): need fix when pruned sync enabled
-//
 // Tests the scenario that all the inserted chain segment are with the configured
 // chain cutoff point. In this case the chain segment before the cutoff should
 // be persisted without the receipts and bodies; chain after should be persisted
 // normally.
-//
-//nolint:unused
-func testInsertChainWithCutoff1(t *testing.T) {
+func TestInsertChainWithCutoff(t *testing.T) {
 	const chainLength = 64
 
 	// Configure and generate a sample block chain
@@ -4558,9 +4554,6 @@ func testInsertChainWithCutoff1(t *testing.T) {
 	})
 }
 
-// TODO(sysvm): need fix when pruned sync enabled
-//
-//nolint:unused
 func testInsertChainWithCutoff(t *testing.T, cutoff uint64, ancientLimit uint64, genesis *Genesis, blocks []*types.Block, receipts []types.Receipts) {
 	// log.SetDefault(log.NewLogger(log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelDebug, true)))
 

--- a/core/rawdb/ancient_scheme.go
+++ b/core/rawdb/ancient_scheme.go
@@ -46,11 +46,11 @@ const (
 // chainFreezerTableConfigs configures the settings for tables in the chain freezer.
 // Compression is disabled for hashes as they don't compress well.
 var chainFreezerTableConfigs = map[string]freezerTableConfig{
-	ChainFreezerHeaderTable:      {noSnappy: false, prunable: true},
-	ChainFreezerHashTable:        {noSnappy: true, prunable: true},
+	ChainFreezerHeaderTable:      {noSnappy: false, prunable: false},
+	ChainFreezerHashTable:        {noSnappy: true, prunable: false},
 	ChainFreezerBodiesTable:      {noSnappy: false, prunable: true},
 	ChainFreezerReceiptTable:     {noSnappy: false, prunable: true},
-	ChainFreezerDifficultyTable:  {noSnappy: true, prunable: true},
+	ChainFreezerDifficultyTable:  {noSnappy: true, prunable: false},
 	ChainFreezerBlobSidecarTable: {noSnappy: false, prunable: true},
 }
 var additionTables = []string{ChainFreezerBlobSidecarTable}

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -430,9 +430,9 @@ func (f *Freezer) validate() error {
 			return fmt.Errorf("freezer table %s has a differing head: %d != %d", kind, table.items.Load(), head)
 		}
 		if !table.config.prunable {
-			// non-prunable tables have to start at 0
+			// BSC: v1.6.5 - v1.7.7 pruned these tables, the tail can't be undone
 			if table.itemHidden.Load() != 0 {
-				return fmt.Errorf("non-prunable freezer table '%s' has a non-zero tail: %d", kind, table.itemHidden.Load())
+				log.Warn("Non-prunable freezer table has a legacy tail", "table", kind, "tail", table.itemHidden.Load())
 			}
 		} else {
 			// prunable tables have to have the same length
@@ -499,9 +499,9 @@ func (f *Freezer) repair() error {
 			return err
 		}
 		if !table.config.prunable {
-			// non-prunable tables have to start at 0
+			// BSC: v1.6.5 - v1.7.7 pruned these tables, the tail can't be undone
 			if table.itemHidden.Load() != 0 {
-				panic(fmt.Sprintf("non-prunable freezer table %s has non-zero tail: %v", kind, table.itemHidden.Load()))
+				log.Warn("Non-prunable freezer table has a legacy tail", "table", kind, "tail", table.itemHidden.Load())
 			}
 		} else {
 			// prunable tables have to have the same length

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -636,6 +636,43 @@ func TestFreezerCloseSync(t *testing.T) {
 	}
 }
 
+// TestFreezerLegacyPrunedTail reopens a store pruned while its tables were still
+// marked prunable, as v1.6.5 - v1.7.7 left them.
+func TestFreezerLegacyPrunedTail(t *testing.T) {
+	t.Parallel()
+
+	f, dir := newFreezerForTesting(t, map[string]freezerTableConfig{
+		"a": {noSnappy: true, prunable: true},
+		"b": {noSnappy: true, prunable: true},
+	})
+	_, err := f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
+		for i := uint64(0); i < 10; i++ {
+			if err := appendSameItem(op, []string{"a", "b"}, i, []byte{byte(i)}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	_, err = f.TruncateTail(5)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Table "a" is non-prunable now, its on-disk tail is still 5.
+	tables := map[string]freezerTableConfig{
+		"a": {noSnappy: true, prunable: false},
+		"b": {noSnappy: true, prunable: true},
+	}
+	for _, readonly := range []bool{false, true} {
+		f, err := NewFreezer(dir, "", readonly, 2049, tables)
+		require.NoError(t, err, "readonly %v", readonly)
+		tail, err := f.Tail()
+		require.NoError(t, err)
+		require.Equal(t, uint64(5), tail, "readonly %v", readonly)
+		require.NoError(t, f.Close())
+	}
+}
+
 func TestFreezerSuite(t *testing.T) {
 	ancienttest.TestAncientSuite(t, func(kinds []string) ethdb.AncientStore {
 		tables := make(map[string]freezerTableConfig)


### PR DESCRIPTION
### Description

Revert #3294 (headers / hashes / diffs freezer tables back to non-prunable), re-enable `TestInsertChainWithCutoff`, and tolerate the tail those releases left on disk so pruned datadirs still start.

### Rationale

#3294 marked every chain table prunable so the incremental snapshot merger could truncate them all. That feature is gone (#3768), so the flags now only serve to delete headers on every tail prune.

They also broke `InsertHeadersBeforeCutoff`, which calls `TruncateTail` right after writing the pre-cutoff headers: with headers/hashes/diffs prunable, that truncation dropped what it had just written, so the following `InsertReceiptChain` could not resolve the parent TD and failed with `ErrUnknownAncestor`. #3294 disabled `TestInsertChainWithCutoff` rather than fixing it.

Flipping the flags back cannot undo what already happened on disk: datadirs pruned by v1.6.5 - v1.7.7 persist a non-zero `virtualTail` in those tables' `.meta` files, and the data files are gone. `Freezer.repair` panicked and `Freezer.validate` errored on such a tail, so every node that ran with `--pruneancient` or `--history.blocks` would fail to start. Both now log a warning and keep the legacy tail — the freezer tail is already the maximum across tables, and reads below it fail today regardless.

### Example

```
go test ./core/ -run TestInsertChainWithCutoff
go test ./core/rawdb/ -run TestFreezerLegacyPrunedTail
```

`TestFreezerLegacyPrunedTail` prunes a table while it is still marked prunable, reopens the store with it marked non-prunable, and asserts both the read-write and read-only paths open with the tail preserved. Without the `freezer.go` change it panics with `non-prunable freezer table a has non-zero tail: 5`.

### Changes

* `core/rawdb/ancient_scheme.go`: header, hash and difficulty tables back to `prunable: false`, matching upstream.
* `core/rawdb/freezer.go`: `repair`/`validate` warn instead of panicking/erroring on a legacy non-zero tail in a non-prunable table.
* `core/blockchain_test.go`: re-enable `TestInsertChainWithCutoff`, drop the `TODO(sysvm)` markers.
* `core/rawdb/freezer_test.go`: add `TestFreezerLegacyPrunedTail`.
