### PR TITLE
eth/protocols/bsc: add per-peer serve rate limit for GetBlocksByRange

### DIFF
--- a/eth/protocols/bsc/handler.go
+++ b/eth/protocols/bsc/handler.go
@@ -183,6 +183,17 @@ func handleGetBlocksByRange(backend Backend, msg Decoder, peer *Peer) error {
 		return fmt.Errorf("msg %v, invalid count: %v", GetBlocksByRangeMsg, req.Count)
 	}
 
+	// Rate-limit block serving per peer, mirroring the vote receive-rate limiter
+	// (handleVotes). A small request can force up to softResponseLimit of disk
+	// lookups, RLP encoding and upload; once a peer has spent its rolling
+	// per-period serving budget, drop further range requests (silently, like
+	// votes — keep the connection) until the period rolls over. The check runs
+	// before any disk lookup so a spamming peer stops costing work.
+	if peer.IsOverBlockServeLimit() {
+		log.Debug("drop GetBlocksByRange over serve rate limit", "from", peer.id)
+		return nil
+	}
+
 	// Get requested blocks
 	blocks := make([]rlp.RawValue, 0, req.Count)
 	var block *types.Block
@@ -214,6 +225,9 @@ func handleGetBlocksByRange(backend Backend, msg Decoder, peer *Peer) error {
 		blocks = append(blocks, enc)
 		responseSize += len(enc)
 	}
+
+	// Account the bytes actually served against the peer's rolling budget.
+	peer.ChargeBlockServe(uint64(responseSize))
 
 	log.Debug("reply GetBlocksByRange msg", "from", peer.id, "req", req.Count, "blocks", len(blocks), "responseSize", responseSize)
 	return p2p.Send(peer.rw, BlocksByRangeMsg, &BlocksByRangeRLPPacket{

--- a/eth/protocols/bsc/peer.go
+++ b/eth/protocols/bsc/peer.go
@@ -26,6 +26,18 @@ const (
 	// so the limit is 47 ~= 21/0.45, here set it to 68 with a buffer.
 	receiveRateLimitPerSecond = 68
 
+	// serveBytesRateLimitPerSecond is the per-peer budget, in response bytes,
+	// for serving GetBlocksByRange over one second. A single small request can
+	// force up to softResponseLimit (8 MiB) of disk lookups, RLP encoding and
+	// upload, so — mirroring the vote receive-rate limiter — a peer that keeps
+	// requesting ranges is bounded to this sustained serving cost.
+	//
+	// 8 MiB/s lets a legitimate quick-block-fetching peer burst several full
+	// responses within a period (the requester only asks when filling a gap
+	// near head, not continuously), while capping a spamming connection to a
+	// predictable, low cost.
+	serveBytesRateLimitPerSecond = 8 * 1024 * 1024
+
 	// the time span of one period
 	secondsPerPeriod = float64(30)
 )
@@ -37,7 +49,11 @@ type Peer struct {
 	voteBroadcast chan []*types.VoteEnvelope // Channel used to queue votes propagation requests
 	periodBegin   time.Time                  // Begin time of the latest period for votes counting
 	periodCounter uint                       // Votes number in the latest period
-	dispatcher    *Dispatcher                // Message request-response dispatcher
+
+	blockServeBegin   time.Time // Begin time of the latest period for block-serving byte counting
+	blockServeCounter uint64    // GetBlocksByRange response bytes served in the latest period
+
+	dispatcher *Dispatcher // Message request-response dispatcher
 
 	*p2p.Peer                   // The embedded P2P package peer
 	rw        p2p.MsgReadWriter // Input/output streams for bsc
@@ -51,16 +67,17 @@ type Peer struct {
 func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter) *Peer {
 	id := p.ID().String()
 	peer := &Peer{
-		id:            id,
-		knownVotes:    newKnownCache(maxKnownVotes),
-		voteBroadcast: make(chan []*types.VoteEnvelope, voteBufferSize),
-		periodBegin:   time.Now(),
-		periodCounter: 0,
-		Peer:          p,
-		rw:            rw,
-		version:       version,
-		logger:        log.New("peer", id[:8]),
-		term:          make(chan struct{}),
+		id:              id,
+		knownVotes:      newKnownCache(maxKnownVotes),
+		voteBroadcast:   make(chan []*types.VoteEnvelope, voteBufferSize),
+		periodBegin:     time.Now(),
+		periodCounter:   0,
+		blockServeBegin: time.Now(),
+		Peer:            p,
+		rw:              rw,
+		version:         version,
+		logger:          log.New("peer", id[:8]),
+		term:            make(chan struct{}),
 	}
 	peer.dispatcher = NewDispatcher(peer)
 	go peer.broadcastVotes()
@@ -138,6 +155,41 @@ func (p *Peer) IsOverLimitAfterReceivingVotes(n uint) bool {
 	}
 	p.periodCounter += n
 	return p.periodCounter > uint(secondsPerPeriod*receiveRateLimitPerSecond)
+}
+
+// blockServeBudget is the rolling per-period serving budget in bytes.
+func blockServeBudget() uint64 {
+	return uint64(secondsPerPeriod * serveBytesRateLimitPerSecond)
+}
+
+// IsOverBlockServeLimit reports whether this peer has already exhausted its
+// per-period GetBlocksByRange serving budget, rolling the period over when it
+// has elapsed. It does not charge the budget; call ChargeBlockServe with the
+// actual response size after a response has been built.
+//
+// These per-peer counters are only ever touched from the peer's single
+// message-handling goroutine (Handle), same as the vote counter above, so no
+// locking is needed.
+func (p *Peer) IsOverBlockServeLimit() bool {
+	if time.Since(p.blockServeBegin).Seconds() >= secondsPerPeriod {
+		if p.blockServeCounter > blockServeBudget() {
+			p.Log().Debug("serving GetBlocksByRange too much", "secondsPerPeriod", secondsPerPeriod, "bytes", p.blockServeCounter)
+		}
+		p.blockServeBegin = time.Now()
+		p.blockServeCounter = 0
+		return false
+	}
+	return p.blockServeCounter > blockServeBudget()
+}
+
+// ChargeBlockServe accounts n response bytes served for a GetBlocksByRange
+// reply against this peer's rolling per-period budget.
+func (p *Peer) ChargeBlockServe(n uint64) {
+	if time.Since(p.blockServeBegin).Seconds() >= secondsPerPeriod {
+		p.blockServeBegin = time.Now()
+		p.blockServeCounter = 0
+	}
+	p.blockServeCounter += n
 }
 
 // broadcastVotes is a write loop that schedules votes broadcasts

--- a/eth/protocols/bsc/peer_ratelimit_test.go
+++ b/eth/protocols/bsc/peer_ratelimit_test.go
@@ -1,0 +1,85 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package bsc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func newRateLimitTestPeer() *Peer {
+	p := &Peer{
+		id:              "rate-limit-test-peer",
+		blockServeBegin: time.Now(),
+	}
+	p.logger = log.New("peer", p.id)
+	return p
+}
+
+// TestBlockServeRateLimit verifies the per-peer GetBlocksByRange serving budget:
+// a fresh peer is under limit, charging beyond the rolling budget trips it, and
+// the period rolls over after secondsPerPeriod.
+func TestBlockServeRateLimit(t *testing.T) {
+	p := newRateLimitTestPeer()
+	budget := blockServeBudget()
+
+	if p.IsOverBlockServeLimit() {
+		t.Fatalf("a fresh peer must be under the serve limit")
+	}
+
+	// Serving up to the budget stays under the limit.
+	p.ChargeBlockServe(budget)
+	if p.IsOverBlockServeLimit() {
+		t.Fatalf("serving exactly the budget must not trip the limit")
+	}
+
+	// One more byte crosses it.
+	p.ChargeBlockServe(1)
+	if !p.IsOverBlockServeLimit() {
+		t.Fatalf("serving beyond the budget must trip the limit")
+	}
+
+	// Simulate the rolling window elapsing: the next check resets the period
+	// and the peer is served again.
+	p.blockServeBegin = time.Now().Add(-time.Duration(secondsPerPeriod+1) * time.Second)
+	if p.IsOverBlockServeLimit() {
+		t.Fatalf("after the period rolls over the peer must be under the limit again")
+	}
+	if p.blockServeCounter != 0 {
+		t.Fatalf("period rollover must reset the counter, got %d", p.blockServeCounter)
+	}
+}
+
+// TestBlockServeRateLimit_ChargeRollover verifies ChargeBlockServe also rolls
+// the period over, so a burst that spans a period boundary is not double-counted.
+func TestBlockServeRateLimit_ChargeRollover(t *testing.T) {
+	p := newRateLimitTestPeer()
+	p.ChargeBlockServe(blockServeBudget())
+
+	// Move the window start into the past, then charge again: the stale counter
+	// must be reset before the new charge is applied.
+	p.blockServeBegin = time.Now().Add(-time.Duration(secondsPerPeriod+1) * time.Second)
+	p.ChargeBlockServe(1)
+	if p.blockServeCounter != 1 {
+		t.Fatalf("charge after rollover must start from a reset counter, got %d", p.blockServeCounter)
+	}
+	if p.IsOverBlockServeLimit() {
+		t.Fatalf("a single byte in a fresh period must be under the limit")
+	}
+}


### PR DESCRIPTION
### Description

`handleGetBlocksByRange` in the `bsc` sub-protocol has no per-peer receive-rate limit, unlike `handleVotes` in the same protocol (which uses `IsOverLimitAfterReceivingVotes`). A peer can send a tiny request (a few dozen bytes: `RequestId`/`Count`/`StartBlockHash`) that forces the server to walk up to 64 blocks by parent hash, read blob sidecars, RLP-encode up to `softResponseLimit` (8 MiB) and upload it — then immediately request again with no throttle. The existing guards (`Count ≤ 64`, `softResponseLimit`, serial per-connection handling) only bound a single request's work and one connection's concurrency; none of them limit request repetition.

This PR adds a symmetric per-peer rolling-window rate limit for serving `GetBlocksByRange`, mirroring the vote receive-rate limiter. The budget is accounted by **served response bytes** (not request count), so a peer cannot bypass it by cherry-picking blocks with large sidecars. Once a peer exhausts its budget for the current period, further range requests are dropped **before any disk lookup** (silently, keeping the connection, exactly like the vote limiter), until the period rolls over.

The limit is **per-peer**, so a single spamming/Sybil connection cannot starve legitimate quick-block-fetching peers of service.

### Rationale

The `bsc` sub-protocol is registered unconditionally (`backend.go`, no gate — unlike `snap`'s `DisableSnapProtocol`), `Bsc2` is advertised by default, and `handleGetBlocksByRange` is in the default `bsc2` handler table, so any default node that accepts inbound connections serves this message — independent of `EnableQuickBlockFetching`, which only gates the requester side. This makes it a default-reachable, unauthenticated, highly-asymmetric resource-exhaustion vector (tiny request → 8 MiB of disk I/O + CPU + upload, repeatable indefinitely) on public full nodes / sentries / RPC backends.

It does not touch consensus (no `InsertChain`, no canonical change) and recovers on disconnect, but the missing throttle — asymmetric with the vote path in the same file — lets a low-cost peer sustain the load. The vote limiter already provides a proven, in-repo pattern to reuse: apply it symmetrically to `GetBlocksByRange`.

### Example

NA

### Changes

Notable changes: 
NA
