### PR TITLE
miner: persist BidBlock revokes across restarts

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -432,6 +432,12 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	legacyPool := legacypool.New(config.TxPool, eth.blockchain)
 
+	// BidBlock revoke lockouts (validator-local MEV policy) journal to a file
+	// under the datadir rather than chaindata.
+	if config.Miner.BidBlockRevokesJournal != "" {
+		config.Miner.BidBlockRevokesJournal = stack.ResolvePath(config.Miner.BidBlockRevokesJournal)
+	}
+
 	if config.BlobPool.Datadir != "" {
 		config.BlobPool.Datadir = stack.ResolvePath(config.BlobPool.Datadir)
 	}

--- a/miner/bid_block_permission.go
+++ b/miner/bid_block_permission.go
@@ -7,12 +7,12 @@ package miner
 
 import (
 	"encoding/json"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	buildertypes "github.com/ethereum/go-ethereum/core/types/builder"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -28,18 +28,20 @@ const (
 	bidBlockGasPriceLowRevokeDuration = 450 * time.Second
 )
 
-// bidBlockRevokesKey is the database key under which the whole revoke map is
-// persisted (a single blob, overwritten on every change) so that lockouts
-// survive a process restart within their window.
+// The revoke map is persisted as a single JSON file under the node's datadir
+// (a whole-map snapshot, atomically replaced on every change) so that lockouts
+// survive a process restart within their window. It deliberately lives OUTSIDE
+// chaindata: revokes are validator-local MEV policy, not chain data — they must
+// not be wiped by a chaindata resync nor carried along when chaindata is cloned.
+// This mirrors how other node-local state is stored (vote journal, txpool
+// journal).
 //
-// The blob is JSON-encoded rather than RLP. RLP is geth's codec for
+// The file is JSON-encoded rather than RLP. RLP is geth's codec for
 // consensus-critical and large/frequent data, but it supports neither maps nor
 // time.Time, so it would require flattening the map and converting timestamps
 // through a separate wire struct. This state is tiny, written rarely (only on
 // bad bids), never on-chain, and benefits from JSON's forgiving schema
-// evolution and readability — matching the existing rawdb precedent for small
-// metadata blobs (e.g. WriteChainConfig).
-var bidBlockRevokesKey = []byte("bidBlockRevokes")
+// evolution and readability.
 
 // BidBlockRevokeRecord holds one active revoke event.
 type BidBlockRevokeRecord struct {
@@ -53,20 +55,20 @@ type BidBlockRevokeRecord struct {
 // BidBlockPermissionManager tracks per-builder SendBidBlock revokes.
 //
 // Revokes are kept in memory and expire lazily after their lockout window.
-// They are also mirrored to the chain database (best-effort, asynchronously)
-// so that a lockout is not silently cleared when the validator restarts within
-// its window — the RPC advertises resetAt = revokedAt + duration as a
-// wall-clock promise, which must hold across restarts.
+// They are also mirrored to a journal file under the datadir (best-effort,
+// asynchronously) so that a lockout is not silently cleared when the validator
+// restarts within its window — the RPC advertises resetAt = revokedAt +
+// duration as a wall-clock promise, which must hold across restarts.
 type BidBlockPermissionManager struct {
 	mu      sync.RWMutex
 	revoked map[common.Address]BidBlockRevokeRecord
 
 	clock func() time.Time
 
-	// db is the optional persistence backend. When nil the manager is purely
-	// in-memory (used by tests and any caller that does not wire a database),
-	// preserving the original behaviour.
-	db ethdb.KeyValueStore
+	// journalPath is the optional persistence backend. When empty the manager
+	// is purely in-memory (used by tests and any caller that does not wire a
+	// journal), preserving the original behaviour.
+	journalPath string
 
 	// Persistence is asynchronous and best-effort: mutations only snapshot the
 	// map under mu and hand it to a background writer, never blocking the
@@ -78,14 +80,15 @@ type BidBlockPermissionManager struct {
 	persistedSeq uint64     // highest seq handled by a writer (guarded by persistMu); advanced before the write, so a failed newer write still blocks older ones
 }
 
-// NewBidBlockPermissionManager returns a manager backed by db (may be nil for a
-// purely in-memory manager). Any revokes persisted by a previous process that
-// are still within their lockout window are restored; expired ones are dropped.
-func NewBidBlockPermissionManager(db ethdb.KeyValueStore) *BidBlockPermissionManager {
+// NewBidBlockPermissionManager returns a manager journalling to journalPath
+// (may be empty for a purely in-memory manager). Any revokes persisted by a
+// previous process that are still within their lockout window are restored;
+// expired ones are dropped.
+func NewBidBlockPermissionManager(journalPath string) *BidBlockPermissionManager {
 	m := &BidBlockPermissionManager{
-		revoked: make(map[common.Address]BidBlockRevokeRecord),
-		clock:   time.Now,
-		db:      db,
+		revoked:     make(map[common.Address]BidBlockRevokeRecord),
+		clock:       time.Now,
+		journalPath: journalPath,
 	}
 	m.load()
 	return m
@@ -95,16 +98,16 @@ func NewBidBlockPermissionManager(db ethdb.KeyValueStore) *BidBlockPermissionMan
 // already elapsed (including time spent offline). It runs once, synchronously,
 // off the hot path. Any error leaves the manager empty — same as a fresh node.
 func (m *BidBlockPermissionManager) load() {
-	if m.db == nil {
+	if m.journalPath == "" {
 		return
 	}
-	blob, err := m.db.Get(bidBlockRevokesKey)
+	blob, err := os.ReadFile(m.journalPath)
 	if err != nil || len(blob) == 0 {
-		return // no persisted state (or key absent): start empty
+		return // no journal yet (or unreadable): start empty
 	}
 	var stored map[common.Address]BidBlockRevokeRecord
 	if err := json.Unmarshal(blob, &stored); err != nil {
-		log.Warn("Failed to decode persisted BidBlock revokes, starting empty", "err", err)
+		log.Warn("Failed to decode persisted BidBlock revokes, starting empty", "path", m.journalPath, "err", err)
 		return
 	}
 	now := m.clock()
@@ -114,7 +117,7 @@ func (m *BidBlockPermissionManager) load() {
 		}
 	}
 	if len(m.revoked) > 0 {
-		log.Info("Restored BidBlock revokes from database", "count", len(m.revoked))
+		log.Info("Restored BidBlock revokes from journal", "path", m.journalPath, "count", len(m.revoked))
 	}
 }
 
@@ -123,7 +126,7 @@ func (m *BidBlockPermissionManager) load() {
 // so the background writer never touches the live map; the caller returns
 // immediately without waiting for the disk write.
 func (m *BidBlockPermissionManager) markDirtyLocked() {
-	if m.db == nil {
+	if m.journalPath == "" {
 		return
 	}
 	m.persistSeq++
@@ -138,12 +141,15 @@ func (m *BidBlockPermissionManager) markDirtyLocked() {
 	go m.persistAsync(seq, snapshot)
 }
 
-// persistAsync writes snapshot to the database unless a newer snapshot has
+// persistAsync writes snapshot to the journal file unless a newer snapshot has
 // already been handled. Errors are logged and swallowed: persistence is
 // best-effort and must not affect the caller.
 //
+// The write is atomic (temp file + rename), so a crash mid-write leaves the
+// previous journal intact rather than a truncated one.
+//
 // persistedSeq is advanced BEFORE the write and regardless of its outcome. This
-// makes the seq that actually reaches db.Put strictly monotonic: once a newer
+// makes the seq that actually reaches the disk strictly monotonic: once a newer
 // snapshot has entered here, every older one is dropped even if the newer
 // write failed. Otherwise a newer write failing could let an older snapshot
 // win the disk afterwards and resurrect stale state (e.g. a revoke overwriting
@@ -161,8 +167,13 @@ func (m *BidBlockPermissionManager) persistAsync(seq uint64, snapshot map[common
 		log.Warn("Failed to encode BidBlock revokes for persistence", "err", err)
 		return
 	}
-	if err := m.db.Put(bidBlockRevokesKey, blob); err != nil {
-		log.Warn("Failed to persist BidBlock revokes", "err", err)
+	tmp := m.journalPath + ".tmp"
+	if err := os.WriteFile(tmp, blob, 0o600); err != nil {
+		log.Warn("Failed to write BidBlock revoke journal", "path", tmp, "err", err)
+		return
+	}
+	if err := os.Rename(tmp, m.journalPath); err != nil {
+		log.Warn("Failed to replace BidBlock revoke journal", "path", m.journalPath, "err", err)
 		return
 	}
 }

--- a/miner/bid_block_permission.go
+++ b/miner/bid_block_permission.go
@@ -43,13 +43,37 @@ const (
 // bad bids), never on-chain, and benefits from JSON's forgiving schema
 // evolution and readability.
 
+// bidBlockRevokeJournalVersion is the on-disk format version. Bump it only for a
+// change JSON cannot absorb on its own: adding a field is already compatible in
+// both directions (an old file decodes with the field zeroed, a new file read by
+// an older binary ignores the unknown key), so a bump is for a change in the
+// MEANING of an existing field, a removal, or a rename — the cases that would
+// otherwise be applied silently and wrongly to old data.
+const bidBlockRevokeJournalVersion = 1
+
+// bidBlockRevokeJournal is the envelope actually written to disk. The version
+// lives beside the payload so an unrecognised format is refused explicitly
+// rather than being half-decoded into whatever the current struct happens to
+// look like.
+type bidBlockRevokeJournal struct {
+	Version int                                     `json:"version"`
+	Revokes map[common.Address]BidBlockRevokeRecord `json:"revokes"`
+}
+
 // BidBlockRevokeRecord holds one active revoke event.
+//
+// The json tags are explicit and MUST stay stable: without them the wire format
+// would be the Go field names, so a routine rename would silently change the
+// on-disk keys, and every renamed field would decode to its zero value on the
+// next start — a zero Duration reads as "already expired", i.e. a lockout that
+// quietly disappears. Renaming a Go field here is free; changing a tag is a
+// format change and needs a version bump.
 type BidBlockRevokeRecord struct {
-	RevokedAt time.Time
-	Duration  time.Duration
-	Reason    string // err detail for auto revokes (InsertChain failure), or RevokeReasonManual
-	BlockHash common.Hash
-	BlockNum  uint64
+	RevokedAt time.Time     `json:"revokedAt"`
+	Duration  time.Duration `json:"duration"`
+	Reason    string        `json:"reason"` // err detail for auto revokes (InsertChain failure), or RevokeReasonManual
+	BlockHash common.Hash   `json:"blockHash"`
+	BlockNum  uint64        `json:"blockNum"`
 }
 
 // BidBlockPermissionManager tracks per-builder SendBidBlock revokes.
@@ -105,13 +129,22 @@ func (m *BidBlockPermissionManager) load() {
 	if err != nil || len(blob) == 0 {
 		return // no journal yet (or unreadable): start empty
 	}
-	var stored map[common.Address]BidBlockRevokeRecord
-	if err := json.Unmarshal(blob, &stored); err != nil {
+	var journal bidBlockRevokeJournal
+	if err := json.Unmarshal(blob, &journal); err != nil {
 		log.Warn("Failed to decode persisted BidBlock revokes, starting empty", "path", m.journalPath, "err", err)
 		return
 	}
+	// Refuse a version this build does not know rather than applying the current
+	// struct's meaning to it. Starting empty costs at most the remaining lockout
+	// windows, which expire on their own within bidBlockRevokeDuration anyway;
+	// misreading a future format could resurrect or drop the wrong builders.
+	if journal.Version != bidBlockRevokeJournalVersion {
+		log.Warn("Unsupported BidBlock revoke journal version, starting empty",
+			"path", m.journalPath, "version", journal.Version, "supported", bidBlockRevokeJournalVersion)
+		return
+	}
 	now := m.clock()
-	for builder, rec := range stored {
+	for builder, rec := range journal.Revokes {
 		if isRevokeActive(rec, now) {
 			m.revoked[builder] = rec
 		}
@@ -162,7 +195,10 @@ func (m *BidBlockPermissionManager) persistAsync(seq uint64, snapshot map[common
 		return // an equal-or-newer snapshot has already been handled; this one is stale
 	}
 	m.persistedSeq = seq
-	blob, err := json.Marshal(snapshot)
+	blob, err := json.Marshal(bidBlockRevokeJournal{
+		Version: bidBlockRevokeJournalVersion,
+		Revokes: snapshot,
+	})
 	if err != nil {
 		log.Warn("Failed to encode BidBlock revokes for persistence", "err", err)
 		return

--- a/miner/bid_block_permission.go
+++ b/miner/bid_block_permission.go
@@ -6,11 +6,14 @@
 package miner
 
 import (
+	"encoding/json"
 	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	buildertypes "github.com/ethereum/go-ethereum/core/types/builder"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // RevokeReasonManual is the Reason value used when an operator manually revokes
@@ -25,6 +28,19 @@ const (
 	bidBlockGasPriceLowRevokeDuration = 450 * time.Second
 )
 
+// bidBlockRevokesKey is the database key under which the whole revoke map is
+// persisted (a single blob, overwritten on every change) so that lockouts
+// survive a process restart within their window.
+//
+// The blob is JSON-encoded rather than RLP. RLP is geth's codec for
+// consensus-critical and large/frequent data, but it supports neither maps nor
+// time.Time, so it would require flattening the map and converting timestamps
+// through a separate wire struct. This state is tiny, written rarely (only on
+// bad bids), never on-chain, and benefits from JSON's forgiving schema
+// evolution and readability — matching the existing rawdb precedent for small
+// metadata blobs (e.g. WriteChainConfig).
+var bidBlockRevokesKey = []byte("bidBlockRevokes")
+
 // BidBlockRevokeRecord holds one active revoke event.
 type BidBlockRevokeRecord struct {
 	RevokedAt time.Time
@@ -35,19 +51,119 @@ type BidBlockRevokeRecord struct {
 }
 
 // BidBlockPermissionManager tracks per-builder SendBidBlock revokes.
+//
 // Revokes are kept in memory and expire lazily after their lockout window.
+// They are also mirrored to the chain database (best-effort, asynchronously)
+// so that a lockout is not silently cleared when the validator restarts within
+// its window — the RPC advertises resetAt = revokedAt + duration as a
+// wall-clock promise, which must hold across restarts.
 type BidBlockPermissionManager struct {
 	mu      sync.RWMutex
 	revoked map[common.Address]BidBlockRevokeRecord
 
 	clock func() time.Time
+
+	// db is the optional persistence backend. When nil the manager is purely
+	// in-memory (used by tests and any caller that does not wire a database),
+	// preserving the original behaviour.
+	db ethdb.KeyValueStore
+
+	// Persistence is asynchronous and best-effort: mutations only snapshot the
+	// map under mu and hand it to a background writer, never blocking the
+	// mining path on disk I/O. Losing the newest write on a crash is
+	// acceptable (at worst one lockout is not restored); what must never happen
+	// is a disk hiccup stalling Revoke/SetAllowed.
+	persistMu    sync.Mutex // serialises background writers so they don't interleave
+	persistSeq   uint64     // bumped under mu on every mutation; identifies the latest snapshot
+	persistedSeq uint64     // highest seq handled by a writer (guarded by persistMu); advanced before the write, so a failed newer write still blocks older ones
 }
 
-// NewBidBlockPermissionManager returns a fresh manager with no builders revoked.
-func NewBidBlockPermissionManager() *BidBlockPermissionManager {
-	return &BidBlockPermissionManager{
+// NewBidBlockPermissionManager returns a manager backed by db (may be nil for a
+// purely in-memory manager). Any revokes persisted by a previous process that
+// are still within their lockout window are restored; expired ones are dropped.
+func NewBidBlockPermissionManager(db ethdb.KeyValueStore) *BidBlockPermissionManager {
+	m := &BidBlockPermissionManager{
 		revoked: make(map[common.Address]BidBlockRevokeRecord),
 		clock:   time.Now,
+		db:      db,
+	}
+	m.load()
+	return m
+}
+
+// load restores persisted revokes at startup, dropping any whose window has
+// already elapsed (including time spent offline). It runs once, synchronously,
+// off the hot path. Any error leaves the manager empty — same as a fresh node.
+func (m *BidBlockPermissionManager) load() {
+	if m.db == nil {
+		return
+	}
+	blob, err := m.db.Get(bidBlockRevokesKey)
+	if err != nil || len(blob) == 0 {
+		return // no persisted state (or key absent): start empty
+	}
+	var stored map[common.Address]BidBlockRevokeRecord
+	if err := json.Unmarshal(blob, &stored); err != nil {
+		log.Warn("Failed to decode persisted BidBlock revokes, starting empty", "err", err)
+		return
+	}
+	now := m.clock()
+	for builder, rec := range stored {
+		if isRevokeActive(rec, now) {
+			m.revoked[builder] = rec
+		}
+	}
+	if len(m.revoked) > 0 {
+		log.Info("Restored BidBlock revokes from database", "count", len(m.revoked))
+	}
+}
+
+// markDirtyLocked snapshots the current map and kicks off an asynchronous write.
+// It MUST be called with m.mu held. The snapshot is taken here (under the lock)
+// so the background writer never touches the live map; the caller returns
+// immediately without waiting for the disk write.
+func (m *BidBlockPermissionManager) markDirtyLocked() {
+	if m.db == nil {
+		return
+	}
+	m.persistSeq++
+	seq := m.persistSeq
+	snapshot := make(map[common.Address]BidBlockRevokeRecord, len(m.revoked))
+	for k, v := range m.revoked {
+		snapshot[k] = v
+	}
+	// Fire-and-forget: mutations are rare (only on bad bids), so spawning a
+	// goroutine per change is cheap. persistAsync serialises writers and drops
+	// stale snapshots via the seq guard.
+	go m.persistAsync(seq, snapshot)
+}
+
+// persistAsync writes snapshot to the database unless a newer snapshot has
+// already been handled. Errors are logged and swallowed: persistence is
+// best-effort and must not affect the caller.
+//
+// persistedSeq is advanced BEFORE the write and regardless of its outcome. This
+// makes the seq that actually reaches db.Put strictly monotonic: once a newer
+// snapshot has entered here, every older one is dropped even if the newer
+// write failed. Otherwise a newer write failing could let an older snapshot
+// win the disk afterwards and resurrect stale state (e.g. a revoke overwriting
+// a later manual clear). Losing the newest write on failure is acceptable
+// (best-effort); an older snapshot overwriting a newer one is not.
+func (m *BidBlockPermissionManager) persistAsync(seq uint64, snapshot map[common.Address]BidBlockRevokeRecord) {
+	m.persistMu.Lock()
+	defer m.persistMu.Unlock()
+	if seq <= m.persistedSeq {
+		return // an equal-or-newer snapshot has already been handled; this one is stale
+	}
+	m.persistedSeq = seq
+	blob, err := json.Marshal(snapshot)
+	if err != nil {
+		log.Warn("Failed to encode BidBlock revokes for persistence", "err", err)
+		return
+	}
+	if err := m.db.Put(bidBlockRevokesKey, blob); err != nil {
+		log.Warn("Failed to persist BidBlock revokes", "err", err)
+		return
 	}
 }
 
@@ -90,6 +206,7 @@ func (m *BidBlockPermissionManager) RevokeFor(
 		BlockHash: blockHash,
 		BlockNum:  blockNum,
 	}
+	m.markDirtyLocked()
 }
 
 func (m *BidBlockPermissionManager) GetStatus(builder common.Address) buildertypes.BidBlockPermissionStatus {
@@ -130,6 +247,7 @@ func (m *BidBlockPermissionManager) SetAllowed(builder common.Address, allowed b
 	defer m.mu.Unlock()
 	if allowed {
 		delete(m.revoked, builder)
+		m.markDirtyLocked()
 		return
 	}
 	m.revoked[builder] = BidBlockRevokeRecord{
@@ -137,6 +255,7 @@ func (m *BidBlockPermissionManager) SetAllowed(builder common.Address, allowed b
 		Duration:  bidBlockRevokeDuration,
 		Reason:    RevokeReasonManual,
 	}
+	m.markDirtyLocked()
 }
 
 // isRevokeActive reports whether now is before the revoke reset time.

--- a/miner/bid_block_permission_test.go
+++ b/miner/bid_block_permission_test.go
@@ -472,9 +472,12 @@ func TestBidBlockPermission_ExpiredNotRestored(t *testing.T) {
 	expired := common.HexToAddress("0x2")
 
 	now := time.Now()
-	seed := map[common.Address]BidBlockRevokeRecord{
-		active:  {RevokedAt: now.Add(-1 * time.Hour), Duration: bidBlockRevokeDuration, Reason: "active"},
-		expired: {RevokedAt: now.Add(-25 * time.Hour), Duration: bidBlockRevokeDuration, Reason: "expired"},
+	seed := bidBlockRevokeJournal{
+		Version: bidBlockRevokeJournalVersion,
+		Revokes: map[common.Address]BidBlockRevokeRecord{
+			active:  {RevokedAt: now.Add(-1 * time.Hour), Duration: bidBlockRevokeDuration, Reason: "active"},
+			expired: {RevokedAt: now.Add(-25 * time.Hour), Duration: bidBlockRevokeDuration, Reason: "expired"},
+		},
 	}
 	blob, err := json.Marshal(seed)
 	if err != nil {
@@ -512,6 +515,75 @@ func TestBidBlockPermission_LoadToleratesBadState(t *testing.T) {
 	m2 := NewBidBlockPermissionManager(testJournalPath(t))
 	if !m2.IsAllowed(builder) {
 		t.Fatal("a missing journal must yield an empty manager")
+	}
+}
+
+// TestBidBlockPermission_RejectsUnknownVersion pins the version envelope: a
+// journal written by a future build must be refused outright rather than
+// decoded with this build's interpretation of the fields. Starting empty only
+// costs the remaining lockout windows, which self-expire; misreading a changed
+// field could revoke or release the wrong builders.
+func TestBidBlockPermission_RejectsUnknownVersion(t *testing.T) {
+	builder := common.HexToAddress("0x1")
+	rec := BidBlockRevokeRecord{
+		RevokedAt: time.Now(),
+		Duration:  bidBlockRevokeDuration,
+		Reason:    testInsertChainReason,
+	}
+
+	// A future version carrying an otherwise-valid record: must NOT be applied.
+	future := testJournalPath(t)
+	blob, err := json.Marshal(bidBlockRevokeJournal{
+		Version: bidBlockRevokeJournalVersion + 1,
+		Revokes: map[common.Address]BidBlockRevokeRecord{builder: rec},
+	})
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := os.WriteFile(future, blob, 0o600); err != nil {
+		t.Fatalf("seed journal: %v", err)
+	}
+	if !NewBidBlockPermissionManager(future).IsAllowed(builder) {
+		t.Fatal("a journal from an unknown version must not be applied")
+	}
+
+	// The pre-envelope format (a bare map) decodes into the envelope with
+	// version 0, so it lands on the same refusal path rather than being
+	// silently half-read.
+	legacy := testJournalPath(t)
+	blob, err = json.Marshal(map[common.Address]BidBlockRevokeRecord{builder: rec})
+	if err != nil {
+		t.Fatalf("marshal legacy seed: %v", err)
+	}
+	if err := os.WriteFile(legacy, blob, 0o600); err != nil {
+		t.Fatalf("seed legacy journal: %v", err)
+	}
+	if !NewBidBlockPermissionManager(legacy).IsAllowed(builder) {
+		t.Fatal("a pre-envelope journal must not be applied")
+	}
+}
+
+// TestBidBlockPermission_JournalKeysAreStable pins the on-disk key names. They
+// are the wire format: renaming a Go field is free, but changing a json tag is
+// a format change and must come with a version bump, or old journals decode
+// their renamed fields to zero — a zero Duration reads as already expired.
+func TestBidBlockPermission_JournalKeysAreStable(t *testing.T) {
+	path := testJournalPath(t)
+	m := NewBidBlockPermissionManager(path)
+	m.Revoke(common.HexToAddress("0x1"), testInsertChainReason, common.HexToHash("0xabc"), 100)
+	waitForBidBlockPersist(t, path)
+
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read journal: %v", err)
+	}
+	for _, key := range []string{
+		`"version"`, `"revokes"`,
+		`"revokedAt"`, `"duration"`, `"reason"`, `"blockHash"`, `"blockNum"`,
+	} {
+		if !strings.Contains(string(blob), key) {
+			t.Errorf("journal is missing the stable key %s; a tag change needs a version bump\ngot: %s", key, blob)
+		}
 	}
 }
 
@@ -566,9 +638,9 @@ func TestBidBlockPermission_SetAllowedPersists(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		blob, _ := os.ReadFile(path)
-		var stored map[common.Address]BidBlockRevokeRecord
+		var stored bidBlockRevokeJournal
 		if json.Unmarshal(blob, &stored) == nil {
-			if _, ok := stored[builder]; !ok {
+			if _, ok := stored.Revokes[builder]; !ok {
 				break
 			}
 		}

--- a/miner/bid_block_permission_test.go
+++ b/miner/bid_block_permission_test.go
@@ -6,16 +6,15 @@ package miner
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	buildertypes "github.com/ethereum/go-ethereum/core/types/builder"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/miner/builderclient"
 	"github.com/ethereum/go-ethereum/miner/minerconfig"
 )
@@ -38,7 +37,7 @@ func setBidBlockPermissionClock(m *BidBlockPermissionManager, f func() time.Time
 }
 
 func TestBidBlockPermission_DefaultActive(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	builder := common.HexToAddress("0x1")
 	if !m.IsAllowed(builder) {
 		t.Fatal("default state should be Active for any builder")
@@ -49,7 +48,7 @@ func TestBidBlockPermission_DefaultActive(t *testing.T) {
 }
 
 func TestBidBlockPermission_RevokeBlocks(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	builder := common.HexToAddress("0x1")
 	hash := common.HexToHash("0xabc")
 
@@ -77,7 +76,7 @@ func TestBidBlockPermission_RevokeBlocks(t *testing.T) {
 }
 
 func TestBidBlockPermission_BuildersIndependent(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	a := common.HexToAddress("0xa")
 	b := common.HexToAddress("0xb")
 
@@ -91,7 +90,7 @@ func TestBidBlockPermission_BuildersIndependent(t *testing.T) {
 }
 
 func TestBidBlockPermission_RevokeForCustomDuration(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	builder := common.HexToAddress("0x1")
 	now := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
 
@@ -113,7 +112,7 @@ func TestBidBlockPermission_RevokeForCustomDuration(t *testing.T) {
 }
 
 func TestBidBlockPermission_RevokeOverwrites(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	builder := common.HexToAddress("0x1")
 
 	m.Revoke(builder, testInsertChainReason, common.HexToHash("0x1"), 1)
@@ -132,7 +131,7 @@ func TestBidBlockPermission_RevokeOverwrites(t *testing.T) {
 }
 
 func TestBidBlockPermission_ExpiresAt24h(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	builder := common.HexToAddress("0x1")
 
 	revokeTime := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
@@ -154,7 +153,7 @@ func TestBidBlockPermission_ExpiresAt24h(t *testing.T) {
 }
 
 func TestBidBlockPermission_StillRevokedWithin24h(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	builder := common.HexToAddress("0x1")
 
 	// UTC midnight should not reset the revoke; only elapsed time matters.
@@ -178,7 +177,7 @@ func TestBidBlockPermission_StillRevokedWithin24h(t *testing.T) {
 
 // Builders revoked at different times should expire independently.
 func TestBidBlockPermission_IndependentResetAt(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	a := common.HexToAddress("0xa")
 	b := common.HexToAddress("0xb")
 
@@ -221,7 +220,7 @@ func TestBidBlockPermission_IndependentResetAt(t *testing.T) {
 }
 
 func TestBidBlockPermission_ConcurrentAccess(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	builders := []common.Address{
 		common.HexToAddress("0xa"),
 		common.HexToAddress("0xb"),
@@ -240,7 +239,7 @@ func TestBidBlockPermission_ConcurrentAccess(t *testing.T) {
 }
 
 func TestBidBlockPermission_ActiveRevokeCount(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 
 	if got := m.ActiveRevokeCount(); got != 0 {
 		t.Fatalf("empty manager: got %d, want 0", got)
@@ -266,7 +265,7 @@ func TestBidBlockPermission_ActiveRevokeCount(t *testing.T) {
 }
 
 func TestBidBlockPermission_GetStatus(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	builder := common.HexToAddress("0x1")
 	now := time.Date(2026, 5, 9, 10, 0, 0, 0, time.UTC)
 	resetAt := now.Add(24 * time.Hour)
@@ -295,7 +294,7 @@ func TestBidBlockPermission_GetStatus(t *testing.T) {
 }
 
 func TestBidBlockAdmission_RevokedDoesNotConsumeQuota(t *testing.T) {
-	permMgr := NewBidBlockPermissionManager(nil)
+	permMgr := NewBidBlockPermissionManager("")
 	b := &bidSimulator{
 		builders:          make(map[common.Address]*builderclient.Client),
 		pending:           make(map[uint64]map[common.Address]map[common.Hash]struct{}),
@@ -374,7 +373,7 @@ func TestBidBlockAdmission_DisabledDoesNotConsumeQuota(t *testing.T) {
 }
 
 func TestMinerBidBlockPermission_UsesWorkerManager(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	miner := &Miner{worker: &worker{permMgr: m}}
 	builder := common.HexToAddress("0x1")
 
@@ -385,7 +384,7 @@ func TestMinerBidBlockPermission_UsesWorkerManager(t *testing.T) {
 }
 
 func TestBidBlockPermission_SetAllowed_Deny(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	builder := common.HexToAddress("0x1")
 
 	m.SetAllowed(builder, false)
@@ -402,7 +401,7 @@ func TestBidBlockPermission_SetAllowed_Deny(t *testing.T) {
 }
 
 func TestBidBlockPermission_SetAllowed_Clear(t *testing.T) {
-	m := NewBidBlockPermissionManager(nil)
+	m := NewBidBlockPermissionManager("")
 	builder := common.HexToAddress("0x1")
 
 	m.Revoke(builder, testInsertChainReason, common.HexToHash("0xabc"), 100)
@@ -415,13 +414,19 @@ func TestBidBlockPermission_SetAllowed_Clear(t *testing.T) {
 	}
 }
 
+// testJournalPath returns a journal file path inside a fresh temp dir.
+func testJournalPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "bidblockrevokes.json")
+}
+
 // waitForBidBlockPersist polls until the asynchronous persistence has written a
-// non-empty blob, or fails the test after a short deadline.
-func waitForBidBlockPersist(t *testing.T, db ethdb.KeyValueStore) {
+// non-empty journal file, or fails the test after a short deadline.
+func waitForBidBlockPersist(t *testing.T, path string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if blob, _ := db.Get(bidBlockRevokesKey); len(blob) > 0 {
+		if blob, _ := os.ReadFile(path); len(blob) > 0 {
 			return
 		}
 		time.Sleep(2 * time.Millisecond)
@@ -431,20 +436,20 @@ func waitForBidBlockPersist(t *testing.T, db ethdb.KeyValueStore) {
 
 // TestBidBlockPermission_SurvivesRestart is the regression for the reported
 // gap: a revoke persisted by one manager must still be in effect (with the same
-// resetAt) after a fresh manager is constructed over the same database, as
+// resetAt) after a fresh manager is constructed over the same journal, as
 // happens when the validator process restarts within the lockout window.
 func TestBidBlockPermission_SurvivesRestart(t *testing.T) {
-	db := rawdb.NewMemoryDatabase()
+	path := testJournalPath(t)
 	builder := common.HexToAddress("0x1")
 	hash := common.HexToHash("0xabc")
 
-	m1 := NewBidBlockPermissionManager(db)
+	m1 := NewBidBlockPermissionManager(path)
 	m1.Revoke(builder, testInsertChainReason, hash, 100)
-	waitForBidBlockPersist(t, db)
+	waitForBidBlockPersist(t, path)
 	want := m1.GetStatus(builder)
 
-	// Simulate a restart: a brand-new manager over the same database.
-	m2 := NewBidBlockPermissionManager(db)
+	// Simulate a restart: a brand-new manager over the same journal.
+	m2 := NewBidBlockPermissionManager(path)
 	if m2.IsAllowed(builder) {
 		t.Fatal("revoke must survive a restart within its window")
 	}
@@ -459,10 +464,10 @@ func TestBidBlockPermission_SurvivesRestart(t *testing.T) {
 
 // TestBidBlockPermission_ExpiredNotRestored verifies that a revoke whose window
 // elapsed while the process was down is dropped on load, while a still-active
-// one is restored. The database is seeded directly so the elapsed time is
+// one is restored. The journal is seeded directly so the elapsed time is
 // deterministic and does not depend on wall-clock waits.
 func TestBidBlockPermission_ExpiredNotRestored(t *testing.T) {
-	db := rawdb.NewMemoryDatabase()
+	path := testJournalPath(t)
 	active := common.HexToAddress("0x1")
 	expired := common.HexToAddress("0x2")
 
@@ -475,11 +480,11 @@ func TestBidBlockPermission_ExpiredNotRestored(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal seed: %v", err)
 	}
-	if err := db.Put(bidBlockRevokesKey, blob); err != nil {
-		t.Fatalf("seed db: %v", err)
+	if err := os.WriteFile(path, blob, 0o600); err != nil {
+		t.Fatalf("seed journal: %v", err)
 	}
 
-	m := NewBidBlockPermissionManager(db)
+	m := NewBidBlockPermissionManager(path)
 	if m.IsAllowed(active) {
 		t.Fatal("still-active revoke must be restored")
 	}
@@ -489,49 +494,36 @@ func TestBidBlockPermission_ExpiredNotRestored(t *testing.T) {
 }
 
 // TestBidBlockPermission_LoadTolERatesBadState verifies that a missing or
-// corrupt persisted blob leaves the manager empty instead of panicking.
+// corrupt journal leaves the manager empty instead of panicking.
 func TestBidBlockPermission_LoadToleratesBadState(t *testing.T) {
 	builder := common.HexToAddress("0x1")
 
-	// Corrupt blob: start empty, no panic.
-	db := rawdb.NewMemoryDatabase()
-	if err := db.Put(bidBlockRevokesKey, []byte("not json")); err != nil {
-		t.Fatalf("seed db: %v", err)
+	// Corrupt journal: start empty, no panic.
+	path := testJournalPath(t)
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("seed journal: %v", err)
 	}
-	m := NewBidBlockPermissionManager(db)
+	m := NewBidBlockPermissionManager(path)
 	if !m.IsAllowed(builder) {
-		t.Fatal("a corrupt persisted blob must yield an empty manager")
+		t.Fatal("a corrupt journal must yield an empty manager")
 	}
 
-	// Missing key (fresh db): start empty, no panic.
-	m2 := NewBidBlockPermissionManager(rawdb.NewMemoryDatabase())
+	// Missing file (fresh datadir): start empty, no panic.
+	m2 := NewBidBlockPermissionManager(testJournalPath(t))
 	if !m2.IsAllowed(builder) {
-		t.Fatal("a fresh db must yield an empty manager")
+		t.Fatal("a missing journal must yield an empty manager")
 	}
-}
-
-// putFailingDB wraps a key-value store and can be told to fail Put calls, to
-// exercise the best-effort persistence paths.
-type putFailingDB struct {
-	ethdb.KeyValueStore
-	failPut bool
-}
-
-func (d *putFailingDB) Put(key, value []byte) error {
-	if d.failPut {
-		return errors.New("simulated put failure")
-	}
-	return d.KeyValueStore.Put(key, value)
 }
 
 // TestBidBlockPermission_FailedNewerBlocksOlder locks the ordering guarantee:
 // once a newer snapshot has entered the writer — even if its write fails — an
 // older snapshot must never overwrite it and resurrect stale state. persistAsync
-// is called directly to control ordering deterministically.
+// is called directly to control ordering deterministically; the write failure
+// is injected by occupying the journal path with a directory, which makes the
+// atomic rename fail.
 func TestBidBlockPermission_FailedNewerBlocksOlder(t *testing.T) {
-	base := rawdb.NewMemoryDatabase()
-	db := &putFailingDB{KeyValueStore: base}
-	m := NewBidBlockPermissionManager(db)
+	path := testJournalPath(t)
+	m := NewBidBlockPermissionManager(path)
 
 	builder := common.HexToAddress("0x1")
 	revoked := map[common.Address]BidBlockRevokeRecord{
@@ -539,8 +531,11 @@ func TestBidBlockPermission_FailedNewerBlocksOlder(t *testing.T) {
 	}
 	cleared := map[common.Address]BidBlockRevokeRecord{} // SetAllowed(true) result
 
-	// The newer snapshot (seq 2, cleared) is attempted first but its write fails.
-	db.failPut = true
+	// The newer snapshot (seq 2, cleared) is attempted first but its write
+	// fails: the journal path is occupied by a directory.
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("occupy journal path: %v", err)
+	}
 	m.persistAsync(2, cleared)
 	if m.persistedSeq != 2 {
 		t.Fatalf("persistedSeq must advance to 2 even when the write fails, got %d", m.persistedSeq)
@@ -548,27 +543,29 @@ func TestBidBlockPermission_FailedNewerBlocksOlder(t *testing.T) {
 
 	// The older snapshot (seq 1, revoked) is now handled with writes working
 	// again — it must be dropped, not overwrite the newer intent.
-	db.failPut = false
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("free journal path: %v", err)
+	}
 	m.persistAsync(1, revoked)
-	if blob, _ := base.Get(bidBlockRevokesKey); len(blob) != 0 {
-		t.Fatalf("older snapshot must not overwrite a newer (failed) one; disk should be empty, got %s", blob)
+	if blob, _ := os.ReadFile(path); len(blob) != 0 {
+		t.Fatalf("older snapshot must not overwrite a newer (failed) one; journal should be absent, got %s", blob)
 	}
 }
 
 // TestBidBlockPermission_SetAllowedPersists verifies that a manual clear is also
 // mirrored to disk, so it is not resurrected on restart.
 func TestBidBlockPermission_SetAllowedPersists(t *testing.T) {
-	db := rawdb.NewMemoryDatabase()
+	path := testJournalPath(t)
 	builder := common.HexToAddress("0x1")
 
-	m1 := NewBidBlockPermissionManager(db)
+	m1 := NewBidBlockPermissionManager(path)
 	m1.Revoke(builder, testInsertChainReason, common.HexToHash("0xabc"), 100)
-	waitForBidBlockPersist(t, db)
+	waitForBidBlockPersist(t, path)
 	m1.SetAllowed(builder, true) // manual clear must persist too
-	// Wait until the cleared (empty-map) blob has been written.
+	// Wait until the cleared (empty-map) journal has been written.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		blob, _ := db.Get(bidBlockRevokesKey)
+		blob, _ := os.ReadFile(path)
 		var stored map[common.Address]BidBlockRevokeRecord
 		if json.Unmarshal(blob, &stored) == nil {
 			if _, ok := stored[builder]; !ok {
@@ -578,7 +575,7 @@ func TestBidBlockPermission_SetAllowedPersists(t *testing.T) {
 		time.Sleep(2 * time.Millisecond)
 	}
 
-	m2 := NewBidBlockPermissionManager(db)
+	m2 := NewBidBlockPermissionManager(path)
 	if !m2.IsAllowed(builder) {
 		t.Fatal("a manually cleared builder must not be resurrected on restart")
 	}

--- a/miner/bid_block_permission_test.go
+++ b/miner/bid_block_permission_test.go
@@ -5,13 +5,17 @@ package miner
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	buildertypes "github.com/ethereum/go-ethereum/core/types/builder"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/miner/builderclient"
 	"github.com/ethereum/go-ethereum/miner/minerconfig"
 )
@@ -34,7 +38,7 @@ func setBidBlockPermissionClock(m *BidBlockPermissionManager, f func() time.Time
 }
 
 func TestBidBlockPermission_DefaultActive(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	builder := common.HexToAddress("0x1")
 	if !m.IsAllowed(builder) {
 		t.Fatal("default state should be Active for any builder")
@@ -45,7 +49,7 @@ func TestBidBlockPermission_DefaultActive(t *testing.T) {
 }
 
 func TestBidBlockPermission_RevokeBlocks(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	builder := common.HexToAddress("0x1")
 	hash := common.HexToHash("0xabc")
 
@@ -73,7 +77,7 @@ func TestBidBlockPermission_RevokeBlocks(t *testing.T) {
 }
 
 func TestBidBlockPermission_BuildersIndependent(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	a := common.HexToAddress("0xa")
 	b := common.HexToAddress("0xb")
 
@@ -87,7 +91,7 @@ func TestBidBlockPermission_BuildersIndependent(t *testing.T) {
 }
 
 func TestBidBlockPermission_RevokeForCustomDuration(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	builder := common.HexToAddress("0x1")
 	now := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
 
@@ -109,7 +113,7 @@ func TestBidBlockPermission_RevokeForCustomDuration(t *testing.T) {
 }
 
 func TestBidBlockPermission_RevokeOverwrites(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	builder := common.HexToAddress("0x1")
 
 	m.Revoke(builder, testInsertChainReason, common.HexToHash("0x1"), 1)
@@ -128,7 +132,7 @@ func TestBidBlockPermission_RevokeOverwrites(t *testing.T) {
 }
 
 func TestBidBlockPermission_ExpiresAt24h(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	builder := common.HexToAddress("0x1")
 
 	revokeTime := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
@@ -150,7 +154,7 @@ func TestBidBlockPermission_ExpiresAt24h(t *testing.T) {
 }
 
 func TestBidBlockPermission_StillRevokedWithin24h(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	builder := common.HexToAddress("0x1")
 
 	// UTC midnight should not reset the revoke; only elapsed time matters.
@@ -174,7 +178,7 @@ func TestBidBlockPermission_StillRevokedWithin24h(t *testing.T) {
 
 // Builders revoked at different times should expire independently.
 func TestBidBlockPermission_IndependentResetAt(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	a := common.HexToAddress("0xa")
 	b := common.HexToAddress("0xb")
 
@@ -217,7 +221,7 @@ func TestBidBlockPermission_IndependentResetAt(t *testing.T) {
 }
 
 func TestBidBlockPermission_ConcurrentAccess(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	builders := []common.Address{
 		common.HexToAddress("0xa"),
 		common.HexToAddress("0xb"),
@@ -236,7 +240,7 @@ func TestBidBlockPermission_ConcurrentAccess(t *testing.T) {
 }
 
 func TestBidBlockPermission_ActiveRevokeCount(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 
 	if got := m.ActiveRevokeCount(); got != 0 {
 		t.Fatalf("empty manager: got %d, want 0", got)
@@ -262,7 +266,7 @@ func TestBidBlockPermission_ActiveRevokeCount(t *testing.T) {
 }
 
 func TestBidBlockPermission_GetStatus(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	builder := common.HexToAddress("0x1")
 	now := time.Date(2026, 5, 9, 10, 0, 0, 0, time.UTC)
 	resetAt := now.Add(24 * time.Hour)
@@ -291,7 +295,7 @@ func TestBidBlockPermission_GetStatus(t *testing.T) {
 }
 
 func TestBidBlockAdmission_RevokedDoesNotConsumeQuota(t *testing.T) {
-	permMgr := NewBidBlockPermissionManager()
+	permMgr := NewBidBlockPermissionManager(nil)
 	b := &bidSimulator{
 		builders:          make(map[common.Address]*builderclient.Client),
 		pending:           make(map[uint64]map[common.Address]map[common.Hash]struct{}),
@@ -370,7 +374,7 @@ func TestBidBlockAdmission_DisabledDoesNotConsumeQuota(t *testing.T) {
 }
 
 func TestMinerBidBlockPermission_UsesWorkerManager(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	miner := &Miner{worker: &worker{permMgr: m}}
 	builder := common.HexToAddress("0x1")
 
@@ -381,7 +385,7 @@ func TestMinerBidBlockPermission_UsesWorkerManager(t *testing.T) {
 }
 
 func TestBidBlockPermission_SetAllowed_Deny(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	builder := common.HexToAddress("0x1")
 
 	m.SetAllowed(builder, false)
@@ -398,7 +402,7 @@ func TestBidBlockPermission_SetAllowed_Deny(t *testing.T) {
 }
 
 func TestBidBlockPermission_SetAllowed_Clear(t *testing.T) {
-	m := NewBidBlockPermissionManager()
+	m := NewBidBlockPermissionManager(nil)
 	builder := common.HexToAddress("0x1")
 
 	m.Revoke(builder, testInsertChainReason, common.HexToHash("0xabc"), 100)
@@ -408,5 +412,174 @@ func TestBidBlockPermission_SetAllowed_Clear(t *testing.T) {
 	}
 	if _, ok := getBidBlockPermissionRecord(m, builder); ok {
 		t.Fatal("record should be cleared")
+	}
+}
+
+// waitForBidBlockPersist polls until the asynchronous persistence has written a
+// non-empty blob, or fails the test after a short deadline.
+func waitForBidBlockPersist(t *testing.T, db ethdb.KeyValueStore) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if blob, _ := db.Get(bidBlockRevokesKey); len(blob) > 0 {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for BidBlock revokes to persist")
+}
+
+// TestBidBlockPermission_SurvivesRestart is the regression for the reported
+// gap: a revoke persisted by one manager must still be in effect (with the same
+// resetAt) after a fresh manager is constructed over the same database, as
+// happens when the validator process restarts within the lockout window.
+func TestBidBlockPermission_SurvivesRestart(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	builder := common.HexToAddress("0x1")
+	hash := common.HexToHash("0xabc")
+
+	m1 := NewBidBlockPermissionManager(db)
+	m1.Revoke(builder, testInsertChainReason, hash, 100)
+	waitForBidBlockPersist(t, db)
+	want := m1.GetStatus(builder)
+
+	// Simulate a restart: a brand-new manager over the same database.
+	m2 := NewBidBlockPermissionManager(db)
+	if m2.IsAllowed(builder) {
+		t.Fatal("revoke must survive a restart within its window")
+	}
+	got := m2.GetStatus(builder)
+	if !got.ResetAt.Equal(want.ResetAt) {
+		t.Fatalf("resetAt changed across restart: got %v, want %v", got.ResetAt, want.ResetAt)
+	}
+	if !got.RevokedAt.Equal(want.RevokedAt) || got.Reason != want.Reason || got.BlockHash != want.BlockHash || got.BlockNum != want.BlockNum {
+		t.Fatalf("restored record differs from persisted one: got %+v, want %+v", got, want)
+	}
+}
+
+// TestBidBlockPermission_ExpiredNotRestored verifies that a revoke whose window
+// elapsed while the process was down is dropped on load, while a still-active
+// one is restored. The database is seeded directly so the elapsed time is
+// deterministic and does not depend on wall-clock waits.
+func TestBidBlockPermission_ExpiredNotRestored(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	active := common.HexToAddress("0x1")
+	expired := common.HexToAddress("0x2")
+
+	now := time.Now()
+	seed := map[common.Address]BidBlockRevokeRecord{
+		active:  {RevokedAt: now.Add(-1 * time.Hour), Duration: bidBlockRevokeDuration, Reason: "active"},
+		expired: {RevokedAt: now.Add(-25 * time.Hour), Duration: bidBlockRevokeDuration, Reason: "expired"},
+	}
+	blob, err := json.Marshal(seed)
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := db.Put(bidBlockRevokesKey, blob); err != nil {
+		t.Fatalf("seed db: %v", err)
+	}
+
+	m := NewBidBlockPermissionManager(db)
+	if m.IsAllowed(active) {
+		t.Fatal("still-active revoke must be restored")
+	}
+	if !m.IsAllowed(expired) {
+		t.Fatal("revoke expired during downtime must not be restored")
+	}
+}
+
+// TestBidBlockPermission_LoadTolERatesBadState verifies that a missing or
+// corrupt persisted blob leaves the manager empty instead of panicking.
+func TestBidBlockPermission_LoadToleratesBadState(t *testing.T) {
+	builder := common.HexToAddress("0x1")
+
+	// Corrupt blob: start empty, no panic.
+	db := rawdb.NewMemoryDatabase()
+	if err := db.Put(bidBlockRevokesKey, []byte("not json")); err != nil {
+		t.Fatalf("seed db: %v", err)
+	}
+	m := NewBidBlockPermissionManager(db)
+	if !m.IsAllowed(builder) {
+		t.Fatal("a corrupt persisted blob must yield an empty manager")
+	}
+
+	// Missing key (fresh db): start empty, no panic.
+	m2 := NewBidBlockPermissionManager(rawdb.NewMemoryDatabase())
+	if !m2.IsAllowed(builder) {
+		t.Fatal("a fresh db must yield an empty manager")
+	}
+}
+
+// putFailingDB wraps a key-value store and can be told to fail Put calls, to
+// exercise the best-effort persistence paths.
+type putFailingDB struct {
+	ethdb.KeyValueStore
+	failPut bool
+}
+
+func (d *putFailingDB) Put(key, value []byte) error {
+	if d.failPut {
+		return errors.New("simulated put failure")
+	}
+	return d.KeyValueStore.Put(key, value)
+}
+
+// TestBidBlockPermission_FailedNewerBlocksOlder locks the ordering guarantee:
+// once a newer snapshot has entered the writer — even if its write fails — an
+// older snapshot must never overwrite it and resurrect stale state. persistAsync
+// is called directly to control ordering deterministically.
+func TestBidBlockPermission_FailedNewerBlocksOlder(t *testing.T) {
+	base := rawdb.NewMemoryDatabase()
+	db := &putFailingDB{KeyValueStore: base}
+	m := NewBidBlockPermissionManager(db)
+
+	builder := common.HexToAddress("0x1")
+	revoked := map[common.Address]BidBlockRevokeRecord{
+		builder: {RevokedAt: time.Now(), Duration: bidBlockRevokeDuration, Reason: "revoke"},
+	}
+	cleared := map[common.Address]BidBlockRevokeRecord{} // SetAllowed(true) result
+
+	// The newer snapshot (seq 2, cleared) is attempted first but its write fails.
+	db.failPut = true
+	m.persistAsync(2, cleared)
+	if m.persistedSeq != 2 {
+		t.Fatalf("persistedSeq must advance to 2 even when the write fails, got %d", m.persistedSeq)
+	}
+
+	// The older snapshot (seq 1, revoked) is now handled with writes working
+	// again — it must be dropped, not overwrite the newer intent.
+	db.failPut = false
+	m.persistAsync(1, revoked)
+	if blob, _ := base.Get(bidBlockRevokesKey); len(blob) != 0 {
+		t.Fatalf("older snapshot must not overwrite a newer (failed) one; disk should be empty, got %s", blob)
+	}
+}
+
+// TestBidBlockPermission_SetAllowedPersists verifies that a manual clear is also
+// mirrored to disk, so it is not resurrected on restart.
+func TestBidBlockPermission_SetAllowedPersists(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	builder := common.HexToAddress("0x1")
+
+	m1 := NewBidBlockPermissionManager(db)
+	m1.Revoke(builder, testInsertChainReason, common.HexToHash("0xabc"), 100)
+	waitForBidBlockPersist(t, db)
+	m1.SetAllowed(builder, true) // manual clear must persist too
+	// Wait until the cleared (empty-map) blob has been written.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		blob, _ := db.Get(bidBlockRevokesKey)
+		var stored map[common.Address]BidBlockRevokeRecord
+		if json.Unmarshal(blob, &stored) == nil {
+			if _, ok := stored[builder]; !ok {
+				break
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	m2 := NewBidBlockPermissionManager(db)
+	if !m2.IsAllowed(builder) {
+		t.Fatal("a manually cleared builder must not be resurrected on restart")
 	}
 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner/minerconfig"
@@ -43,6 +44,8 @@ type Backend interface {
 	BlockChain() *core.BlockChain
 	TxPool() *txpool.TxPool
 	SubscribeSyncEvents(ch chan<- downloader.SyncEvent) event.Subscription
+	// ChainDb is used to persist BidBlock revoke lockouts across restarts.
+	ChainDb() ethdb.Database
 }
 
 // Miner is the main object which takes care of submitting new work to consensus
@@ -62,7 +65,7 @@ type Miner struct {
 }
 
 func New(eth Backend, config *minerconfig.Config, eventMux *event.TypeMux, engine consensus.Engine) *Miner {
-	bidBlockPermMgr := NewBidBlockPermissionManager()
+	bidBlockPermMgr := NewBidBlockPermissionManager(eth.ChainDb())
 	miner := &Miner{
 		mux:     eventMux,
 		eth:     eth,

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/downloader"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner/minerconfig"
@@ -44,8 +43,6 @@ type Backend interface {
 	BlockChain() *core.BlockChain
 	TxPool() *txpool.TxPool
 	SubscribeSyncEvents(ch chan<- downloader.SyncEvent) event.Subscription
-	// ChainDb is used to persist BidBlock revoke lockouts across restarts.
-	ChainDb() ethdb.Database
 }
 
 // Miner is the main object which takes care of submitting new work to consensus
@@ -65,7 +62,7 @@ type Miner struct {
 }
 
 func New(eth Backend, config *minerconfig.Config, eventMux *event.TypeMux, engine consensus.Engine) *Miner {
-	bidBlockPermMgr := NewBidBlockPermissionManager(eth.ChainDb())
+	bidBlockPermMgr := NewBidBlockPermissionManager(config.BidBlockRevokesJournal)
 	miner := &Miner{
 		mux:     eventMux,
 		eth:     eth,

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/miner/minerconfig"
 	"github.com/ethereum/go-ethereum/params"
@@ -59,6 +60,10 @@ func (m *mockBackend) BlockChain() *core.BlockChain {
 
 func (m *mockBackend) TxPool() *txpool.TxPool {
 	return m.txPool
+}
+
+func (m *mockBackend) ChainDb() ethdb.Database {
+	return rawdb.NewMemoryDatabase()
 }
 
 func (m *mockBackend) SubscribeSyncEvents(ch chan<- downloader.SyncEvent) event.Subscription {

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/downloader"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/miner/minerconfig"
 	"github.com/ethereum/go-ethereum/params"
@@ -60,10 +59,6 @@ func (m *mockBackend) BlockChain() *core.BlockChain {
 
 func (m *mockBackend) TxPool() *txpool.TxPool {
 	return m.txPool
-}
-
-func (m *mockBackend) ChainDb() ethdb.Database {
-	return rawdb.NewMemoryDatabase()
 }
 
 func (m *mockBackend) SubscribeSyncEvents(ch chan<- downloader.SyncEvent) event.Subscription {

--- a/miner/minerconfig/config.go
+++ b/miner/minerconfig/config.go
@@ -36,6 +36,9 @@ var (
 	// Extra time for finalizing and committing blocks (excludes writing to disk).
 	defaultDelayLeftOver         = 15 * time.Millisecond
 	defaultBidSimulationLeftOver = 20 * time.Millisecond
+
+	// defaultBidBlockRevokesJournal is resolved relative to the node's datadir.
+	defaultBidBlockRevokesJournal = "bidblockrevokes.json"
 )
 
 func getDefaultNoInterruptLeftOver() *time.Duration {
@@ -73,6 +76,12 @@ type Config struct {
 	DisableVoteAttestation bool           // Whether to skip assembling vote attestation
 	MaxBlobsPerBlock       int            `toml:",omitempty"` // Maximum number of blobs per block (0 for unset uses protocol default)
 
+	// BidBlockRevokesJournal is the file BidBlock revoke lockouts are persisted
+	// to so they survive restarts (BEP-675). A relative path is resolved under
+	// the node's datadir; empty disables persistence. It is validator-local MEV
+	// policy, deliberately kept out of chaindata.
+	BidBlockRevokesJournal string `toml:",omitempty"`
+
 	Mev MevConfig // Mev configuration
 }
 
@@ -90,6 +99,8 @@ var DefaultConfig = Config{
 	// The default value is set to 45 seconds.
 	// Because the avg restart time in mainnet could be 30+ seconds, so the node try to wait for the next multi-proposals to be done.
 	MaxWaitProposalInSecs: &defaultMaxWaitProposalInSecs,
+
+	BidBlockRevokesJournal: defaultBidBlockRevokesJournal,
 
 	Mev: DefaultMevConfig,
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -268,7 +268,7 @@ type worker struct {
 
 func newWorker(config *minerconfig.Config, engine consensus.Engine, eth Backend, mux *event.TypeMux, permMgr *BidBlockPermissionManager) *worker {
 	if permMgr == nil {
-		permMgr = NewBidBlockPermissionManager()
+		permMgr = NewBidBlockPermissionManager(nil)
 	}
 	chainConfig := eth.BlockChain().Config()
 	prefetcher := core.NewStatePrefetcher(chainConfig, eth.BlockChain().HeadChain())

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -268,7 +268,7 @@ type worker struct {
 
 func newWorker(config *minerconfig.Config, engine consensus.Engine, eth Backend, mux *event.TypeMux, permMgr *BidBlockPermissionManager) *worker {
 	if permMgr == nil {
-		permMgr = NewBidBlockPermissionManager(nil)
+		permMgr = NewBidBlockPermissionManager("")
 	}
 	chainConfig := eth.BlockChain().Config()
 	prefetcher := core.NewStatePrefetcher(chainConfig, eth.BlockChain().HeadChain())

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -151,7 +151,6 @@ func newTestWorkerBackend(t *testing.T, chainConfig *params.ChainConfig, engine 
 
 func (b *testWorkerBackend) BlockChain() *core.BlockChain { return b.chain }
 func (b *testWorkerBackend) TxPool() *txpool.TxPool       { return b.txPool }
-func (b *testWorkerBackend) ChainDb() ethdb.Database      { return b.db }
 
 // SubscribeSyncEvents subscribes to a throwaway feed that never fires; the
 // worker tests do not exercise downloader-driven start/stop behavior.
@@ -173,7 +172,7 @@ func (b *testWorkerBackend) newRandomTx(creation bool) *types.Transaction {
 func newTestWorker(t *testing.T, chainConfig *params.ChainConfig, engine consensus.Engine, db ethdb.Database, blocks int) (*worker, *testWorkerBackend) {
 	backend := newTestWorkerBackend(t, chainConfig, engine, db, blocks)
 	backend.txPool.Add(pendingTxs, true)
-	w := newWorker(testConfig, engine, backend, new(event.TypeMux), NewBidBlockPermissionManager(nil))
+	w := newWorker(testConfig, engine, backend, new(event.TypeMux), NewBidBlockPermissionManager(""))
 	w.setEtherbase(testBankAddress)
 	return w, backend
 }

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -151,6 +151,7 @@ func newTestWorkerBackend(t *testing.T, chainConfig *params.ChainConfig, engine 
 
 func (b *testWorkerBackend) BlockChain() *core.BlockChain { return b.chain }
 func (b *testWorkerBackend) TxPool() *txpool.TxPool       { return b.txPool }
+func (b *testWorkerBackend) ChainDb() ethdb.Database      { return b.db }
 
 // SubscribeSyncEvents subscribes to a throwaway feed that never fires; the
 // worker tests do not exercise downloader-driven start/stop behavior.
@@ -172,7 +173,7 @@ func (b *testWorkerBackend) newRandomTx(creation bool) *types.Transaction {
 func newTestWorker(t *testing.T, chainConfig *params.ChainConfig, engine consensus.Engine, db ethdb.Database, blocks int) (*worker, *testWorkerBackend) {
 	backend := newTestWorkerBackend(t, chainConfig, engine, db, blocks)
 	backend.txPool.Add(pendingTxs, true)
-	w := newWorker(testConfig, engine, backend, new(event.TypeMux), NewBidBlockPermissionManager())
+	w := newWorker(testConfig, engine, backend, new(event.TypeMux), NewBidBlockPermissionManager(nil))
 	w.setEtherbase(testBankAddress)
 	return w, backend
 }


### PR DESCRIPTION
### Description

BidBlock `SendBidBlock` revokes (BEP-675 Layer 2) were held only in an in-memory map in `BidBlockPermissionManager`, reconstructed empty on every `miner.New`. A validator that revoked a builder for 24h and then restarted within that window (upgrade, crash, OOM) came back with an empty map, so the builder was immediately allowed to `SendBidBlock` again — even though the permission RPC still advertised `resetAt = revokedAt + duration` as a wall-clock promise.

This PR persists the revoke map to the chain database and restores it on startup:

* The whole map is mirrored to a single database key (`bidBlockRevokes`), overwritten on every change. It is JSON-encoded — RLP is geth's codec for consensus-critical / large / frequent data, but supports neither maps nor `time.Time`; this state is tiny, written rarely, never on-chain, and benefits from JSON's schema tolerance and readability, matching the existing `WriteChainConfig` precedent.
* On startup the manager loads the persisted map and keeps only revokes still within their window, dropping any whose lockout elapsed while the node was offline. So a revoke survives a restart within its window; one that fully expired during downtime is not resurrected.
* Persistence is **asynchronous and best-effort**: mutations snapshot the map under the lock and hand it to a fire-and-forget writer, so the mining path never blocks on disk I/O. Losing the newest write on a crash is acceptable; what must not happen is a disk hiccup stalling `Revoke`/`SetAllowed`.
* Writers are serialized and carry a monotonic sequence number. The seq guard is advanced **before** the write and **regardless of its outcome**, so the seq that actually reaches `db.Put` is strictly increasing: once a newer snapshot has entered the writer, an older one is dropped even if the newer write failed — an older snapshot can never overwrite a newer one and resurrect stale state (e.g. a revoke overwriting a later manual clear).

The manager keeps a nil-database path (unchanged in-memory behavior) for callers and tests that don't wire a database.

### Rationale

A revoke that silently vanishes on restart lets a misbehaving builder resume `SendBidBlock` (bypassing the weaker `SendBid` fallback) before its lockout should have ended, and makes the RPC's `resetAt` a promise the node doesn't keep. Durability of the lockout across restarts is what the advertised 24h window requires.

Scope is deliberately limited to durability across restarts: revoke triggers, the 24h / 450s durations, the RPC semantics and the per-validator (non-shared) nature of the lockout are all unchanged.

### Example

NA

### Changes

Notable changes:
NA