### PR TITLE
miner: reject BidBlock with empty state root

### DIFF
--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -91,8 +91,9 @@ var (
 		Timeout:   5 * time.Second,
 		Transport: transport,
 	}
-	errBetterBid  = errors.New("simulation abort due to better bid arrived")
-	errNoTimeLeft = errors.New("bid discarded due to lack of simulation time")
+	errBetterBid             = errors.New("simulation abort due to better bid arrived")
+	errNoTimeLeft            = errors.New("bid discarded due to lack of simulation time")
+	errZeroBidBlockStateRoot = errors.New("bid block rejected due to zero state root")
 )
 
 type bidWorker interface {
@@ -714,11 +715,16 @@ func (b *bidSimulator) recordBidBlockBuilder(builder common.Address) {
 func (b *bidSimulator) preSealVerifyBidBlock(decoded *buildertypes.DecodedBidBlock) error {
 	start := time.Now()
 	defer bidBlockPreSealVerifyTimer.UpdateSince(start)
+	header := decoded.Header
+
+	if header.Root == (common.Hash{}) {
+		return errZeroBidBlockStateRoot
+	}
+
 	parliaEngine, ok := b.engine.(*parlia.Parlia)
 	if !ok {
 		return errors.New("consensus engine is not parlia")
 	}
-	header := decoded.Header
 
 	if header.Coinbase != b.bidWorker.etherbase() {
 		return fmt.Errorf("invalid coinbase: got %s, want %s",


### PR DESCRIPTION
### Description

An unset state root can never match the root replayed at InsertChain, so drop it here instead of paying for a seal that is guaranteed to fail

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
