### PR TITLE
miner: revoke bidblock builder on cross-validator bad block evidence

### DIFF
--- a/consensus/parlia/bid_block.go
+++ b/consensus/parlia/bid_block.go
@@ -2,18 +2,24 @@ package parlia
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/systemcontracts"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	buildertypes "github.com/ethereum/go-ethereum/core/types/builder"
+	"github.com/ethereum/go-ethereum/internal/ethapi"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 var signableSystemTxSelectors = map[string][4]byte{
@@ -194,6 +200,94 @@ func (p *Parlia) selectorFor(methodName string) [4]byte {
 		panic(fmt.Sprintf("missing fixed system tx selector %s", methodName))
 	}
 	return selector
+}
+
+// ValidatorRole classifies an address within the working validator set.
+type ValidatorRole uint8
+
+const (
+	// ValidatorRoleNone means the address is not a working validator.
+	ValidatorRoleNone ValidatorRole = iota
+	ValidatorRoleCabinet
+	// ValidatorRoleCandidate also covers cabinet validators selected into the
+	// rotating tail, which are conservatively counted as candidates.
+	ValidatorRoleCandidate
+)
+
+func (r ValidatorRole) String() string {
+	switch r {
+	case ValidatorRoleCabinet:
+		return "cabinet"
+	case ValidatorRoleCandidate:
+		return "candidate"
+	default:
+		return "none"
+	}
+}
+
+// initNumOfCabinets mirrors BSCValidatorSet.INIT_NUM_OF_CABINETS, its fallback
+// while numOfCabinets is unset.
+const initNumOfCabinets = 21
+
+// SealerRole classifies addr against the mining validator set at blockHash. The
+// fixed prefix is guaranteed to contain cabinets; the rotating tail is
+// conservatively treated as candidates.
+func (p *Parlia) SealerRole(blockHash common.Hash, addr common.Address) (ValidatorRole, error) {
+	var validators []common.Address
+	var voteAddrs []types.BLSPublicKey
+	if err := p.callValidatorSet(blockHash, "getMiningValidators", &validators, &voteAddrs); err != nil {
+		return ValidatorRoleNone, fmt.Errorf("getMiningValidators: %w", err)
+	}
+	idx := slices.Index(validators, addr)
+	if idx < 0 {
+		return ValidatorRoleNone, nil
+	}
+
+	var numOfCabinets *big.Int
+	if err := p.callValidatorSet(blockHash, "numOfCabinets", &numOfCabinets); err != nil {
+		return ValidatorRoleNone, fmt.Errorf("numOfCabinets: %w", err)
+	}
+	cabinets := initNumOfCabinets
+	if numOfCabinets != nil && numOfCabinets.IsInt64() && numOfCabinets.Sign() > 0 {
+		cabinets = int(numOfCabinets.Int64())
+	}
+	var maxWorkingCandidates *big.Int
+	if err := p.callValidatorSet(blockHash, "maxNumOfWorkingCandidates", &maxWorkingCandidates); err != nil {
+		return ValidatorRoleNone, fmt.Errorf("maxNumOfWorkingCandidates: %w", err)
+	}
+	guaranteedCabinets := min(len(validators), cabinets)
+	if maxWorkingCandidates != nil && maxWorkingCandidates.IsInt64() && maxWorkingCandidates.Sign() > 0 {
+		workingCandidates := min(int(maxWorkingCandidates.Int64()), guaranteedCabinets)
+		guaranteedCabinets -= workingCandidates
+	}
+	if idx < guaranteedCabinets {
+		return ValidatorRoleCabinet, nil
+	}
+	return ValidatorRoleCandidate, nil
+}
+
+// callValidatorSet performs a no-argument view call on the validator contract.
+func (p *Parlia) callValidatorSet(blockHash common.Hash, method string, out ...interface{}) error {
+	data, err := p.validatorSetABI.Pack(method)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	blockNr := rpc.BlockNumberOrHashWithHash(blockHash, false)
+	msgData := (hexutil.Bytes)(data)
+	toAddress := common.HexToAddress(systemcontracts.ValidatorContract)
+	gas := (hexutil.Uint64)(uint64(math.MaxUint64 / 2))
+	result, err := p.ethAPI.Call(ctx, ethapi.TransactionArgs{
+		Gas:  &gas,
+		To:   &toAddress,
+		Data: &msgData,
+	}, &blockNr, nil, nil)
+	if err != nil {
+		return err
+	}
+	return p.validatorSetABI.UnpackIntoInterface(&out, method, result)
 }
 
 func (p *Parlia) BlockTimeUpperCheck(chain consensus.ChainHeaderReader, header *types.Header) error {

--- a/consensus/parlia/bid_block.go
+++ b/consensus/parlia/bid_block.go
@@ -207,11 +207,9 @@ func (p *Parlia) selectorFor(methodName string) [4]byte {
 type ValidatorRole uint8
 
 const (
-	// ValidatorRoleNone means the address is not a working validator.
+	// ValidatorRoleNone means the address is not in the validator set.
 	ValidatorRoleNone ValidatorRole = iota
 	ValidatorRoleCabinet
-	// ValidatorRoleCandidate also covers cabinet validators selected into the
-	// rotating tail, which are conservatively counted as candidates.
 	ValidatorRoleCandidate
 )
 
@@ -230,45 +228,35 @@ func (r ValidatorRole) String() string {
 // while numOfCabinets is unset.
 const initNumOfCabinets = 21
 
-// SealerRole classifies addr against the mining validator set at blockHash. The
-// fixed prefix is guaranteed to contain cabinets; the rotating tail is
-// conservatively treated as candidates.
-func (p *Parlia) SealerRole(blockHash common.Hash, addr common.Address) (ValidatorRole, error) {
+// SealerRole classifies addr against the validator set at blockHash and returns
+// the cabinet and full validator-set sizes used for majority thresholds.
+func (p *Parlia) SealerRole(blockHash common.Hash, addr common.Address) (ValidatorRole, int, int, error) {
 	var validators []common.Address
-	var voteAddrs []types.BLSPublicKey
-	if err := p.callValidatorSet(blockHash, "getMiningValidators", &validators, &voteAddrs); err != nil {
-		return ValidatorRoleNone, fmt.Errorf("getMiningValidators: %w", err)
+	if err := p.callValidatorSet(blockHash, "getValidators", &validators); err != nil {
+		return ValidatorRoleNone, 0, 0, fmt.Errorf("getValidators: %w", err)
 	}
 	idx := slices.Index(validators, addr)
 	if idx < 0 {
-		return ValidatorRoleNone, nil
+		return ValidatorRoleNone, 0, 0, nil
 	}
 
 	var numOfCabinets *big.Int
 	if err := p.callValidatorSet(blockHash, "numOfCabinets", &numOfCabinets); err != nil {
-		return ValidatorRoleNone, fmt.Errorf("numOfCabinets: %w", err)
+		return ValidatorRoleNone, 0, 0, fmt.Errorf("numOfCabinets: %w", err)
 	}
 	cabinets := initNumOfCabinets
 	if numOfCabinets != nil && numOfCabinets.IsInt64() && numOfCabinets.Sign() > 0 {
 		cabinets = int(numOfCabinets.Int64())
 	}
-	var maxWorkingCandidates *big.Int
-	if err := p.callValidatorSet(blockHash, "maxNumOfWorkingCandidates", &maxWorkingCandidates); err != nil {
-		return ValidatorRoleNone, fmt.Errorf("maxNumOfWorkingCandidates: %w", err)
+	cabinets = min(cabinets, len(validators))
+	if idx < cabinets {
+		return ValidatorRoleCabinet, cabinets, len(validators), nil
 	}
-	guaranteedCabinets := min(len(validators), cabinets)
-	if maxWorkingCandidates != nil && maxWorkingCandidates.IsInt64() && maxWorkingCandidates.Sign() > 0 {
-		workingCandidates := min(int(maxWorkingCandidates.Int64()), guaranteedCabinets)
-		guaranteedCabinets -= workingCandidates
-	}
-	if idx < guaranteedCabinets {
-		return ValidatorRoleCabinet, nil
-	}
-	return ValidatorRoleCandidate, nil
+	return ValidatorRoleCandidate, cabinets, len(validators), nil
 }
 
 // callValidatorSet performs a no-argument view call on the validator contract.
-func (p *Parlia) callValidatorSet(blockHash common.Hash, method string, out ...interface{}) error {
+func (p *Parlia) callValidatorSet(blockHash common.Hash, method string, out interface{}) error {
 	data, err := p.validatorSetABI.Pack(method)
 	if err != nil {
 		return err
@@ -288,18 +276,12 @@ func (p *Parlia) callValidatorSet(blockHash common.Hash, method string, out ...i
 	if err != nil {
 		return err
 	}
-	return unpackValidatorSet(p.validatorSetABI, method, result, out...)
+	return unpackValidatorSet(p.validatorSetABI, method, result, out)
 }
 
-// unpackValidatorSet decodes a validator-contract return value. A single output
-// must be decoded into the destination itself: the abi package routes that case
-// through copyAtomic, which cannot write into a []interface{} and fails with
-// "cannot unmarshal ... in to []interface {}".
-func unpackValidatorSet(contractABI abi.ABI, method string, result []byte, out ...interface{}) error {
-	if len(out) == 1 {
-		return contractABI.UnpackIntoInterface(out[0], method, result)
-	}
-	return contractABI.UnpackIntoInterface(&out, method, result)
+// unpackValidatorSet decodes a single-output validator-contract return value.
+func unpackValidatorSet(contractABI abi.ABI, method string, result []byte, out interface{}) error {
+	return contractABI.UnpackIntoInterface(out, method, result)
 }
 
 func (p *Parlia) BlockTimeUpperCheck(chain consensus.ChainHeaderReader, header *types.Header) error {

--- a/consensus/parlia/bid_block.go
+++ b/consensus/parlia/bid_block.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 
 	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -287,7 +288,18 @@ func (p *Parlia) callValidatorSet(blockHash common.Hash, method string, out ...i
 	if err != nil {
 		return err
 	}
-	return p.validatorSetABI.UnpackIntoInterface(&out, method, result)
+	return unpackValidatorSet(p.validatorSetABI, method, result, out...)
+}
+
+// unpackValidatorSet decodes a validator-contract return value. A single output
+// must be decoded into the destination itself: the abi package routes that case
+// through copyAtomic, which cannot write into a []interface{} and fails with
+// "cannot unmarshal ... in to []interface {}".
+func unpackValidatorSet(contractABI abi.ABI, method string, result []byte, out ...interface{}) error {
+	if len(out) == 1 {
+		return contractABI.UnpackIntoInterface(out[0], method, result)
+	}
+	return contractABI.UnpackIntoInterface(&out, method, result)
 }
 
 func (p *Parlia) BlockTimeUpperCheck(chain consensus.ChainHeaderReader, header *types.Header) error {

--- a/consensus/parlia/bid_block_abi_test.go
+++ b/consensus/parlia/bid_block_abi_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+
+package parlia
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// The validator-set calls behind SealerRole decode through one shared helper.
+// A decode failure there silently disables evidence-based revocation, so both
+// output shapes are pinned here.
+
+func testValidatorSetABI(t *testing.T) abi.ABI {
+	t.Helper()
+	parsed, err := abi.JSON(strings.NewReader(validatorSetABI))
+	if err != nil {
+		t.Fatalf("parse validatorSetABI: %v", err)
+	}
+	return parsed
+}
+
+func TestValidatorSetUnpackSingleOutput(t *testing.T) {
+	vABI := testValidatorSetABI(t)
+
+	for _, method := range []string{"numOfCabinets", "maxNumOfWorkingCandidates"} {
+		want := big.NewInt(21)
+		packed, err := vABI.Methods[method].Outputs.Pack(want)
+		if err != nil {
+			t.Fatalf("%s: pack: %v", method, err)
+		}
+
+		var got *big.Int
+		if err := unpackValidatorSet(vABI, method, packed, &got); err != nil {
+			t.Fatalf("%s: unpack: %v", method, err)
+		}
+		if got == nil || got.Cmp(want) != 0 {
+			t.Fatalf("%s: got %v, want %v", method, got, want)
+		}
+	}
+}
+
+func TestValidatorSetUnpackMultipleOutputs(t *testing.T) {
+	vABI := testValidatorSetABI(t)
+
+	wantAddrs := []common.Address{
+		common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		common.HexToAddress("0x2222222222222222222222222222222222222222"),
+	}
+	wantVotes := [][]byte{make([]byte, types.BLSPublicKeyLength), make([]byte, types.BLSPublicKeyLength)}
+	wantVotes[1][0] = 0xaa
+
+	packed, err := vABI.Methods["getMiningValidators"].Outputs.Pack(wantAddrs, wantVotes)
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+
+	var (
+		gotAddrs []common.Address
+		gotVotes []types.BLSPublicKey
+	)
+	if err := unpackValidatorSet(vABI, "getMiningValidators", packed, &gotAddrs, &gotVotes); err != nil {
+		t.Fatalf("unpack: %v", err)
+	}
+	if len(gotAddrs) != len(wantAddrs) {
+		t.Fatalf("got %d addresses, want %d", len(gotAddrs), len(wantAddrs))
+	}
+	for i := range wantAddrs {
+		if gotAddrs[i] != wantAddrs[i] {
+			t.Fatalf("address %d: got %s, want %s", i, gotAddrs[i], wantAddrs[i])
+		}
+	}
+	if len(gotVotes) != len(wantVotes) || gotVotes[1][0] != 0xaa {
+		t.Fatalf("vote addresses did not round-trip: %v", gotVotes)
+	}
+}

--- a/consensus/parlia/bid_block_abi_test.go
+++ b/consensus/parlia/bid_block_abi_test.go
@@ -5,17 +5,17 @@ package parlia
 
 import (
 	"math/big"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // The validator-set calls behind SealerRole decode through one shared helper.
 // A decode failure there silently disables evidence-based revocation, so both
-// output shapes are pinned here.
+// single-output types are pinned here.
 
 func testValidatorSetABI(t *testing.T) abi.ABI {
 	t.Helper()
@@ -28,55 +28,37 @@ func testValidatorSetABI(t *testing.T) abi.ABI {
 
 func TestValidatorSetUnpackSingleOutput(t *testing.T) {
 	vABI := testValidatorSetABI(t)
-
-	for _, method := range []string{"numOfCabinets", "maxNumOfWorkingCandidates"} {
-		want := big.NewInt(21)
-		packed, err := vABI.Methods[method].Outputs.Pack(want)
-		if err != nil {
-			t.Fatalf("%s: pack: %v", method, err)
-		}
-
-		var got *big.Int
-		if err := unpackValidatorSet(vABI, method, packed, &got); err != nil {
-			t.Fatalf("%s: unpack: %v", method, err)
-		}
-		if got == nil || got.Cmp(want) != 0 {
-			t.Fatalf("%s: got %v, want %v", method, got, want)
-		}
-	}
-}
-
-func TestValidatorSetUnpackMultipleOutputs(t *testing.T) {
-	vABI := testValidatorSetABI(t)
-
-	wantAddrs := []common.Address{
-		common.HexToAddress("0x1111111111111111111111111111111111111111"),
-		common.HexToAddress("0x2222222222222222222222222222222222222222"),
-	}
-	wantVotes := [][]byte{make([]byte, types.BLSPublicKeyLength), make([]byte, types.BLSPublicKeyLength)}
-	wantVotes[1][0] = 0xaa
-
-	packed, err := vABI.Methods["getMiningValidators"].Outputs.Pack(wantAddrs, wantVotes)
+	want := big.NewInt(21)
+	packed, err := vABI.Methods["numOfCabinets"].Outputs.Pack(want)
 	if err != nil {
 		t.Fatalf("pack: %v", err)
 	}
 
-	var (
-		gotAddrs []common.Address
-		gotVotes []types.BLSPublicKey
-	)
-	if err := unpackValidatorSet(vABI, "getMiningValidators", packed, &gotAddrs, &gotVotes); err != nil {
+	var got *big.Int
+	if err := unpackValidatorSet(vABI, "numOfCabinets", packed, &got); err != nil {
 		t.Fatalf("unpack: %v", err)
 	}
-	if len(gotAddrs) != len(wantAddrs) {
-		t.Fatalf("got %d addresses, want %d", len(gotAddrs), len(wantAddrs))
+	if got == nil || got.Cmp(want) != 0 {
+		t.Fatalf("got %v, want %v", got, want)
 	}
-	for i := range wantAddrs {
-		if gotAddrs[i] != wantAddrs[i] {
-			t.Fatalf("address %d: got %s, want %s", i, gotAddrs[i], wantAddrs[i])
-		}
+}
+
+func TestValidatorSetUnpackValidators(t *testing.T) {
+	vABI := testValidatorSetABI(t)
+	want := []common.Address{
+		common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		common.HexToAddress("0x2222222222222222222222222222222222222222"),
 	}
-	if len(gotVotes) != len(wantVotes) || gotVotes[1][0] != 0xaa {
-		t.Fatalf("vote addresses did not round-trip: %v", gotVotes)
+	packed, err := vABI.Methods["getValidators"].Outputs.Pack(want)
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+
+	var got []common.Address
+	if err := unpackValidatorSet(vABI, "getValidators", packed, &got); err != nil {
+		t.Fatalf("unpack: %v", err)
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
 	}
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -67,6 +67,9 @@ var (
 	badBlockRecordslimit = 1000
 	badBlockGauge        = metrics.NewRegisteredGauge("chain/insert/badBlock", nil)
 
+	// badBidBlockQueueSize bounds pending evidence; overflow is dropped.
+	badBidBlockQueueSize = 64
+
 	badBidBlockCounter = metrics.NewRegisteredCounter("chain/insert/badBidblock", nil)
 	// Not badBlockRecords: that set stops accepting entries at badBlockRecordslimit,
 	// which would freeze the counter for the rest of the process lifetime.
@@ -391,6 +394,7 @@ type BlockChain struct {
 	finalizedHeaderFeed      event.Feed
 	highestVerifiedBlockFeed event.Feed
 	badBidBlockFeed          event.Feed
+	badBidBlockCh            chan BadBidBlockEvent
 	blockProcCounter         int32
 	scope                    event.SubscriptionScope
 	genesisBlock             *types.Block
@@ -487,6 +491,7 @@ func NewBlockChain(db ethdb.Database, genesis *Genesis, engine consensus.Engine,
 		codedb:             state.NewCodeDB(db),
 		triegc:             prque.New[int64, common.Hash](nil),
 		quit:               make(chan struct{}),
+		badBidBlockCh:      make(chan BadBidBlockEvent, badBidBlockQueueSize),
 		triesInMemory:      cfg.TriesInMemory,
 		chainmu:            syncx.NewClosableMutex(),
 		bodyCache:          lru.NewCache[common.Hash, *types.Body](bodyCacheLimit),
@@ -674,6 +679,9 @@ func NewBlockChain(db ethdb.Database, genesis *Genesis, engine consensus.Engine,
 	// Start future block processor.
 	bc.wg.Add(1)
 	go bc.updateFutureBlocks()
+
+	bc.wg.Add(1)
+	go bc.publishBadBidBlockEvidence()
 
 	if bc.doubleSignMonitor != nil {
 		bc.wg.Add(1)
@@ -3415,6 +3423,20 @@ func countBadBidBlock(block *types.Block) {
 	}
 }
 
+// publishBadBidBlockEvidence fans evidence out to subscribers. One goroutine for
+// the chain's lifetime, so adversarial block volume cannot grow the goroutine count.
+func (bc *BlockChain) publishBadBidBlockEvidence() {
+	defer bc.wg.Done()
+	for {
+		select {
+		case ev := <-bc.badBidBlockCh:
+			bc.badBidBlockFeed.Send(ev)
+		case <-bc.quit:
+			return
+		}
+	}
+}
+
 // reportBadBidBlockEvidence posts evidence that a BidBlock failed execution.
 //
 // Only call it for blocks past header and body verification: the sync path feeds
@@ -3432,9 +3454,15 @@ func (bc *BlockChain) reportBadBidBlockEvidence(block *types.Block) {
 		ParentHash: block.ParentHash(),
 		Number:     block.NumberU64(),
 	}
-	// Off the import path: Send blocks until every subscriber accepts, and the
-	// miner's reads contract state. Blocking here would stall import under chainmu.
-	go bc.badBidBlockFeed.Send(ev)
+	// Handed to the publisher rather than sent here: Send blocks until every
+	// subscriber accepts, and the miner's reads contract state, so sending under
+	// chainmu would stall import. Dropped when the queue is full — evidence is
+	// best-effort, and losing some only delays a revoke.
+	select {
+	case bc.badBidBlockCh <- ev:
+	default:
+		log.Debug("Bad BidBlock evidence dropped, queue full", "builder", builder, "number", ev.Number)
+	}
 }
 
 // badBidBlockBuilder returns the builder encoded in the header of a block produced

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -75,6 +75,12 @@ var (
 	// which would freeze the counter for the rest of the process lifetime.
 	badBidBlockCounted = lru.NewCache[common.Hash, struct{}](badBlockRecordslimit)
 
+	// badBidBlockEvidenced deduplicates evidence per block, since peers re-announce
+	// and the fetcher requeues the same bad block. Kept apart from
+	// badBidBlockCounted, which also covers blocks that never reach execution.
+	badBidBlockEvidenced      = lru.NewCache[common.Hash, struct{}](badBlockRecordslimit)
+	badBidBlockDroppedCounter = metrics.NewRegisteredCounter("chain/insert/badBidblockDropped", nil)
+
 	headBlockGauge     = metrics.NewRegisteredGauge("chain/head/block", nil)
 	headHeaderGauge    = metrics.NewRegisteredGauge("chain/head/header", nil)
 	headFastBlockGauge = metrics.NewRegisteredGauge("chain/head/receipt", nil)
@@ -3447,10 +3453,18 @@ func (bc *BlockChain) reportBadBidBlockEvidence(block *types.Block) {
 	if !ok {
 		return
 	}
+	// Deduplicated here rather than in the consumer, which would still pay for a
+	// validator-set lookup per copy and let one re-announced block crowd the queue.
+	hash := block.Hash()
+	if badBidBlockEvidenced.Contains(hash) {
+		return
+	}
+	badBidBlockEvidenced.Add(hash, struct{}{})
+
 	ev := BadBidBlockEvent{
 		Builder:    builder,
 		Sealer:     block.Coinbase(),
-		Hash:       block.Hash(),
+		Hash:       hash,
 		ParentHash: block.ParentHash(),
 		Number:     block.NumberU64(),
 	}
@@ -3461,7 +3475,8 @@ func (bc *BlockChain) reportBadBidBlockEvidence(block *types.Block) {
 	select {
 	case bc.badBidBlockCh <- ev:
 	default:
-		log.Debug("Bad BidBlock evidence dropped, queue full", "builder", builder, "number", ev.Number)
+		badBidBlockDroppedCounter.Inc(1)
+		log.Warn("Bad BidBlock evidence dropped, queue full", "builder", builder, "number", ev.Number, "hash", hash)
 	}
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -390,6 +390,7 @@ type BlockChain struct {
 	newPayloadFeed           event.Feed // Feed for engine API newPayload events
 	finalizedHeaderFeed      event.Feed
 	highestVerifiedBlockFeed event.Feed
+	badBidBlockFeed          event.Feed
 	blockProcCounter         int32
 	scope                    event.SubscriptionScope
 	genesisBlock             *types.Block
@@ -2720,6 +2721,7 @@ func (bc *BlockChain) ProcessBlock(ctx context.Context, parentRoot common.Hash, 
 	spanEnd(&err)
 	if err != nil {
 		bc.reportBadBlock(block, res, err)
+		bc.reportBadBidBlockEvidence(block)
 		return nil, err
 	}
 	ptime := time.Since(pstart)
@@ -2731,6 +2733,7 @@ func (bc *BlockChain) ProcessBlock(ctx context.Context, parentRoot common.Hash, 
 	spanEnd(&err)
 	if err != nil {
 		bc.reportBadBlock(block, res, err)
+		bc.reportBadBidBlockEvidence(block)
 		return nil, err
 	}
 	vtime := time.Since(vstart)
@@ -3410,6 +3413,28 @@ func countBadBidBlock(block *types.Block) {
 		badBidBlockCounted.Add(hash, struct{}{})
 		badBidBlockCounter.Inc(1)
 	}
+}
+
+// reportBadBidBlockEvidence posts evidence that a BidBlock failed execution.
+//
+// Only call it for blocks past header and body verification: the sync path feeds
+// unverified blocks straight to InsertChain, so an earlier reject proves nothing
+// about the sealer and would let any peer frame a builder.
+func (bc *BlockChain) reportBadBidBlockEvidence(block *types.Block) {
+	builder, ok := badBidBlockBuilder(block)
+	if !ok {
+		return
+	}
+	ev := BadBidBlockEvent{
+		Builder:    builder,
+		Sealer:     block.Coinbase(),
+		Hash:       block.Hash(),
+		ParentHash: block.ParentHash(),
+		Number:     block.NumberU64(),
+	}
+	// Off the import path: Send blocks until every subscriber accepts, and the
+	// miner's reads contract state. Blocking here would stall import under chainmu.
+	go bc.badBidBlockFeed.Send(ev)
 }
 
 // badBidBlockBuilder returns the builder encoded in the header of a block produced

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -659,6 +659,11 @@ func (bc *BlockChain) SubscribeChainHeadEvent(ch chan<- ChainHeadEvent) event.Su
 	return bc.scope.Track(bc.chainHeadFeed.Subscribe(ch))
 }
 
+// SubscribeBadBidBlockEvent registers a subscription of BadBidBlockEvent.
+func (bc *BlockChain) SubscribeBadBidBlockEvent(ch chan<- BadBidBlockEvent) event.Subscription {
+	return bc.scope.Track(bc.badBidBlockFeed.Subscribe(ch))
+}
+
 // SubscribeHighestVerifiedHeaderEvent registers a subscription of HighestVerifiedBlockEvent.
 func (bc *BlockChain) SubscribeHighestVerifiedHeaderEvent(ch chan<- HighestVerifiedBlockEvent) event.Subscription {
 	return bc.scope.Track(bc.highestVerifiedBlockFeed.Subscribe(ch))

--- a/core/events.go
+++ b/core/events.go
@@ -41,6 +41,18 @@ type NewVoteEvent struct{ Vote *types.VoteEnvelope }
 // FinalizedHeaderEvent is posted when a finalized header is reached.
 type FinalizedHeaderEvent struct{ Header *types.Header }
 
+// BadBidBlockEvent is posted when a block from the MEV v2 (BEP-675 SendBidBlock)
+// path fails execution locally. Only posted for header- and body-verified blocks,
+// so Sealer is the validator parlia recovered from the seal. ParentHash anchors
+// the validator-set lookup, which head cannot: it may have moved on by then.
+type BadBidBlockEvent struct {
+	Builder    common.Address
+	Sealer     common.Address
+	Hash       common.Hash
+	ParentHash common.Hash
+	Number     uint64
+}
+
 type ChainEvent struct {
 	Header       *types.Header
 	Receipts     []*types.Receipt

--- a/miner/bid_block.go
+++ b/miner/bid_block.go
@@ -236,6 +236,79 @@ func (w *worker) enqueueBidBlockTask(task *task, systemTxs int) {
 	}
 }
 
+// badBidBlockLoop revokes builders that have already burned enough other
+// validators, so this node need not be burned in turn.
+func (w *worker) badBidBlockLoop() {
+	defer w.wg.Done()
+	defer w.badBidBlockSub.Unsubscribe()
+
+	for {
+		select {
+		case ev := <-w.badBidBlockCh:
+			w.handleBadBidBlockEvidence(ev)
+		case <-w.badBidBlockSub.Err():
+			return
+		case <-w.exitCh:
+			return
+		}
+	}
+}
+
+// handleBadBidBlockEvidence records one validator's failing BidBlock and revokes
+// the builder once the evidence covers enough distinct validators.
+func (w *worker) handleBadBidBlockEvidence(ev core.BadBidBlockEvent) {
+	// Nil-checked: chain events reach nodes that never ran ApplyDefaultMinerConfig.
+	if !isTrue(w.config.Mev.Enabled) || !isTrue(w.config.Mev.BidBlockEnabled) {
+		return
+	}
+	if !w.permMgr.IsAllowed(ev.Builder) {
+		return
+	}
+	p, ok := w.engine.(*parlia.Parlia)
+	if !ok {
+		return
+	}
+	// At the parent, the state that decided this sealer's role. Not head: delivery
+	// is async, and head may already have crossed a breathe block.
+	role, err := p.SealerRole(ev.ParentHash, ev.Sealer)
+	if err != nil {
+		log.Warn("[BID BLOCK EVIDENCE] validator lookup failed",
+			"sealer", ev.Sealer, "builder", ev.Builder, "err", err)
+		return
+	}
+	if role == parlia.ValidatorRoleNone {
+		// The seal was already verified, so this means a stale view, not a forgery.
+		log.Debug("[BID BLOCK EVIDENCE] sealer not in working validator set",
+			"sealer", ev.Sealer, "builder", ev.Builder, "number", ev.Number)
+		return
+	}
+
+	cabinetVotes, totalVotes := w.badBidBlocks.add(ev.Builder, ev.Sealer, role == parlia.ValidatorRoleCabinet)
+	if cabinetVotes < badBidBlockCabinetThreshold && totalVotes < badBidBlockTotalThreshold {
+		log.Info("[BID BLOCK EVIDENCE]",
+			"builder", ev.Builder,
+			"sealer", ev.Sealer,
+			"role", role,
+			"number", ev.Number,
+			"hash", ev.Hash,
+			"cabinetVotes", cabinetVotes,
+			"totalVotes", totalVotes)
+		return
+	}
+
+	reason := fmt.Sprintf("bad BidBlocks from %d cabinet / %d total validators", cabinetVotes, totalVotes)
+	log.Error("[BID BLOCK EVIDENCE REVOKE]",
+		"builder", ev.Builder,
+		"cabinetVotes", cabinetVotes,
+		"totalVotes", totalVotes,
+		"lastSealer", ev.Sealer,
+		"number", ev.Number,
+		"hash", ev.Hash)
+	w.revokeBidBlockBuilder(ev.Builder, reason, ev.Hash, ev.Number)
+	bidBlockEvidenceRevokeCounter.Inc(1)
+	w.badBidBlocks.clear(ev.Builder)
+}
+
 func (w *worker) revokeBidBlockBuilder(builder common.Address, reason string, hash common.Hash, blockNum uint64) {
 	w.revokeBidBlockBuilderFor(builder, reason, hash, blockNum, bidBlockRevokeDuration)
 }

--- a/miner/bid_block.go
+++ b/miner/bid_block.go
@@ -270,7 +270,7 @@ func (w *worker) handleBadBidBlockEvidence(ev core.BadBidBlockEvent) {
 	}
 	// At the parent, the state that decided this sealer's role. Not head: delivery
 	// is async, and head may already have crossed a breathe block.
-	role, err := p.SealerRole(ev.ParentHash, ev.Sealer)
+	role, cabinetCount, totalCount, err := p.SealerRole(ev.ParentHash, ev.Sealer)
 	if err != nil {
 		log.Warn("[BID BLOCK EVIDENCE] validator lookup failed",
 			"sealer", ev.Sealer, "builder", ev.Builder, "err", err)
@@ -278,13 +278,17 @@ func (w *worker) handleBadBidBlockEvidence(ev core.BadBidBlockEvent) {
 	}
 	if role == parlia.ValidatorRoleNone {
 		// The seal was already verified, so this means a stale view, not a forgery.
-		log.Debug("[BID BLOCK EVIDENCE] sealer not in working validator set",
+		log.Debug("[BID BLOCK EVIDENCE] sealer not in validator set",
 			"sealer", ev.Sealer, "builder", ev.Builder, "number", ev.Number)
 		return
 	}
 
 	cabinetVotes, totalVotes := w.badBidBlocks.add(ev.Builder, ev.Sealer, role == parlia.ValidatorRoleCabinet)
-	if cabinetVotes < badBidBlockCabinetThreshold && totalVotes < badBidBlockTotalThreshold {
+	// Thresholds follow this event's parent state. Valid sightings remain in the
+	// rolling window across validator-set changes, including jailing.
+	cabinetThreshold := majorityThreshold(cabinetCount)
+	totalThreshold := majorityThreshold(totalCount)
+	if cabinetVotes < cabinetThreshold && totalVotes < totalThreshold {
 		log.Info("[BID BLOCK EVIDENCE]",
 			"builder", ev.Builder,
 			"sealer", ev.Sealer,
@@ -292,15 +296,20 @@ func (w *worker) handleBadBidBlockEvidence(ev core.BadBidBlockEvent) {
 			"number", ev.Number,
 			"hash", ev.Hash,
 			"cabinetVotes", cabinetVotes,
-			"totalVotes", totalVotes)
+			"cabinetThreshold", cabinetThreshold,
+			"totalVotes", totalVotes,
+			"totalThreshold", totalThreshold)
 		return
 	}
 
-	reason := fmt.Sprintf("bad BidBlocks from %d cabinet / %d total validators", cabinetVotes, totalVotes)
+	reason := fmt.Sprintf("bad BidBlocks from %d/%d cabinet and %d/%d total validators",
+		cabinetVotes, cabinetThreshold, totalVotes, totalThreshold)
 	log.Error("[BID BLOCK EVIDENCE REVOKE]",
 		"builder", ev.Builder,
 		"cabinetVotes", cabinetVotes,
+		"cabinetThreshold", cabinetThreshold,
 		"totalVotes", totalVotes,
+		"totalThreshold", totalThreshold,
 		"lastSealer", ev.Sealer,
 		"number", ev.Number,
 		"hash", ev.Hash)

--- a/miner/bid_block_evidence.go
+++ b/miner/bid_block_evidence.go
@@ -14,17 +14,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const (
-	// Distinct validators that must have sealed a builder's failing blocks before
-	// it is revoked, counted over the cabinet alone and over every role. The
-	// cabinet threshold sits above the Byzantine tolerance of a 21-seat cabinet
-	// (f = 6), so framing a builder needs a colluding set larger than consensus
-	// already assumes could exist. Do not lower it back to f or below.
-	badBidBlockCabinetThreshold = 7
-	badBidBlockTotalThreshold   = 15
-	// badBidBlockEvidenceWindow keeps incidents months apart from accumulating.
-	badBidBlockEvidenceWindow = 24 * time.Hour
-)
+// badBidBlockEvidenceWindow keeps incidents months apart from accumulating.
+const badBidBlockEvidenceWindow = 24 * time.Hour
+
+func majorityThreshold(validators int) int { return validators/2 + 1 }
 
 // isTrue reports whether an optional config flag is set and enabled.
 func isTrue(flag *bool) bool { return flag != nil && *flag }

--- a/miner/bid_block_evidence.go
+++ b/miner/bid_block_evidence.go
@@ -16,8 +16,11 @@ import (
 
 const (
 	// Distinct validators that must have sealed a builder's failing blocks before
-	// it is revoked, counted over the cabinet alone and over every role.
-	badBidBlockCabinetThreshold = 6
+	// it is revoked, counted over the cabinet alone and over every role. The
+	// cabinet threshold sits above the Byzantine tolerance of a 21-seat cabinet
+	// (f = 6), so framing a builder needs a colluding set larger than consensus
+	// already assumes could exist. Do not lower it back to f or below.
+	badBidBlockCabinetThreshold = 7
 	badBidBlockTotalThreshold   = 15
 	// badBidBlockEvidenceWindow keeps incidents months apart from accumulating.
 	badBidBlockEvidenceWindow = 24 * time.Hour

--- a/miner/bid_block_evidence.go
+++ b/miner/bid_block_evidence.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// BEP-675 bad-BidBlock evidence tracking. Local revoke only fires after a builder
+// has burned this node's own slot; counting the blocks it broke for other
+// validators lets a node revoke it before its turn comes.
+
+package miner
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	// Distinct validators that must have sealed a builder's failing blocks before
+	// it is revoked, counted over the cabinet alone and over every role.
+	badBidBlockCabinetThreshold = 6
+	badBidBlockTotalThreshold   = 15
+	// badBidBlockEvidenceWindow keeps incidents months apart from accumulating.
+	badBidBlockEvidenceWindow = 24 * time.Hour
+)
+
+// isTrue reports whether an optional config flag is set and enabled.
+func isTrue(flag *bool) bool { return flag != nil && *flag }
+
+// badBidBlockSighting records one validator's failing block for a builder.
+type badBidBlockSighting struct {
+	at      time.Time
+	cabinet bool
+}
+
+// badBidBlockTracker counts distinct validators that sealed a failing BidBlock
+// per builder. In memory only: losing it on restart just delays a revoke.
+type badBidBlockTracker struct {
+	mu    sync.Mutex
+	seen  map[common.Address]map[common.Address]badBidBlockSighting
+	clock func() time.Time
+}
+
+func newBadBidBlockTracker() *badBidBlockTracker {
+	return &badBidBlockTracker{
+		seen:  make(map[common.Address]map[common.Address]badBidBlockSighting),
+		clock: time.Now,
+	}
+}
+
+// add records a sighting and reports the cabinet and total votes still inside the
+// evidence window. Repeat sightings from one sealer refresh it without voting again.
+func (t *badBidBlockTracker) add(builder, sealer common.Address, cabinet bool) (cabinetVotes, totalVotes int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := t.clock()
+	sightings := t.seen[builder]
+	if sightings == nil {
+		sightings = make(map[common.Address]badBidBlockSighting)
+		t.seen[builder] = sightings
+	}
+	// cabinet is sticky, so a later sighting of a demoted sealer cannot lower the count.
+	previous := sightings[sealer]
+	sightings[sealer] = badBidBlockSighting{
+		at:      now,
+		cabinet: previous.cabinet || cabinet,
+	}
+
+	for addr, s := range sightings {
+		if now.Sub(s.at) >= badBidBlockEvidenceWindow {
+			delete(sightings, addr)
+			continue
+		}
+		totalVotes++
+		if s.cabinet {
+			cabinetVotes++
+		}
+	}
+	return cabinetVotes, totalVotes
+}
+
+// clear drops a revoked builder's evidence so the next lockout starts fresh.
+func (t *badBidBlockTracker) clear(builder common.Address) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.seen, builder)
+}

--- a/miner/bid_block_evidence_test.go
+++ b/miner/bid_block_evidence_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+
+package miner
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func testBuilder() common.Address { return common.HexToAddress("0xb0") }
+
+func sealerN(n int) common.Address {
+	return common.BigToAddress(big.NewInt(int64(n)))
+}
+
+func newTestTracker(now *time.Time) *badBidBlockTracker {
+	t := newBadBidBlockTracker()
+	t.clock = func() time.Time { return *now }
+	return t
+}
+
+func TestBadBidBlockTracker(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := newTestTracker(&now)
+	builder := testBuilder()
+
+	tracker.add(builder, sealerN(1), true)
+	tracker.add(builder, sealerN(1), true)
+	cabinet, total := tracker.add(builder, sealerN(2), false)
+	if cabinet != 1 || total != 2 {
+		t.Fatalf("got cabinet=%d total=%d, want 1/2", cabinet, total)
+	}
+
+	now = now.Add(badBidBlockEvidenceWindow + time.Second)
+	cabinet, total = tracker.add(builder, sealerN(3), false)
+	if cabinet != 0 || total != 1 {
+		t.Fatalf("stale sightings must be dropped: got cabinet=%d total=%d, want 0/1", cabinet, total)
+	}
+}

--- a/miner/bid_block_evidence_test.go
+++ b/miner/bid_block_evidence_test.go
@@ -41,3 +41,20 @@ func TestBadBidBlockTracker(t *testing.T) {
 		t.Fatalf("stale sightings must be dropped: got cabinet=%d total=%d, want 0/1", cabinet, total)
 	}
 }
+
+func TestMajorityThreshold(t *testing.T) {
+	tests := []struct {
+		validators int
+		want       int
+	}{
+		{validators: 21, want: 11},
+		{validators: 45, want: 23},
+		{validators: 3, want: 2},
+		{validators: 4, want: 3},
+	}
+	for _, test := range tests {
+		if got := majorityThreshold(test.validators); got != test.want {
+			t.Errorf("majorityThreshold(%d) = %d, want %d", test.validators, got, test.want)
+		}
+	}
+}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -59,6 +59,8 @@ const (
 
 	// chainHeadChanSize is the size of channel listening to ChainHeadEvent.
 	chainHeadChanSize = 10
+	// badBidBlockChanSize is the size of channel listening to BadBidBlockEvent.
+	badBidBlockChanSize = 10
 
 	// minRecommitInterval is the minimal time interval to recreate the sealing block with
 	// any newly arrived transactions.
@@ -87,6 +89,9 @@ var (
 	bidBlockVerifyFailedGauge = metrics.NewRegisteredGauge("worker/bidBlockVerifyFailed", nil)
 	// bidBlockRevokedBuildersGauge snapshots how many builders are revoked, taken at each revoke.
 	bidBlockRevokedBuildersGauge = metrics.NewRegisteredGauge("worker/bidBlockRevokedBuilders", nil)
+	// bidBlockEvidenceRevokeCounter counts revokes driven by other validators' bad
+	// BidBlocks rather than by this node's own InsertChain failure.
+	bidBlockEvidenceRevokeCounter = metrics.NewRegisteredCounter("worker/bidBlockEvidenceRevoke", nil)
 
 	writeBlockTimer      = metrics.NewRegisteredTimer("worker/writeblock", nil)
 	finalizeBlockTimer   = metrics.NewRegisteredTimer("worker/finalizeblock", nil)
@@ -225,9 +230,12 @@ type worker struct {
 	chain       *core.BlockChain
 
 	// Subscriptions
-	mux          *event.TypeMux
-	chainHeadCh  chan core.ChainHeadEvent
-	chainHeadSub event.Subscription
+	mux            *event.TypeMux
+	chainHeadCh    chan core.ChainHeadEvent
+	chainHeadSub   event.Subscription
+	badBidBlockCh  chan core.BadBidBlockEvent
+	badBidBlockSub event.Subscription
+	badBidBlocks   *badBidBlockTracker
 
 	// Channels
 	newWorkCh          chan *newWorkReq
@@ -289,6 +297,8 @@ func newWorker(config *minerconfig.Config, engine consensus.Engine, eth Backend,
 		tip:                uint256.MustFromBig(config.GasPrice),
 		pendingTasks:       make(map[common.Hash]*task),
 		chainHeadCh:        make(chan core.ChainHeadEvent, chainHeadChanSize),
+		badBidBlockCh:      make(chan core.BadBidBlockEvent, badBidBlockChanSize),
+		badBidBlocks:       newBadBidBlockTracker(),
 		newWorkCh:          make(chan *newWorkReq),
 		getWorkCh:          make(chan *getWorkReq),
 		taskCh:             make(chan *task),
@@ -313,6 +323,12 @@ func newWorker(config *minerconfig.Config, engine consensus.Engine, eth Backend,
 	go worker.newWorkLoop(recommit)
 	go worker.resultLoop()
 	go worker.taskLoop()
+
+	// Subscribed unconditionally: BidBlock acceptance depends on the Pasteur fork
+	// being active, which it need not be when the worker is built.
+	worker.badBidBlockSub = eth.BlockChain().SubscribeBadBidBlockEvent(worker.badBidBlockCh)
+	worker.wg.Add(1)
+	go worker.badBidBlockLoop()
 
 	return worker
 }


### PR DESCRIPTION
### Description

## Description

BEP-675 currently revokes a builder only after it has burned **this node's own** block slot: `handleBidBlockResult` revokes when the sealed BidBlock fails `InsertChain`. A builder shipping broken blocks — a code bug, not necessarily malice — therefore costs every validator one slot before each of them independently blacklists it. On a 45-validator set that is 45 wasted slots.

This PR lets a validator act on the failing blocks **other** validators already sealed, so it can revoke such a builder before its own turn comes. Local revoke stays as the backstop; this only moves the revoke earlier. A builder is revoked once its failing blocks have spread across enough distinct validators — evidence other validators produced, not just this node's own.

- **Evidence**: a block carrying the BEP-675 header tag that fails execution counts as one vote against its builder, attributed to the validator that sealed it.
- **One vote per `(builder, sealer)`**, expiring on a 24h sliding window.
- **Revoke at N/2+1 distinct cabinet validators, or N/2+1  distinct validators of any role** → 24h lockout, the same window local revoke uses. The builder falls back to `SendBid`, which is simBid-protected.
- **Cabinet vs. candidate** is decided by the sealer's index in the mining validator set at the bad block's parent; the rotating tail is conservatively counted as candidates, so cabinet votes are never over-counted.

Thresholds are fixed rather than proportional. On Chapel the 15-validator tier is simply unreachable and the 6-cabinet tier applies, so there is no chain-specific code path.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
