### PR TITLE
miner, core/types: include DelayLeftOver in MevParams

### DIFF
--- a/core/types/builder/bep-675-builder-integration.md
+++ b/core/types/builder/bep-675-builder-integration.md
@@ -167,8 +167,10 @@ The main BidBlock failure modes have dedicated JSON-RPC codes; match by code whe
 The BidBlock path skips validator-side simulation, so the receive deadline is:
 
 ```
-BidMustBefore = parent.MilliTimestamp + BlockInterval - DelayLeftOver  // 15ms
+BidMustBefore = parent.MilliTimestamp + BlockInterval - DelayLeftOver
 ```
+
+`DelayLeftOver` is the validator's `--miner.delayleftover` (default 15ms), exposed as `mev_params.DelayLeftOver`. Builders should read it from `mev_params` rather than assuming 15ms.
 
 As the validator still needs µs-level time for signature recovery, tx decoding, pre-seal verification, and `Extra` overwrite before sealing, arrivals **exactly at** `BidMustBefore` may still miss the seal. We recommend builders leave a buffer of ≈100µs–1ms before `BidMustBefore`.
 

--- a/core/types/builder/bid.go
+++ b/core/types/builder/bid.go
@@ -309,7 +309,8 @@ type MevParams struct {
 	ValidatorCommission   uint64 // 100 means 1%
 	BidSimulationLeftOver time.Duration
 	NoInterruptLeftOver   time.Duration
-	MaxBidsPerBuilder     uint32 // Maximum number of bids allowed per builder per block
+	DelayLeftOver         time.Duration // Time reserved to finalize a block; BidMustBefore = header.Time - DelayLeftOver
+	MaxBidsPerBuilder     uint32        // Maximum number of bids allowed per builder per block
 	GasCeil               uint64
 	GasPrice              *big.Int // Minimum avg gas price for bid block
 	BuilderFeeCeil        *big.Int

--- a/miner/miner_mev.go
+++ b/miner/miner_mev.go
@@ -264,6 +264,7 @@ func (miner *Miner) MevParams() *buildertypes.MevParams {
 		ValidatorCommission:   *miner.worker.config.Mev.ValidatorCommission,
 		BidSimulationLeftOver: *miner.worker.config.Mev.BidSimulationLeftOver,
 		NoInterruptLeftOver:   *miner.worker.config.Mev.NoInterruptLeftOver,
+		DelayLeftOver:         *miner.worker.config.DelayLeftOver,
 		MaxBidsPerBuilder:     *miner.worker.config.Mev.MaxBidsPerBuilder,
 		GasCeil:               miner.worker.config.GasCeil,
 		GasPrice:              miner.worker.config.GasPrice,


### PR DESCRIPTION
### Description

Expose `Miner.Config.DelayLeftOver` through `mev_params` so builders can compute the bid collection deadline per validator.

### Rationale

`mev_params` already returns `BidSimulationLeftOver` and `NoInterruptLeftOver` from `MevConfig`. Builders also need `DelayLeftOver` from `Miner.Config` (`--miner.delayleftover`, default 15ms) to calculate the hard receive deadline:

```
BidMustBefore = parent.MilliTimestamp + BlockInterval - DelayLeftOver
BidBetterBefore = BidMustBefore - BidSimulationLeftOver
```

Validators can change `DelayLeftOver`, so hardcoding 15ms is incorrect. This matches the original sentry docs: builders should obtain `delayLeftOver` and `bidSimulationLeftOver` from `mev_params`.

### Example

`mev_params` response (durations are nanoseconds, same as the existing leftover fields):

```json
{
  "ValidatorCommission": 100,
  "BidSimulationLeftOver": 20000000,
  "NoInterruptLeftOver": 135000000,
  "DelayLeftOver": 15000000,
  "MaxBidsPerBuilder": 2,
  "GasCeil": 55000000,
  "BidBlockEnabled": true
}
```

### Changes

* Add `DelayLeftOver` to `buildertypes.MevParams`
* Fill it from `miner.worker.config.DelayLeftOver` in `Miner.MevParams()`
* Document in the BEP-675 builder notes that this value comes from `mev_params` and must not be hardcoded