### PR TITLE
consensus/parlia: validate BlockAccessListHash and SlotNumber in header verification

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -663,6 +663,31 @@ func (p *Parlia) VerifyUnsealedHeader(chain consensus.ChainHeaderReader, header 
 		}
 	}
 
+	// BlockAccessListHash (EIP-7928) and SlotNumber (EIP-7843) are trailing
+	// rlp:"optional" fields that the block seal does not commit to. Before
+	// Amsterdam they must be absent: honest blocks never set them, so without
+	// this check an unprivileged peer could append a crafted value to a
+	// validator-signed block, changing its block hash while leaving the seal
+	// valid. From Amsterdam they are required; their content is then bound by
+	// state validation (BlockAccessListHash is recomputed from execution) and
+	// the slot rules, not by the seal.
+	amsterdam := chain.Config().IsAmsterdam(header.Number, header.Time)
+	if !amsterdam {
+		if header.BlockAccessListHash != nil {
+			return fmt.Errorf("invalid BlockAccessListHash, have %#x, expected nil", header.BlockAccessListHash)
+		}
+		if header.SlotNumber != nil {
+			return fmt.Errorf("invalid SlotNumber, have %d, expected nil", *header.SlotNumber)
+		}
+	} else {
+		if header.BlockAccessListHash == nil {
+			return errors.New("header has nil BlockAccessListHash after Amsterdam")
+		}
+		if header.SlotNumber == nil {
+			return errors.New("header has nil SlotNumber after Amsterdam")
+		}
+	}
+
 	// All basic checks passed, verify cascading fields
 	return p.verifyCascadingFields(chain, header, parents)
 }


### PR DESCRIPTION
### Description

Validate the two trailing `rlp:"optional"` header fields `BlockAccessListHash` (EIP-7928) and `SlotNumber` (EIP-7843) in Parlia's header verification, mirroring the existing fork-gated handling of `RequestsHash` and `ParentBeaconRoot`: they must be absent before Amsterdam and present from Amsterdam on.

### Rationale

These optional fields are covered by the block hash but not by the Parlia seal preimage (`EncodeSigHeader` stops after `RequestsHash`), and header verification previously did not check them at all. Because they are absent from honest blocks before Amsterdam, the missing check left a validator-signed block's hash malleable: the fields could be added without invalidating the seal, yielding a different block hash on an otherwise validly-sealed block. Adding the same nil/presence validation Parlia already applies to the other post-Prague optional fields closes that gap. From Amsterdam the fields are legitimately present, and their content is bound by state validation (`BlockAccessListHash` is recomputed from execution) and the slot rules rather than by the seal.

### Example

A pre-Amsterdam header carrying a non-nil `BlockAccessListHash` or `SlotNumber` is now rejected by `VerifyHeader` before seal verification, instead of being accepted.

### Changes

- `consensus/parlia`: in `VerifyUnsealedHeader` (on the `VerifyHeader` peer-import path and the bid pre-seal path), require `BlockAccessListHash` and `SlotNumber` to be nil before Amsterdam and non-nil from Amsterdam on.
