### PR TITLE
core/vm: let a memo transfer declare its payload's format (BEP-702)

### DIFF
--- a/core/systemcontracts/upgrade.go
+++ b/core/systemcontracts/upgrade.go
@@ -1119,6 +1119,19 @@ func TryUpdateBuildInSystemContract(config *params.ChainConfig, blockNumber *big
 			statedb.SetNonce(params.HistoryStorageAddress, 1, tracing.NonceChangeNewContract)
 			log.Info("Set code for HistoryStorageAddress", "blockNumber", blockNumber.Int64(), "blockTime", blockTime)
 		}
+		// The CAS20 registries are precompiles rather than upgradeable contracts, so
+		// their account sentinels are planted here instead of through an Upgrade
+		// config. Nothing else is written and no feature is opened; the activation
+		// admin is governance's to appoint afterwards.
+		//
+		// The sentinels are what make that appointment possible at all: GovHub
+		// refuses a proposal target carrying no code, so a registry without one
+		// could never receive its first parameter change — and GovHub reports the
+		// refusal in an event while leaving the proposal successful.
+		if config.IsOnJenner(blockNumber, lastBlockTime, blockTime) {
+			vm.SeedCAS20Activation(statedb)
+			log.Info("Planted CAS20 registry sentinels", "blockNumber", blockNumber.Int64(), "blockTime", blockTime)
+		}
 	} else {
 		if config.IsFeynman(blockNumber, lastBlockTime) {
 			upgradeBuildInSystemContract(config, blockNumber, lastBlockTime, blockTime, statedb)

--- a/core/systemcontracts/upgrade.go
+++ b/core/systemcontracts/upgrade.go
@@ -1119,15 +1119,8 @@ func TryUpdateBuildInSystemContract(config *params.ChainConfig, blockNumber *big
 			statedb.SetNonce(params.HistoryStorageAddress, 1, tracing.NonceChangeNewContract)
 			log.Info("Set code for HistoryStorageAddress", "blockNumber", blockNumber.Int64(), "blockTime", blockTime)
 		}
-		// The CAS20 registries are precompiles rather than upgradeable contracts, so
-		// their account sentinels are planted here instead of through an Upgrade
-		// config. Nothing else is written and no feature is opened; the activation
-		// admin is governance's to appoint afterwards.
-		//
-		// The sentinels are what make that appointment possible at all: GovHub
-		// refuses a proposal target carrying no code, so a registry without one
-		// could never receive its first parameter change — and GovHub reports the
-		// refusal in an event while leaving the proposal successful.
+		// The CAS20 registries are precompiles, not upgradeable contracts, so their
+		// sentinels are planted here rather than through an Upgrade config.
 		if config.IsOnJenner(blockNumber, lastBlockTime, blockTime) {
 			vm.SeedCAS20Activation(statedb)
 			log.Info("Planted CAS20 registry sentinels", "blockNumber", blockNumber.Int64(), "blockTime", blockTime)

--- a/core/systemcontracts/upgrade_test.go
+++ b/core/systemcontracts/upgrade_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -70,4 +71,79 @@ func TestUpgradeBuildInSystemContractNilValue(t *testing.T) {
 	GenesisHash = params.BSCGenesisHash
 
 	upgradeBuildInSystemContract(config, blockNumber, lastBlockTime, blockTime, statedb)
+}
+
+// TestCAS20SentinelsPlantedAtFork pins the boundary hook: the two registries get
+// their account sentinels on the block that crosses Jenner, and on no other. The
+// hook writes nothing else — the activation authority is a constant, so there is
+// no admin to seed.
+func TestCAS20SentinelsPlantedAtFork(t *testing.T) {
+	const forkTime = 1000
+	// The fork is timestamp-based but still requires London, which on BSC is at
+	// block 31302048 — a block number below it would make the predicate false for
+	// reasons that have nothing to do with the fork under test.
+	postLondon := big.NewInt(50_000_000)
+
+	newState := func() *state.StateDB {
+		statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return statedb
+	}
+	bscConfig := func() *params.ChainConfig {
+		cfg := *params.BSCChainConfig
+		ft := uint64(forkTime)
+		cfg.JennerTime = &ft
+		return &cfg
+	}
+	planted := func(statedb *state.StateDB) bool {
+		return len(statedb.GetCode(vm.CAS20ActivationRegistryAddress)) != 0 &&
+			len(statedb.GetCode(vm.CAS20PolicyRegistryAddress)) != 0
+	}
+
+	// A chain whose genesis is already Jenner-active. Nothing about it ever
+	// crosses the fork, so block 1 has to stand in for the boundary: without it
+	// the registries keep no code, GovHub refuses them as a proposal target, and
+	// the activation admin can never be appointed.
+	bornActive := func() *params.ChainConfig {
+		cfg := *params.BSCChainConfig
+		zero := uint64(0)
+		cfg.JennerTime = &zero
+		cfg.LondonBlock = big.NewInt(0)
+		return &cfg
+	}
+
+	for _, tc := range []struct {
+		name                     string
+		cfg                      *params.ChainConfig
+		number                   *big.Int
+		lastBlockTime, blockTime uint64
+		atBlockBegin             bool
+		want                     bool
+	}{
+		{"the block crossing the fork", bscConfig(), postLondon, forkTime - 1, forkTime, true, true},
+		{"wholly before the fork", bscConfig(), postLondon, forkTime - 2, forkTime - 1, true, false},
+		{"wholly after the boundary", bscConfig(), postLondon, forkTime + 1, forkTime + 2, true, false},
+		{"the block-end pass", bscConfig(), postLondon, forkTime - 1, forkTime, false, false},
+
+		{"block 1 of a chain born active", bornActive(), big.NewInt(1), 100, 200, true, true},
+		{"block 2 of a chain born active", bornActive(), big.NewInt(2), 200, 300, true, false},
+		{"block 1 before the fork is scheduled", bscConfig(), big.NewInt(1), 1, 2, true, false},
+	} {
+		statedb := newState()
+		TryUpdateBuildInSystemContract(tc.cfg, tc.number, tc.lastBlockTime, tc.blockTime, statedb, tc.atBlockBegin)
+		if got := planted(statedb); got != tc.want {
+			t.Errorf("%s: sentinels planted = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+
+	// Planting is BSC-only: a non-Parlia chain gets nothing even at the boundary.
+	statedb := newState()
+	nonBSC := *bscConfig()
+	nonBSC.Parlia = nil
+	TryUpdateBuildInSystemContract(&nonBSC, postLondon, forkTime-1, forkTime, statedb, true)
+	if planted(statedb) {
+		t.Error("a non-BSC chain had sentinels planted")
+	}
 }

--- a/core/systemcontracts/upgrade_test.go
+++ b/core/systemcontracts/upgrade_test.go
@@ -75,6 +75,14 @@ func TestUpgradeBuildInSystemContractNilValue(t *testing.T) {
 
 // TestCAS20SentinelsPlantedAtFork pins the boundary hook: the two registries get
 // their account sentinels on the block that crosses Jenner, and on no other.
+// The constant is duplicated because this package imports core/vm; a drift would
+// silently move the ActivationRegistry's governance root.
+func TestCAS20GovHubAddressMatchesTheSystemContract(t *testing.T) {
+	if params.CAS20GovHubAddress != common.HexToAddress(GovHubContract) {
+		t.Fatalf("params.CAS20GovHubAddress = %s, GovHubContract = %s", params.CAS20GovHubAddress, GovHubContract)
+	}
+}
+
 func TestCAS20SentinelsPlantedAtFork(t *testing.T) {
 	const forkTime = 1000
 	// The fork is timestamp-based but still requires London, which on BSC is at

--- a/core/systemcontracts/upgrade_test.go
+++ b/core/systemcontracts/upgrade_test.go
@@ -74,9 +74,7 @@ func TestUpgradeBuildInSystemContractNilValue(t *testing.T) {
 }
 
 // TestCAS20SentinelsPlantedAtFork pins the boundary hook: the two registries get
-// their account sentinels on the block that crosses Jenner, and on no other. The
-// hook writes nothing else — the activation authority is a constant, so there is
-// no admin to seed.
+// their account sentinels on the block that crosses Jenner, and on no other.
 func TestCAS20SentinelsPlantedAtFork(t *testing.T) {
 	const forkTime = 1000
 	// The fork is timestamp-based but still requires London, which on BSC is at
@@ -102,10 +100,12 @@ func TestCAS20SentinelsPlantedAtFork(t *testing.T) {
 			len(statedb.GetCode(vm.CAS20PolicyRegistryAddress)) != 0
 	}
 
-	// A chain whose genesis is already Jenner-active. Nothing about it ever
-	// crosses the fork, so block 1 has to stand in for the boundary: without it
-	// the registries keep no code, GovHub refuses them as a proposal target, and
-	// the activation admin can never be appointed.
+	// Born Jenner-active: nothing ever crosses the fork, so block 1 stands in (IsOnJenner).
+	nonBSC := func() *params.ChainConfig {
+		cfg := *bscConfig()
+		cfg.Parlia = nil
+		return &cfg
+	}
 	bornActive := func() *params.ChainConfig {
 		cfg := *params.BSCChainConfig
 		zero := uint64(0)
@@ -130,20 +130,12 @@ func TestCAS20SentinelsPlantedAtFork(t *testing.T) {
 		{"block 1 of a chain born active", bornActive(), big.NewInt(1), 100, 200, true, true},
 		{"block 2 of a chain born active", bornActive(), big.NewInt(2), 200, 300, true, false},
 		{"block 1 before the fork is scheduled", bscConfig(), big.NewInt(1), 1, 2, true, false},
+		{"a non-BSC chain at the boundary", nonBSC(), postLondon, forkTime - 1, forkTime, true, false},
 	} {
 		statedb := newState()
 		TryUpdateBuildInSystemContract(tc.cfg, tc.number, tc.lastBlockTime, tc.blockTime, statedb, tc.atBlockBegin)
 		if got := planted(statedb); got != tc.want {
 			t.Errorf("%s: sentinels planted = %v, want %v", tc.name, got, tc.want)
 		}
-	}
-
-	// Planting is BSC-only: a non-Parlia chain gets nothing even at the boundary.
-	statedb := newState()
-	nonBSC := *bscConfig()
-	nonBSC.Parlia = nil
-	TryUpdateBuildInSystemContract(&nonBSC, postLondon, forkTime-1, forkTime, statedb, true)
-	if planted(statedb) {
-		t.Error("a non-BSC chain had sentinels planted")
 	}
 }

--- a/core/systemcontracts/upgrade_test.go
+++ b/core/systemcontracts/upgrade_test.go
@@ -105,7 +105,8 @@ func TestCAS20SentinelsPlantedAtFork(t *testing.T) {
 	}
 	planted := func(statedb *state.StateDB) bool {
 		return len(statedb.GetCode(vm.CAS20ActivationRegistryAddress)) != 0 &&
-			len(statedb.GetCode(vm.CAS20PolicyRegistryAddress)) != 0
+			len(statedb.GetCode(vm.CAS20PolicyRegistryAddress)) != 0 &&
+			len(statedb.GetCode(vm.CAS20MemoFormatRegistryAddress)) != 0
 	}
 
 	// Born Jenner-active: nothing ever crosses the fork, so the sentinels have to

--- a/core/systemcontracts/upgrade_test.go
+++ b/core/systemcontracts/upgrade_test.go
@@ -100,7 +100,8 @@ func TestCAS20SentinelsPlantedAtFork(t *testing.T) {
 			len(statedb.GetCode(vm.CAS20PolicyRegistryAddress)) != 0
 	}
 
-	// Born Jenner-active: nothing ever crosses the fork, so block 1 stands in (IsOnJenner).
+	// Born Jenner-active: nothing ever crosses the fork, so the sentinels have to
+	// come from the genesis alloc.
 	nonBSC := func() *params.ChainConfig {
 		cfg := *bscConfig()
 		cfg.Parlia = nil
@@ -127,7 +128,7 @@ func TestCAS20SentinelsPlantedAtFork(t *testing.T) {
 		{"wholly after the boundary", bscConfig(), postLondon, forkTime + 1, forkTime + 2, true, false},
 		{"the block-end pass", bscConfig(), postLondon, forkTime - 1, forkTime, false, false},
 
-		{"block 1 of a chain born active", bornActive(), big.NewInt(1), 100, 200, true, true},
+		{"block 1 of a chain born active", bornActive(), big.NewInt(1), 100, 200, true, false},
 		{"block 2 of a chain born active", bornActive(), big.NewInt(2), 200, 300, true, false},
 		{"block 1 before the fork is scheduled", bscConfig(), big.NewInt(1), 1, 2, true, false},
 		{"a non-BSC chain at the boundary", nonBSC(), postLondon, forkTime - 1, forkTime, true, false},

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -278,6 +278,12 @@ type (
 	// StorageChangeHook is called when the storage of an account changes.
 	StorageChangeHook = func(addr common.Address, slot common.Hash, prev, new common.Hash)
 
+	// StorageReadHook is called when native code reads a storage slot outside the
+	// interpreter, where no SLOAD or SSTORE opcode announces the access. Stateful
+	// precompiles emit it for every slot they read or are about to write, so a
+	// tracer that discovers storage through opcodes sees the same slots.
+	StorageReadHook = func(addr common.Address, slot common.Hash)
+
 	// LogHook is called when a log is emitted.
 	LogHook = func(log *types.Log)
 
@@ -317,6 +323,7 @@ type Hooks struct {
 	OnCodeChange    CodeChangeHook
 	OnCodeChangeV2  CodeChangeHookV2
 	OnStorageChange StorageChangeHook
+	OnStorageRead   StorageReadHook
 	OnLog           LogHook
 	// Block hash read
 	OnBlockHashRead BlockHashReadHook

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -284,6 +284,11 @@ type (
 	// tracer that discovers storage through opcodes sees the same slots.
 	StorageReadHook = func(addr common.Address, slot common.Hash)
 
+	// AccountReadHook is called when native code reads an account — its code hash,
+	// balance or nonce — outside the interpreter, where no opcode announces it.
+	// Emitted before the read, so a tracer captures the account as it was.
+	AccountReadHook = func(addr common.Address)
+
 	// LogHook is called when a log is emitted.
 	LogHook = func(log *types.Log)
 
@@ -324,6 +329,7 @@ type Hooks struct {
 	OnCodeChangeV2  CodeChangeHookV2
 	OnStorageChange StorageChangeHook
 	OnStorageRead   StorageReadHook
+	OnAccountRead   AccountReadHook
 	OnLog           LogHook
 	// Block hash read
 	OnBlockHashRead BlockHashReadHook

--- a/core/vm/cas20.go
+++ b/core/vm/cas20.go
@@ -1,0 +1,258 @@
+package vm
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// CAS20 native token family. The factory, the two variants and the registries are
+// native precompiles; a token deploys no executable bytecode, only the one-byte
+// sentinel. It is identified by its address, routed by the address prefix, and
+// isolated by the state stored under that address (BEP-702 §3.3).
+var cas20MarkerPrefix = [2]byte{0xca, 0x50}
+
+const (
+	cas20VariantAsset      = 0x00
+	cas20VariantStablecoin = 0x01
+
+	// cas20VariantMax is the highest ordinal the variant enum defines. A word above
+	// it is outside the enum, which is a different failure from a word inside it
+	// that no handler claims — see createCAS20.
+	cas20VariantMax = cas20VariantStablecoin
+)
+
+// The three singletons (BEP-702 §3.1). The factory's second byte is 0x5F where
+// the token space pins 0x50, so IsCAS20Address matches no singleton.
+// CAS20PolicyRegistryAddress is declared in cas20_policy.go.
+var (
+	CAS20FactoryAddress            = common.HexToAddress("0xCA5F000000000000000000000000000000000000")
+	CAS20ActivationRegistryAddress = common.HexToAddress("0x7020000000000000000000000000000000000001")
+)
+
+var (
+	// ErrCAS20DelegateCall is returned when a token precompile is reached via a
+	// non-direct call (DELEGATECALL/CALLCODE), where Self could not be trusted
+	// as the storage root.
+	ErrCAS20DelegateCall = errors.New("cas20: delegate call not allowed")
+
+	// ErrCAS20StatelessDispatch guards the plain Run path: CAS20 precompiles must be
+	// reached through runPrecompile's stateful route. cas20Precompile makes this
+	// unreachable; it stays as a backstop.
+	ErrCAS20StatelessDispatch = errors.New("cas20: stateful precompile invoked without state")
+)
+
+// IsCAS20Address reports whether addr falls in the reserved CAS20 token space:
+// byte[0:2] == 0xCA50 and byte[2:10] all zero. The variant byte is deliberately
+// not inspected, so a future variant's addresses still read as CAS20, matching the
+// spec's isCAS20 rule.
+func IsCAS20Address(addr common.Address) bool {
+	if addr[0] != cas20MarkerPrefix[0] || addr[1] != cas20MarkerPrefix[1] {
+		return false
+	}
+	for i := 2; i < 10; i++ {
+		if addr[i] != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// cas20MarkerCodeHash is keccak256(0xEF), the code hash of the factory's sentinel.
+// EIP-3541 makes 0xEF-prefixed code undeployable, so nothing an attacker installs
+// can hash to it (BEP-702 3.3).
+var cas20MarkerCodeHash = crypto.Keccak256Hash(CAS20MarkerCode)
+
+// cas20InitializedMetered reports whether a CAS20 token exists at addr, charged as an
+// account access. Exact-hash, not non-empty: foreign code is not a token.
+func cas20InitializedMetered(ctx *PrecompileContext, addr common.Address) bool {
+	if !ctx.chargeAccountAccess(addr) {
+		return false
+	}
+	return ctx.StateDB.GetCodeHash(addr) == cas20MarkerCodeHash
+}
+
+// cas20AddressOccupied reports whether a derived address is already taken, by a
+// token or by anything else. createCAS20 must reject on any code, not only on
+// the sentinel: overwriting foreign code would destroy it (BEP-702 3.4).
+func cas20AddressOccupied(ctx *PrecompileContext, addr common.Address) bool {
+	if !ctx.chargeAccountAccess(addr) {
+		// Reported occupied: the caller refuses on true, which is the safe answer
+		// when the frame can no longer pay to find out.
+		return true
+	}
+	return !hadNoCode(ctx.StateDB, addr)
+}
+
+// hadNoCode reports whether addr carries no code at all — the condition under
+// which writing code owes the account-creation cost.
+func hadNoCode(state StateDB, addr common.Address) bool {
+	ch := state.GetCodeHash(addr)
+	return ch == (common.Hash{}) || ch == types.EmptyCodeHash
+}
+
+// ensureSentinel keeps a registry's storage out of reach of EIP-161 clearing. It
+// plants the marker only on an account with no code at all (BEP-702 3.16).
+func (ctx *PrecompileContext) ensureSentinel() {
+	if !ctx.chargeAccountAccess(ctx.Self) {
+		return
+	}
+	if !hadNoCode(ctx.StateDB, ctx.Self) {
+		return
+	}
+	if !ctx.chargeCodeWrite(ctx.Self, CAS20MarkerCode) {
+		return
+	}
+	ctx.StateDB.SetCode(ctx.Self, CAS20MarkerCode, tracing.CodeChangeContractCreation)
+}
+
+// cas20EnterCall applies the guards every CAS20 entry point shares: direct calls
+// only, nonpayable, and calldata charged once (BEP-702 3.14). The value check
+// precedes the charge, so a value-bearing call consumes no gas.
+func cas20EnterCall(ctx *PrecompileContext, input []byte) error {
+	if !ctx.DirectCall {
+		return ErrCAS20DelegateCall
+	}
+	if ctx.Value != nil && !ctx.Value.IsZero() {
+		return revCAS20("NonPayable()", errSelNonPayable)
+	}
+	// Fail here rather than at the exit. RequiredGas is zero, so the interpreter
+	// charges nothing before the handler runs, and a caller that cannot even
+	// afford the calldata charge would otherwise still get the whole handler's
+	// native work — decoding, trie reads, keccak, permit's ecrecover — for the
+	// cost of a warm CALL, repeatable in a loop against already-expanded memory.
+	// Every later charge is bounded by what this one proves the caller can pay.
+	if !ctx.chargeCalldata(input) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// cas20Precompile is both host interfaces at once. They are independent, and only
+// PrecompiledContract is enforced by flowing through evm.precompile: runPrecompile
+// reaches RunStateful by runtime type assertion, so a precompile missing it would
+// build and then answer every call with ErrCAS20StatelessDispatch. The resolvers
+// return this type so the compiler catches that instead.
+type cas20Precompile interface {
+	PrecompiledContract
+	StatefulPrecompiledContract
+}
+
+// resolveCAS20Token routes a recognized variant without checking existence, so a
+// value-bearing call to an empty CAS20 address is refused rather than stranded. An
+// unrecognized variant is not routed at all (BEP-702 3.3).
+func resolveCAS20Token(addr common.Address) (cas20Precompile, bool) {
+	v, ok := cas20Variants[addr[10]]
+	return v.precompile, ok
+}
+
+// cas20Variants is the variant table. One entry per ordinal, so the handler an
+// address routes to and the feature that gates it cannot disagree — they used to
+// be three separate switches with a test holding two of them together.
+var cas20Variants = map[byte]struct {
+	precompile cas20Precompile
+	feature    common.Hash
+}{
+	cas20VariantAsset:      {cas20Asset, featureCAS20Asset},
+	cas20VariantStablecoin: {cas20Stablecoin, featureCAS20Stablecoin},
+}
+
+// resolveCAS20 decides whether an address is a CAS20 precompile — a singleton or a
+// dynamic token — and returns the bound instance. Fork gating is the caller's.
+func resolveCAS20(addr common.Address) (cas20Precompile, bool) {
+	switch addr {
+	case CAS20FactoryAddress:
+		return cas20Factory, true
+	case CAS20PolicyRegistryAddress:
+		return cas20Policy, true
+	case CAS20ActivationRegistryAddress:
+		return cas20Activation, true
+	}
+	if IsCAS20Address(addr) {
+		return resolveCAS20Token(addr)
+	}
+	return nil, false
+}
+
+var (
+	cas20Factory    = &cas20FactoryPrecompile{}
+	cas20Policy     = &cas20PolicyPrecompile{}
+	cas20Activation = &cas20ActivationPrecompile{}
+	cas20Asset      = &cas20AssetPrecompile{}
+	cas20Stablecoin = &cas20StablecoinPrecompile{}
+)
+
+type cas20StatefulBase struct{}
+
+func (cas20StatefulBase) Run([]byte) ([]byte, error) { return nil, ErrCAS20StatelessDispatch }
+
+// RequiredGas is zero for every CAS20 precompile: the cost depends on state not yet
+// read — whether a slot is cold, whether a write creates or rewrites — so all
+// metering happens inside RunStateful as the work is performed (BEP-702 3.14, see
+// cas20_gas.go).
+func (cas20StatefulBase) RequiredGas([]byte) uint64 { return 0 }
+
+type cas20FactoryPrecompile struct{ cas20StatefulBase }
+
+func (p *cas20FactoryPrecompile) Name() string { return "CAS20Factory" }
+
+func (p *cas20FactoryPrecompile) RunStateful(ctx *PrecompileContext, input []byte) ([]byte, error) {
+	if err := cas20EnterCall(ctx, input); err != nil {
+		return finishCAS20(nil, err)
+	}
+	ret, err := runCAS20Factory(ctx, input)
+	return finishCAS20Metered(ctx, ret, err)
+}
+
+// cas20AssetPrecompile is the Asset (RWA) variant. Stateless: the token it acts on
+// comes from ctx.Self, so one value serves every Asset address.
+type cas20AssetPrecompile struct{ cas20StatefulBase }
+
+func (p *cas20AssetPrecompile) Name() string { return "CAS20Asset" }
+
+func (p *cas20AssetPrecompile) RunStateful(ctx *PrecompileContext, input []byte) ([]byte, error) {
+	return runCAS20Token(ctx, input, bindAsset)
+}
+
+// bindAsset binds the Asset variant's token and extension. The extension
+// intercepts decimals, so the shared token's field is unused here.
+func bindAsset(ctx *PrecompileContext, input []byte) ([]byte, error) {
+	return assetDispatch(newCAS20Token(ctx, 0), newAssetExt(ctx), input)
+}
+
+// cas20StablecoinPrecompile is the Stablecoin variant, stateless for the same reason.
+type cas20StablecoinPrecompile struct{ cas20StatefulBase }
+
+func (p *cas20StablecoinPrecompile) Name() string { return "CAS20Stablecoin" }
+
+func (p *cas20StablecoinPrecompile) RunStateful(ctx *PrecompileContext, input []byte) ([]byte, error) {
+	return runCAS20Token(ctx, input, bindStablecoin)
+}
+
+// bindStablecoin binds the Stablecoin variant's token and extension. Its decimals
+// are fixed at 6 (BEP-702 3.13).
+func bindStablecoin(ctx *PrecompileContext, input []byte) ([]byte, error) {
+	return stablecoinDispatch(newCAS20Token(ctx, 6), newStablecoinExt(ctx), input)
+}
+
+// runCAS20Token is the sequence both variants share: entry guards, existence check,
+// then the variant's binding behind the metered exit. The order is observable
+// through the error a caller gets, so it lives in one place. bind is a top-level
+// function value, not a closure, so the split allocates nothing.
+func runCAS20Token(ctx *PrecompileContext, input []byte,
+	bind func(*PrecompileContext, []byte) ([]byte, error),
+) ([]byte, error) {
+	if err := cas20EnterCall(ctx, input); err != nil {
+		return finishCAS20(nil, err)
+	}
+	if !cas20InitializedMetered(ctx, ctx.Self) {
+		// Metered exit: if the check's own charge exhausted the budget, this is
+		// out of gas rather than a revert.
+		return finishCAS20Metered(ctx, nil, ErrExecutionReverted)
+	}
+	ret, err := bind(ctx, input)
+	return finishCAS20Metered(ctx, ret, err)
+}

--- a/core/vm/cas20.go
+++ b/core/vm/cas20.go
@@ -24,9 +24,7 @@ var (
 )
 
 var (
-	// ErrCAS20DelegateCall is returned when a token precompile is reached via a
-	// non-direct call (DELEGATECALL/CALLCODE), where Self could not be trusted
-	// as the storage root.
+	// Refused because under delegation Self no longer names the storage owner.
 	ErrCAS20DelegateCall = errors.New("cas20: delegate call not allowed")
 
 	// ErrCAS20StatelessDispatch guards the plain Run path: CAS20 precompiles must be

--- a/core/vm/cas20.go
+++ b/core/vm/cas20.go
@@ -9,25 +9,15 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// CAS20 native token family. The factory, the two variants and the registries are
-// native precompiles; a token deploys no executable bytecode, only the one-byte
-// sentinel. It is identified by its address, routed by the address prefix, and
-// isolated by the state stored under that address (BEP-702 §3.3).
-var cas20MarkerPrefix = [2]byte{0xca, 0x50}
+// cas20MarkerPrefix opens every CAS20 token address.
+var cas20MarkerPrefix = [2]byte{0xca, 0x52}
 
 const (
 	cas20VariantAsset      = 0x00
 	cas20VariantStablecoin = 0x01
-
-	// cas20VariantMax is the highest ordinal the variant enum defines. A word above
-	// it is outside the enum, which is a different failure from a word inside it
-	// that no handler claims — see createCAS20.
-	cas20VariantMax = cas20VariantStablecoin
+	cas20VariantMax        = cas20VariantStablecoin
 )
 
-// The three singletons (BEP-702 §3.1). The factory's second byte is 0x5F where
-// the token space pins 0x50, so IsCAS20Address matches no singleton.
-// CAS20PolicyRegistryAddress is declared in cas20_policy.go.
 var (
 	CAS20FactoryAddress            = common.HexToAddress("0xCA5F000000000000000000000000000000000000")
 	CAS20ActivationRegistryAddress = common.HexToAddress("0x7020000000000000000000000000000000000001")
@@ -46,7 +36,7 @@ var (
 )
 
 // IsCAS20Address reports whether addr falls in the reserved CAS20 token space:
-// byte[0:2] == 0xCA50 and byte[2:10] all zero. The variant byte is deliberately
+// byte[0:2] == 0xCA52 and byte[2:10] all zero. The variant byte is deliberately
 // not inspected, so a future variant's addresses still read as CAS20, matching the
 // spec's isCAS20 rule.
 func IsCAS20Address(addr common.Address) bool {

--- a/core/vm/cas20.go
+++ b/core/vm/cas20.go
@@ -23,19 +23,11 @@ var (
 )
 
 var (
-	// Refused because under delegation Self no longer names the storage owner.
-	ErrCAS20DelegateCall = errors.New("cas20: delegate call not allowed")
-
-	// ErrCAS20StatelessDispatch guards the plain Run path: CAS20 precompiles must be
-	// reached through runPrecompile's stateful route. cas20Precompile makes this
-	// unreachable; it stays as a backstop.
+	ErrCAS20DelegateCall      = errors.New("cas20: delegate call not allowed")
 	ErrCAS20StatelessDispatch = errors.New("cas20: stateful precompile invoked without state")
 )
 
-// IsCAS20Address reports whether addr falls in the reserved CAS20 token space:
-// byte[0:2] == 0xCA52 and byte[2:10] all zero. The variant byte is deliberately
-// not inspected, so a future variant's addresses still read as CAS20, matching the
-// spec's isCAS20 rule.
+// IsCAS20Address: byte[0:2] == 0xCA52 and byte[2:10] all zero.
 func IsCAS20Address(addr common.Address) bool {
 	if addr[0] != cas20MarkerPrefix[0] || addr[1] != cas20MarkerPrefix[1] {
 		return false
@@ -48,13 +40,9 @@ func IsCAS20Address(addr common.Address) bool {
 	return true
 }
 
-// cas20MarkerCodeHash is keccak256(0xEF), the code hash of the factory's sentinel.
-// EIP-3541 makes 0xEF-prefixed code undeployable, so nothing an attacker installs
-// can hash to it (BEP-702 3.3).
 var cas20MarkerCodeHash = crypto.Keccak256Hash(CAS20MarkerCode)
 
-// cas20InitializedMetered reports whether a CAS20 token exists at addr, charged as an
-// account access. Exact-hash, not non-empty: foreign code is not a token.
+// Exact-hash, not non-empty: foreign code is not a token.
 func cas20InitializedMetered(ctx *PrecompileContext, addr common.Address) bool {
 	if !ctx.chargeAccountAccess(addr) {
 		return false
@@ -62,28 +50,23 @@ func cas20InitializedMetered(ctx *PrecompileContext, addr common.Address) bool {
 	return ctx.StateDB.GetCodeHash(addr) == cas20MarkerCodeHash
 }
 
-// cas20AddressOccupied reports whether a derived address is already taken, by a
-// token or by anything else. createCAS20 must reject on any code, not only on
-// the sentinel: overwriting foreign code would destroy it (BEP-702 3.4).
+// Any code counts, not just the sentinel: overwriting foreign code would destroy it.
 func cas20AddressOccupied(ctx *PrecompileContext, addr common.Address) bool {
 	if !ctx.chargeAccountAccess(addr) {
-		// Reported occupied: the caller refuses on true, which is the safe answer
-		// when the frame can no longer pay to find out.
+		// True is the safe answer when the frame can no longer pay to find out.
 		return true
 	}
 	return !hadNoCode(ctx.StateDB, addr)
 }
 
-// hadNoCode reports whether addr carries no code at all — the condition under
-// which writing code owes the account-creation cost.
+// No code at all is the condition under which writing code owes the
+// account-creation cost.
 func hadNoCode(state StateDB, addr common.Address) bool {
 	ch := state.GetCodeHash(addr)
 	return ch == (common.Hash{}) || ch == types.EmptyCodeHash
 }
 
-// cas20EnterCall applies the guards every CAS20 entry point shares: direct calls
-// only, nonpayable, and calldata charged once (BEP-702 3.14). The value check
-// precedes the charge, so a value-bearing call consumes no gas.
+// cas20EnterCall is the prologue every CAS20 entry point runs.
 func cas20EnterCall(ctx *PrecompileContext, input []byte) error {
 	if !ctx.DirectCall {
 		return ErrCAS20DelegateCall
@@ -91,39 +74,23 @@ func cas20EnterCall(ctx *PrecompileContext, input []byte) error {
 	if ctx.Value != nil && !ctx.Value.IsZero() {
 		return revCAS20("NonPayable()", errSelNonPayable)
 	}
-	// Fail here rather than at the exit. RequiredGas is zero, so the interpreter
-	// charges nothing before the handler runs, and a caller that cannot even
-	// afford the calldata charge would otherwise still get the whole handler's
-	// native work — decoding, trie reads, keccak, permit's ecrecover — for the
-	// cost of a warm CALL, repeatable in a loop against already-expanded memory.
-	// Every later charge is bounded by what this one proves the caller can pay.
 	if !ctx.chargeCalldata(input) {
 		return ErrOutOfGas
 	}
 	return nil
 }
 
-// cas20Precompile is both host interfaces at once. They are independent, and only
-// PrecompiledContract is enforced by flowing through evm.precompile: runPrecompile
-// reaches RunStateful by runtime type assertion, so a precompile missing it would
-// build and then answer every call with ErrCAS20StatelessDispatch. The resolvers
-// return this type so the compiler catches that instead.
 type cas20Precompile interface {
 	PrecompiledContract
 	StatefulPrecompiledContract
 }
 
-// resolveCAS20Token routes a recognized variant without checking existence, so a
-// value-bearing call to an empty CAS20 address is refused rather than stranded. An
-// unrecognized variant is not routed at all (BEP-702 3.3).
 func resolveCAS20Token(addr common.Address) (cas20Precompile, bool) {
 	v, ok := cas20Variants[addr[10]]
 	return v.precompile, ok
 }
 
-// cas20Variants is the variant table. One entry per ordinal, so the handler an
-// address routes to and the feature that gates it cannot disagree — they used to
-// be three separate switches with a test holding two of them together.
+// One entry per ordinal, so routing and feature gating cannot disagree.
 var cas20Variants = map[byte]struct {
 	precompile cas20Precompile
 	feature    common.Hash
@@ -132,8 +99,7 @@ var cas20Variants = map[byte]struct {
 	cas20VariantStablecoin: {cas20Stablecoin, featureCAS20Stablecoin},
 }
 
-// resolveCAS20 decides whether an address is a CAS20 precompile — a singleton or a
-// dynamic token — and returns the bound instance. Fork gating is the caller's.
+// resolveCAS20 leaves fork gating to the caller.
 func resolveCAS20(addr common.Address) (cas20Precompile, bool) {
 	switch addr {
 	case CAS20FactoryAddress:
@@ -161,10 +127,7 @@ type cas20StatefulBase struct{}
 
 func (cas20StatefulBase) Run([]byte) ([]byte, error) { return nil, ErrCAS20StatelessDispatch }
 
-// RequiredGas is zero for every CAS20 precompile: the cost depends on state not yet
-// read — whether a slot is cold, whether a write creates or rewrites — so all
-// metering happens inside RunStateful as the work is performed (BEP-702 3.14, see
-// cas20_gas.go).
+// RequiredGas : so all metering happens inside RunStateful.
 func (cas20StatefulBase) RequiredGas([]byte) uint64 { return 0 }
 
 type cas20FactoryPrecompile struct{ cas20StatefulBase }
@@ -179,8 +142,7 @@ func (p *cas20FactoryPrecompile) RunStateful(ctx *PrecompileContext, input []byt
 	return finishCAS20Metered(ctx, ret, err)
 }
 
-// cas20AssetPrecompile is the Asset (RWA) variant. Stateless: the token it acts on
-// comes from ctx.Self, so one value serves every Asset address.
+// Stateless: the token is ctx.Self, so one value serves every Asset address.
 type cas20AssetPrecompile struct{ cas20StatefulBase }
 
 func (p *cas20AssetPrecompile) Name() string { return "CAS20Asset" }
@@ -189,13 +151,10 @@ func (p *cas20AssetPrecompile) RunStateful(ctx *PrecompileContext, input []byte)
 	return runCAS20Token(ctx, input, bindAsset)
 }
 
-// bindAsset binds the Asset variant's token and extension. The extension
-// intercepts decimals, so the shared token's field is unused here.
 func bindAsset(ctx *PrecompileContext, input []byte) ([]byte, error) {
 	return assetDispatch(newCAS20Token(ctx, 0), newAssetExt(ctx), input)
 }
 
-// cas20StablecoinPrecompile is the Stablecoin variant, stateless for the same reason.
 type cas20StablecoinPrecompile struct{ cas20StatefulBase }
 
 func (p *cas20StablecoinPrecompile) Name() string { return "CAS20Stablecoin" }
@@ -204,16 +163,10 @@ func (p *cas20StablecoinPrecompile) RunStateful(ctx *PrecompileContext, input []
 	return runCAS20Token(ctx, input, bindStablecoin)
 }
 
-// bindStablecoin binds the Stablecoin variant's token and extension. Its decimals
-// are fixed at 6 (BEP-702 3.13).
 func bindStablecoin(ctx *PrecompileContext, input []byte) ([]byte, error) {
 	return stablecoinDispatch(newCAS20Token(ctx, 6), newStablecoinExt(ctx), input)
 }
 
-// runCAS20Token is the sequence both variants share: entry guards, existence check,
-// then the variant's binding behind the metered exit. The order is observable
-// through the error a caller gets, so it lives in one place. bind is a top-level
-// function value, not a closure, so the split allocates nothing.
 func runCAS20Token(ctx *PrecompileContext, input []byte,
 	bind func(*PrecompileContext, []byte) ([]byte, error),
 ) ([]byte, error) {
@@ -221,8 +174,6 @@ func runCAS20Token(ctx *PrecompileContext, input []byte,
 		return finishCAS20(nil, err)
 	}
 	if !cas20InitializedMetered(ctx, ctx.Self) {
-		// Metered exit: if the check's own charge exhausted the budget, this is
-		// out of gas rather than a revert.
 		return finishCAS20Metered(ctx, nil, ErrExecutionReverted)
 	}
 	ret, err := bind(ctx, input)

--- a/core/vm/cas20.go
+++ b/core/vm/cas20.go
@@ -32,7 +32,8 @@ var (
 // Jenner is active: the token space and the three singletons.
 func IsCAS20Routed(addr common.Address) bool {
 	return IsCAS20Address(addr) || addr == CAS20FactoryAddress ||
-		addr == CAS20PolicyRegistryAddress || addr == CAS20ActivationRegistryAddress
+		addr == CAS20PolicyRegistryAddress || addr == CAS20ActivationRegistryAddress ||
+		addr == CAS20MemoFormatRegistryAddress
 }
 
 // DisabledPrecompile, placed in an EVM's precompile map, makes dispatch treat the
@@ -127,6 +128,8 @@ func resolveCAS20(addr common.Address) (cas20Precompile, bool) {
 		return cas20Policy, true
 	case CAS20ActivationRegistryAddress:
 		return cas20Activation, true
+	case CAS20MemoFormatRegistryAddress:
+		return cas20Memo, true
 	}
 	if IsCAS20Address(addr) {
 		return resolveCAS20Token(addr)
@@ -138,6 +141,7 @@ var (
 	cas20Factory    = &cas20FactoryPrecompile{}
 	cas20Policy     = &cas20PolicyPrecompile{}
 	cas20Activation = &cas20ActivationPrecompile{}
+	cas20Memo       = &cas20MemoPrecompile{}
 	cas20Asset      = &cas20AssetPrecompile{}
 	cas20Stablecoin = &cas20StablecoinPrecompile{}
 )

--- a/core/vm/cas20.go
+++ b/core/vm/cas20.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 )
@@ -80,21 +79,6 @@ func cas20AddressOccupied(ctx *PrecompileContext, addr common.Address) bool {
 func hadNoCode(state StateDB, addr common.Address) bool {
 	ch := state.GetCodeHash(addr)
 	return ch == (common.Hash{}) || ch == types.EmptyCodeHash
-}
-
-// ensureSentinel keeps a registry's storage out of reach of EIP-161 clearing. It
-// plants the marker only on an account with no code at all (BEP-702 3.16).
-func (ctx *PrecompileContext) ensureSentinel() {
-	if !ctx.chargeAccountAccess(ctx.Self) {
-		return
-	}
-	if !hadNoCode(ctx.StateDB, ctx.Self) {
-		return
-	}
-	if !ctx.chargeCodeWrite(ctx.Self, CAS20MarkerCode) {
-		return
-	}
-	ctx.StateDB.SetCode(ctx.Self, CAS20MarkerCode, tracing.CodeChangeContractCreation)
 }
 
 // cas20EnterCall applies the guards every CAS20 entry point shares: direct calls

--- a/core/vm/cas20.go
+++ b/core/vm/cas20.go
@@ -28,6 +28,25 @@ var (
 )
 
 // IsCAS20Address: byte[0:2] == 0xCA52 and byte[2:10] all zero.
+// IsCAS20Routed reports whether dispatch resolves addr to native CAS20 code once
+// Jenner is active: the token space and the three singletons.
+func IsCAS20Routed(addr common.Address) bool {
+	return IsCAS20Address(addr) || addr == CAS20FactoryAddress ||
+		addr == CAS20PolicyRegistryAddress || addr == CAS20ActivationRegistryAddress
+}
+
+// DisabledPrecompile, placed in an EVM's precompile map, makes dispatch treat the
+// address as an ordinary account. A state override that replaces a CAS20
+// account's code puts it there, since the address would otherwise be routed to
+// native code whatever the override said.
+var DisabledPrecompile PrecompiledContract = disabledPrecompile{}
+
+type disabledPrecompile struct{}
+
+func (disabledPrecompile) RequiredGas([]byte) uint64  { return 0 }
+func (disabledPrecompile) Run([]byte) ([]byte, error) { return nil, ErrExecutionReverted }
+func (disabledPrecompile) Name() string               { return "disabled" }
+
 func IsCAS20Address(addr common.Address) bool {
 	if addr[0] != cas20MarkerPrefix[0] || addr[1] != cas20MarkerPrefix[1] {
 		return false

--- a/core/vm/cas20_abi_test.go
+++ b/core/vm/cas20_abi_test.go
@@ -1,0 +1,203 @@
+package vm
+
+import (
+	"bytes"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+// TestCAS20RevertData verifies typed revert payloads travel end to end: a
+// business-rule failure inside a CAS20 precompile surfaces through evm.Call as
+// (ABI-encoded error, ErrExecutionReverted), exactly like a Solidity
+// `revert CustomError(...)`.
+func TestCAS20RevertData(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xdec0de")
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	initCalls := [][]byte{
+		cas20Call(selGrantRole, rolePause, addrKey(creator)),
+		cas20Call(selGrantRole, roleUnpause, addrKey(creator)),
+		cas20Call(selGrantRole, roleMint, addrKey(creator)),
+		cas20Call(selMint, addrKey(cas20Alice), u256hash(100)),
+	}
+	ret, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0x5e"), creator, initCalls))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	// ContractPaused(TRANSFER): selector ++ uint8 word.
+	if _, err := call(creator, token, cas20CallU8Array(selPause, byte(cas20PauseTransfer))); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	ret, err = call(cas20Alice, token, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(1)))
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("paused transfer err = %v, want ErrExecutionReverted", err)
+	}
+	want := append(append([]byte{}, errSelContractPaused[:]...), wU8(cas20PauseTransfer).Bytes()...)
+	if !bytes.Equal(ret, want) {
+		t.Fatalf("revert data = %x, want ContractPaused(TRANSFER) = %x", ret, want)
+	}
+
+	// InsufficientBalance(sender, balance, needed) carries the observed values.
+	if _, err := call(creator, token, cas20CallU8Array(selUnpause, byte(cas20PauseTransfer))); err != nil {
+		t.Fatalf("unpause: %v", err)
+	}
+	ret, err = call(cas20Alice, token, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(1000)))
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("over-balance transfer err = %v, want ErrExecutionReverted", err)
+	}
+	want = append([]byte{}, errSelInsufficientBalance[:]...)
+	want = append(want, addrKey(cas20Alice).Bytes()...)
+	want = append(want, u256hash(100).Bytes()...)
+	want = append(want, u256hash(1000).Bytes()...)
+	if !bytes.Equal(ret, want) {
+		t.Fatalf("revert data = %x, want InsufficientBalance(alice,100,1000) = %x", ret, want)
+	}
+
+	// NonPayable(): a value-bearing call is refused across the routed space.
+	ret, _, err = evm.Call(creator, token, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(1)), NewGasBudget(5_000_000), uint256.NewInt(7))
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("value-bearing call err = %v, want ErrExecutionReverted", err)
+	}
+	if !bytes.Equal(ret, errSelNonPayable[:]) {
+		t.Fatalf("revert data = %x, want NonPayable() = %x", ret, errSelNonPayable)
+	}
+
+	// The role and policy-scope ids themselves, which base-std publishes as full
+	// hashes next to those selectors. A getter can return the right shape and the
+	// wrong constant; these are what a token's storage is actually keyed on.
+	for _, tc := range []struct {
+		name string
+		got  common.Hash
+		want string
+	}{
+		{"SEIZE_ROLE", roleSeize, "0x3469b8b0d89e9604f8510ed143f74a8336d22955d4f83e23bf53d9414e27f432"},
+		{"SEIZE_HOLDER_POLICY", scopeSeizeHolder, "0x1497ab2b67ebb0a75dd9cdd6aec9f0e64620e6b87e911af7a088ac12e58d9ef2"},
+		{"SEIZE_RECEIVER_POLICY", scopeSeizeReceiver, "0xbf15b19caf5c77422c038bc25f26b8b815c3a14f6d04c6616076b81bcfe07b3d"},
+	} {
+		if got := tc.got.Hex(); got != tc.want {
+			t.Errorf("%s = %s, want %s (base-std's published value)", tc.name, got, tc.want)
+		}
+	}
+
+	// And the one event topic0 it publishes in full.
+	const wantSeized = "0xa9aec5d8b86e2fa2fd6ac3af62f2622e3dfdab1967d4cbbb56a5df7d74cb887c"
+	if got := cas20TopicSeized.Hex(); got != wantSeized {
+		t.Errorf("Seized topic0 = %s, want %s (base-std's published value)", got, wantSeized)
+	}
+	const wantComposite = "0x4ff6adaab31b0df87aa7b8b7320c52b8b3b5eede3bf28a6baaaa8b8b7e1d6363"
+	if got := cas20TopicCompositeUpdated.Hex(); got != wantComposite {
+		t.Errorf("CompositePolicyUpdated topic0 = %s, want %s (base-std's published value)", got, wantComposite)
+	}
+}
+
+// TestCAS20UndecodableCalldataRevertsEmpty pins BEP-702 3.2's second failure kind:
+// calldata that cannot be decoded reverts with no returndata at all, across
+// every entry point.
+func TestCAS20UndecodableCalldataRevertsEmpty(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xdec0de")
+	call := func(to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(creator, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	// Open the Asset feature and create a token so the token path is live too.
+	if _, err := call(CAS20ActivationRegistryAddress, cas20Call(selActivate, featureCAS20Asset)); err != nil {
+		// The harness seeds every feature already; activating again is fine to skip.
+		_ = err
+	}
+	ret, err := call(CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xd0"), creator, nil))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	targets := map[string]common.Address{
+		"factory":             CAS20FactoryAddress,
+		"policy registry":     CAS20PolicyRegistryAddress,
+		"activation registry": CAS20ActivationRegistryAddress,
+		"token":               token,
+	}
+	inputs := map[string][]byte{
+		"unknown selector":      {0xde, 0xad, 0xbe, 0xef},
+		"empty calldata":        {},
+		"shorter than selector": {0x01, 0x02, 0x03},
+		"selector, no args":     append([]byte{}, selBalanceOf[:]...),
+	}
+	for tname, to := range targets {
+		for iname, input := range inputs {
+			got, err := call(to, input)
+			if !errors.Is(err, ErrExecutionReverted) {
+				t.Errorf("%s / %s: err = %v, want revert", tname, iname, err)
+				continue
+			}
+			if len(got) != 0 {
+				t.Errorf("%s / %s: returndata = %x, want empty", tname, iname, got)
+			}
+		}
+	}
+}
+
+// TestCAS20ErrorOverloadsAreDeliberate is what remains of a constraint solc used to
+// enforce. Solidity forbids two errors of one name in one interface, and the
+// deleted .sol mirror failed to compile until a duplicate PolicyNotFound was
+// split — the only time anything checked this.
+//
+// The check cannot be rebuilt from the specification: BEP-702 declares errors
+// inside an interface only for IActivationRegistry, four of the fifty-five, so
+// there is no attribution to test against and inventing one would pin this
+// implementation to its own guess. What is checkable without inventing anything
+// is that the overloaded names stay a closed, named set. A third form appearing
+// beside an existing name is the accidental case — the one the mirror caught —
+// and it fails here.
+func TestCAS20ErrorOverloadsAreDeliberate(t *testing.T) {
+	// Each entry is legitimate only because the two forms live in different
+	// interfaces, which BEP-702 states in prose rather than in a declaration.
+	allowed := map[string]string{
+		"PolicyNotFound": "IPolicyRegistry answers about a policy the caller named, so " +
+			"the argument-less form suffices; a token names the id it could not find (3.8)",
+		"Unauthorized": "IPolicyRegistry rejects a caller who is not the policy admin; " +
+			"IActivationRegistry names the caller (3.8, 3.15)",
+	}
+
+	forms := map[string][]string{}
+	for sig := range cas20ErrSigs {
+		name := sig[:strings.IndexByte(sig, '(')]
+		forms[name] = append(forms[name], sig)
+	}
+	for name, sigs := range forms {
+		if len(sigs) == 1 {
+			continue
+		}
+		sort.Strings(sigs)
+		if _, ok := allowed[name]; !ok {
+			t.Errorf("%s is registered in %d forms (%s) and is not a declared overload. "+
+				"Two errors of one name are illegal in one Solidity interface, so either "+
+				"they belong to different ones — say which, here — or one of them is a "+
+				"mistake", name, len(sigs), strings.Join(sigs, ", "))
+		}
+		if len(sigs) > 2 {
+			t.Errorf("%s has %d forms (%s); the exemption covers a pair in two interfaces, "+
+				"not a family", name, len(sigs), strings.Join(sigs, ", "))
+		}
+	}
+	// And the exemptions must stay earned: an entry whose second form was removed
+	// is a stale licence for the next duplicate to slip through.
+	for name := range allowed {
+		if len(forms[name]) < 2 {
+			t.Errorf("%s is exempted as an overload but has %d form(s); drop the exemption",
+				name, len(forms[name]))
+		}
+	}
+}

--- a/core/vm/cas20_abi_test.go
+++ b/core/vm/cas20_abi_test.go
@@ -11,10 +11,6 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// TestCAS20RevertData verifies typed revert payloads travel end to end: a
-// business-rule failure inside a CAS20 precompile surfaces through evm.Call as
-// (ABI-encoded error, ErrExecutionReverted), exactly like a Solidity
-// `revert CustomError(...)`.
 func TestCAS20RevertData(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xdec0de")
@@ -35,7 +31,6 @@ func TestCAS20RevertData(t *testing.T) {
 	}
 	token := common.BytesToAddress(ret)
 
-	// ContractPaused(TRANSFER): selector ++ uint8 word.
 	if _, err := call(creator, token, cas20CallU8Array(selPause, byte(cas20PauseTransfer))); err != nil {
 		t.Fatalf("pause: %v", err)
 	}
@@ -48,7 +43,6 @@ func TestCAS20RevertData(t *testing.T) {
 		t.Fatalf("revert data = %x, want ContractPaused(TRANSFER) = %x", ret, want)
 	}
 
-	// InsufficientBalance(sender, balance, needed) carries the observed values.
 	if _, err := call(creator, token, cas20CallU8Array(selUnpause, byte(cas20PauseTransfer))); err != nil {
 		t.Fatalf("unpause: %v", err)
 	}
@@ -64,7 +58,6 @@ func TestCAS20RevertData(t *testing.T) {
 		t.Fatalf("revert data = %x, want InsufficientBalance(alice,100,1000) = %x", ret, want)
 	}
 
-	// NonPayable(): a value-bearing call is refused across the routed space.
 	ret, _, err = evm.Call(creator, token, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(1)), NewGasBudget(5_000_000), uint256.NewInt(7))
 	if !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("value-bearing call err = %v, want ErrExecutionReverted", err)
@@ -73,9 +66,7 @@ func TestCAS20RevertData(t *testing.T) {
 		t.Fatalf("revert data = %x, want NonPayable() = %x", ret, errSelNonPayable)
 	}
 
-	// The role and policy-scope ids themselves, which base-std publishes as full
-	// hashes next to those selectors. A getter can return the right shape and the
-	// wrong constant; these are what a token's storage is actually keyed on.
+	// The hashes base-std publishes in full; a getter can return the right shape and the wrong constant.
 	for _, tc := range []struct {
 		name string
 		got  common.Hash
@@ -90,7 +81,6 @@ func TestCAS20RevertData(t *testing.T) {
 		}
 	}
 
-	// And the one event topic0 it publishes in full.
 	const wantSeized = "0xa9aec5d8b86e2fa2fd6ac3af62f2622e3dfdab1967d4cbbb56a5df7d74cb887c"
 	if got := cas20TopicSeized.Hex(); got != wantSeized {
 		t.Errorf("Seized topic0 = %s, want %s (base-std's published value)", got, wantSeized)
@@ -101,9 +91,7 @@ func TestCAS20RevertData(t *testing.T) {
 	}
 }
 
-// TestCAS20UndecodableCalldataRevertsEmpty pins BEP-702 3.2's second failure kind:
-// calldata that cannot be decoded reverts with no returndata at all, across
-// every entry point.
+// BEP-702 3.2: undecodable calldata reverts with no returndata, at every entry point.
 func TestCAS20UndecodableCalldataRevertsEmpty(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xdec0de")
@@ -112,11 +100,6 @@ func TestCAS20UndecodableCalldataRevertsEmpty(t *testing.T) {
 		return ret, err
 	}
 
-	// Open the Asset feature and create a token so the token path is live too.
-	if _, err := call(CAS20ActivationRegistryAddress, cas20Call(selActivate, featureCAS20Asset)); err != nil {
-		// The harness seeds every feature already; activating again is fine to skip.
-		_ = err
-	}
 	ret, err := call(CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xd0"), creator, nil))
 	if err != nil {
 		t.Fatalf("createCAS20: %v", err)
@@ -149,21 +132,9 @@ func TestCAS20UndecodableCalldataRevertsEmpty(t *testing.T) {
 	}
 }
 
-// TestCAS20ErrorOverloadsAreDeliberate is what remains of a constraint solc used to
-// enforce. Solidity forbids two errors of one name in one interface, and the
-// deleted .sol mirror failed to compile until a duplicate PolicyNotFound was
-// split — the only time anything checked this.
-//
-// The check cannot be rebuilt from the specification: BEP-702 declares errors
-// inside an interface only for IActivationRegistry, four of the fifty-five, so
-// there is no attribution to test against and inventing one would pin this
-// implementation to its own guess. What is checkable without inventing anything
-// is that the overloaded names stay a closed, named set. A third form appearing
-// beside an existing name is the accidental case — the one the mirror caught —
-// and it fails here.
+// Solidity forbids two errors of one name in one interface. BEP-702 attributes
+// errors to interfaces only in prose, so the overloads are a closed, named set.
 func TestCAS20ErrorOverloadsAreDeliberate(t *testing.T) {
-	// Each entry is legitimate only because the two forms live in different
-	// interfaces, which BEP-702 states in prose rather than in a declaration.
 	allowed := map[string]string{
 		"PolicyNotFound": "IPolicyRegistry answers about a policy the caller named, so " +
 			"the argument-less form suffices; a token names the id it could not find (3.8)",
@@ -192,8 +163,6 @@ func TestCAS20ErrorOverloadsAreDeliberate(t *testing.T) {
 				"not a family", name, len(sigs), strings.Join(sigs, ", "))
 		}
 	}
-	// And the exemptions must stay earned: an entry whose second form was removed
-	// is a stale licence for the next duplicate to slip through.
 	for name := range allowed {
 		if len(forms[name]) < 2 {
 			t.Errorf("%s is exempted as an overload but has %d form(s); drop the exemption",

--- a/core/vm/cas20_abi_test.go
+++ b/core/vm/cas20_abi_test.go
@@ -110,6 +110,7 @@ func TestCAS20UndecodableCalldataRevertsEmpty(t *testing.T) {
 		"factory":             CAS20FactoryAddress,
 		"policy registry":     CAS20PolicyRegistryAddress,
 		"activation registry": CAS20ActivationRegistryAddress,
+		"memo registry":       CAS20MemoFormatRegistryAddress,
 		"token":               token,
 	}
 	inputs := map[string][]byte{

--- a/core/vm/cas20_abi_test.go
+++ b/core/vm/cas20_abi_test.go
@@ -66,7 +66,7 @@ func TestCAS20RevertData(t *testing.T) {
 		t.Fatalf("revert data = %x, want NonPayable() = %x", ret, errSelNonPayable)
 	}
 
-	// The hashes base-std publishes in full; a getter can return the right shape and the wrong constant.
+	// The hashes the standard publishes in full; a getter can return the right shape and the wrong constant.
 	for _, tc := range []struct {
 		name string
 		got  common.Hash
@@ -77,17 +77,17 @@ func TestCAS20RevertData(t *testing.T) {
 		{"SEIZE_RECEIVER_POLICY", scopeSeizeReceiver, "0xbf15b19caf5c77422c038bc25f26b8b815c3a14f6d04c6616076b81bcfe07b3d"},
 	} {
 		if got := tc.got.Hex(); got != tc.want {
-			t.Errorf("%s = %s, want %s (base-std's published value)", tc.name, got, tc.want)
+			t.Errorf("%s = %s, want the published value %s", tc.name, got, tc.want)
 		}
 	}
 
 	const wantSeized = "0xa9aec5d8b86e2fa2fd6ac3af62f2622e3dfdab1967d4cbbb56a5df7d74cb887c"
 	if got := cas20TopicSeized.Hex(); got != wantSeized {
-		t.Errorf("Seized topic0 = %s, want %s (base-std's published value)", got, wantSeized)
+		t.Errorf("Seized topic0 = %s, want the published value %s", got, wantSeized)
 	}
 	const wantComposite = "0x4ff6adaab31b0df87aa7b8b7320c52b8b3b5eede3bf28a6baaaa8b8b7e1d6363"
 	if got := cas20TopicCompositeUpdated.Hex(); got != wantComposite {
-		t.Errorf("CompositePolicyUpdated topic0 = %s, want %s (base-std's published value)", got, wantComposite)
+		t.Errorf("CompositePolicyUpdated topic0 = %s, want the published value %s", got, wantComposite)
 	}
 }
 

--- a/core/vm/cas20_activation.go
+++ b/core/vm/cas20_activation.go
@@ -1,0 +1,266 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// ActivationRegistry: the per-feature governance switch (BEP-702 3.15). It gates
+// token creation and PolicyRegistry writes only — deactivation never reaches an
+// existing token, so it cannot freeze balances.
+
+const cas20ActivationNamespace = "bsc.activation_registry"
+
+// Slots are append-only: never reorder them across forks.
+const (
+	actSlotFeatures = 0 // mapping(bytes32 feature => bool)
+	actSlotAdmin    = 1 // address, zero means no admin exists
+)
+
+// cas20ParamAdmin is the only parameter this registry takes. Governance appoints
+// the activation admin and the admin operates the switch, so opening or closing
+// a feature does not wait out a voting period while the authority behind it
+// still belongs to governance. Any other key is refused: GovHub reports a
+// target's revert in an event and leaves the proposal successful, so a key
+// accepted by accident would read as a deliberate governance action.
+const cas20ParamAdmin = "admin"
+
+var cas20ActivationRoot = erc7201Root(cas20ActivationNamespace)
+
+// Feature identifiers: keccak256 of the canonical feature name (BEP-702 3.15).
+// The names are consensus-visible and independent of the ERC-7201 storage
+// namespaces, which the first two deliberately spell differently
+// ("bsc.cas20.asset") and the third does not: featurePolicyRegistry and
+// cas20PolicyNamespace are the same string for two unrelated derivations. Renaming
+// the namespace must not carry the feature with it, or every integrator's
+// activate() call breaks.
+var (
+	featureCAS20Asset      = crypto.Keccak256Hash([]byte("bsc.cas20_asset"))
+	featureCAS20Stablecoin = crypto.Keccak256Hash([]byte("bsc.cas20_stablecoin"))
+	featurePolicyRegistry  = crypto.Keccak256Hash([]byte("bsc.policy_registry"))
+)
+
+var (
+	selIsActivated    = selector("isActivated(bytes32)")
+	selCheckActivated = selector("checkActivated(bytes32)")
+	selActivationAdm  = selector("admin()")
+	selActivate       = selector("activate(bytes32)")
+	selDeactivate     = selector("deactivate(bytes32)")
+	selUpdateParam    = selector("updateParam(string,bytes)")
+
+	cas20TopicFeatureActivated   = eventTopic("FeatureActivated(bytes32,address)")
+	cas20TopicFeatureDeactivated = eventTopic("FeatureDeactivated(bytes32,address)")
+	cas20TopicAdminChanged       = eventTopic("AdminChanged(address,address,address)")
+	cas20TopicParamChange        = eventTopic("ParamChange(string,bytes)")
+)
+
+// activationReg is a gas-metered view over the registry's storage.
+type activationReg struct{ s cas20Storage }
+
+func newActivationReg(ctx *PrecompileContext) activationReg {
+	return activationReg{s: newMeteredCAS20StorageAt(ctx, CAS20ActivationRegistryAddress)}
+}
+
+func actSlot(offset uint64) common.Hash {
+	return offsetSlot(cas20ActivationRoot, offset)
+}
+
+func (r activationReg) isActivated(feature common.Hash) bool {
+	return r.s.getWord(r.s.mapSlot(actSlot(actSlotFeatures), feature)) != (common.Hash{})
+}
+
+func (r activationReg) setActivated(feature common.Hash, on bool) {
+	var v common.Hash
+	if on {
+		v[31] = 1
+	}
+	// Deactivating clears the slot rather than writing false, so the storage
+	// refund applies exactly as it would for a Solidity `delete`.
+	r.s.setWord(r.s.mapSlot(actSlot(actSlotFeatures), feature), v)
+}
+
+// admin returns the activation admin. Zero means none is set, so nothing can be
+// activated yet — a state governance can always leave, unlike the seeded slot
+// this replaced.
+func (r activationReg) admin() common.Address {
+	return common.BytesToAddress(r.s.getWord(actSlot(actSlotAdmin)).Bytes())
+}
+
+func (r activationReg) setAdmin(a common.Address) { r.s.setWord(actSlot(actSlotAdmin), addrKey(a)) }
+
+// requireAdmin reverts unless the caller is the activation admin. The stored
+// address must be non-zero: an empty slot means no admin exists, and equality
+// alone would let a caller with no address hold the switch.
+func (r activationReg) requireAdmin(ctx *PrecompileContext) error {
+	if a := r.admin(); a == (common.Address{}) || ctx.Caller != a {
+		return revCAS20("Unauthorized(address)", errSelUnauthorizedAddr, addrKey(ctx.Caller))
+	}
+	return nil
+}
+
+// requireGov reverts unless the caller is GovHub. Appointment authority is a
+// constant rather than configuration, so there is nothing to seed at the fork and
+// no way to ship a chain whose switch can never be thrown: an appointment is an
+// ordinary parameter-change proposal, and a lost admin key is replaced by another
+// one rather than by a fork.
+func requireGov(ctx *PrecompileContext) error {
+	if ctx.Caller != params.CAS20GovHubAddress {
+		return revCAS20("Unauthorized(address)", errSelUnauthorizedAddr, addrKey(ctx.Caller))
+	}
+	return nil
+}
+
+type cas20ActivationPrecompile struct{ cas20StatefulBase }
+
+func (p *cas20ActivationPrecompile) Name() string { return "CAS20ActivationRegistry" }
+
+func (p *cas20ActivationPrecompile) RunStateful(ctx *PrecompileContext, input []byte) ([]byte, error) {
+	if err := cas20EnterCall(ctx, input); err != nil {
+		return finishCAS20(nil, err)
+	}
+	ret, err := runCAS20Activation(ctx, input)
+	return finishCAS20Metered(ctx, ret, err)
+}
+
+func runCAS20Activation(ctx *PrecompileContext, input []byte) ([]byte, error) {
+	if len(input) < 4 {
+		return nil, ErrExecutionReverted
+	}
+	var sel [4]byte
+	copy(sel[:], input[:4])
+	args := input[4:]
+	reg := newActivationReg(ctx)
+
+	switch sel {
+	// reads (permitted in read-only frames)
+	case selIsActivated:
+		feature, err := readWord(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		return encBool(reg.isActivated(feature)), nil
+	case selCheckActivated:
+		feature, err := readWord(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		if !reg.isActivated(feature) {
+			return nil, revCAS20("FeatureNotActivated(bytes32)", errSelFeatureNotActive, feature)
+		}
+		return nil, nil
+	case selActivationAdm:
+		return addrKey(reg.admin()).Bytes(), nil
+
+	// writes: governance appoints the admin, the admin works the switch
+	case selUpdateParam:
+		return nil, updateParam(ctx, reg, args)
+	case selActivate:
+		return nil, setFeature(ctx, reg, args, true)
+	case selDeactivate:
+		return nil, setFeature(ctx, reg, args, false)
+	}
+	return nil, ErrExecutionReverted
+}
+
+// updateParam is the governance entry point, in the shape every BSC system
+// contract uses: a canonical name and a raw value, with address values 20 bytes
+// wide. It takes exactly one key. Governance appoints the admin here; the admin
+// then works the switch through activate and deactivate, so opening or closing a
+// feature does not wait out a voting period while the authority behind it still
+// belongs to governance.
+func updateParam(ctx *PrecompileContext, reg activationReg, args []byte) error {
+	// Refused before the decode. The metering layer would refuse the write anyway
+	// and the exit reports the same error either way, so this bounds the work a
+	// read-only frame can ask for rather than deciding the outcome.
+	if ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	// Decoded before the authorization check, as Solidity's external decoder does.
+	key, err := readStringArg(args, 0)
+	if err != nil {
+		return err
+	}
+	value, err := readBytesArg(args, 1)
+	if err != nil {
+		return err
+	}
+	if err := requireGov(ctx); err != nil {
+		return err
+	}
+
+	if key != cas20ParamAdmin {
+		return revCAS20StringBytes("UnknownParam(string,bytes)", errSelUnknownParam, key, value)
+	}
+	// Twenty raw bytes, as every address-valued system parameter takes, and
+	// non-zero because an admin nobody holds cannot open anything.
+	if len(value) != 20 {
+		return revCAS20StringBytes("InvalidValue(string,bytes)", errSelInvalidValue, key, value)
+	}
+	next := common.BytesToAddress(value)
+	if next == (common.Address{}) {
+		return revCAS20StringBytes("InvalidValue(string,bytes)", errSelInvalidValue, key, value)
+	}
+	previous := reg.admin()
+	ctx.ensureSentinel()
+	reg.setAdmin(next)
+	if !ctx.AddLog([]common.Hash{cas20TopicAdminChanged, addrKey(previous), addrKey(next), addrKey(ctx.Caller)}, nil) {
+		return ErrOutOfGas
+	}
+	// Every system contract logs the parameter change alongside its own event, so
+	// one stream carries the exact key and raw value governance submitted.
+	if !ctx.AddLog([]common.Hash{cas20TopicParamChange},
+		encodeTuple(abiString(key), abiBytes(value))) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// setFeature flips one feature, for the admin governance appointed. A no-op is
+// surfaced rather than accepted: activating an active feature fails, and
+// deactivating an inactive one reuses FeatureNotActivated.
+func setFeature(ctx *PrecompileContext, reg activationReg, args []byte, on bool) error {
+	if ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	feature, err := readWord(args, 0)
+	if err != nil {
+		return err
+	}
+	if err := reg.requireAdmin(ctx); err != nil {
+		return err
+	}
+	switch active := reg.isActivated(feature); {
+	case on && active:
+		return revCAS20("AlreadyActivated(bytes32)", errSelAlreadyActivated, feature)
+	case !on && !active:
+		return revCAS20("FeatureNotActivated(bytes32)", errSelFeatureNotActive, feature)
+	}
+	if on {
+		ctx.ensureSentinel() // only the activating write creates state worth keeping
+	}
+	reg.setActivated(feature, on)
+	topic := cas20TopicFeatureDeactivated
+	if on {
+		topic = cas20TopicFeatureActivated
+	}
+	if !ctx.AddLog([]common.Hash{topic, feature, addrKey(ctx.Caller)}, nil) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// ensureFeatureActivated is the gate the factory and the PolicyRegistry apply to
+// their creation paths. It is deliberately not applied on any path of a token
+// that already exists (BEP-702 3.15).
+func ensureFeatureActivated(ctx *PrecompileContext, feature common.Hash) error {
+	if !newActivationReg(ctx).isActivated(feature) {
+		return revCAS20("FeatureNotActivated(bytes32)", errSelFeatureNotActive, feature)
+	}
+	return nil
+}
+
+func variantFeature(variant byte) (common.Hash, bool) {
+	v, ok := cas20Variants[variant]
+	return v.feature, ok
+}

--- a/core/vm/cas20_activation.go
+++ b/core/vm/cas20_activation.go
@@ -6,35 +6,22 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// ActivationRegistry: the per-feature governance switch (BEP-702 3.15). It gates
-// token creation and PolicyRegistry writes only — deactivation never reaches an
+// ActivationRegistry: the per-feature governance switch. It gates token creation
+// and PolicyRegistry writes only — deactivation never reaches an
 // existing token, so it cannot freeze balances.
 
 const cas20ActivationNamespace = "bsc.activation_registry"
 
-// Slots are append-only: never reorder them across forks.
 const (
 	actSlotFeatures = 0 // mapping(bytes32 feature => bool)
 	actSlotAdmin    = 1 // address, zero means no admin exists
 )
 
-// cas20ParamAdmin is the only parameter this registry takes. Governance appoints
-// the activation admin and the admin operates the switch, so opening or closing
-// a feature does not wait out a voting period while the authority behind it
-// still belongs to governance. Any other key is refused: GovHub reports a
-// target's revert in an event and leaves the proposal successful, so a key
-// accepted by accident would read as a deliberate governance action.
+// cas20ParamAdmin is the only key this registry takes.
 const cas20ParamAdmin = "admin"
 
 var cas20ActivationRoot = erc7201Root(cas20ActivationNamespace)
 
-// Feature identifiers: keccak256 of the canonical feature name (BEP-702 3.15).
-// The names are consensus-visible and independent of the ERC-7201 storage
-// namespaces, which the first two deliberately spell differently
-// ("bsc.cas20.asset") and the third does not: featurePolicyRegistry and
-// cas20PolicyNamespace are the same string for two unrelated derivations. Renaming
-// the namespace must not carry the feature with it, or every integrator's
-// activate() call breaks.
 var (
 	featureCAS20Asset      = crypto.Keccak256Hash([]byte("bsc.cas20_asset"))
 	featureCAS20Stablecoin = crypto.Keccak256Hash([]byte("bsc.cas20_stablecoin"))
@@ -75,23 +62,16 @@ func (r activationReg) setActivated(feature common.Hash, on bool) {
 	if on {
 		v[31] = 1
 	}
-	// Deactivating clears the slot rather than writing false, so the storage
-	// refund applies exactly as it would for a Solidity `delete`.
+	// Cleared, not written false, so the refund matches a Solidity `delete`.
 	r.s.setWord(r.s.mapSlot(actSlot(actSlotFeatures), feature), v)
 }
 
-// admin returns the activation admin. Zero means none is set, so nothing can be
-// activated yet — a state governance can always leave, unlike the seeded slot
-// this replaced.
 func (r activationReg) admin() common.Address {
 	return common.BytesToAddress(r.s.getWord(actSlot(actSlotAdmin)).Bytes())
 }
 
 func (r activationReg) setAdmin(a common.Address) { r.s.setWord(actSlot(actSlotAdmin), addrKey(a)) }
 
-// requireAdmin reverts unless the caller is the activation admin. The stored
-// address must be non-zero: an empty slot means no admin exists, and equality
-// alone would let a caller with no address hold the switch.
 func (r activationReg) requireAdmin(ctx *PrecompileContext) error {
 	if a := r.admin(); a == (common.Address{}) || ctx.Caller != a {
 		return revCAS20("Unauthorized(address)", errSelUnauthorizedAddr, addrKey(ctx.Caller))
@@ -99,11 +79,6 @@ func (r activationReg) requireAdmin(ctx *PrecompileContext) error {
 	return nil
 }
 
-// requireGov reverts unless the caller is GovHub. Appointment authority is a
-// constant rather than configuration, so there is nothing to seed at the fork and
-// no way to ship a chain whose switch can never be thrown: an appointment is an
-// ordinary parameter-change proposal, and a lost admin key is replaced by another
-// one rather than by a fork.
 func requireGov(ctx *PrecompileContext) error {
 	if ctx.Caller != params.CAS20GovHubAddress {
 		return revCAS20("Unauthorized(address)", errSelUnauthorizedAddr, addrKey(ctx.Caller))
@@ -163,16 +138,10 @@ func runCAS20Activation(ctx *PrecompileContext, input []byte) ([]byte, error) {
 	return nil, ErrExecutionReverted
 }
 
-// updateParam is the governance entry point, in the shape every BSC system
-// contract uses: a canonical name and a raw value, with address values 20 bytes
-// wide. It takes exactly one key. Governance appoints the admin here; the admin
-// then works the switch through activate and deactivate, so opening or closing a
-// feature does not wait out a voting period while the authority behind it still
-// belongs to governance.
+// updateParam is the governance contract entry point, in the shape every BSC system
+// contract uses. Governance appoints the admin here and the admin works the
+// switch, so a feature opens without a voting period while authority stays with governance.
 func updateParam(ctx *PrecompileContext, reg activationReg, args []byte) error {
-	// Refused before the decode. The metering layer would refuse the write anyway
-	// and the exit reports the same error either way, so this bounds the work a
-	// read-only frame can ask for rather than deciding the outcome.
 	if ctx.ReadOnly {
 		return ErrWriteProtection
 	}
@@ -192,8 +161,6 @@ func updateParam(ctx *PrecompileContext, reg activationReg, args []byte) error {
 	if key != cas20ParamAdmin {
 		return revCAS20StringBytes("UnknownParam(string,bytes)", errSelUnknownParam, key, value)
 	}
-	// Twenty raw bytes, as every address-valued system parameter takes, and
-	// non-zero because an admin nobody holds cannot open anything.
 	if len(value) != 20 {
 		return revCAS20StringBytes("InvalidValue(string,bytes)", errSelInvalidValue, key, value)
 	}
@@ -206,8 +173,7 @@ func updateParam(ctx *PrecompileContext, reg activationReg, args []byte) error {
 	if !ctx.AddLog([]common.Hash{cas20TopicAdminChanged, addrKey(previous), addrKey(next), addrKey(ctx.Caller)}, nil) {
 		return ErrOutOfGas
 	}
-	// Every system contract logs the parameter change alongside its own event, so
-	// one stream carries the exact key and raw value governance submitted.
+	// Logged alongside the registry's own event, as every system contract does.
 	if !ctx.AddLog([]common.Hash{cas20TopicParamChange},
 		encodeTuple(abiString(key), abiBytes(value))) {
 		return ErrOutOfGas
@@ -215,9 +181,6 @@ func updateParam(ctx *PrecompileContext, reg activationReg, args []byte) error {
 	return nil
 }
 
-// setFeature flips one feature, for the admin governance appointed. A no-op is
-// surfaced rather than accepted: activating an active feature fails, and
-// deactivating an inactive one reuses FeatureNotActivated.
 func setFeature(ctx *PrecompileContext, reg activationReg, args []byte, on bool) error {
 	if ctx.ReadOnly {
 		return ErrWriteProtection
@@ -246,9 +209,6 @@ func setFeature(ctx *PrecompileContext, reg activationReg, args []byte, on bool)
 	return nil
 }
 
-// ensureFeatureActivated is the gate the factory and the PolicyRegistry apply to
-// their creation paths. It is deliberately not applied on any path of a token
-// that already exists (BEP-702 3.15).
 func ensureFeatureActivated(ctx *PrecompileContext, feature common.Hash) error {
 	if !newActivationReg(ctx).isActivated(feature) {
 		return revCAS20("FeatureNotActivated(bytes32)", errSelFeatureNotActive, feature)

--- a/core/vm/cas20_activation.go
+++ b/core/vm/cas20_activation.go
@@ -202,7 +202,6 @@ func updateParam(ctx *PrecompileContext, reg activationReg, args []byte) error {
 		return revCAS20StringBytes("InvalidValue(string,bytes)", errSelInvalidValue, key, value)
 	}
 	previous := reg.admin()
-	ctx.ensureSentinel()
 	reg.setAdmin(next)
 	if !ctx.AddLog([]common.Hash{cas20TopicAdminChanged, addrKey(previous), addrKey(next), addrKey(ctx.Caller)}, nil) {
 		return ErrOutOfGas
@@ -235,9 +234,6 @@ func setFeature(ctx *PrecompileContext, reg activationReg, args []byte, on bool)
 		return revCAS20("AlreadyActivated(bytes32)", errSelAlreadyActivated, feature)
 	case !on && !active:
 		return revCAS20("FeatureNotActivated(bytes32)", errSelFeatureNotActive, feature)
-	}
-	if on {
-		ctx.ensureSentinel() // only the activating write creates state worth keeping
 	}
 	reg.setActivated(feature, on)
 	topic := cas20TopicFeatureDeactivated

--- a/core/vm/cas20_activation_test.go
+++ b/core/vm/cas20_activation_test.go
@@ -1,0 +1,429 @@
+package vm
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// encodeSetAdmin builds the governance call that appoints the activation admin.
+func encodeSetAdmin(a common.Address) []byte {
+	return encodeUpdateParamRaw(cas20ParamAdmin, a.Bytes())
+}
+
+// encodeUpdateParamRaw builds updateParam(string,bytes) with the value passed
+// through verbatim, so a test can submit a wrong-length one.
+func encodeUpdateParamRaw(key string, value []byte) []byte {
+	out := append([]byte{}, selUpdateParam[:]...)
+	out = append(out, u256hash(0x40).Bytes()...)
+	out = append(out, u256hash(0x40+32+32*wordsOf(len(key))).Bytes()...)
+	out = append(out, u256hash(uint64(len(key))).Bytes()...)
+	out = append(out, padRight32([]byte(key))...)
+	out = append(out, u256hash(uint64(len(value))).Bytes()...)
+	out = append(out, padRight32(value)...)
+	return out
+}
+
+func wordsOf(n int) uint64 {
+	if n == 0 {
+		return 0
+	}
+	return uint64((n + 31) / 32)
+}
+
+func padRight32(b []byte) []byte {
+	if len(b) == 0 {
+		return nil
+	}
+	out := make([]byte, 32*((len(b)+31)/32))
+	copy(out, b)
+	return out
+}
+
+// featureNameAsset and featureNameStablecoin are the canonical names the feature
+// identifiers hash from, spelled here so a rename has to change the tests too.
+const (
+	featureNameAsset      = "bsc.cas20_asset"
+	featureNameStablecoin = "bsc.cas20_stablecoin"
+	featureNamePolicy     = "bsc.policy_registry"
+)
+
+// TestCAS20ActivationRegistry exercises the two-step authority: governance
+// appoints the activation admin, the admin works the switch, and reads never
+// revert. Neither half can do the other's job.
+func TestCAS20ActivationRegistry(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	reg := CAS20ActivationRegistryAddress
+	gov := params.CAS20GovHubAddress
+	admin := common.HexToAddress("0xad4149")
+	stranger := common.HexToAddress("0x5747a9e")
+
+	call := func(caller common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, reg, input, NewGasBudget(1_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	feature := common.HexToHash("0xf1") // not seeded, so it starts inactive
+
+	// Reads never revert, whatever the flag.
+	if ret, err := call(stranger, cas20Call(selIsActivated, feature)); err != nil {
+		t.Fatalf("isActivated: %v", err)
+	} else if !bytes.Equal(ret, encBool(false)) {
+		t.Errorf("isActivated = %x, want false", ret)
+	}
+	if _, err := call(stranger, cas20Call(selCheckActivated, feature)); !errors.Is(err, ErrExecutionReverted) {
+		t.Errorf("checkActivated on an inactive feature: err = %v, want a revert", err)
+	}
+
+	// Only governance appoints, and only the appointed admin may flip a feature.
+	if _, err := call(stranger, encodeSetAdmin(admin)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("updateParam from a stranger: err = %v, want a revert", err)
+	}
+	if _, err := call(gov, encodeSetAdmin(admin)); err != nil {
+		t.Fatalf("governance appointing the admin: %v", err)
+	}
+	if ret, err := call(stranger, cas20Call(selActivationAdm)); err != nil || !bytes.Equal(ret, addrKey(admin).Bytes()) {
+		t.Fatalf("admin() = %x err %v, want %s", ret, err, admin.Hex())
+	}
+	if _, err := call(gov, cas20Call(selActivate, feature)); !errors.Is(err, ErrExecutionReverted) {
+		t.Error("governance holds the appointment, not the switch; activate from GovHub must fail")
+	}
+	if _, err := call(stranger, cas20Call(selActivate, feature)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatal("activate from a stranger must fail")
+	}
+	if _, err := call(admin, cas20Call(selActivate, feature)); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+
+	// No-ops are surfaced in both directions.
+	if _, err := call(admin, cas20Call(selActivate, feature)); !errors.Is(err, ErrExecutionReverted) {
+		t.Error("activating an active feature should report AlreadyActivated")
+	}
+	if _, err := call(admin, cas20Call(selDeactivate, feature)); err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+	if _, err := call(admin, cas20Call(selDeactivate, feature)); !errors.Is(err, ErrExecutionReverted) {
+		t.Error("deactivating an inactive feature should report FeatureNotActivated")
+	}
+
+	// Governance can rotate, and the previous admin loses the switch at once —
+	// which is what makes a compromised key recoverable without a fork.
+	next := common.HexToAddress("0xad4150")
+	if _, err := call(gov, encodeSetAdmin(next)); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if _, err := call(admin, cas20Call(selActivate, feature)); !errors.Is(err, ErrExecutionReverted) {
+		t.Error("the replaced admin must no longer hold the switch")
+	}
+	if _, err := call(next, cas20Call(selActivate, feature)); err != nil {
+		t.Errorf("the new admin cannot use the switch: %v", err)
+	}
+}
+
+// policies, and nothing on a token that already exists (BEP-702 3.15).
+func TestCAS20ActivationGates(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc4ea70")
+
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	// A token created while the feature is open.
+	initCalls := [][]byte{
+		cas20Call(selGrantRole, roleMint, addrKey(creator)),
+		cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
+	}
+	ret, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xa1"), creator, initCalls))
+	if err != nil {
+		t.Fatalf("createCAS20 while activated: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	// Deactivate the Asset variant.
+	if _, err := call(cas20TestCaller, CAS20ActivationRegistryAddress, cas20Call(selDeactivate, featureCAS20Asset)); err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+
+	// Creation stops.
+	if _, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xa2"), creator, nil)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("createCAS20 while deactivated err = %v, want FeatureNotActivated", err)
+	}
+	// The other variant is unaffected — the switch is per feature.
+	if _, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantStablecoin, common.HexToHash("0xa3"), creator, nil)); err != nil {
+		t.Fatalf("stablecoin creation must be unaffected: %v", err)
+	}
+
+	// The existing token keeps working: transfers, reads, everything.
+	if _, err := call(cas20Alice, token, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(10))); err != nil {
+		t.Fatalf("transfer on a live token must not be gated: %v", err)
+	}
+	view := newUnmeteredCAS20Storage(statedb, token)
+	if got := view.balanceOf(cas20Bob).Uint64(); got != 10 {
+		t.Fatalf("bob balance = %d, want 10", got)
+	}
+
+	// PolicyRegistry: reads stay open, writes stop.
+	if _, err := call(cas20TestCaller, CAS20ActivationRegistryAddress, cas20Call(selDeactivate, featurePolicyRegistry)); err != nil {
+		t.Fatalf("deactivate policy registry: %v", err)
+	}
+	if _, err := call(creator, CAS20PolicyRegistryAddress, cas20Call(selIsAuthorized, u256hash(0), addrKey(cas20Alice))); err != nil {
+		t.Fatalf("isAuthorized must never be gated: %v", err)
+	}
+	if _, err := call(creator, CAS20PolicyRegistryAddress, cas20Call(selCreatePolicy, addrKey(creator), u256hash(cas20PolicyBlocklist))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("createPolicy while deactivated err = %v, want FeatureNotActivated", err)
+	}
+}
+
+// TestCAS20RegistrySentinel pins the fix for the reaping hazard: a registry has
+// no factory to create it, so its first write must plant the account sentinel.
+// Storage alone leaves the account EIP-161-empty, and a clearing pass would
+// take every flag and policy with it (BEP-702 3.16).
+func TestCAS20RegistrySentinel(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc0ffee")
+
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	// Strip the sentinel the fork planted, so the registry is bare going in. This
+	// is deliberately a state the fork never leaves behind — the point is that the
+	// guard does not depend on the fork having run, which is what makes it a
+	// backstop rather than a duplicate of the seeding.
+	statedb.SetCode(CAS20PolicyRegistryAddress, nil, tracing.CodeChangeContractCreation)
+	if got := statedb.GetCodeHash(CAS20PolicyRegistryAddress); got == cas20MarkerCodeHash {
+		t.Fatal("precondition: the policy registry should start without a sentinel")
+	}
+	if _, err := call(creator, CAS20PolicyRegistryAddress, cas20Call(selCreatePolicy, addrKey(creator), u256hash(cas20PolicyBlocklist))); err != nil {
+		t.Fatalf("createPolicy: %v", err)
+	}
+	if got := statedb.GetCodeHash(CAS20PolicyRegistryAddress); got != cas20MarkerCodeHash {
+		t.Fatalf("policy registry code hash = %x, want the sentinel %x", got, cas20MarkerCodeHash)
+	}
+
+	// The account must now survive a clearing pass with its storage intact.
+	statedb.Finalise(true)
+	if got := statedb.GetCodeHash(CAS20PolicyRegistryAddress); got != cas20MarkerCodeHash {
+		t.Fatal("the policy registry was reaped despite the sentinel")
+	}
+
+	// The activation registry is the same story. Idempotence in gas terms is
+	// asserted precisely by TestCAS20EnsureSentinelIdempotent; here the point is
+	// only that a later write leaves the planted sentinel alone.
+	const laterName = "bsc.something_else"
+	if _, err := call(cas20TestCaller, CAS20ActivationRegistryAddress,
+		cas20Call(selActivate, crypto.Keccak256Hash([]byte(laterName)))); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	planted := statedb.GetCodeHash(CAS20ActivationRegistryAddress)
+	if planted != cas20MarkerCodeHash {
+		t.Fatalf("activation registry code hash = %x, want the sentinel %x", planted, cas20MarkerCodeHash)
+	}
+	if _, err := call(cas20TestCaller, CAS20ActivationRegistryAddress,
+		cas20Call(selDeactivate, crypto.Keccak256Hash([]byte(laterName)))); err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+	if after := statedb.GetCodeHash(CAS20ActivationRegistryAddress); after != planted {
+		t.Fatalf("the sentinel changed on a subsequent write: %x, want %x", after, planted)
+	}
+}
+
+// TestCAS20EnsureSentinelIdempotent asserts the write-once property exactly, at
+// the unit level. A loose "cheaper than CreateGas" bound is not enough: with
+// the guard removed the account already has code, so CreateGas is not charged
+// again and only the deposit and hash costs leak — a few hundred gas that a
+// coarse bound cannot see. The second call must therefore charge the warm
+// account access and nothing else.
+func TestCAS20EnsureSentinelIdempotent(t *testing.T) {
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := CAS20PolicyRegistryAddress
+	gas := NewGasBudget(1_000_000)
+	ctx := &PrecompileContext{StateDB: statedb, Self: addr, gas: &gas}
+
+	charged := func(fn func()) uint64 {
+		before := gas.RegularGas
+		fn()
+		return before - gas.RegularGas
+	}
+
+	codeWrite := params.CreateGas +
+		params.CreateDataGas*uint64(len(CAS20MarkerCode)) +
+		params.Keccak256Gas + params.Keccak256WordGas
+	first := charged(ctx.ensureSentinel)
+	if first < codeWrite {
+		t.Fatalf("first ensureSentinel charged %d, want at least the code write %d", first, codeWrite)
+	}
+	if statedb.GetCodeHash(addr) != cas20MarkerCodeHash {
+		t.Fatal("first ensureSentinel did not plant the sentinel")
+	}
+
+	second := charged(ctx.ensureSentinel)
+	if second != params.WarmStorageReadCostEIP2929 {
+		t.Fatalf("second ensureSentinel charged %d, want %d — the warm account access alone; "+
+			"anything more means the code write ran again",
+			second, params.WarmStorageReadCostEIP2929)
+	}
+}
+
+// TestCAS20NeverOverwritesForeignCode pins BEP-702 3.4 and 3.16: an address that
+// already carries code is occupied, whoever put it there. createCAS20 must refuse
+// it rather than plant the sentinel over it, and a registry must not either.
+func TestCAS20NeverOverwritesForeignCode(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc0de")
+	foreign := []byte{0x60, 0x00, 0x60, 0x00, 0xf3} // a plausible runtime stub
+
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	// A token address that is occupied by something that is not a CAS20 token.
+	salt := common.HexToHash("0xf01e")
+	predicted := cas20DeriveAddress(cas20VariantAsset, creator, salt)
+	statedb.SetCode(predicted, foreign, tracing.CodeChangeContractCreation)
+	foreignHash := statedb.GetCodeHash(predicted)
+
+	if _, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, salt, creator, nil)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("createCAS20 at an occupied address err = %v, want TokenAlreadyExists", err)
+	}
+	if got := statedb.GetCodeHash(predicted); got != foreignHash {
+		t.Fatalf("foreign code was overwritten: hash %x, want %x", got, foreignHash)
+	}
+
+	// A registry that somehow carries foreign code: the first write must not
+	// plant over it. The account is already non-empty, so nothing is at risk.
+	reg := CAS20PolicyRegistryAddress
+	statedb.SetCode(reg, foreign, tracing.CodeChangeContractCreation)
+	if _, err := call(creator, reg, cas20Call(selCreatePolicy, addrKey(creator), u256hash(cas20PolicyBlocklist))); err != nil {
+		t.Fatalf("createPolicy: %v", err)
+	}
+	if got := statedb.GetCodeHash(reg); got != foreignHash {
+		t.Fatalf("registry foreign code was overwritten: hash %x, want %x", got, foreignHash)
+	}
+}
+
+// TestCAS20ParamKeySpaceIsClosed pins the parameter surface. The registry takes
+// exactly one key and refuses everything else, as BSC's system contracts do —
+// GovHub reports a target's revert in an event and leaves the proposal
+// successful, so a key accepted by accident would read as a deliberate
+// governance action that in fact changed nothing.
+func TestCAS20ParamKeySpaceIsClosed(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	gov := params.CAS20GovHubAddress
+	call := func(input []byte) error {
+		_, _, err := evm.Call(gov, CAS20ActivationRegistryAddress, input, NewGasBudget(1_000_000), uint256.NewInt(0))
+		return err
+	}
+	addr := common.HexToAddress("0xad4151").Bytes()
+
+	for _, tc := range []struct {
+		name   string
+		key    string
+		value  []byte
+		accept bool
+	}{
+		{"the one key", cas20ParamAdmin, addr, true},
+		{"miscased", "Admin", addr, false},
+		{"an unknown key", "bsc.something_later", addr, false},
+		{"an empty key", "", addr, false},
+		{"a padded address", cas20ParamAdmin, common.HexToHash("0xad4151").Bytes(), false},
+		{"a short value", cas20ParamAdmin, addr[:19], false},
+		{"the zero address", cas20ParamAdmin, make([]byte, 20), false},
+	} {
+		err := call(encodeUpdateParamRaw(tc.key, tc.value))
+		if tc.accept && err != nil {
+			t.Errorf("%s: err = %v, want accepted", tc.name, err)
+		}
+		if !tc.accept && !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("%s: err = %v, want a revert", tc.name, err)
+		}
+	}
+}
+
+// TestCAS20ActivationAdminMustBeSet covers the clause that stops an empty admin
+// slot from being matchable. The harness seeds an admin, so this builds a
+// registry without one — the state a network is in between the fork and
+// governance's first appointment. Equality alone would let the zero address hold
+// the switch there.
+func TestCAS20ActivationAdminMustBeSet(t *testing.T) {
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := *cas20TestChainConfig()
+	evm := NewEVM(cas20BlockContext(1), statedb, &cfg, Config{})
+	if _, ok := evm.precompile(CAS20ActivationRegistryAddress); !ok {
+		t.Fatal("the activation registry does not resolve; the fork gate is in the way")
+	}
+	reg := cas20Storage{state: statedb, token: CAS20ActivationRegistryAddress}
+	if got := reg.getWord(actSlot(actSlotAdmin)); got != (common.Hash{}) {
+		t.Fatalf("the admin slot holds %x, want empty for this test to mean anything", got)
+	}
+
+	feature := common.HexToHash("0xf3")
+	for _, caller := range []common.Address{{}, common.HexToAddress("0x57ra9e")} {
+		_, _, err := evm.Call(caller, CAS20ActivationRegistryAddress,
+			cas20Call(selActivate, feature), NewGasBudget(5_000_000), uint256.NewInt(0))
+		if !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("activate from %s against an empty admin slot: err = %v, want a revert",
+				caller.Hex(), err)
+		}
+	}
+	if got := reg.getWord(mappingSlot(actSlot(actSlotFeatures), feature)); got != (common.Hash{}) {
+		t.Errorf("the feature reads %x, want off", got)
+	}
+}
+
+// TestCAS20FeatureNamesArePinned holds the three canonical feature names against
+// the identifiers derived from them. The names are consensus-visible: a feature
+// id is keccak256 of its name, so changing one character breaks every
+// integrator's activate() call and silently returns an activated feature to
+// inactive. Nothing else in the suite reads the strings — every other test uses
+// the Go variables, which move together with any rename.
+func TestCAS20FeatureNamesArePinned(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		id   common.Hash
+	}{
+		{featureNameAsset, featureCAS20Asset},
+		{featureNameStablecoin, featureCAS20Stablecoin},
+		{featureNamePolicy, featurePolicyRegistry},
+	} {
+		if got := crypto.Keccak256Hash([]byte(tc.name)); got != tc.id {
+			t.Errorf("keccak256(%q) = %x, want %x", tc.name, got, tc.id)
+		}
+	}
+
+	// The policy registry's feature name and its ERC-7201 storage namespace are
+	// the same string for two unrelated derivations, while the other two features
+	// spell themselves differently from their namespaces. A rename must not carry
+	// one into the other.
+	if featureNamePolicy != cas20PolicyNamespace {
+		t.Errorf("the policy feature name %q and namespace %q have diverged; if that is "+
+			"deliberate, both values changed and every integrator's activate() call with it",
+			featureNamePolicy, cas20PolicyNamespace)
+	}
+	for _, tc := range []struct{ feature, namespace string }{
+		{featureNameAsset, cas20AssetNamespace},
+		{featureNameStablecoin, cas20StablecoinNamespace},
+	} {
+		if tc.feature == tc.namespace {
+			t.Errorf("feature %q now equals its storage namespace; they are independent "+
+				"derivations and a namespace rename must not move the feature id", tc.feature)
+		}
+	}
+}

--- a/core/vm/cas20_activation_test.go
+++ b/core/vm/cas20_activation_test.go
@@ -14,13 +14,10 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// encodeSetAdmin builds the governance call that appoints the activation admin.
 func encodeSetAdmin(a common.Address) []byte {
 	return encodeUpdateParamRaw(cas20ParamAdmin, a.Bytes())
 }
 
-// encodeUpdateParamRaw builds updateParam(string,bytes) with the value passed
-// through verbatim, so a test can submit a wrong-length one.
 func encodeUpdateParamRaw(key string, value []byte) []byte {
 	out := append([]byte{}, selUpdateParam[:]...)
 	out = append(out, u256hash(0x40).Bytes()...)
@@ -48,17 +45,13 @@ func padRight32(b []byte) []byte {
 	return out
 }
 
-// featureNameAsset and featureNameStablecoin are the canonical names the feature
-// identifiers hash from, spelled here so a rename has to change the tests too.
+// Spelled out so a rename has to change the tests too.
 const (
 	featureNameAsset      = "bsc.cas20_asset"
 	featureNameStablecoin = "bsc.cas20_stablecoin"
 	featureNamePolicy     = "bsc.policy_registry"
 )
 
-// TestCAS20ActivationRegistry exercises the two-step authority: governance
-// appoints the activation admin, the admin works the switch, and reads never
-// revert. Neither half can do the other's job.
 func TestCAS20ActivationRegistry(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	reg := CAS20ActivationRegistryAddress
@@ -72,7 +65,6 @@ func TestCAS20ActivationRegistry(t *testing.T) {
 	}
 	feature := common.HexToHash("0xf1") // not seeded, so it starts inactive
 
-	// Reads never revert, whatever the flag.
 	if ret, err := call(stranger, cas20Call(selIsActivated, feature)); err != nil {
 		t.Fatalf("isActivated: %v", err)
 	} else if !bytes.Equal(ret, encBool(false)) {
@@ -82,7 +74,6 @@ func TestCAS20ActivationRegistry(t *testing.T) {
 		t.Errorf("checkActivated on an inactive feature: err = %v, want a revert", err)
 	}
 
-	// Only governance appoints, and only the appointed admin may flip a feature.
 	if _, err := call(stranger, encodeSetAdmin(admin)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("updateParam from a stranger: err = %v, want a revert", err)
 	}
@@ -102,7 +93,6 @@ func TestCAS20ActivationRegistry(t *testing.T) {
 		t.Fatalf("activate: %v", err)
 	}
 
-	// No-ops are surfaced in both directions.
 	if _, err := call(admin, cas20Call(selActivate, feature)); !errors.Is(err, ErrExecutionReverted) {
 		t.Error("activating an active feature should report AlreadyActivated")
 	}
@@ -113,8 +103,7 @@ func TestCAS20ActivationRegistry(t *testing.T) {
 		t.Error("deactivating an inactive feature should report FeatureNotActivated")
 	}
 
-	// Governance can rotate, and the previous admin loses the switch at once —
-	// which is what makes a compromised key recoverable without a fork.
+	// Rotation is what makes a compromised admin key recoverable without a fork.
 	next := common.HexToAddress("0xad4150")
 	if _, err := call(gov, encodeSetAdmin(next)); err != nil {
 		t.Fatalf("rotate: %v", err)
@@ -127,7 +116,8 @@ func TestCAS20ActivationRegistry(t *testing.T) {
 	}
 }
 
-// policies, and nothing on a token that already exists (BEP-702 3.15).
+// Deactivation stops creation and policy writes, and nothing on a token that
+// already exists (BEP-702 3.15).
 func TestCAS20ActivationGates(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xc4ea70")
@@ -137,7 +127,6 @@ func TestCAS20ActivationGates(t *testing.T) {
 		return ret, err
 	}
 
-	// A token created while the feature is open.
 	initCalls := [][]byte{
 		cas20Call(selGrantRole, roleMint, addrKey(creator)),
 		cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
@@ -148,21 +137,17 @@ func TestCAS20ActivationGates(t *testing.T) {
 	}
 	token := common.BytesToAddress(ret)
 
-	// Deactivate the Asset variant.
 	if _, err := call(cas20TestCaller, CAS20ActivationRegistryAddress, cas20Call(selDeactivate, featureCAS20Asset)); err != nil {
 		t.Fatalf("deactivate: %v", err)
 	}
 
-	// Creation stops.
 	if _, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xa2"), creator, nil)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("createCAS20 while deactivated err = %v, want FeatureNotActivated", err)
 	}
-	// The other variant is unaffected — the switch is per feature.
 	if _, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantStablecoin, common.HexToHash("0xa3"), creator, nil)); err != nil {
 		t.Fatalf("stablecoin creation must be unaffected: %v", err)
 	}
 
-	// The existing token keeps working: transfers, reads, everything.
 	if _, err := call(cas20Alice, token, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(10))); err != nil {
 		t.Fatalf("transfer on a live token must not be gated: %v", err)
 	}
@@ -171,7 +156,6 @@ func TestCAS20ActivationGates(t *testing.T) {
 		t.Fatalf("bob balance = %d, want 10", got)
 	}
 
-	// PolicyRegistry: reads stay open, writes stop.
 	if _, err := call(cas20TestCaller, CAS20ActivationRegistryAddress, cas20Call(selDeactivate, featurePolicyRegistry)); err != nil {
 		t.Fatalf("deactivate policy registry: %v", err)
 	}
@@ -183,104 +167,7 @@ func TestCAS20ActivationGates(t *testing.T) {
 	}
 }
 
-// TestCAS20RegistrySentinel pins the fix for the reaping hazard: a registry has
-// no factory to create it, so its first write must plant the account sentinel.
-// Storage alone leaves the account EIP-161-empty, and a clearing pass would
-// take every flag and policy with it (BEP-702 3.16).
-func TestCAS20RegistrySentinel(t *testing.T) {
-	statedb, evm := newCAS20EVM(t)
-	creator := common.HexToAddress("0xc0ffee")
-
-	call := func(caller, to common.Address, input []byte) ([]byte, error) {
-		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
-		return ret, err
-	}
-
-	// Strip the sentinel the fork planted, so the registry is bare going in. This
-	// is deliberately a state the fork never leaves behind — the point is that the
-	// guard does not depend on the fork having run, which is what makes it a
-	// backstop rather than a duplicate of the seeding.
-	statedb.SetCode(CAS20PolicyRegistryAddress, nil, tracing.CodeChangeContractCreation)
-	if got := statedb.GetCodeHash(CAS20PolicyRegistryAddress); got == cas20MarkerCodeHash {
-		t.Fatal("precondition: the policy registry should start without a sentinel")
-	}
-	if _, err := call(creator, CAS20PolicyRegistryAddress, cas20Call(selCreatePolicy, addrKey(creator), u256hash(cas20PolicyBlocklist))); err != nil {
-		t.Fatalf("createPolicy: %v", err)
-	}
-	if got := statedb.GetCodeHash(CAS20PolicyRegistryAddress); got != cas20MarkerCodeHash {
-		t.Fatalf("policy registry code hash = %x, want the sentinel %x", got, cas20MarkerCodeHash)
-	}
-
-	// The account must now survive a clearing pass with its storage intact.
-	statedb.Finalise(true)
-	if got := statedb.GetCodeHash(CAS20PolicyRegistryAddress); got != cas20MarkerCodeHash {
-		t.Fatal("the policy registry was reaped despite the sentinel")
-	}
-
-	// The activation registry is the same story. Idempotence in gas terms is
-	// asserted precisely by TestCAS20EnsureSentinelIdempotent; here the point is
-	// only that a later write leaves the planted sentinel alone.
-	const laterName = "bsc.something_else"
-	if _, err := call(cas20TestCaller, CAS20ActivationRegistryAddress,
-		cas20Call(selActivate, crypto.Keccak256Hash([]byte(laterName)))); err != nil {
-		t.Fatalf("activate: %v", err)
-	}
-	planted := statedb.GetCodeHash(CAS20ActivationRegistryAddress)
-	if planted != cas20MarkerCodeHash {
-		t.Fatalf("activation registry code hash = %x, want the sentinel %x", planted, cas20MarkerCodeHash)
-	}
-	if _, err := call(cas20TestCaller, CAS20ActivationRegistryAddress,
-		cas20Call(selDeactivate, crypto.Keccak256Hash([]byte(laterName)))); err != nil {
-		t.Fatalf("deactivate: %v", err)
-	}
-	if after := statedb.GetCodeHash(CAS20ActivationRegistryAddress); after != planted {
-		t.Fatalf("the sentinel changed on a subsequent write: %x, want %x", after, planted)
-	}
-}
-
-// TestCAS20EnsureSentinelIdempotent asserts the write-once property exactly, at
-// the unit level. A loose "cheaper than CreateGas" bound is not enough: with
-// the guard removed the account already has code, so CreateGas is not charged
-// again and only the deposit and hash costs leak — a few hundred gas that a
-// coarse bound cannot see. The second call must therefore charge the warm
-// account access and nothing else.
-func TestCAS20EnsureSentinelIdempotent(t *testing.T) {
-	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := CAS20PolicyRegistryAddress
-	gas := NewGasBudget(1_000_000)
-	ctx := &PrecompileContext{StateDB: statedb, Self: addr, gas: &gas}
-
-	charged := func(fn func()) uint64 {
-		before := gas.RegularGas
-		fn()
-		return before - gas.RegularGas
-	}
-
-	codeWrite := params.CreateGas +
-		params.CreateDataGas*uint64(len(CAS20MarkerCode)) +
-		params.Keccak256Gas + params.Keccak256WordGas
-	first := charged(ctx.ensureSentinel)
-	if first < codeWrite {
-		t.Fatalf("first ensureSentinel charged %d, want at least the code write %d", first, codeWrite)
-	}
-	if statedb.GetCodeHash(addr) != cas20MarkerCodeHash {
-		t.Fatal("first ensureSentinel did not plant the sentinel")
-	}
-
-	second := charged(ctx.ensureSentinel)
-	if second != params.WarmStorageReadCostEIP2929 {
-		t.Fatalf("second ensureSentinel charged %d, want %d — the warm account access alone; "+
-			"anything more means the code write ran again",
-			second, params.WarmStorageReadCostEIP2929)
-	}
-}
-
-// TestCAS20NeverOverwritesForeignCode pins BEP-702 3.4 and 3.16: an address that
-// already carries code is occupied, whoever put it there. createCAS20 must refuse
-// it rather than plant the sentinel over it, and a registry must not either.
+// An address that already carries code is occupied, whoever put it there (BEP-702 3.4, 3.16).
 func TestCAS20NeverOverwritesForeignCode(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xc0de")
@@ -291,7 +178,6 @@ func TestCAS20NeverOverwritesForeignCode(t *testing.T) {
 		return ret, err
 	}
 
-	// A token address that is occupied by something that is not a CAS20 token.
 	salt := common.HexToHash("0xf01e")
 	predicted := cas20DeriveAddress(cas20VariantAsset, creator, salt)
 	statedb.SetCode(predicted, foreign, tracing.CodeChangeContractCreation)
@@ -304,23 +190,16 @@ func TestCAS20NeverOverwritesForeignCode(t *testing.T) {
 		t.Fatalf("foreign code was overwritten: hash %x, want %x", got, foreignHash)
 	}
 
-	// A registry that somehow carries foreign code: the first write must not
-	// plant over it. The account is already non-empty, so nothing is at risk.
 	reg := CAS20PolicyRegistryAddress
 	statedb.SetCode(reg, foreign, tracing.CodeChangeContractCreation)
-	if _, err := call(creator, reg, cas20Call(selCreatePolicy, addrKey(creator), u256hash(cas20PolicyBlocklist))); err != nil {
-		t.Fatalf("createPolicy: %v", err)
-	}
+	seedCAS20Sentinel(statedb, reg)
 	if got := statedb.GetCodeHash(reg); got != foreignHash {
 		t.Fatalf("registry foreign code was overwritten: hash %x, want %x", got, foreignHash)
 	}
 }
 
-// TestCAS20ParamKeySpaceIsClosed pins the parameter surface. The registry takes
-// exactly one key and refuses everything else, as BSC's system contracts do —
-// GovHub reports a target's revert in an event and leaves the proposal
-// successful, so a key accepted by accident would read as a deliberate
-// governance action that in fact changed nothing.
+// GovHub swallows a target's revert into an event, so a key accepted by accident
+// would read as a governance action that changed nothing.
 func TestCAS20ParamKeySpaceIsClosed(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	gov := params.CAS20GovHubAddress
@@ -354,11 +233,8 @@ func TestCAS20ParamKeySpaceIsClosed(t *testing.T) {
 	}
 }
 
-// TestCAS20ActivationAdminMustBeSet covers the clause that stops an empty admin
-// slot from being matchable. The harness seeds an admin, so this builds a
-// registry without one — the state a network is in between the fork and
-// governance's first appointment. Equality alone would let the zero address hold
-// the switch there.
+// Between the fork and governance's first appointment the admin slot is empty;
+// equality alone would let the zero address hold the switch.
 func TestCAS20ActivationAdminMustBeSet(t *testing.T) {
 	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	if err != nil {
@@ -388,12 +264,8 @@ func TestCAS20ActivationAdminMustBeSet(t *testing.T) {
 	}
 }
 
-// TestCAS20FeatureNamesArePinned holds the three canonical feature names against
-// the identifiers derived from them. The names are consensus-visible: a feature
-// id is keccak256 of its name, so changing one character breaks every
-// integrator's activate() call and silently returns an activated feature to
-// inactive. Nothing else in the suite reads the strings — every other test uses
-// the Go variables, which move together with any rename.
+// A feature id is keccak256 of its name, so a rename silently returns an
+// activated feature to inactive. Every other test uses the Go variables.
 func TestCAS20FeatureNamesArePinned(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -408,10 +280,8 @@ func TestCAS20FeatureNamesArePinned(t *testing.T) {
 		}
 	}
 
-	// The policy registry's feature name and its ERC-7201 storage namespace are
-	// the same string for two unrelated derivations, while the other two features
-	// spell themselves differently from their namespaces. A rename must not carry
-	// one into the other.
+	// The policy registry's feature name and its storage namespace are the same
+	// string for two unrelated derivations; a rename must not carry one into the other.
 	if featureNamePolicy != cas20PolicyNamespace {
 		t.Errorf("the policy feature name %q and namespace %q have diverged; if that is "+
 			"deliberate, both values changed and every integrator's activate() call with it",
@@ -424,6 +294,46 @@ func TestCAS20FeatureNamesArePinned(t *testing.T) {
 		if tc.feature == tc.namespace {
 			t.Errorf("feature %q now equals its storage namespace; they are independent "+
 				"derivations and a namespace rename must not move the feature id", tc.feature)
+		}
+	}
+}
+
+// The negative control comes first: without it the seeded case would prove only
+// that a byte was written.
+func TestCAS20SeededSentinelSurvivesClearing(t *testing.T) {
+	slot, value := common.HexToHash("0x01"), common.HexToHash("0x2a")
+	registries := []common.Address{CAS20ActivationRegistryAddress, CAS20PolicyRegistryAddress}
+
+	bare, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, addr := range registries {
+		bare.SetState(addr, slot, value)
+	}
+	bare.Finalise(true)
+	for _, addr := range registries {
+		if bare.Exist(addr) || bare.GetState(addr, slot) != (common.Hash{}) {
+			t.Fatalf("%s with storage and no code survived a clearing pass; the hazard this test "+
+				"guards against is not present in this StateDB", addr.Hex())
+		}
+	}
+
+	seeded, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	SeedCAS20Activation(seeded)
+	for _, addr := range registries {
+		seeded.SetState(addr, slot, value)
+	}
+	seeded.Finalise(true)
+	for _, addr := range registries {
+		if got := seeded.GetCodeHash(addr); got != cas20MarkerCodeHash {
+			t.Fatalf("%s after a clearing pass: code hash %x, want the sentinel %x", addr.Hex(), got, cas20MarkerCodeHash)
+		}
+		if got := seeded.GetState(addr, slot); got != value {
+			t.Fatalf("%s lost its storage across a clearing pass despite the sentinel: %x", addr.Hex(), got)
 		}
 	}
 }

--- a/core/vm/cas20_activation_test.go
+++ b/core/vm/cas20_activation_test.go
@@ -50,6 +50,7 @@ const (
 	featureNameAsset      = "bsc.cas20_asset"
 	featureNameStablecoin = "bsc.cas20_stablecoin"
 	featureNamePolicy     = "bsc.policy_registry"
+	featureNameMemo       = "bsc.memo_registry"
 )
 
 func TestCAS20ActivationRegistry(t *testing.T) {
@@ -274,6 +275,7 @@ func TestCAS20FeatureNamesArePinned(t *testing.T) {
 		{featureNameAsset, featureCAS20Asset},
 		{featureNameStablecoin, featureCAS20Stablecoin},
 		{featureNamePolicy, featurePolicyRegistry},
+		{featureNameMemo, featureMemoRegistry},
 	} {
 		if got := crypto.Keccak256Hash([]byte(tc.name)); got != tc.id {
 			t.Errorf("keccak256(%q) = %x, want %x", tc.name, got, tc.id)

--- a/core/vm/cas20_admin.go
+++ b/core/vm/cas20_admin.go
@@ -1,0 +1,697 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+)
+
+// Built-in role ids. DEFAULT_ADMIN is bytes32(0); the rest are keccak of their
+// canonical names. An unset role admin (zero) therefore means DEFAULT_ADMIN.
+var (
+	roleDefaultAdmin = common.Hash{}
+	roleMint         = crypto.Keccak256Hash([]byte("MINT_ROLE"))
+	roleBurn         = crypto.Keccak256Hash([]byte("BURN_ROLE"))
+	roleSeize        = crypto.Keccak256Hash([]byte("SEIZE_ROLE"))
+	rolePause        = crypto.Keccak256Hash([]byte("PAUSE_ROLE"))
+	roleUnpause      = crypto.Keccak256Hash([]byte("UNPAUSE_ROLE"))
+	roleMetadata     = crypto.Keccak256Hash([]byte("METADATA_ROLE"))
+)
+
+var (
+	selHasRole           = selector("hasRole(bytes32,address)")
+	selGetRoleAdmin      = selector("getRoleAdmin(bytes32)")
+	selGrantRole         = selector("grantRole(bytes32,address)")
+	selRevokeRole        = selector("revokeRole(bytes32,address)")
+	selRenounceRole      = selector("renounceRole(bytes32,address)")
+	selSetRoleAdmin      = selector("setRoleAdmin(bytes32,bytes32)")
+	selRenounceLastAdmin = selector("renounceLastAdmin()")
+
+	selDefaultAdminRole = selector("DEFAULT_ADMIN_ROLE()")
+	selMintRole         = selector("MINT_ROLE()")
+	selBurnRole         = selector("BURN_ROLE()")
+	selSeizeRole        = selector("SEIZE_ROLE()")
+	selPauseRole        = selector("PAUSE_ROLE()")
+	selUnpauseRole      = selector("UNPAUSE_ROLE()")
+	selMetadataRole     = selector("METADATA_ROLE()")
+
+	// Policy scope identifiers: keccak256 of the canonical scope names
+	// (BEP-702 section 3.8).
+	scopeTransferSender   = crypto.Keccak256Hash([]byte("TRANSFER_SENDER_POLICY"))
+	scopeTransferReceiver = crypto.Keccak256Hash([]byte("TRANSFER_RECEIVER_POLICY"))
+	scopeTransferExecutor = crypto.Keccak256Hash([]byte("TRANSFER_EXECUTOR_POLICY"))
+	scopeMintReceiver     = crypto.Keccak256Hash([]byte("MINT_RECEIVER_POLICY"))
+	scopeSeizeHolder      = crypto.Keccak256Hash([]byte("SEIZE_HOLDER_POLICY"))
+	scopeSeizeReceiver    = crypto.Keccak256Hash([]byte("SEIZE_RECEIVER_POLICY"))
+
+	selTransferSenderScope   = selector("TRANSFER_SENDER_POLICY()")
+	selTransferReceiverScope = selector("TRANSFER_RECEIVER_POLICY()")
+	selTransferExecutorScope = selector("TRANSFER_EXECUTOR_POLICY()")
+	selMintReceiverScope     = selector("MINT_RECEIVER_POLICY()")
+	selSeizeHolderScope      = selector("SEIZE_HOLDER_POLICY()")
+	selSeizeReceiverScope    = selector("SEIZE_RECEIVER_POLICY()")
+	selPolicyId              = selector("policyId(bytes32)")
+
+	selIsPaused        = selector("isPaused(uint8)")
+	selPause           = selector("pause(uint8[])")
+	selUnpause         = selector("unpause(uint8[])")
+	selMint            = selector("mint(address,uint256)")
+	selBurn            = selector("burn(uint256)")
+	selSeizeWithMemo   = selector("seizeWithMemo(address,address,uint256,bytes32)")
+	selUpdateSupplyCap = selector("updateSupplyCap(uint256)")
+	selUpdatePolicy    = selector("updatePolicy(bytes32,uint64)")
+
+	cas20TopicRoleGranted      = eventTopic("RoleGranted(bytes32,address,address)")
+	cas20TopicRoleRevoked      = eventTopic("RoleRevoked(bytes32,address,address)")
+	cas20TopicRoleAdminChanged = eventTopic("RoleAdminChanged(bytes32,bytes32,bytes32)")
+	cas20TopicSeized           = eventTopic("Seized(address,address,address,uint256)")
+
+	cas20TopicLastAdminRenounced = eventTopic("LastAdminRenounced(address)")
+	cas20TopicPolicyUpdated      = eventTopic("PolicyUpdated(bytes32,uint64,uint64)")
+	cas20TopicPaused             = eventTopic("Paused(address,uint8[])")
+	cas20TopicUnpaused           = eventTopic("Unpaused(address,uint8[])")
+	cas20TopicSupplyCapUpdated   = eventTopic("SupplyCapUpdated(address,uint256,uint256)")
+)
+
+// dispatchAdmin handles the RBAC / pause / mint-burn selectors. ok is false
+// when sel is none of them, so the caller can continue matching.
+func (t cas20Token) dispatchAdmin(sel [4]byte, args []byte) (ret []byte, err error, ok bool) {
+	switch sel {
+	case selDefaultAdminRole:
+		return roleDefaultAdmin.Bytes(), nil, true
+	case selMintRole:
+		return roleMint.Bytes(), nil, true
+	case selBurnRole:
+		return roleBurn.Bytes(), nil, true
+	case selSeizeRole:
+		return roleSeize.Bytes(), nil, true
+	case selPauseRole:
+		return rolePause.Bytes(), nil, true
+	case selUnpauseRole:
+		return roleUnpause.Bytes(), nil, true
+	case selMetadataRole:
+		return roleMetadata.Bytes(), nil, true
+
+	case selHasRole:
+		role, err := readWord(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		acct, err := readAddress(args, 1)
+		if err != nil {
+			return nil, err, true
+		}
+		return encBool(t.s.hasRole(role, acct)), nil, true
+	case selGetRoleAdmin:
+		role, err := readWord(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		admin := t.s.roleAdmin(role)
+		return admin.Bytes(), nil, true
+
+	case selGrantRole:
+		role, acct, err := readRoleAccount(args)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, t.grantRole(role, acct), true
+	case selRevokeRole:
+		role, acct, err := readRoleAccount(args)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, t.revokeRole(role, acct), true
+	case selRenounceRole:
+		role, confirm, err := readRoleAccount(args)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, t.renounceRole(role, confirm), true
+	case selSetRoleAdmin:
+		role, err := readWord(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		newAdmin, err := readWord(args, 1)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, t.setRoleAdmin(role, newAdmin), true
+	case selRenounceLastAdmin:
+		return nil, t.renounceLastAdmin(), true
+
+	case selIsPaused:
+		// Decoded exactly as pause()/unpause() decode their elements: a word with
+		// dirty high bytes is a malformed encoding, and a well-formed value
+		// outside the enum is Panic(0x21).
+		w, err := readWord(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		if !isEnumWord(w, 0xff) {
+			return nil, ErrExecutionReverted, true
+		}
+		if uint(w[31]) > cas20PauseSeize {
+			return nil, revPanic(0x21), true
+		}
+		return encBool(t.isPaused(uint(w[31]))), nil, true
+	case selPause:
+		return nil, t.setPause(args, true), true
+	case selUnpause:
+		return nil, t.setPause(args, false), true
+
+	case selMint:
+		to, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		amount, err := readU256(args, 1)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, t.mint(to, amount), true
+	case selBurn:
+		amount, err := readU256(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, t.burn(t.ctx.Caller, amount), true
+	case selSeizeWithMemo:
+		from, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		to, err := readAddress(args, 1)
+		if err != nil {
+			return nil, err, true
+		}
+		amount, err := readU256(args, 2)
+		if err != nil {
+			return nil, err, true
+		}
+		memo, err := readWord(args, 3)
+		if err != nil {
+			return nil, err, true
+		}
+		if err := t.seizeWithMemo(from, to, amount, memo); err != nil {
+			return nil, err, true
+		}
+		return encBool(true), nil, true
+
+	case selUpdateSupplyCap:
+		cap, err := readU256(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, t.updateSupplyCap(cap), true
+	case selUpdatePolicy:
+		scope, err := readWord(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		id, err := readU64(args, 1)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, t.updatePolicy(scope, id), true
+	case selTransferSenderScope:
+		return scopeTransferSender.Bytes(), nil, true
+	case selTransferReceiverScope:
+		return scopeTransferReceiver.Bytes(), nil, true
+	case selTransferExecutorScope:
+		return scopeTransferExecutor.Bytes(), nil, true
+	case selMintReceiverScope:
+		return scopeMintReceiver.Bytes(), nil, true
+	case selSeizeHolderScope:
+		return scopeSeizeHolder.Bytes(), nil, true
+	case selSeizeReceiverScope:
+		return scopeSeizeReceiver.Bytes(), nil, true
+	case selPolicyId:
+		scope, err := readWord(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		id, ok := t.policyIdByScope(scope)
+		if !ok {
+			return nil, revCAS20("UnsupportedPolicyType(bytes32)", errSelUnsupportedScope, scope), true
+		}
+		return encU256(uint256.NewInt(id)), nil, true
+	}
+	return nil, nil, false
+}
+
+// cas20PolicyLanes maps each policy scope to the packed lane holding its id.
+//
+// One table, because policyId and updatePolicy used to map the same six scopes
+// through separate switches: a lane wired wrong in one showed up only if a test
+// happened to round-trip that scope, and a pair wired wrong the same way in both
+// round-tripped cleanly. TestCAS20PolicyLanePositions checks each entry against the
+// byte the id actually lands on.
+var cas20PolicyLanes = map[common.Hash]struct {
+	slot    uint64
+	byteOff uint
+}{
+	scopeTransferSender:   {cas20SlotTransferPolicies, cas20OffTransferSender},
+	scopeTransferReceiver: {cas20SlotTransferPolicies, cas20OffTransferReceiver},
+	scopeTransferExecutor: {cas20SlotTransferPolicies, cas20OffTransferExecutor},
+	scopeMintReceiver:     {cas20SlotMintPolicy, cas20OffMintReceiver},
+	scopeSeizeHolder:      {cas20SlotSeizePolicies, cas20OffSeizeHolder},
+	scopeSeizeReceiver:    {cas20SlotSeizePolicies, cas20OffSeizeReceiver},
+}
+
+func (t cas20Token) policyIdByScope(scope common.Hash) (uint64, bool) {
+	lane, ok := cas20PolicyLanes[scope]
+	if !ok {
+		return 0, false
+	}
+	return t.s.getPackedU64(lane.slot, lane.byteOff), true
+}
+
+func readRoleAccount(args []byte) (common.Hash, common.Address, error) {
+	role, err := readWord(args, 0)
+	if err != nil {
+		return common.Hash{}, common.Address{}, err
+	}
+	acct, err := readAddress(args, 1)
+	if err != nil {
+		return common.Hash{}, common.Address{}, err
+	}
+	return role, acct, nil
+}
+
+// --- RoleManaged ------------------------------------------------------------
+
+// roleMutable reports whether role mutations are still possible: adminCount == 0
+// freezes them, except inside the factory's privileged bootstrap.
+func (t cas20Token) grantRole(role common.Hash, account common.Address) error {
+	if err := t.ensureRoleMutable(role); err != nil {
+		return err
+	}
+	if !t.s.hasRole(role, account) {
+		t.s.setRole(role, account, true)
+		if role == roleDefaultAdmin {
+			t.s.setAdminCount(new(uint256.Int).AddUint64(t.s.adminCount(), 1))
+		}
+		if !t.ctx.AddLog([]common.Hash{cas20TopicRoleGranted, role, addrKey(account), addrKey(t.ctx.Caller)}, nil) {
+			return ErrOutOfGas
+		}
+	}
+	return nil
+}
+
+func (t cas20Token) revokeRole(role common.Hash, account common.Address) error {
+	if err := t.ensureRoleMutable(role); err != nil {
+		return err
+	}
+	// The last DEFAULT_ADMIN cannot be removed via revoke; use renounceLastAdmin.
+	if role == roleDefaultAdmin && t.s.hasRole(role, account) && t.s.adminCount().Eq(uint256.NewInt(1)) {
+		return revCAS20("LastAdminCannotRenounce()", errSelLastAdminRenounce)
+	}
+	if !t.removeRole(role, account) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func (t cas20Token) renounceRole(role common.Hash, confirmation common.Address) error {
+	if t.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	// Confirmation must equal the caller (OZ 5.x anti-misuse guard).
+	if confirmation != t.ctx.Caller {
+		return revCAS20("AccessControlBadConfirmation()", errSelACBadConfirmation)
+	}
+	// The sole DEFAULT_ADMIN must use renounceLastAdmin, not this path.
+	if role == roleDefaultAdmin && t.s.hasRole(role, t.ctx.Caller) && t.s.adminCount().Eq(uint256.NewInt(1)) {
+		return revCAS20("LastAdminCannotRenounce()", errSelLastAdminRenounce)
+	}
+	if !t.removeRole(role, t.ctx.Caller) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func (t cas20Token) renounceLastAdmin() error {
+	if t.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	// Two checks, not one condition: a caller who holds no admin role is
+	// unauthorized, and NotSoleAdmin is reserved for one who does hold it but is
+	// not the last. Collapsing them told a stranger they were "not the sole
+	// admin", which is true but says the wrong thing.
+	if !t.s.hasRole(roleDefaultAdmin, t.ctx.Caller) {
+		return revCAS20("AccessControlUnauthorizedAccount(address,bytes32)", errSelACUnauthorized,
+			addrKey(t.ctx.Caller), roleDefaultAdmin)
+	}
+	if !t.s.adminCount().Eq(uint256.NewInt(1)) {
+		return revCAS20("NotSoleAdmin()", errSelNotSoleAdmin)
+	}
+	t.s.setRole(roleDefaultAdmin, t.ctx.Caller, false)
+	t.s.setAdminCount(new(uint256.Int))
+	t.ctx.adminRenounced = true
+	if !t.ctx.AddLog([]common.Hash{cas20TopicRoleRevoked, roleDefaultAdmin, addrKey(t.ctx.Caller), addrKey(t.ctx.Caller)}, nil) {
+		return ErrOutOfGas
+	}
+	// The dedicated event marks the transition an indexer cannot infer from
+	// RoleRevoked alone: the token is now permanently ungovernable.
+	if !t.ctx.AddLog([]common.Hash{cas20TopicLastAdminRenounced, addrKey(t.ctx.Caller)}, nil) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func (t cas20Token) setRoleAdmin(role, newAdminRole common.Hash) error {
+	if err := t.ensureRoleMutable(role); err != nil {
+		return err
+	}
+	prev := t.s.roleAdmin(role)
+	t.s.setRoleAdmin(role, newAdminRole)
+	if !t.ctx.AddLog([]common.Hash{cas20TopicRoleAdminChanged, role, prev, newAdminRole}, nil) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// removeRole clears role from account (if held), maintaining adminCount, and
+// emits RoleRevoked. Renounce silently succeeds when the role is not held.
+func (t cas20Token) removeRole(role common.Hash, account common.Address) bool {
+	if !t.s.hasRole(role, account) {
+		return true
+	}
+	t.s.setRole(role, account, false)
+	if role == roleDefaultAdmin {
+		t.s.setAdminCount(new(uint256.Int).SubUint64(t.s.adminCount(), 1))
+	}
+	return t.ctx.AddLog([]common.Hash{cas20TopicRoleRevoked, role, addrKey(account), addrKey(t.ctx.Caller)}, nil)
+}
+
+// ensureRole reverts unless the caller holds role (skipped when privileged).
+func (t cas20Token) ensureRole(role common.Hash) error {
+	if t.privileged || t.s.hasRole(role, t.ctx.Caller) {
+		return nil
+	}
+	return revCAS20("AccessControlUnauthorizedAccount(address,bytes32)", errSelACUnauthorized,
+		addrKey(t.ctx.Caller), role)
+}
+
+func (t cas20Token) ensureRoleMutable(role common.Hash) error {
+	if t.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	// The zero-admin freeze yields to the bootstrap window so an ownerless token
+	// can be configured, but not once this frame has renounced: that transition is
+	// advertised as permanent, and the window is not a way back (BEP-702 3.4).
+	if (!t.privileged || t.ctx.adminRenounced) && t.s.adminCount().IsZero() {
+		return revCAS20("AccessControlUnauthorizedAccount(address,bytes32)", errSelACUnauthorized,
+			addrKey(t.ctx.Caller), t.s.roleAdmin(role))
+	}
+	if !t.privileged && !t.s.hasRole(t.s.roleAdmin(role), t.ctx.Caller) {
+		return revCAS20("AccessControlUnauthorizedAccount(address,bytes32)", errSelACUnauthorized,
+			addrKey(t.ctx.Caller), t.s.roleAdmin(role))
+	}
+	return nil
+}
+
+// --- Pausable ---------------------------------------------------------------
+
+func (t cas20Token) setPause(args []byte, on bool) error {
+	if t.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	// Decoded before the role check, because that is where Solidity does it: the
+	// external dispatcher decodes the argument before any modifier runs, so a
+	// malformed array is reported as malformed whether or not the caller is
+	// authorized.
+	features, err := readUint8Array(args)
+	if err != nil {
+		return err
+	}
+	role := rolePause
+	if !on {
+		role = roleUnpause
+	}
+	if err := t.ensureRole(role); err != nil {
+		return err
+	}
+	if len(features) == 0 {
+		return revCAS20("EmptyFeatureSet()", errSelEmptyFeatureSet)
+	}
+	// Read before the caller-sized loop and the encoding below: a mask this frame
+	// could not pay to read is zero, which says "nothing paused", and the work that
+	// follows is proportional to the caller's array.
+	p, ok := t.s.pausedChecked()
+	if !ok {
+		return ErrOutOfGas
+	}
+	words := make([]common.Hash, len(features))
+	for i, f := range features {
+		if uint(f) > cas20PauseSeize {
+			return revPanic(0x21) // invalid enum value
+		}
+		words[i] = wU8(f)
+		mask := new(uint256.Int).Lsh(uint256.NewInt(1), uint(f))
+		if on {
+			p.Or(p, mask)
+		} else {
+			p.And(p, mask.Not(mask))
+		}
+	}
+	t.s.setPaused(p)
+	topic := cas20TopicPaused
+	if !on {
+		topic = cas20TopicUnpaused
+	}
+	// The event carries the requested feature list, not the resulting mask: it
+	// records the action taken, so re-pausing an already-paused feature is
+	// visible rather than indistinguishable from a no-op.
+	if !t.ctx.AddLog([]common.Hash{topic, addrKey(t.ctx.Caller)}, encodeTuple(abiWordArray(words))) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// --- Mintable / Burnable ----------------------------------------------------
+
+func (t cas20Token) mint(to common.Address, amount *uint256.Int) error {
+	if t.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	if t.isPaused(cas20PauseMint) {
+		return revCAS20("ContractPaused(uint8)", errSelContractPaused, wU8(cas20PauseMint))
+	}
+	if err := t.ensureRole(roleMint); err != nil {
+		return err
+	}
+	return t.mintCore(to, amount)
+}
+
+// mintCore performs the mint accounting (supply cap + credit + Transfer) after
+// the caller has checked pause and role. Used by mint and batchMint.
+func (t cas20Token) mintCore(to common.Address, amount *uint256.Int) error {
+	if to == (common.Address{}) {
+		return revCAS20("InvalidReceiver(address)", errSelInvalidReceiver, addrKey(to))
+	}
+	// MINT_RECEIVER compliance is enforced even during privileged bootstrap. Each
+	// value below is read once and reused, the revert payloads included.
+	mintReceiver := t.s.mintReceiverPolicy()
+	if !t.policyAllows(mintReceiver, to) {
+		return revCAS20("PolicyForbids(bytes32,uint64)", errSelPolicyForbids,
+			scopeMintReceiver, wU64(mintReceiver))
+	}
+	supply := t.s.totalSupply()
+	newSupply := new(uint256.Int).Add(supply, amount)
+	if newSupply.Lt(supply) {
+		return revPanic(0x11) // supply overflow
+	}
+	if cap := t.s.supplyCap(); newSupply.Gt(cap) {
+		return revCAS20("SupplyCapExceeded(uint256,uint256)", errSelSupplyCapExceeded,
+			wU256(cap), wU256(newSupply))
+	}
+	toSlot := t.s.balanceSlot(to)
+	t.s.setU256At(toSlot, new(uint256.Int).Add(t.s.getU256At(toSlot), amount))
+	t.s.setTotalSupply(newSupply)
+	if !t.emit(cas20TopicTransfer, common.Address{}, to, amount) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func (t cas20Token) burn(from common.Address, amount *uint256.Int) error {
+	if t.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	if t.isPaused(cas20PauseBurn) {
+		return revCAS20("ContractPaused(uint8)", errSelContractPaused, wU8(cas20PauseBurn))
+	}
+	if err := t.ensureRole(roleBurn); err != nil {
+		return err
+	}
+	fromSlot := t.s.balanceSlot(from)
+	bal := t.s.getU256At(fromSlot)
+	if bal.Lt(amount) {
+		return revCAS20("InsufficientBalance(address,uint256,uint256)", errSelInsufficientBalance,
+			addrKey(from), wU256(bal), wU256(amount))
+	}
+	t.s.setU256At(fromSlot, new(uint256.Int).Sub(bal, amount))
+	// Checked, as mint checks its own direction and as Solidity's arithmetic would:
+	// the balance check above bounds this only while the balances sum to
+	// totalSupply, and an unchecked Sub would wrap that to near 2^256 rather than
+	// halting.
+	supply := t.s.totalSupply()
+	if supply.Lt(amount) {
+		return revPanic(0x11) // supply underflow
+	}
+	t.s.setTotalSupply(new(uint256.Int).Sub(supply, amount))
+	if !t.emit(cas20TopicTransfer, from, common.Address{}, amount) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// seizeWithMemo reassigns a frozen account's balance. SEIZE_HOLDER is inverted:
+// only a disallowed holder is seizable, so an ALWAYS_ALLOW scope makes every
+// account non-seizable.
+func (t cas20Token) seizeWithMemo(from, to common.Address, amount *uint256.Int, memo common.Hash) error {
+	if t.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	if t.isPaused(cas20PauseSeize) {
+		return revCAS20("ContractPaused(uint8)", errSelContractPaused, wU8(cas20PauseSeize))
+	}
+	if err := t.ensureRole(roleSeize); err != nil {
+		return err
+	}
+	// A seizure is a reassignment, so it needs a real source and a different
+	// destination: self-seizing would emit Seized over a no-op, and a zero source
+	// would report InsufficientBalance for what is really a malformed argument.
+	if to == (common.Address{}) || from == to {
+		return revCAS20("InvalidReceiver(address)", errSelInvalidReceiver, addrKey(to))
+	}
+	if from == (common.Address{}) {
+		return revCAS20("InvalidSender(address)", errSelInvalidSender, addrKey(from))
+	}
+	// Both seize ids share a slot, so they are read together.
+	seizeHolder, seizeReceiver := t.s.seizePolicies()
+	if t.policyAllows(seizeHolder, from) {
+		return revCAS20("AccountNotSeizable(address)", errSelAccountNotSeizable, addrKey(from))
+	}
+	if !t.policyAllows(seizeReceiver, to) {
+		return revCAS20("PolicyForbids(bytes32,uint64)", errSelPolicyForbids,
+			scopeSeizeReceiver, wU64(seizeReceiver))
+	}
+	fromSlot := t.s.balanceSlot(from)
+	bal := t.s.getU256At(fromSlot)
+	if bal.Lt(amount) {
+		return revCAS20("InsufficientBalance(address,uint256,uint256)", errSelInsufficientBalance,
+			addrKey(from), wU256(bal), wU256(amount))
+	}
+	t.s.setU256At(fromSlot, new(uint256.Int).Sub(bal, amount))
+	toSlot := t.s.balanceSlot(to)
+	t.s.setU256At(toSlot, new(uint256.Int).Add(t.s.getU256At(toSlot), amount))
+	if !t.emit(cas20TopicTransfer, from, to, amount) {
+		return ErrOutOfGas
+	}
+	if !t.emitMemo(memo) {
+		return ErrOutOfGas
+	}
+	ab := amount.Bytes32()
+	if !t.ctx.AddLog([]common.Hash{cas20TopicSeized, addrKey(t.ctx.Caller), addrKey(from), addrKey(to)}, ab[:]) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// --- Configurable (subset) --------------------------------------------------
+
+func (t cas20Token) updateSupplyCap(newCap *uint256.Int) error {
+	if t.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	if err := t.ensureRole(roleDefaultAdmin); err != nil {
+		return err
+	}
+	if supply := t.s.totalSupply(); newCap.Lt(supply) || newCap.Gt(cas20NoSupplyCap) {
+		return revCAS20("InvalidSupplyCap(uint256,uint256)", errSelInvalidSupplyCap,
+			wU256(supply), wU256(newCap))
+	}
+	previous := t.s.supplyCap()
+	t.s.setSupplyCap(newCap)
+	if !t.ctx.AddLog([]common.Hash{cas20TopicSupplyCapUpdated, addrKey(t.ctx.Caller)},
+		append(wU256(previous).Bytes(), wU256(newCap).Bytes()...)) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// updatePolicy binds a policy id to one of the token's six compliance scopes.
+// The id must reference an existing registry policy (or a sentinel); binding a
+// never-created id is rejected so the read path's empty-set tolerance cannot be
+// exploited.
+func (t cas20Token) updatePolicy(scope common.Hash, id uint64) error {
+	if t.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	if err := t.ensureRole(roleDefaultAdmin); err != nil {
+		return err
+	}
+	// The scope is validated before the id: an unrecognized scope is reported as
+	// such whatever id accompanies it. Resolving it to its accessors first is what
+	// puts that check ahead of the registry lookup.
+	lane, ok := cas20PolicyLanes[scope]
+	if !ok {
+		return revCAS20("UnsupportedPolicyType(bytes32)", errSelUnsupportedScope, scope)
+	}
+	read := func() uint64 { return t.s.getPackedU64(lane.slot, lane.byteOff) }
+	write := func(id uint64) { t.s.setPackedU64(lane.slot, lane.byteOff, id) }
+
+	// policyExists answers for the sentinels itself, so binding one needs no
+	// special case here (BEP-702 3.8).
+	if !newPolicyReg(t.ctx).policyExists(id) {
+		return revCAS20("PolicyNotFound(uint64)", errSelPolicyNotFoundID, wU64(id))
+	}
+	// The event carries the id being replaced, so the previous binding is read
+	// before the write — an SLOAD a Solidity implementation emitting the same
+	// event would also pay.
+	previous := read()
+	write(id)
+	if !t.ctx.AddLog([]common.Hash{cas20TopicPolicyUpdated, scope},
+		append(wU64(previous).Bytes(), wU64(id).Bytes()...)) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// --- ABI: dynamic uint8[] ---------------------------------------------------
+
+// readUint8Array decodes a dynamic uint8[] argument. Offsets, the length and
+// every element are read strictly: a word with dirty high bits is a malformed
+// encoding, not a value to be truncated into something plausible. Truncating an
+// element would be the worst of the three — 0x0100 would silently become
+// feature 0 and pause a feature the caller never named.
+func readUint8Array(args []byte) ([]uint8, error) {
+	L := uint64(len(args))
+	off, ok := wordU64(args, 0)
+	if !ok || off > L || L-off < 32 {
+		return nil, ErrExecutionReverted
+	}
+	n, ok := wordU64(args, off)
+	if !ok {
+		return nil, ErrExecutionReverted
+	}
+	dataPos := off + 32
+	if n > (L-dataPos)/32 {
+		return nil, ErrExecutionReverted
+	}
+	out := make([]uint8, n)
+	for i := uint64(0); i < n; i++ {
+		// Byte-addressed, not word-indexed: the head offset is caller-supplied
+		// and need not be 32-aligned.
+		v, ok := wordU64(args, dataPos+i*32)
+		if !ok || v > 0xff {
+			return nil, ErrExecutionReverted
+		}
+		out[i] = byte(v)
+	}
+	return out, nil
+}

--- a/core/vm/cas20_admin.go
+++ b/core/vm/cas20_admin.go
@@ -142,18 +142,16 @@ func (t cas20Token) dispatchAdmin(sel [4]byte, args []byte) (ret []byte, err err
 		return nil, t.renounceLastAdmin(), true
 
 	case selIsPaused:
-		// Decoded exactly as pause()/unpause() decode their elements: a word with
-		// dirty high bytes is a malformed encoding, and a well-formed value
-		// outside the enum is Panic(0x21).
+		// Decoded exactly as pause()/unpause() decode their elements. Solidity's
+		// external decoder validates an enum argument and reverts with empty
+		// returndata, both for dirty padding and for a clean value outside the
+		// enum; Panic(0x21) belongs to an internal uint-to-enum cast, not here.
 		w, err := readWord(args, 0)
 		if err != nil {
 			return nil, err, true
 		}
-		if !isEnumWord(w, 0xff) {
+		if !isEnumWord(w, cas20PauseSeize) {
 			return nil, ErrExecutionReverted, true
-		}
-		if uint(w[31]) > cas20PauseSeize {
-			return nil, revPanic(0x21), true
 		}
 		return encBool(t.isPaused(uint(w[31]))), nil, true
 	case selPause:
@@ -447,7 +445,7 @@ func (t cas20Token) setPause(args []byte, on bool) error {
 	words := make([]common.Hash, len(features))
 	for i, f := range features {
 		if uint(f) > cas20PauseSeize {
-			return revPanic(0x21) // invalid enum value
+			return ErrExecutionReverted
 		}
 		words[i] = wU8(f)
 		mask := new(uint256.Int).Lsh(uint256.NewInt(1), uint(f))

--- a/core/vm/cas20_admin.go
+++ b/core/vm/cas20_admin.go
@@ -385,12 +385,12 @@ func (t cas20Token) ensureRoleMutable(role common.Hash) error {
 // --- Pausable ---------------------------------------------------------------
 
 func (t cas20Token) setPause(args []byte, on bool) error {
-	if t.ctx.ReadOnly {
-		return ErrWriteProtection
-	}
 	features, err := readUint8Array(args)
 	if err != nil {
 		return err
+	}
+	if t.ctx.ReadOnly {
+		return ErrWriteProtection
 	}
 	role := rolePause
 	if !on {

--- a/core/vm/cas20_admin.go
+++ b/core/vm/cas20_admin.go
@@ -6,8 +6,7 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// Built-in role ids. DEFAULT_ADMIN is bytes32(0); the rest are keccak of their
-// canonical names. An unset role admin (zero) therefore means DEFAULT_ADMIN.
+// DEFAULT_ADMIN is bytes32(0), so an unset role admin reads as DEFAULT_ADMIN.
 var (
 	roleDefaultAdmin = common.Hash{}
 	roleMint         = crypto.Keccak256Hash([]byte("MINT_ROLE"))
@@ -35,8 +34,6 @@ var (
 	selUnpauseRole      = selector("UNPAUSE_ROLE()")
 	selMetadataRole     = selector("METADATA_ROLE()")
 
-	// Policy scope identifiers: keccak256 of the canonical scope names
-	// (BEP-702 section 3.8).
 	scopeTransferSender   = crypto.Keccak256Hash([]byte("TRANSFER_SENDER_POLICY"))
 	scopeTransferReceiver = crypto.Keccak256Hash([]byte("TRANSFER_RECEIVER_POLICY"))
 	scopeTransferExecutor = crypto.Keccak256Hash([]byte("TRANSFER_EXECUTOR_POLICY"))
@@ -73,8 +70,6 @@ var (
 	cas20TopicSupplyCapUpdated   = eventTopic("SupplyCapUpdated(address,uint256,uint256)")
 )
 
-// dispatchAdmin handles the RBAC / pause / mint-burn selectors. ok is false
-// when sel is none of them, so the caller can continue matching.
 func (t cas20Token) dispatchAdmin(sel [4]byte, args []byte) (ret []byte, err error, ok bool) {
 	switch sel {
 	case selDefaultAdminRole:
@@ -142,10 +137,6 @@ func (t cas20Token) dispatchAdmin(sel [4]byte, args []byte) (ret []byte, err err
 		return nil, t.renounceLastAdmin(), true
 
 	case selIsPaused:
-		// Decoded exactly as pause()/unpause() decode their elements. Solidity's
-		// external decoder validates an enum argument and reverts with empty
-		// returndata, both for dirty padding and for a clean value outside the
-		// enum; Panic(0x21) belongs to an internal uint-to-enum cast, not here.
 		w, err := readWord(args, 0)
 		if err != nil {
 			return nil, err, true
@@ -239,13 +230,7 @@ func (t cas20Token) dispatchAdmin(sel [4]byte, args []byte) (ret []byte, err err
 	return nil, nil, false
 }
 
-// cas20PolicyLanes maps each policy scope to the packed lane holding its id.
-//
-// One table, because policyId and updatePolicy used to map the same six scopes
-// through separate switches: a lane wired wrong in one showed up only if a test
-// happened to round-trip that scope, and a pair wired wrong the same way in both
-// round-tripped cleanly. TestCAS20PolicyLanePositions checks each entry against the
-// byte the id actually lands on.
+// One table for policyId and updatePolicy, so the two cannot disagree on a lane.
 var cas20PolicyLanes = map[common.Hash]struct {
 	slot    uint64
 	byteOff uint
@@ -280,8 +265,6 @@ func readRoleAccount(args []byte) (common.Hash, common.Address, error) {
 
 // --- RoleManaged ------------------------------------------------------------
 
-// roleMutable reports whether role mutations are still possible: adminCount == 0
-// freezes them, except inside the factory's privileged bootstrap.
 func (t cas20Token) grantRole(role common.Hash, account common.Address) error {
 	if err := t.ensureRoleMutable(role); err != nil {
 		return err
@@ -302,7 +285,6 @@ func (t cas20Token) revokeRole(role common.Hash, account common.Address) error {
 	if err := t.ensureRoleMutable(role); err != nil {
 		return err
 	}
-	// The last DEFAULT_ADMIN cannot be removed via revoke; use renounceLastAdmin.
 	if role == roleDefaultAdmin && t.s.hasRole(role, account) && t.s.adminCount().Eq(uint256.NewInt(1)) {
 		return revCAS20("LastAdminCannotRenounce()", errSelLastAdminRenounce)
 	}
@@ -316,11 +298,9 @@ func (t cas20Token) renounceRole(role common.Hash, confirmation common.Address) 
 	if t.ctx.ReadOnly {
 		return ErrWriteProtection
 	}
-	// Confirmation must equal the caller (OZ 5.x anti-misuse guard).
 	if confirmation != t.ctx.Caller {
 		return revCAS20("AccessControlBadConfirmation()", errSelACBadConfirmation)
 	}
-	// The sole DEFAULT_ADMIN must use renounceLastAdmin, not this path.
 	if role == roleDefaultAdmin && t.s.hasRole(role, t.ctx.Caller) && t.s.adminCount().Eq(uint256.NewInt(1)) {
 		return revCAS20("LastAdminCannotRenounce()", errSelLastAdminRenounce)
 	}
@@ -334,10 +314,7 @@ func (t cas20Token) renounceLastAdmin() error {
 	if t.ctx.ReadOnly {
 		return ErrWriteProtection
 	}
-	// Two checks, not one condition: a caller who holds no admin role is
-	// unauthorized, and NotSoleAdmin is reserved for one who does hold it but is
-	// not the last. Collapsing them told a stranger they were "not the sole
-	// admin", which is true but says the wrong thing.
+	// A stranger is unauthorized; NotSoleAdmin is for an admin who is not the last.
 	if !t.s.hasRole(roleDefaultAdmin, t.ctx.Caller) {
 		return revCAS20("AccessControlUnauthorizedAccount(address,bytes32)", errSelACUnauthorized,
 			addrKey(t.ctx.Caller), roleDefaultAdmin)
@@ -351,8 +328,6 @@ func (t cas20Token) renounceLastAdmin() error {
 	if !t.ctx.AddLog([]common.Hash{cas20TopicRoleRevoked, roleDefaultAdmin, addrKey(t.ctx.Caller), addrKey(t.ctx.Caller)}, nil) {
 		return ErrOutOfGas
 	}
-	// The dedicated event marks the transition an indexer cannot infer from
-	// RoleRevoked alone: the token is now permanently ungovernable.
 	if !t.ctx.AddLog([]common.Hash{cas20TopicLastAdminRenounced, addrKey(t.ctx.Caller)}, nil) {
 		return ErrOutOfGas
 	}
@@ -371,8 +346,6 @@ func (t cas20Token) setRoleAdmin(role, newAdminRole common.Hash) error {
 	return nil
 }
 
-// removeRole clears role from account (if held), maintaining adminCount, and
-// emits RoleRevoked. Renounce silently succeeds when the role is not held.
 func (t cas20Token) removeRole(role common.Hash, account common.Address) bool {
 	if !t.s.hasRole(role, account) {
 		return true
@@ -384,7 +357,6 @@ func (t cas20Token) removeRole(role common.Hash, account common.Address) bool {
 	return t.ctx.AddLog([]common.Hash{cas20TopicRoleRevoked, role, addrKey(account), addrKey(t.ctx.Caller)}, nil)
 }
 
-// ensureRole reverts unless the caller holds role (skipped when privileged).
 func (t cas20Token) ensureRole(role common.Hash) error {
 	if t.privileged || t.s.hasRole(role, t.ctx.Caller) {
 		return nil
@@ -397,9 +369,8 @@ func (t cas20Token) ensureRoleMutable(role common.Hash) error {
 	if t.ctx.ReadOnly {
 		return ErrWriteProtection
 	}
-	// The zero-admin freeze yields to the bootstrap window so an ownerless token
-	// can be configured, but not once this frame has renounced: that transition is
-	// advertised as permanent, and the window is not a way back (BEP-702 3.4).
+	// The bootstrap window may configure an ownerless token, but not one this frame
+	// has just renounced: that transition is permanent.
 	if (!t.privileged || t.ctx.adminRenounced) && t.s.adminCount().IsZero() {
 		return revCAS20("AccessControlUnauthorizedAccount(address,bytes32)", errSelACUnauthorized,
 			addrKey(t.ctx.Caller), t.s.roleAdmin(role))
@@ -417,10 +388,6 @@ func (t cas20Token) setPause(args []byte, on bool) error {
 	if t.ctx.ReadOnly {
 		return ErrWriteProtection
 	}
-	// Decoded before the role check, because that is where Solidity does it: the
-	// external dispatcher decodes the argument before any modifier runs, so a
-	// malformed array is reported as malformed whether or not the caller is
-	// authorized.
 	features, err := readUint8Array(args)
 	if err != nil {
 		return err
@@ -435,9 +402,7 @@ func (t cas20Token) setPause(args []byte, on bool) error {
 	if len(features) == 0 {
 		return revCAS20("EmptyFeatureSet()", errSelEmptyFeatureSet)
 	}
-	// Read before the caller-sized loop and the encoding below: a mask this frame
-	// could not pay to read is zero, which says "nothing paused", and the work that
-	// follows is proportional to the caller's array.
+	// Read before the caller-sized loop: an unpaid read must be out-of-gas, not an empty mask.
 	p, ok := t.s.pausedChecked()
 	if !ok {
 		return ErrOutOfGas
@@ -460,9 +425,6 @@ func (t cas20Token) setPause(args []byte, on bool) error {
 	if !on {
 		topic = cas20TopicUnpaused
 	}
-	// The event carries the requested feature list, not the resulting mask: it
-	// records the action taken, so re-pausing an already-paused feature is
-	// visible rather than indistinguishable from a no-op.
 	if !t.ctx.AddLog([]common.Hash{topic, addrKey(t.ctx.Caller)}, encodeTuple(abiWordArray(words))) {
 		return ErrOutOfGas
 	}
@@ -484,14 +446,12 @@ func (t cas20Token) mint(to common.Address, amount *uint256.Int) error {
 	return t.mintCore(to, amount)
 }
 
-// mintCore performs the mint accounting (supply cap + credit + Transfer) after
-// the caller has checked pause and role. Used by mint and batchMint.
+// mintCore assumes the caller has checked pause and role.
 func (t cas20Token) mintCore(to common.Address, amount *uint256.Int) error {
 	if to == (common.Address{}) {
 		return revCAS20("InvalidReceiver(address)", errSelInvalidReceiver, addrKey(to))
 	}
-	// MINT_RECEIVER compliance is enforced even during privileged bootstrap. Each
-	// value below is read once and reused, the revert payloads included.
+	// Enforced even during the privileged bootstrap.
 	mintReceiver := t.s.mintReceiverPolicy()
 	if !t.policyAllows(mintReceiver, to) {
 		return revCAS20("PolicyForbids(bytes32,uint64)", errSelPolicyForbids,
@@ -500,7 +460,7 @@ func (t cas20Token) mintCore(to common.Address, amount *uint256.Int) error {
 	supply := t.s.totalSupply()
 	newSupply := new(uint256.Int).Add(supply, amount)
 	if newSupply.Lt(supply) {
-		return revPanic(0x11) // supply overflow
+		return revPanic(0x11)
 	}
 	if cap := t.s.supplyCap(); newSupply.Gt(cap) {
 		return revCAS20("SupplyCapExceeded(uint256,uint256)", errSelSupplyCapExceeded,
@@ -532,13 +492,9 @@ func (t cas20Token) burn(from common.Address, amount *uint256.Int) error {
 			addrKey(from), wU256(bal), wU256(amount))
 	}
 	t.s.setU256At(fromSlot, new(uint256.Int).Sub(bal, amount))
-	// Checked, as mint checks its own direction and as Solidity's arithmetic would:
-	// the balance check above bounds this only while the balances sum to
-	// totalSupply, and an unchecked Sub would wrap that to near 2^256 rather than
-	// halting.
 	supply := t.s.totalSupply()
 	if supply.Lt(amount) {
-		return revPanic(0x11) // supply underflow
+		return revPanic(0x11)
 	}
 	t.s.setTotalSupply(new(uint256.Int).Sub(supply, amount))
 	if !t.emit(cas20TopicTransfer, from, common.Address{}, amount) {
@@ -547,9 +503,7 @@ func (t cas20Token) burn(from common.Address, amount *uint256.Int) error {
 	return nil
 }
 
-// seizeWithMemo reassigns a frozen account's balance. SEIZE_HOLDER is inverted:
-// only a disallowed holder is seizable, so an ALWAYS_ALLOW scope makes every
-// account non-seizable.
+// SEIZE_HOLDER is inverted: only a disallowed holder is seizable.
 func (t cas20Token) seizeWithMemo(from, to common.Address, amount *uint256.Int, memo common.Hash) error {
 	if t.ctx.ReadOnly {
 		return ErrWriteProtection
@@ -560,16 +514,14 @@ func (t cas20Token) seizeWithMemo(from, to common.Address, amount *uint256.Int, 
 	if err := t.ensureRole(roleSeize); err != nil {
 		return err
 	}
-	// A seizure is a reassignment, so it needs a real source and a different
-	// destination: self-seizing would emit Seized over a no-op, and a zero source
-	// would report InsufficientBalance for what is really a malformed argument.
+	// A self-seize is a no-op that would still emit Seized; a zero source is a
+	// malformed argument, not an empty balance.
 	if to == (common.Address{}) || from == to {
 		return revCAS20("InvalidReceiver(address)", errSelInvalidReceiver, addrKey(to))
 	}
 	if from == (common.Address{}) {
 		return revCAS20("InvalidSender(address)", errSelInvalidSender, addrKey(from))
 	}
-	// Both seize ids share a slot, so they are read together.
 	seizeHolder, seizeReceiver := t.s.seizePolicies()
 	if t.policyAllows(seizeHolder, from) {
 		return revCAS20("AccountNotSeizable(address)", errSelAccountNotSeizable, addrKey(from))
@@ -622,10 +574,8 @@ func (t cas20Token) updateSupplyCap(newCap *uint256.Int) error {
 	return nil
 }
 
-// updatePolicy binds a policy id to one of the token's six compliance scopes.
-// The id must reference an existing registry policy (or a sentinel); binding a
-// never-created id is rejected so the read path's empty-set tolerance cannot be
-// exploited.
+// updatePolicy rejects a never-created id so the read path's empty-set tolerance
+// cannot be bound on purpose.
 func (t cas20Token) updatePolicy(scope common.Hash, id uint64) error {
 	if t.ctx.ReadOnly {
 		return ErrWriteProtection
@@ -633,9 +583,7 @@ func (t cas20Token) updatePolicy(scope common.Hash, id uint64) error {
 	if err := t.ensureRole(roleDefaultAdmin); err != nil {
 		return err
 	}
-	// The scope is validated before the id: an unrecognized scope is reported as
-	// such whatever id accompanies it. Resolving it to its accessors first is what
-	// puts that check ahead of the registry lookup.
+	// Scope before id: an unknown scope is reported as such whatever id accompanies it.
 	lane, ok := cas20PolicyLanes[scope]
 	if !ok {
 		return revCAS20("UnsupportedPolicyType(bytes32)", errSelUnsupportedScope, scope)
@@ -643,14 +591,9 @@ func (t cas20Token) updatePolicy(scope common.Hash, id uint64) error {
 	read := func() uint64 { return t.s.getPackedU64(lane.slot, lane.byteOff) }
 	write := func(id uint64) { t.s.setPackedU64(lane.slot, lane.byteOff, id) }
 
-	// policyExists answers for the sentinels itself, so binding one needs no
-	// special case here (BEP-702 3.8).
 	if !newPolicyReg(t.ctx).policyExists(id) {
 		return revCAS20("PolicyNotFound(uint64)", errSelPolicyNotFoundID, wU64(id))
 	}
-	// The event carries the id being replaced, so the previous binding is read
-	// before the write — an SLOAD a Solidity implementation emitting the same
-	// event would also pay.
 	previous := read()
 	write(id)
 	if !t.ctx.AddLog([]common.Hash{cas20TopicPolicyUpdated, scope},
@@ -662,11 +605,6 @@ func (t cas20Token) updatePolicy(scope common.Hash, id uint64) error {
 
 // --- ABI: dynamic uint8[] ---------------------------------------------------
 
-// readUint8Array decodes a dynamic uint8[] argument. Offsets, the length and
-// every element are read strictly: a word with dirty high bits is a malformed
-// encoding, not a value to be truncated into something plausible. Truncating an
-// element would be the worst of the three — 0x0100 would silently become
-// feature 0 and pause a feature the caller never named.
 func readUint8Array(args []byte) ([]uint8, error) {
 	L := uint64(len(args))
 	off, ok := wordU64(args, 0)
@@ -683,8 +621,7 @@ func readUint8Array(args []byte) ([]uint8, error) {
 	}
 	out := make([]uint8, n)
 	for i := uint64(0); i < n; i++ {
-		// Byte-addressed, not word-indexed: the head offset is caller-supplied
-		// and need not be 32-aligned.
+		// Byte-addressed: the caller-supplied head offset need not be 32-aligned.
 		v, ok := wordU64(args, dataPos+i*32)
 		if !ok || v > 0xff {
 			return nil, ErrExecutionReverted

--- a/core/vm/cas20_admin_test.go
+++ b/core/vm/cas20_admin_test.go
@@ -1,0 +1,296 @@
+package vm
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+func cas20CallU8Array(sel [4]byte, vals ...byte) []byte {
+	out := append([]byte{}, sel[:]...)
+	out = append(out, u256hash(0x20).Bytes()...)              // head offset
+	out = append(out, u256hash(uint64(len(vals))).Bytes()...) // length
+	for _, v := range vals {
+		out = append(out, u256hash(uint64(v)).Bytes()...)
+	}
+	return out
+}
+
+// TestCAS20PauseRejectsMalformedArray pins strict uint8[] decoding. A truncating
+// decoder is worse than a permissive one here: 0x0100 would silently become
+// feature 0 and pause a feature the caller never named.
+func TestCAS20PauseRejectsMalformedArray(t *testing.T) {
+	admin := common.HexToAddress("0xad4149")
+	_, _, run := newTokenWithEVM(t, 1, func(s cas20Storage) {
+		s.setRole(rolePause, admin, true)
+	})
+
+	word := func(v uint64) []byte { return u256hash(v).Bytes() }
+	dirty := func(hi byte) []byte { // a word with a nonzero byte above the low one
+		var w common.Hash
+		w[0], w[31] = hi, 0
+		return w.Bytes()
+	}
+
+	cases := []struct {
+		name string
+		args []byte
+	}{
+		{"element above uint8 range",
+			append(append(word(0x20), word(1)...), word(0x100)...)},
+		{"element with dirty high bytes",
+			append(append(word(0x20), word(1)...), dirty(1)...)},
+		{"length word with dirty high bytes",
+			append(append(word(0x20), dirty(1)...), word(0)...)},
+		{"head offset with dirty high bytes",
+			append(append(dirty(1), word(1)...), word(0)...)},
+		{"head offset past the end",
+			append(append(word(0x4000), word(1)...), word(0)...)},
+	}
+	for _, tc := range cases {
+		input := append(append([]byte{}, selPause[:]...), tc.args...)
+		if _, err := run(admin, input); !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("%s: err = %v, want revert", tc.name, err)
+		}
+	}
+
+	// The well-formed equivalent still works, so the checks are not just
+	// rejecting everything.
+	if _, err := run(admin, cas20CallU8Array(selPause, byte(cas20PauseTransfer))); err != nil {
+		t.Errorf("well-formed pause: %v", err)
+	}
+}
+
+func TestCAS20AdminLifecycle(t *testing.T) {
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := cas20Addr(cas20VariantAsset, 1)
+	admin := common.HexToAddress("0xad4149")
+	minter := common.HexToAddress("0x33333")
+
+	// Seed: admin holds DEFAULT_ADMIN, adminCount 1, generous cap.
+	view := newUnmeteredCAS20Storage(statedb, token)
+	view.setRole(roleDefaultAdmin, admin, true)
+	view.setAdminCount(uint256.NewInt(1))
+	view.setSupplyCap(uint256.NewInt(1_000_000))
+
+	run := func(caller common.Address, input []byte) ([]byte, error) {
+		gas := NewGasBudget(2_000_000)
+		ctx := &PrecompileContext{StateDB: statedb, Self: token, Caller: caller, DirectCall: true, gas: &gas}
+		return newCAS20Token(ctx, 18).dispatch(input)
+	}
+	mustOK := func(what string, caller common.Address, input []byte) {
+		t.Helper()
+		if _, err := run(caller, input); err != nil {
+			t.Fatalf("%s: unexpected err %v", what, err)
+		}
+	}
+	mustRevert := func(what string, caller common.Address, input []byte) {
+		t.Helper()
+		if _, err := run(caller, input); !errors.Is(err, ErrExecutionReverted) {
+			t.Fatalf("%s: err = %v, want revert", what, err)
+		}
+	}
+	bal := func(a common.Address) uint64 { return view.balanceOf(a).Uint64() }
+
+	// role constant getter.
+	if ret, err := run(admin, cas20Call(selMintRole)); err != nil || !bytes.Equal(ret, roleMint.Bytes()) {
+		t.Fatalf("MINT_ROLE() = %x err %v", ret, err)
+	}
+
+	// admin grants MINT / BURN / PAUSE / UNPAUSE.
+	mustOK("grant MINT", admin, cas20Call(selGrantRole, roleMint, addrKey(minter)))
+	mustOK("grant BURN", admin, cas20Call(selGrantRole, roleBurn, addrKey(minter)))
+	mustOK("grant PAUSE", admin, cas20Call(selGrantRole, rolePause, addrKey(admin)))
+	mustOK("grant UNPAUSE", admin, cas20Call(selGrantRole, roleUnpause, addrKey(admin)))
+	if ret, _ := run(admin, cas20Call(selHasRole, roleMint, addrKey(minter))); !bytes.Equal(ret, encBool(true)) {
+		t.Fatal("minter should hold MINT_ROLE")
+	}
+
+	// non-minter mint reverts; minter mint succeeds.
+	mustRevert("unauthorized mint", admin, cas20Call(selMint, addrKey(cas20Alice), u256hash(100)))
+	mustOK("mint", minter, cas20Call(selMint, addrKey(cas20Alice), u256hash(500)))
+	if bal(cas20Alice) != 500 || view.totalSupply().Uint64() != 500 {
+		t.Fatalf("after mint: bal %d supply %d", bal(cas20Alice), view.totalSupply().Uint64())
+	}
+
+	// mint beyond supply cap reverts.
+	mustRevert("cap exceeded", minter, cas20Call(selMint, addrKey(cas20Alice), u256hash(1_000_000)))
+
+	// pause TRANSFER -> transfer reverts; unpause -> ok.
+	mustOK("pause TRANSFER", admin, cas20CallU8Array(selPause, cas20PauseTransfer))
+	mustRevert("transfer while paused", cas20Alice, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(1)))
+	mustOK("unpause TRANSFER", admin, cas20CallU8Array(selUnpause, cas20PauseTransfer))
+	mustOK("transfer after unpause", cas20Alice, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(100)))
+	if bal(cas20Bob) != 100 {
+		t.Fatalf("bob balance %d", bal(cas20Bob))
+	}
+
+	// pause MINT -> mint reverts.
+	mustOK("pause MINT", admin, cas20CallU8Array(selPause, cas20PauseMint))
+	mustRevert("mint while paused", minter, cas20Call(selMint, addrKey(cas20Alice), u256hash(1)))
+	mustOK("unpause MINT", admin, cas20CallU8Array(selUnpause, cas20PauseMint))
+
+	// burn by holder-with-role.
+	supplyBefore := view.totalSupply().Uint64()
+	mustOK("burn", minter, cas20Call(selBurn, u256hash(0))) // minter has 0, burning 0 ok
+	mustOK("mint to minter", minter, cas20Call(selMint, addrKey(minter), u256hash(50)))
+	mustOK("burn 50", minter, cas20Call(selBurn, u256hash(50)))
+	if view.totalSupply().Uint64() != supplyBefore {
+		t.Fatalf("supply after mint+burn = %d, want %d", view.totalSupply().Uint64(), supplyBefore)
+	}
+
+	// empty feature set reverts.
+	mustRevert("empty pause set", admin, cas20CallU8Array(selPause))
+}
+
+func TestCAS20AdminLastAdminProtection(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	token := cas20Addr(cas20VariantStablecoin, 1)
+	admin := common.HexToAddress("0xad4149")
+
+	view := newUnmeteredCAS20Storage(statedb, token)
+	view.setRole(roleDefaultAdmin, admin, true)
+	view.setAdminCount(uint256.NewInt(1))
+
+	run := func(caller common.Address, input []byte) ([]byte, error) {
+		gas := NewGasBudget(2_000_000)
+		ctx := &PrecompileContext{StateDB: statedb, Self: token, Caller: caller, DirectCall: true, gas: &gas}
+		return newCAS20Token(ctx, 6).dispatch(input)
+	}
+
+	// revoking the sole DEFAULT_ADMIN via revokeRole is blocked.
+	if _, err := run(admin, cas20Call(selRevokeRole, roleDefaultAdmin, addrKey(admin))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatal("revoking last admin should revert")
+	}
+	// renounceRole with mismatched confirmation reverts.
+	if _, err := run(admin, cas20Call(selRenounceRole, roleDefaultAdmin, addrKey(cas20Bob))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatal("bad confirmation should revert")
+	}
+	// second admin can be added, then original can renounce normally.
+	if _, err := run(admin, cas20Call(selGrantRole, roleDefaultAdmin, addrKey(cas20Bob))); err != nil {
+		t.Fatalf("grant second admin: %v", err)
+	}
+	if view.adminCount().Uint64() != 2 {
+		t.Fatalf("adminCount = %d, want 2", view.adminCount().Uint64())
+	}
+
+	// now the sole-admin path: renounceLastAdmin only works when count == 1.
+	if _, err := run(admin, cas20Call(selRenounceLastAdmin)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatal("renounceLastAdmin with 2 admins should revert")
+	}
+	// bob renounces via normal path (not last).
+	if _, err := run(cas20Bob, cas20Call(selRenounceRole, roleDefaultAdmin, addrKey(cas20Bob))); err != nil {
+		t.Fatalf("bob renounce: %v", err)
+	}
+	if view.adminCount().Uint64() != 1 {
+		t.Fatalf("adminCount = %d, want 1", view.adminCount().Uint64())
+	}
+
+	// sole admin renounces permanently; token becomes ungovernable.
+	statedb.SetTxContext(common.HexToHash("0x1a57"), 0)
+	if _, err := run(admin, cas20Call(selRenounceLastAdmin)); err != nil {
+		t.Fatalf("renounceLastAdmin: %v", err)
+	}
+	if !view.adminCount().IsZero() {
+		t.Fatalf("adminCount = %d, want 0", view.adminCount().Uint64())
+	}
+	// RoleRevoked alone cannot express that no admin can ever exist again, so a
+	// dedicated event names the departing admin.
+	logs := statedb.GetLogs(common.HexToHash("0x1a57"), 1, common.Hash{}, 1)
+	if len(logs) != 2 {
+		t.Fatalf("renounceLastAdmin emitted %d logs, want 2 (RoleRevoked, LastAdminRenounced)", len(logs))
+	}
+	last := logs[1]
+	if len(last.Topics) != 2 || last.Topics[0] != cas20TopicLastAdminRenounced || last.Topics[1] != addrKey(admin) {
+		t.Errorf("LastAdminRenounced topics = %v, want [LastAdminRenounced, admin]", last.Topics)
+	}
+	if len(last.Data) != 0 {
+		t.Errorf("LastAdminRenounced data = %x, want empty", last.Data)
+	}
+	// no further role mutations are possible.
+	if _, err := run(admin, cas20Call(selGrantRole, roleMint, addrKey(admin))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatal("grant after renounceLastAdmin should revert (ungovernable)")
+	}
+}
+
+// TestCAS20BurnChecksSupplyUnderflow covers the subtraction the balance check only
+// bounds while the balances sum to totalSupply.
+func TestCAS20BurnChecksSupplyUnderflow(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xdec0de")
+	ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xbb"), creator, [][]byte{
+			cas20Call(selGrantRole, roleMint, addrKey(creator)),
+			cas20Call(selGrantRole, roleBurn, addrKey(creator)),
+			cas20Call(selMint, addrKey(cas20Alice), u256hash(100)),
+		}), NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+	view := newUnmeteredCAS20Storage(statedb, token)
+
+	if _, _, err := evm.Call(creator, token, cas20Call(selGrantRole, roleBurn, addrKey(cas20Alice)),
+		NewGasBudget(1_000_000), uint256.NewInt(0)); err != nil {
+		t.Fatalf("granting alice BURN_ROLE: %v", err)
+	}
+	// Break the invariant the way a bad state import or a future field could:
+	// alice holds more than the token has ever issued.
+	view.setBalance(cas20Alice, uint256.NewInt(500))
+	if view.totalSupply().Uint64() != 100 {
+		t.Fatalf("totalSupply = %d, want 100 — the fixture is not set up", view.totalSupply().Uint64())
+	}
+
+	_, _, err = evm.Call(cas20Alice, token, cas20Call(selBurn, u256hash(300)),
+		NewGasBudget(1_000_000), uint256.NewInt(0))
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("burning past totalSupply: err = %v, want a revert", err)
+	}
+	if got := view.totalSupply().Uint64(); got != 100 {
+		t.Errorf("totalSupply = %d after the refused burn, want 100. An unchecked Sub would "+
+			"have wrapped it to near 2^256", got)
+	}
+}
+
+// TestCAS20PauseDecodesBeforeAuthorizing pins the order Solidity's dispatcher has.
+func TestCAS20PauseDecodesBeforeAuthorizing(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xdec0de")
+	ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xba"), creator, nil),
+		NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	// cas20Bob holds no role, so both checks would refuse him. The malformed array
+	// has to be the one reported: a Solidity implementation decodes in the external
+	// dispatcher, before any modifier runs, so it answers the same way.
+	good := cas20CallU8Array(selPause, byte(cas20PauseTransfer))
+	out, _, err := evm.Call(cas20Bob, token, good[:len(good)-1], NewGasBudget(1_000_000), uint256.NewInt(0))
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("truncated pause args: err = %v, want a revert", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("returndata = %x, want empty. Malformed calldata reverts with no reason "+
+			"(BEP-702 3.2); a role error here means authorization ran first", out)
+	}
+
+	// And a well-formed array from the same caller still reports the role.
+	out, _, err = evm.Call(cas20Bob, token, good, NewGasBudget(1_000_000), uint256.NewInt(0))
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("unauthorized pause: err = %v, want a revert", err)
+	}
+	if len(out) < 4 || [4]byte(out[:4]) != errSelACUnauthorized {
+		t.Errorf("returndata = %x, want AccessControlUnauthorizedAccount", out)
+	}
+}

--- a/core/vm/cas20_admin_test.go
+++ b/core/vm/cas20_admin_test.go
@@ -13,17 +13,15 @@ import (
 
 func cas20CallU8Array(sel [4]byte, vals ...byte) []byte {
 	out := append([]byte{}, sel[:]...)
-	out = append(out, u256hash(0x20).Bytes()...)              // head offset
-	out = append(out, u256hash(uint64(len(vals))).Bytes()...) // length
+	out = append(out, u256hash(0x20).Bytes()...)
+	out = append(out, u256hash(uint64(len(vals))).Bytes()...)
 	for _, v := range vals {
 		out = append(out, u256hash(uint64(v)).Bytes()...)
 	}
 	return out
 }
 
-// TestCAS20PauseRejectsMalformedArray pins strict uint8[] decoding. A truncating
-// decoder is worse than a permissive one here: 0x0100 would silently become
-// feature 0 and pause a feature the caller never named.
+// A truncating decoder would turn 0x0100 into feature 0 and pause one the caller never named.
 func TestCAS20PauseRejectsMalformedArray(t *testing.T) {
 	admin := common.HexToAddress("0xad4149")
 	_, _, run := newTokenWithEVM(t, 1, func(s cas20Storage) {
@@ -31,7 +29,7 @@ func TestCAS20PauseRejectsMalformedArray(t *testing.T) {
 	})
 
 	word := func(v uint64) []byte { return u256hash(v).Bytes() }
-	dirty := func(hi byte) []byte { // a word with a nonzero byte above the low one
+	dirty := func(hi byte) []byte {
 		var w common.Hash
 		w[0], w[31] = hi, 0
 		return w.Bytes()
@@ -59,8 +57,6 @@ func TestCAS20PauseRejectsMalformedArray(t *testing.T) {
 		}
 	}
 
-	// The well-formed equivalent still works, so the checks are not just
-	// rejecting everything.
 	if _, err := run(admin, cas20CallU8Array(selPause, byte(cas20PauseTransfer))); err != nil {
 		t.Errorf("well-formed pause: %v", err)
 	}
@@ -75,7 +71,6 @@ func TestCAS20AdminLifecycle(t *testing.T) {
 	admin := common.HexToAddress("0xad4149")
 	minter := common.HexToAddress("0x33333")
 
-	// Seed: admin holds DEFAULT_ADMIN, adminCount 1, generous cap.
 	view := newUnmeteredCAS20Storage(statedb, token)
 	view.setRole(roleDefaultAdmin, admin, true)
 	view.setAdminCount(uint256.NewInt(1))
@@ -100,12 +95,10 @@ func TestCAS20AdminLifecycle(t *testing.T) {
 	}
 	bal := func(a common.Address) uint64 { return view.balanceOf(a).Uint64() }
 
-	// role constant getter.
 	if ret, err := run(admin, cas20Call(selMintRole)); err != nil || !bytes.Equal(ret, roleMint.Bytes()) {
 		t.Fatalf("MINT_ROLE() = %x err %v", ret, err)
 	}
 
-	// admin grants MINT / BURN / PAUSE / UNPAUSE.
 	mustOK("grant MINT", admin, cas20Call(selGrantRole, roleMint, addrKey(minter)))
 	mustOK("grant BURN", admin, cas20Call(selGrantRole, roleBurn, addrKey(minter)))
 	mustOK("grant PAUSE", admin, cas20Call(selGrantRole, rolePause, addrKey(admin)))
@@ -114,17 +107,14 @@ func TestCAS20AdminLifecycle(t *testing.T) {
 		t.Fatal("minter should hold MINT_ROLE")
 	}
 
-	// non-minter mint reverts; minter mint succeeds.
 	mustRevert("unauthorized mint", admin, cas20Call(selMint, addrKey(cas20Alice), u256hash(100)))
 	mustOK("mint", minter, cas20Call(selMint, addrKey(cas20Alice), u256hash(500)))
 	if bal(cas20Alice) != 500 || view.totalSupply().Uint64() != 500 {
 		t.Fatalf("after mint: bal %d supply %d", bal(cas20Alice), view.totalSupply().Uint64())
 	}
 
-	// mint beyond supply cap reverts.
 	mustRevert("cap exceeded", minter, cas20Call(selMint, addrKey(cas20Alice), u256hash(1_000_000)))
 
-	// pause TRANSFER -> transfer reverts; unpause -> ok.
 	mustOK("pause TRANSFER", admin, cas20CallU8Array(selPause, cas20PauseTransfer))
 	mustRevert("transfer while paused", cas20Alice, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(1)))
 	mustOK("unpause TRANSFER", admin, cas20CallU8Array(selUnpause, cas20PauseTransfer))
@@ -133,21 +123,18 @@ func TestCAS20AdminLifecycle(t *testing.T) {
 		t.Fatalf("bob balance %d", bal(cas20Bob))
 	}
 
-	// pause MINT -> mint reverts.
 	mustOK("pause MINT", admin, cas20CallU8Array(selPause, cas20PauseMint))
 	mustRevert("mint while paused", minter, cas20Call(selMint, addrKey(cas20Alice), u256hash(1)))
 	mustOK("unpause MINT", admin, cas20CallU8Array(selUnpause, cas20PauseMint))
 
-	// burn by holder-with-role.
 	supplyBefore := view.totalSupply().Uint64()
-	mustOK("burn", minter, cas20Call(selBurn, u256hash(0))) // minter has 0, burning 0 ok
+	mustOK("burn 0", minter, cas20Call(selBurn, u256hash(0)))
 	mustOK("mint to minter", minter, cas20Call(selMint, addrKey(minter), u256hash(50)))
 	mustOK("burn 50", minter, cas20Call(selBurn, u256hash(50)))
 	if view.totalSupply().Uint64() != supplyBefore {
 		t.Fatalf("supply after mint+burn = %d, want %d", view.totalSupply().Uint64(), supplyBefore)
 	}
 
-	// empty feature set reverts.
 	mustRevert("empty pause set", admin, cas20CallU8Array(selPause))
 }
 
@@ -166,15 +153,12 @@ func TestCAS20AdminLastAdminProtection(t *testing.T) {
 		return newCAS20Token(ctx, 6).dispatch(input)
 	}
 
-	// revoking the sole DEFAULT_ADMIN via revokeRole is blocked.
 	if _, err := run(admin, cas20Call(selRevokeRole, roleDefaultAdmin, addrKey(admin))); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatal("revoking last admin should revert")
 	}
-	// renounceRole with mismatched confirmation reverts.
 	if _, err := run(admin, cas20Call(selRenounceRole, roleDefaultAdmin, addrKey(cas20Bob))); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatal("bad confirmation should revert")
 	}
-	// second admin can be added, then original can renounce normally.
 	if _, err := run(admin, cas20Call(selGrantRole, roleDefaultAdmin, addrKey(cas20Bob))); err != nil {
 		t.Fatalf("grant second admin: %v", err)
 	}
@@ -182,11 +166,9 @@ func TestCAS20AdminLastAdminProtection(t *testing.T) {
 		t.Fatalf("adminCount = %d, want 2", view.adminCount().Uint64())
 	}
 
-	// now the sole-admin path: renounceLastAdmin only works when count == 1.
 	if _, err := run(admin, cas20Call(selRenounceLastAdmin)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatal("renounceLastAdmin with 2 admins should revert")
 	}
-	// bob renounces via normal path (not last).
 	if _, err := run(cas20Bob, cas20Call(selRenounceRole, roleDefaultAdmin, addrKey(cas20Bob))); err != nil {
 		t.Fatalf("bob renounce: %v", err)
 	}
@@ -194,7 +176,6 @@ func TestCAS20AdminLastAdminProtection(t *testing.T) {
 		t.Fatalf("adminCount = %d, want 1", view.adminCount().Uint64())
 	}
 
-	// sole admin renounces permanently; token becomes ungovernable.
 	statedb.SetTxContext(common.HexToHash("0x1a57"), 0)
 	if _, err := run(admin, cas20Call(selRenounceLastAdmin)); err != nil {
 		t.Fatalf("renounceLastAdmin: %v", err)
@@ -202,8 +183,6 @@ func TestCAS20AdminLastAdminProtection(t *testing.T) {
 	if !view.adminCount().IsZero() {
 		t.Fatalf("adminCount = %d, want 0", view.adminCount().Uint64())
 	}
-	// RoleRevoked alone cannot express that no admin can ever exist again, so a
-	// dedicated event names the departing admin.
 	logs := statedb.GetLogs(common.HexToHash("0x1a57"), 1, common.Hash{}, 1)
 	if len(logs) != 2 {
 		t.Fatalf("renounceLastAdmin emitted %d logs, want 2 (RoleRevoked, LastAdminRenounced)", len(logs))
@@ -215,14 +194,12 @@ func TestCAS20AdminLastAdminProtection(t *testing.T) {
 	if len(last.Data) != 0 {
 		t.Errorf("LastAdminRenounced data = %x, want empty", last.Data)
 	}
-	// no further role mutations are possible.
 	if _, err := run(admin, cas20Call(selGrantRole, roleMint, addrKey(admin))); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatal("grant after renounceLastAdmin should revert (ungovernable)")
 	}
 }
 
-// TestCAS20BurnChecksSupplyUnderflow covers the subtraction the balance check only
-// bounds while the balances sum to totalSupply.
+// The balance check bounds the supply subtraction only while balances sum to totalSupply.
 func TestCAS20BurnChecksSupplyUnderflow(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xdec0de")
@@ -242,8 +219,7 @@ func TestCAS20BurnChecksSupplyUnderflow(t *testing.T) {
 		NewGasBudget(1_000_000), uint256.NewInt(0)); err != nil {
 		t.Fatalf("granting alice BURN_ROLE: %v", err)
 	}
-	// Break the invariant the way a bad state import or a future field could:
-	// alice holds more than the token has ever issued.
+	// Break the invariant: alice holds more than the token has ever issued.
 	view.setBalance(cas20Alice, uint256.NewInt(500))
 	if view.totalSupply().Uint64() != 100 {
 		t.Fatalf("totalSupply = %d, want 100 — the fixture is not set up", view.totalSupply().Uint64())
@@ -260,7 +236,6 @@ func TestCAS20BurnChecksSupplyUnderflow(t *testing.T) {
 	}
 }
 
-// TestCAS20PauseDecodesBeforeAuthorizing pins the order Solidity's dispatcher has.
 func TestCAS20PauseDecodesBeforeAuthorizing(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xdec0de")
@@ -272,9 +247,7 @@ func TestCAS20PauseDecodesBeforeAuthorizing(t *testing.T) {
 	}
 	token := common.BytesToAddress(ret)
 
-	// cas20Bob holds no role, so both checks would refuse him. The malformed array
-	// has to be the one reported: a Solidity implementation decodes in the external
-	// dispatcher, before any modifier runs, so it answers the same way.
+	// cas20Bob holds no role, so both checks would refuse him.
 	good := cas20CallU8Array(selPause, byte(cas20PauseTransfer))
 	out, _, err := evm.Call(cas20Bob, token, good[:len(good)-1], NewGasBudget(1_000_000), uint256.NewInt(0))
 	if !errors.Is(err, ErrExecutionReverted) {
@@ -285,7 +258,6 @@ func TestCAS20PauseDecodesBeforeAuthorizing(t *testing.T) {
 			"(BEP-702 3.2); a role error here means authorization ran first", out)
 	}
 
-	// And a well-formed array from the same caller still reports the role.
 	out, _, err = evm.Call(cas20Bob, token, good, NewGasBudget(1_000_000), uint256.NewInt(0))
 	if !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("unauthorized pause: err = %v, want a revert", err)

--- a/core/vm/cas20_asset.go
+++ b/core/vm/cas20_asset.go
@@ -261,12 +261,13 @@ func dispatchAsset(tok cas20Token, ext assetExt, input []byte) (ret []byte, err 
 			return nil, err, true
 		}
 		// bytes4 occupies the high four bytes of its word; anything in the
-		// remaining 28 is not a valid bytes4 and cannot be advertised.
+		// remaining 28 is a malformed encoding, which Solidity's external decoder
+		// refuses with empty returndata rather than answering for.
 		var want [4]byte
 		copy(want[:], id[:4])
 		for _, b := range id[4:] {
 			if b != 0 {
-				return encBool(false), nil, true
+				return nil, ErrExecutionReverted, true
 			}
 		}
 		return encBool(cas20AssetInterfaceIDs[want]), nil, true

--- a/core/vm/cas20_asset.go
+++ b/core/vm/cas20_asset.go
@@ -1,0 +1,629 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+)
+
+// The Asset variant keeps its state in its own ERC-7201 namespace, disjoint
+// from the core one, so the extension composes without touching the shared
+// layout.
+const cas20AssetNamespace = "bsc.cas20.asset"
+
+const (
+	cas20AssetSlotDecimals      = 0
+	cas20AssetSlotMultiplier    = 1
+	cas20AssetSlotAnnouncements = 2 // mapping(string id => bool used)
+	cas20AssetSlotExtraMeta     = 3 // mapping(string key => string value)
+	cas20AssetSlotPending       = 4 // packed: multiplier (u128) | effectiveAt (u64)
+)
+
+// Packed lane offsets in the pending slot, LSB-first as Solidity packs a struct
+// of {uint128 multiplier; uint64 effectiveAt}.
+const (
+	cas20PendingMulBits  = 0
+	cas20PendingWhenBits = 128
+)
+
+var (
+	cas20AssetRoot = erc7201Root(cas20AssetNamespace)
+	// cas20WAD is the multiplier fixed-point base (1e18 = 1.0x).
+	cas20WAD = uint256.NewInt(1_000_000_000_000_000_000)
+	// cas20U128Mask isolates the pending slot's low lane, and is also the ceiling
+	// every multiplier is bounded by (type(uint128).max).
+	cas20U64Max   = new(uint256.Int).SetUint64(^uint64(0))
+	cas20U128Mask = new(uint256.Int).Sub(new(uint256.Int).Lsh(uint256.NewInt(1), 128), uint256.NewInt(1))
+
+	roleOperator = crypto.Keccak256Hash([]byte("OPERATOR_ROLE"))
+
+	selMultiplier       = selector("multiplier()")
+	selWadPrecision     = selector("WAD_PRECISION()")
+	selScaledBalanceOf  = selector("scaledBalanceOf(address)")
+	selToScaledBalance  = selector("toScaledBalance(uint256)")
+	selToRawBalance     = selector("toRawBalance(uint256)")
+	selUpdateMultiplier = selector("updateMultiplier(uint256)")
+	selOperatorRole     = selector("OPERATOR_ROLE()")
+	selBatchMint        = selector("batchMint(address[],uint256[])")
+
+	selAnnounce             = selector("announce(bytes[],string,string,string)")
+	selIsAnnouncementIdUsed = selector("isAnnouncementIdUsed(string)")
+
+	selExtraMetadata       = selector("extraMetadata(string)")
+	selUpdateExtraMetadata = selector("updateExtraMetadata(string,string)")
+
+	// ERC-8056 (Cobalt). The canonical names alias the Beryl ones, which stay
+	// dialable; updateUIMultiplier is the scheduled setter and is not a rename of
+	// updateMultiplier, which remains as the instant failsafe.
+	selUIMultiplier       = selector("uiMultiplier()")
+	selToUIAmount         = selector("toUIAmount(uint256)")
+	selFromUIAmount       = selector("fromUIAmount(uint256)")
+	selBalanceOfUI        = selector("balanceOfUI(address)")
+	selTotalSupplyUI      = selector("totalSupplyUI()")
+	selNewUIMultiplier    = selector("newUIMultiplier()")
+	selEffectiveAt        = selector("effectiveAt()")
+	selUpdateUIMultiplier = selector("updateUIMultiplier(uint256,uint256)")
+	selCancelUIMultiplier = selector("cancelUIMultiplierUpdate()")
+	selMaxUIMultiplier    = selector("MAX_UI_MULTIPLIER()")
+	selSupportsInterface  = selector("supportsInterface(bytes4)")
+
+	cas20TopicMultiplierUpdated    = eventTopic("MultiplierUpdated(uint256)")
+	cas20TopicAnnouncement         = eventTopic("Announcement(address,string,string,string)")
+	cas20TopicEndAnnouncement      = eventTopic("EndAnnouncement(string)")
+	cas20TopicExtraMetadataUpdated = eventTopic("ExtraMetadataUpdated(string,string)")
+
+	cas20TopicUIMultiplierUpdated   = eventTopic("UIMultiplierUpdated(uint256,uint256,uint256)")
+	cas20TopicUIMultiplierCancelled = eventTopic("UIMultiplierUpdateCancelled(uint256,uint256)")
+)
+
+// The ERC-165 ids the Asset variant advertises: ERC-165 itself and all four
+// ERC-8056 interfaces, Conversion included — toUIAmount and fromUIAmount are its
+// canonical converters and both are implemented. The advertised set is observable
+// surface, so it has to match what is implemented rather than merely be a subset
+// of it.
+var cas20AssetInterfaceIDs = map[[4]byte]bool{
+	{0x01, 0xff, 0xc9, 0xa7}: true, // IERC165
+	{0xa6, 0x0b, 0xf1, 0x3d}: true, // IScaledUIAmount
+	{0x4b, 0xd2, 0x76, 0x48}: true, // IScaledUIAmountNewUIMultiplier
+	{0xd8, 0x90, 0xfd, 0x71}: true, // IScaledUIAmountBalances
+	{0x57, 0x85, 0x4f, 0xc3}: true, // IScaledUIAmountConversion
+}
+
+// assetExt is a gas-metered view over the Asset extension storage.
+type assetExt struct{ s cas20Storage }
+
+func newAssetExt(ctx *PrecompileContext) assetExt { return assetExt{s: newMeteredCAS20Storage(ctx)} }
+
+func assetSlot(offset uint64) common.Hash { return offsetSlot(cas20AssetRoot, offset) }
+
+func (e assetExt) decimals() uint8 {
+	return uint8(new(uint256.Int).SetBytes(e.s.getWord(assetSlot(cas20AssetSlotDecimals)).Bytes()).Uint64())
+}
+func (e assetExt) setDecimals(d uint8) {
+	e.s.setWord(assetSlot(cas20AssetSlotDecimals), uint256.NewInt(uint64(d)).Bytes32())
+}
+func (e assetExt) multiplier() *uint256.Int {
+	return new(uint256.Int).SetBytes(e.s.getWord(assetSlot(cas20AssetSlotMultiplier)).Bytes())
+}
+func (e assetExt) setMultiplier(m *uint256.Int) {
+	e.s.setWord(assetSlot(cas20AssetSlotMultiplier), m.Bytes32())
+}
+
+// --- ERC-8056 scheduled multiplier (Cobalt) ---------------------------------
+//
+// Two values decide what a holder's balance is worth: the multiplier at slot 1,
+// set by the instant setter, and a pending schedule at slot 4. The *effective*
+// multiplier is the pending one once its timestamp has passed, and the stored one
+// otherwise — so multiplier() changes value at a timestamp, with no transaction
+// and no event at the flip. That is why adopting ERC-8056 is not a pure
+// addition: an indexer rebuilding state from logs alone will diverge
+// (BEP-702 3.12).
+
+func (e assetExt) pendingSlot() common.Hash { return assetSlot(cas20AssetSlotPending) }
+
+// pending reads the scheduled update. A zero effectiveAt means none is recorded;
+// a non-zero one may be live or already matured.
+func (e assetExt) pending() (mul *uint256.Int, effectiveAt uint64) {
+	w := new(uint256.Int).SetBytes(e.s.getWord(e.pendingSlot()).Bytes())
+	lane := new(uint256.Int).Rsh(w, cas20PendingWhenBits)
+	return new(uint256.Int).And(w, cas20U128Mask), lane.Uint64()
+}
+
+func (e assetExt) setPending(mul *uint256.Int, effectiveAt uint64) {
+	packed := new(uint256.Int).And(mul, cas20U128Mask)
+	packed.Or(packed, new(uint256.Int).Lsh(uint256.NewInt(effectiveAt), cas20PendingWhenBits))
+	e.s.setWord(e.pendingSlot(), packed.Bytes32())
+}
+
+func (e assetExt) clearPending() { e.s.setWord(e.pendingSlot(), common.Hash{}) }
+
+// settleMatured folds a matured schedule into the stored multiplier. Reads compute
+// the effective value and cannot write, so the fold has to happen on the next write
+// that reuses the pending slot — otherwise replacing a matured schedule would
+// silently revert the token to the value from before it matured.
+func (e assetExt) settleMatured(now uint64) {
+	if mul, at := e.pending(); at != 0 && now >= at {
+		e.setMultiplier(mul)
+	}
+}
+
+// effectiveMultiplier is what every conversion and balance view uses. It is the
+// scheduled value once its timestamp has arrived, and the stored one until then.
+func (e assetExt) effectiveMultiplier(now uint64) *uint256.Int {
+	if mul, at := e.pending(); at != 0 && now >= at {
+		return mul
+	}
+	return e.multiplier()
+}
+
+func (e assetExt) announcementSlot(id string) common.Hash {
+	return e.s.strMapSlot(assetSlot(cas20AssetSlotAnnouncements), id)
+}
+
+// announcementUsed reports whether the id has been announced, and whether the
+// answer is real. False/false means the read could not be paid for: announce must
+// stop there rather than treat an unpaid read as "unused" and go on to re-hash the
+// caller-sized id and encode all three strings into two events.
+func (e assetExt) announcementUsed(id string) (bool, bool) {
+	w, ok := e.s.getWordChecked(e.announcementSlot(id))
+	return w != (common.Hash{}), ok
+}
+func (e assetExt) markAnnouncement(id string) bool {
+	var one common.Hash
+	one[31] = 1
+	return e.s.setWord(e.announcementSlot(id), one)
+}
+
+func (e assetExt) extraMetaSlot(key string) common.Hash {
+	return e.s.strMapSlot(assetSlot(cas20AssetSlotExtraMeta), key)
+}
+func (e assetExt) extraMetadata(key string) (string, bool) {
+	return e.s.getStringAt(e.extraMetaSlot(key))
+}
+func (e assetExt) setExtraMetadata(key, value string) bool {
+	return e.s.setStringAt(e.extraMetaSlot(key), value)
+}
+
+// initAssetExtension seeds a new Asset token's extension storage. decimals is
+// fixed at creation and never changes (BEP-702 section 4.10).
+func initAssetExtension(ctx *PrecompileContext, decimals byte) {
+	e := newAssetExt(ctx)
+	e.setDecimals(decimals)
+	e.setMultiplier(cas20WAD)
+}
+
+func applyMultiplier(raw, mul *uint256.Int) (*uint256.Int, error) {
+	p, overflow := new(uint256.Int).MulOverflow(raw, mul)
+	if overflow {
+		return nil, revPanic(0x11)
+	}
+	return p.Div(p, cas20WAD), nil
+}
+
+// removeMultiplier answers zero for a zero multiplier without a guard of its own:
+// uint256 division by zero yields zero. updateMultiplier rejects zero anyway.
+func removeMultiplier(scaled, mul *uint256.Int) (*uint256.Int, error) {
+	p, overflow := new(uint256.Int).MulOverflow(scaled, cas20WAD)
+	if overflow {
+		return nil, revPanic(0x11)
+	}
+	return p.Div(p, mul), nil
+}
+
+// assetDispatch tries the extension selectors first, then the shared surface.
+func assetDispatch(tok cas20Token, ext assetExt, input []byte) ([]byte, error) {
+	if ret, err, ok := dispatchAsset(tok, ext, input); ok {
+		return ret, err
+	}
+	return tok.dispatch(input)
+}
+
+// dispatchAsset handles the Asset-variant selectors, returning ok=false so the
+// caller falls back to the shared IB20 dispatch.
+func dispatchAsset(tok cas20Token, ext assetExt, input []byte) (ret []byte, err error, ok bool) {
+	if len(input) < 4 {
+		return nil, nil, false
+	}
+	var sel [4]byte
+	copy(sel[:], input[:4])
+	args := input[4:]
+
+	// Every conversion and balance view reads the effective multiplier, which is
+	// the scheduled one once its timestamp has passed (ERC-8056).
+	effective := func() *uint256.Int { return ext.effectiveMultiplier(tok.ctx.BlockTime()) }
+
+	switch sel {
+	case selDecimals:
+		return encU256(uint256.NewInt(uint64(ext.decimals()))), nil, true
+	case selMultiplier, selUIMultiplier:
+		return encU256(effective()), nil, true
+	case selWadPrecision:
+		return encU256(cas20WAD), nil, true
+	case selMaxUIMultiplier:
+		return encU256(cas20U128Mask), nil, true
+	case selOperatorRole:
+		return roleOperator.Bytes(), nil, true
+	case selNewUIMultiplier:
+		mul, _ := ext.pending()
+		return encU256(mul), nil, true
+	case selEffectiveAt:
+		_, at := ext.pending()
+		return encU256(uint256.NewInt(at)), nil, true
+	case selTotalSupplyUI:
+		v, err := applyMultiplier(tok.s.totalSupply(), effective())
+		if err != nil {
+			return nil, err, true
+		}
+		return encU256(v), nil, true
+	case selSupportsInterface:
+		id, err := readWord(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		// bytes4 occupies the high four bytes of its word; anything in the
+		// remaining 28 is not a valid bytes4 and cannot be advertised.
+		var want [4]byte
+		copy(want[:], id[:4])
+		for _, b := range id[4:] {
+			if b != 0 {
+				return encBool(false), nil, true
+			}
+		}
+		return encBool(cas20AssetInterfaceIDs[want]), nil, true
+	case selCancelUIMultiplier:
+		return nil, cancelUIMultiplier(tok, ext), true
+	case selUpdateUIMultiplier:
+		mul, err := readU256(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		at, err := readU256(args, 1)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, updateUIMultiplier(tok, ext, mul, at), true
+	case selScaledBalanceOf, selBalanceOfUI:
+		a, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		v, err := applyMultiplier(tok.s.balanceOf(a), effective())
+		if err != nil {
+			return nil, err, true
+		}
+		return encU256(v), nil, true
+	case selToScaledBalance, selToUIAmount:
+		raw, err := readU256(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		v, err := applyMultiplier(raw, effective())
+		if err != nil {
+			return nil, err, true
+		}
+		return encU256(v), nil, true
+	case selToRawBalance, selFromUIAmount:
+		scaled, err := readU256(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		v, err := removeMultiplier(scaled, effective())
+		if err != nil {
+			return nil, err, true
+		}
+		return encU256(v), nil, true
+	case selUpdateMultiplier:
+		m, err := readU256(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, updateMultiplier(tok, ext, m), true
+	case selBatchMint:
+		return nil, batchMint(tok, args), true
+	case selIsAnnouncementIdUsed:
+		id, err := readStringArg(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		used, ok := ext.announcementUsed(id)
+		if !ok {
+			return nil, ErrOutOfGas, true
+		}
+		return encBool(used), nil, true
+	case selAnnounce:
+		return nil, announce(tok, ext, args), true
+	case selExtraMetadata:
+		key, err := readStringArg(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		v, ok := ext.extraMetadata(key)
+		if !ok {
+			return nil, ErrOutOfGas, true
+		}
+		return encString(v), nil, true
+	case selUpdateExtraMetadata:
+		key, err := readStringArg(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		value, err := readStringArg(args, 1)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, updateExtraMetadata(tok, ext, key, value), true
+	}
+	return nil, nil, false
+}
+
+// updateExtraMetadata writes/clears (value == "") a custom metadata entry.
+func updateExtraMetadata(tok cas20Token, ext assetExt, key, value string) error {
+	if tok.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	if err := tok.ensureRole(roleMetadata); err != nil {
+		return err
+	}
+	if len(key) == 0 {
+		return revCAS20("InvalidMetadataKey()", errSelInvalidMetadataKey)
+	}
+	if !ext.setExtraMetadata(key, value) {
+		return ErrOutOfGas
+	}
+	if !tok.ctx.AddLog([]common.Hash{cas20TopicExtraMetadataUpdated},
+		encodeTuple(abiString(key), abiString(value))) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func readStringArg(args []byte, argIndex int) (string, error) {
+	L := uint64(len(args))
+	off, ok := wordU64(args, uint64(argIndex)*32)
+	if !ok || off > L || L-off < 32 {
+		return "", ErrExecutionReverted
+	}
+	n, ok2 := wordU64(args, off)
+	if !ok2 {
+		return "", ErrExecutionReverted // malformed length word
+	}
+	dataPos := off + 32
+	if n > L-dataPos {
+		return "", ErrExecutionReverted
+	}
+	return string(args[dataPos : dataPos+n]), nil
+}
+
+// announce publishes a disclosure and atomically runs a bundle of internal
+// calls against this token, preserving the caller's identity (role checks
+// still apply). Any failure — malformed call, re-entrant announce, or a
+// reverting internal call — rolls back the whole disclosure.
+func announce(tok cas20Token, ext assetExt, args []byte) error {
+	if tok.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	if tok.inAnnounce {
+		return revCAS20("AnnouncementInProgress()", errSelAnnounceInProgress)
+	}
+	if err := tok.ensureRole(roleOperator); err != nil {
+		return err
+	}
+	calls, err := readBytesArray(args, 0)
+	if err != nil {
+		return err
+	}
+	// All three strings are decoded before the id is looked up, so a malformed
+	// payload is reported as malformed rather than as AnnouncementIdAlreadyUsed.
+	// The order is observable through which error the caller receives.
+	id, err := readStringArg(args, 1)
+	if err != nil {
+		return err
+	}
+	description, err := readStringArg(args, 2)
+	if err != nil {
+		return err
+	}
+	uri, err := readStringArg(args, 3)
+	if err != nil {
+		return err
+	}
+	used, ok := ext.announcementUsed(id)
+	if !ok {
+		return ErrOutOfGas
+	}
+	if used {
+		return revCAS20Bytes("AnnouncementIdAlreadyUsed(string)", errSelAnnounceIdUsed, []byte(id))
+	}
+	if !ext.markAnnouncement(id) { // marked before execution
+		return ErrOutOfGas
+	}
+	if !tok.ctx.AddLog([]common.Hash{cas20TopicAnnouncement, addrKey(tok.ctx.Caller)},
+		encodeTuple(abiString(id), abiString(description), abiString(uri))) {
+		return ErrOutOfGas
+	}
+
+	tok.inAnnounce = true // threaded into the internal calls below by value
+	for _, c := range calls {
+		if tok.ctx.OutOfGas() {
+			return ErrOutOfGas
+		}
+		if len(c) < 4 {
+			return revCAS20Bytes("InternalCallMalformed(bytes)", errSelInternalMalformed, c)
+		}
+		if _, err := assetDispatch(tok, ext, c); err != nil {
+			return revCAS20Bytes("InternalCallFailed(bytes)", errSelInternalFailed, c)
+		}
+	}
+	if !tok.ctx.AddLog([]common.Hash{cas20TopicEndAnnouncement}, encodeTuple(abiString(id))) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// updateUIMultiplier schedules a multiplier change for a future timestamp. Check
+// order: role, then the value, then the two timestamp bounds, then whether a live
+// schedule already exists.
+func updateUIMultiplier(tok cas20Token, ext assetExt, newMul, at *uint256.Int) error {
+	if tok.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	if err := tok.ensureRole(roleOperator); err != nil {
+		return err
+	}
+	if newMul.IsZero() || newMul.Gt(cas20U128Mask) { // (0, type(uint128).max]
+		return revCAS20("InvalidMultiplier()", errSelInvalidMultiplier)
+	}
+	now := tok.ctx.BlockTime()
+	if !at.GtUint64(now) {
+		return revCAS20("EffectiveAtInPast(uint256)", errSelEffectiveAtInPast, wU256(at))
+	}
+	if at.Gt(cas20U64Max) {
+		return revCAS20("EffectiveAtTooFar(uint256)", errSelEffectiveAtTooFar, wU256(at))
+	}
+	// Only a *live* schedule blocks a new one. A matured record is stale state,
+	// not a commitment, so it is silently replaced.
+	if _, existing := ext.pending(); existing > now {
+		return revCAS20("UIMultiplierUpdateExists(uint256)", errSelUIMulExists, wU64(existing))
+	}
+	// The outgoing schedule may already be in force. Persist it before the slot is
+	// reused, or the token drops back to its pre-maturity multiplier until the new
+	// schedule arrives — a silent revaluation of every holder's balance.
+	ext.settleMatured(now)
+	previous := ext.multiplier()
+	ext.setPending(newMul, at.Uint64())
+	// The third argument is when the value takes effect, which for a schedule is
+	// the future timestamp rather than now.
+	if !tok.ctx.AddLog([]common.Hash{cas20TopicUIMultiplierUpdated},
+		append(append(wU256(previous).Bytes(), wU256(newMul).Bytes()...), wU256(at).Bytes()...)) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// cancelUIMultiplier drops a live schedule. A matured one is not cancellable —
+// its value is already in force, so there is nothing pending to withdraw.
+func cancelUIMultiplier(tok cas20Token, ext assetExt) error {
+	if tok.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	if err := tok.ensureRole(roleOperator); err != nil {
+		return err
+	}
+	mul, at := ext.pending()
+	if at <= tok.ctx.BlockTime() {
+		return revCAS20("UIMultiplierUpdateDoesNotExist()", errSelUIMulMissing)
+	}
+	ext.clearPending()
+	if !tok.ctx.AddLog([]common.Hash{cas20TopicUIMultiplierCancelled},
+		append(wU256(mul).Bytes(), wU64(at).Bytes()...)) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func updateMultiplier(tok cas20Token, ext assetExt, newMul *uint256.Int) error {
+	if tok.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	if err := tok.ensureRole(roleOperator); err != nil {
+		return err
+	}
+	if newMul.IsZero() || newMul.Gt(cas20U128Mask) { // (0, type(uint128).max]
+		return revCAS20("InvalidMultiplier()", errSelInvalidMultiplier)
+	}
+	// The instant setter is the failsafe, so it overrides any schedule. A live one
+	// is withdrawn loudly; a matured one is stale state and goes quietly, since its
+	// value was already in force and is now being replaced.
+	now := tok.ctx.BlockTime()
+	previous := ext.effectiveMultiplier(now)
+	if pendingMul, at := ext.pending(); at != 0 {
+		ext.clearPending()
+		if at > now {
+			if !tok.ctx.AddLog([]common.Hash{cas20TopicUIMultiplierCancelled},
+				append(wU256(pendingMul).Bytes(), wU64(at).Bytes()...)) {
+				return ErrOutOfGas
+			}
+		}
+	}
+	ext.setMultiplier(newMul)
+	mb := newMul.Bytes32()
+	if !tok.ctx.AddLog([]common.Hash{cas20TopicMultiplierUpdated}, mb[:]) {
+		return ErrOutOfGas
+	}
+	// ERC-8056's canonical event, emitted by both setters so one stream carries
+	// every change.
+	if !tok.ctx.AddLog([]common.Hash{cas20TopicUIMultiplierUpdated},
+		append(append(wU256(previous).Bytes(), wU256(newMul).Bytes()...), wU256(uint256.NewInt(now)).Bytes()...)) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func batchMint(tok cas20Token, args []byte) error {
+	if tok.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	if tok.isPaused(cas20PauseMint) {
+		return revCAS20("ContractPaused(uint8)", errSelContractPaused, wU8(cas20PauseMint))
+	}
+	if err := tok.ensureRole(roleMint); err != nil {
+		return err
+	}
+	recipients, err := readWordArray(args, 0)
+	if err != nil {
+		return err
+	}
+	amounts, err := readWordArray(args, 1)
+	if err != nil {
+		return err
+	}
+	if len(recipients) != len(amounts) {
+		return revCAS20("LengthMismatch(uint256,uint256)", errSelLengthMismatch,
+			wU64(uint64(len(recipients))), wU64(uint64(len(amounts))))
+	}
+	if len(recipients) == 0 {
+		return revCAS20("EmptyBatch()", errSelEmptyBatch)
+	}
+	for i := range recipients {
+		// chargeGas marks the frame out of gas and returns, so without this
+		// the loop would run to completion on an exhausted budget — the state is
+		// discarded either way, but the node has already done the work. A batch
+		// long enough to exhaust its gas on the first recipient measured the same
+		// wall-clock as one that paid for every one of them.
+		if tok.ctx.OutOfGas() {
+			return ErrOutOfGas
+		}
+		to, ok := addressFromWord(recipients[i])
+		if !ok {
+			return ErrExecutionReverted
+		}
+		amount := new(uint256.Int).SetBytes(amounts[i].Bytes())
+		if err := tok.mintCore(to, amount); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readWordArray decodes an ABI dynamic array of 32-byte words (address[] /
+// uint256[]) at head word argIndex.
+func readWordArray(args []byte, argIndex int) ([]common.Hash, error) {
+	L := uint64(len(args))
+	base, ok := wordU64(args, uint64(argIndex)*32)
+	if !ok || base > L || L-base < 32 {
+		return nil, ErrExecutionReverted
+	}
+	n, ok2 := wordU64(args, base)
+	if !ok2 {
+		return nil, ErrExecutionReverted // malformed length word
+	}
+	dataPos := base + 32
+	if n > (L-dataPos)/32 {
+		return nil, ErrExecutionReverted
+	}
+	out := make([]common.Hash, n)
+	for i := uint64(0); i < n; i++ {
+		out[i] = common.BytesToHash(args[dataPos+i*32 : dataPos+i*32+32])
+	}
+	return out, nil
+}

--- a/core/vm/cas20_asset.go
+++ b/core/vm/cas20_asset.go
@@ -205,7 +205,11 @@ func dispatchAsset(tok cas20Token, ext assetExt, input []byte) (ret []byte, err 
 	case selOperatorRole:
 		return roleOperator.Bytes(), nil, true
 	case selNewUIMultiplier:
-		mul, _ := ext.pending()
+		// With no live schedule it answers as uiMultiplier does (ERC-8056).
+		mul, at := ext.pending()
+		if at <= tok.ctx.BlockTime() {
+			mul = effective()
+		}
 		return encU256(mul), nil, true
 	case selEffectiveAt:
 		_, at := ext.pending()

--- a/core/vm/cas20_asset.go
+++ b/core/vm/cas20_asset.go
@@ -403,19 +403,14 @@ func announce(tok cas20Token, ext assetExt, args []byte) error {
 	if tok.ctx.ReadOnly {
 		return ErrWriteProtection
 	}
-	if tok.inAnnounce {
-		return revCAS20("AnnouncementInProgress()", errSelAnnounceInProgress)
-	}
-	if err := tok.ensureRole(roleOperator); err != nil {
-		return err
-	}
+	// Decoded before any check of the caller or the token's state: Solidity's
+	// dispatcher decodes a function's arguments before its modifiers run, so
+	// calldata that does not decode is reported as such whoever sent it. The
+	// order is observable through which error the caller receives.
 	calls, err := readBytesArray(args, 0)
 	if err != nil {
 		return err
 	}
-	// All three strings are decoded before the id is looked up, so a malformed
-	// payload is reported as malformed rather than as AnnouncementIdAlreadyUsed.
-	// The order is observable through which error the caller receives.
 	id, err := readStringArg(args, 1)
 	if err != nil {
 		return err
@@ -426,6 +421,12 @@ func announce(tok cas20Token, ext assetExt, args []byte) error {
 	}
 	uri, err := readStringArg(args, 3)
 	if err != nil {
+		return err
+	}
+	if tok.inAnnounce {
+		return revCAS20("AnnouncementInProgress()", errSelAnnounceInProgress)
+	}
+	if err := tok.ensureRole(roleOperator); err != nil {
 		return err
 	}
 	used, ok := ext.announcementUsed(id)
@@ -564,18 +565,20 @@ func batchMint(tok cas20Token, args []byte) error {
 	if tok.ctx.ReadOnly {
 		return ErrWriteProtection
 	}
-	if tok.isPaused(cas20PauseMint) {
-		return revCAS20("ContractPaused(uint8)", errSelContractPaused, wU8(cas20PauseMint))
-	}
-	if err := tok.ensureRole(roleMint); err != nil {
-		return err
-	}
+	// Decoded first, as Solidity's dispatcher does, so a payload that does not
+	// decode is reported as such rather than as a pause or a missing role.
 	recipients, err := readWordArray(args, 0)
 	if err != nil {
 		return err
 	}
 	amounts, err := readWordArray(args, 1)
 	if err != nil {
+		return err
+	}
+	if tok.isPaused(cas20PauseMint) {
+		return revCAS20("ContractPaused(uint8)", errSelContractPaused, wU8(cas20PauseMint))
+	}
+	if err := tok.ensureRole(roleMint); err != nil {
 		return err
 	}
 	if len(recipients) != len(amounts) {

--- a/core/vm/cas20_asset.go
+++ b/core/vm/cas20_asset.go
@@ -6,9 +6,7 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// The Asset variant keeps its state in its own ERC-7201 namespace, disjoint
-// from the core one, so the extension composes without touching the shared
-// layout.
+// The Asset extension lives in its own ERC-7201 namespace, disjoint from the core layout.
 const cas20AssetNamespace = "bsc.cas20.asset"
 
 const (
@@ -19,21 +17,14 @@ const (
 	cas20AssetSlotPending       = 4 // packed: multiplier (u128) | effectiveAt (u64)
 )
 
-// Packed lane offsets in the pending slot, LSB-first as Solidity packs a struct
-// of {uint128 multiplier; uint64 effectiveAt}.
-const (
-	cas20PendingMulBits  = 0
-	cas20PendingWhenBits = 128
-)
+// LSB-first, as Solidity packs {uint128 multiplier; uint64 effectiveAt}.
+const cas20PendingWhenBits = 128
 
 var (
 	cas20AssetRoot = erc7201Root(cas20AssetNamespace)
-	// cas20WAD is the multiplier fixed-point base (1e18 = 1.0x).
-	cas20WAD = uint256.NewInt(1_000_000_000_000_000_000)
-	// cas20U128Mask isolates the pending slot's low lane, and is also the ceiling
-	// every multiplier is bounded by (type(uint128).max).
-	cas20U64Max   = new(uint256.Int).SetUint64(^uint64(0))
-	cas20U128Mask = new(uint256.Int).Sub(new(uint256.Int).Lsh(uint256.NewInt(1), 128), uint256.NewInt(1))
+	cas20WAD       = uint256.NewInt(1_000_000_000_000_000_000) // 1.0x
+	cas20U64Max    = new(uint256.Int).SetUint64(^uint64(0))
+	cas20U128Mask  = new(uint256.Int).Sub(new(uint256.Int).Lsh(uint256.NewInt(1), 128), uint256.NewInt(1))
 
 	roleOperator = crypto.Keccak256Hash([]byte("OPERATOR_ROLE"))
 
@@ -52,9 +43,7 @@ var (
 	selExtraMetadata       = selector("extraMetadata(string)")
 	selUpdateExtraMetadata = selector("updateExtraMetadata(string,string)")
 
-	// ERC-8056 (Cobalt). The canonical names alias the Beryl ones, which stay
-	// dialable; updateUIMultiplier is the scheduled setter and is not a rename of
-	// updateMultiplier, which remains as the instant failsafe.
+	// ERC-8056 names; the earlier ones stay dialable as aliases.
 	selUIMultiplier       = selector("uiMultiplier()")
 	selToUIAmount         = selector("toUIAmount(uint256)")
 	selFromUIAmount       = selector("fromUIAmount(uint256)")
@@ -76,11 +65,7 @@ var (
 	cas20TopicUIMultiplierCancelled = eventTopic("UIMultiplierUpdateCancelled(uint256,uint256)")
 )
 
-// The ERC-165 ids the Asset variant advertises: ERC-165 itself and all four
-// ERC-8056 interfaces, Conversion included — toUIAmount and fromUIAmount are its
-// canonical converters and both are implemented. The advertised set is observable
-// surface, so it has to match what is implemented rather than merely be a subset
-// of it.
+// All four ERC-8056 interfaces are implemented, so all four are advertised.
 var cas20AssetInterfaceIDs = map[[4]byte]bool{
 	{0x01, 0xff, 0xc9, 0xa7}: true, // IERC165
 	{0xa6, 0x0b, 0xf1, 0x3d}: true, // IScaledUIAmount
@@ -89,7 +74,6 @@ var cas20AssetInterfaceIDs = map[[4]byte]bool{
 	{0x57, 0x85, 0x4f, 0xc3}: true, // IScaledUIAmountConversion
 }
 
-// assetExt is a gas-metered view over the Asset extension storage.
 type assetExt struct{ s cas20Storage }
 
 func newAssetExt(ctx *PrecompileContext) assetExt { return assetExt{s: newMeteredCAS20Storage(ctx)} }
@@ -109,20 +93,13 @@ func (e assetExt) setMultiplier(m *uint256.Int) {
 	e.s.setWord(assetSlot(cas20AssetSlotMultiplier), m.Bytes32())
 }
 
-// --- ERC-8056 scheduled multiplier (Cobalt) ---------------------------------
+// --- ERC-8056 scheduled multiplier -------------------------------------------
 //
-// Two values decide what a holder's balance is worth: the multiplier at slot 1,
-// set by the instant setter, and a pending schedule at slot 4. The *effective*
-// multiplier is the pending one once its timestamp has passed, and the stored one
-// otherwise — so multiplier() changes value at a timestamp, with no transaction
-// and no event at the flip. That is why adopting ERC-8056 is not a pure
-// addition: an indexer rebuilding state from logs alone will diverge
-// (BEP-702 3.12).
+// The effective multiplier flips from the stored value to the scheduled one at a
+// timestamp, with no transaction and no event at the flip.
 
 func (e assetExt) pendingSlot() common.Hash { return assetSlot(cas20AssetSlotPending) }
 
-// pending reads the scheduled update. A zero effectiveAt means none is recorded;
-// a non-zero one may be live or already matured.
 func (e assetExt) pending() (mul *uint256.Int, effectiveAt uint64) {
 	w := new(uint256.Int).SetBytes(e.s.getWord(e.pendingSlot()).Bytes())
 	lane := new(uint256.Int).Rsh(w, cas20PendingWhenBits)
@@ -137,18 +114,14 @@ func (e assetExt) setPending(mul *uint256.Int, effectiveAt uint64) {
 
 func (e assetExt) clearPending() { e.s.setWord(e.pendingSlot(), common.Hash{}) }
 
-// settleMatured folds a matured schedule into the stored multiplier. Reads compute
-// the effective value and cannot write, so the fold has to happen on the next write
-// that reuses the pending slot — otherwise replacing a matured schedule would
-// silently revert the token to the value from before it matured.
+// Reads cannot write, so a matured schedule is folded into the stored multiplier by
+// the next write that reuses the slot; otherwise that write would revalue the token.
 func (e assetExt) settleMatured(now uint64) {
 	if mul, at := e.pending(); at != 0 && now >= at {
 		e.setMultiplier(mul)
 	}
 }
 
-// effectiveMultiplier is what every conversion and balance view uses. It is the
-// scheduled value once its timestamp has arrived, and the stored one until then.
 func (e assetExt) effectiveMultiplier(now uint64) *uint256.Int {
 	if mul, at := e.pending(); at != 0 && now >= at {
 		return mul
@@ -160,10 +133,6 @@ func (e assetExt) announcementSlot(id string) common.Hash {
 	return e.s.strMapSlot(assetSlot(cas20AssetSlotAnnouncements), id)
 }
 
-// announcementUsed reports whether the id has been announced, and whether the
-// answer is real. False/false means the read could not be paid for: announce must
-// stop there rather than treat an unpaid read as "unused" and go on to re-hash the
-// caller-sized id and encode all three strings into two events.
 func (e assetExt) announcementUsed(id string) (bool, bool) {
 	w, ok := e.s.getWordChecked(e.announcementSlot(id))
 	return w != (common.Hash{}), ok
@@ -184,8 +153,6 @@ func (e assetExt) setExtraMetadata(key, value string) bool {
 	return e.s.setStringAt(e.extraMetaSlot(key), value)
 }
 
-// initAssetExtension seeds a new Asset token's extension storage. decimals is
-// fixed at creation and never changes (BEP-702 section 4.10).
 func initAssetExtension(ctx *PrecompileContext, decimals byte) {
 	e := newAssetExt(ctx)
 	e.setDecimals(decimals)
@@ -200,8 +167,7 @@ func applyMultiplier(raw, mul *uint256.Int) (*uint256.Int, error) {
 	return p.Div(p, cas20WAD), nil
 }
 
-// removeMultiplier answers zero for a zero multiplier without a guard of its own:
-// uint256 division by zero yields zero. updateMultiplier rejects zero anyway.
+// uint256 division by zero yields zero; the setters reject a zero multiplier anyway.
 func removeMultiplier(scaled, mul *uint256.Int) (*uint256.Int, error) {
 	p, overflow := new(uint256.Int).MulOverflow(scaled, cas20WAD)
 	if overflow {
@@ -210,7 +176,6 @@ func removeMultiplier(scaled, mul *uint256.Int) (*uint256.Int, error) {
 	return p.Div(p, mul), nil
 }
 
-// assetDispatch tries the extension selectors first, then the shared surface.
 func assetDispatch(tok cas20Token, ext assetExt, input []byte) ([]byte, error) {
 	if ret, err, ok := dispatchAsset(tok, ext, input); ok {
 		return ret, err
@@ -218,8 +183,6 @@ func assetDispatch(tok cas20Token, ext assetExt, input []byte) ([]byte, error) {
 	return tok.dispatch(input)
 }
 
-// dispatchAsset handles the Asset-variant selectors, returning ok=false so the
-// caller falls back to the shared IB20 dispatch.
 func dispatchAsset(tok cas20Token, ext assetExt, input []byte) (ret []byte, err error, ok bool) {
 	if len(input) < 4 {
 		return nil, nil, false
@@ -228,8 +191,6 @@ func dispatchAsset(tok cas20Token, ext assetExt, input []byte) (ret []byte, err 
 	copy(sel[:], input[:4])
 	args := input[4:]
 
-	// Every conversion and balance view reads the effective multiplier, which is
-	// the scheduled one once its timestamp has passed (ERC-8056).
 	effective := func() *uint256.Int { return ext.effectiveMultiplier(tok.ctx.BlockTime()) }
 
 	switch sel {
@@ -260,9 +221,6 @@ func dispatchAsset(tok cas20Token, ext assetExt, input []byte) (ret []byte, err 
 		if err != nil {
 			return nil, err, true
 		}
-		// bytes4 occupies the high four bytes of its word; anything in the
-		// remaining 28 is a malformed encoding, which Solidity's external decoder
-		// refuses with empty returndata rather than answering for.
 		var want [4]byte
 		copy(want[:], id[:4])
 		for _, b := range id[4:] {
@@ -357,7 +315,6 @@ func dispatchAsset(tok cas20Token, ext assetExt, input []byte) (ret []byte, err 
 	return nil, nil, false
 }
 
-// updateExtraMetadata writes/clears (value == "") a custom metadata entry.
 func updateExtraMetadata(tok cas20Token, ext assetExt, key, value string) error {
 	if tok.ctx.ReadOnly {
 		return ErrWriteProtection
@@ -386,7 +343,7 @@ func readStringArg(args []byte, argIndex int) (string, error) {
 	}
 	n, ok2 := wordU64(args, off)
 	if !ok2 {
-		return "", ErrExecutionReverted // malformed length word
+		return "", ErrExecutionReverted
 	}
 	dataPos := off + 32
 	if n > L-dataPos {
@@ -395,18 +352,10 @@ func readStringArg(args []byte, argIndex int) (string, error) {
 	return string(args[dataPos : dataPos+n]), nil
 }
 
-// announce publishes a disclosure and atomically runs a bundle of internal
-// calls against this token, preserving the caller's identity (role checks
-// still apply). Any failure — malformed call, re-entrant announce, or a
-// reverting internal call — rolls back the whole disclosure.
 func announce(tok cas20Token, ext assetExt, args []byte) error {
 	if tok.ctx.ReadOnly {
 		return ErrWriteProtection
 	}
-	// Decoded before any check of the caller or the token's state: Solidity's
-	// dispatcher decodes a function's arguments before its modifiers run, so
-	// calldata that does not decode is reported as such whoever sent it. The
-	// order is observable through which error the caller receives.
 	calls, err := readBytesArray(args, 0)
 	if err != nil {
 		return err
@@ -436,7 +385,7 @@ func announce(tok cas20Token, ext assetExt, args []byte) error {
 	if used {
 		return revCAS20Bytes("AnnouncementIdAlreadyUsed(string)", errSelAnnounceIdUsed, []byte(id))
 	}
-	if !ext.markAnnouncement(id) { // marked before execution
+	if !ext.markAnnouncement(id) {
 		return ErrOutOfGas
 	}
 	if !tok.ctx.AddLog([]common.Hash{cas20TopicAnnouncement, addrKey(tok.ctx.Caller)},
@@ -444,7 +393,7 @@ func announce(tok cas20Token, ext assetExt, args []byte) error {
 		return ErrOutOfGas
 	}
 
-	tok.inAnnounce = true // threaded into the internal calls below by value
+	tok.inAnnounce = true
 	for _, c := range calls {
 		if tok.ctx.OutOfGas() {
 			return ErrOutOfGas
@@ -462,9 +411,7 @@ func announce(tok cas20Token, ext assetExt, args []byte) error {
 	return nil
 }
 
-// updateUIMultiplier schedules a multiplier change for a future timestamp. Check
-// order: role, then the value, then the two timestamp bounds, then whether a live
-// schedule already exists.
+// Check order: role, value, both timestamp bounds, then a live schedule.
 func updateUIMultiplier(tok cas20Token, ext assetExt, newMul, at *uint256.Int) error {
 	if tok.ctx.ReadOnly {
 		return ErrWriteProtection
@@ -472,7 +419,7 @@ func updateUIMultiplier(tok cas20Token, ext assetExt, newMul, at *uint256.Int) e
 	if err := tok.ensureRole(roleOperator); err != nil {
 		return err
 	}
-	if newMul.IsZero() || newMul.Gt(cas20U128Mask) { // (0, type(uint128).max]
+	if newMul.IsZero() || newMul.Gt(cas20U128Mask) {
 		return revCAS20("InvalidMultiplier()", errSelInvalidMultiplier)
 	}
 	now := tok.ctx.BlockTime()
@@ -482,19 +429,13 @@ func updateUIMultiplier(tok cas20Token, ext assetExt, newMul, at *uint256.Int) e
 	if at.Gt(cas20U64Max) {
 		return revCAS20("EffectiveAtTooFar(uint256)", errSelEffectiveAtTooFar, wU256(at))
 	}
-	// Only a *live* schedule blocks a new one. A matured record is stale state,
-	// not a commitment, so it is silently replaced.
+	// Only a live schedule blocks a new one; a matured record is stale state, not a commitment.
 	if _, existing := ext.pending(); existing > now {
 		return revCAS20("UIMultiplierUpdateExists(uint256)", errSelUIMulExists, wU64(existing))
 	}
-	// The outgoing schedule may already be in force. Persist it before the slot is
-	// reused, or the token drops back to its pre-maturity multiplier until the new
-	// schedule arrives — a silent revaluation of every holder's balance.
 	ext.settleMatured(now)
 	previous := ext.multiplier()
 	ext.setPending(newMul, at.Uint64())
-	// The third argument is when the value takes effect, which for a schedule is
-	// the future timestamp rather than now.
 	if !tok.ctx.AddLog([]common.Hash{cas20TopicUIMultiplierUpdated},
 		append(append(wU256(previous).Bytes(), wU256(newMul).Bytes()...), wU256(at).Bytes()...)) {
 		return ErrOutOfGas
@@ -502,8 +443,7 @@ func updateUIMultiplier(tok cas20Token, ext assetExt, newMul, at *uint256.Int) e
 	return nil
 }
 
-// cancelUIMultiplier drops a live schedule. A matured one is not cancellable —
-// its value is already in force, so there is nothing pending to withdraw.
+// A matured schedule is already in force, so there is nothing to withdraw.
 func cancelUIMultiplier(tok cas20Token, ext assetExt) error {
 	if tok.ctx.ReadOnly {
 		return ErrWriteProtection
@@ -530,12 +470,11 @@ func updateMultiplier(tok cas20Token, ext assetExt, newMul *uint256.Int) error {
 	if err := tok.ensureRole(roleOperator); err != nil {
 		return err
 	}
-	if newMul.IsZero() || newMul.Gt(cas20U128Mask) { // (0, type(uint128).max]
+	if newMul.IsZero() || newMul.Gt(cas20U128Mask) {
 		return revCAS20("InvalidMultiplier()", errSelInvalidMultiplier)
 	}
-	// The instant setter is the failsafe, so it overrides any schedule. A live one
-	// is withdrawn loudly; a matured one is stale state and goes quietly, since its
-	// value was already in force and is now being replaced.
+	// The instant setter is the failsafe and overrides any schedule: a live one is
+	// withdrawn loudly, a matured one is stale state and goes quietly.
 	now := tok.ctx.BlockTime()
 	previous := ext.effectiveMultiplier(now)
 	if pendingMul, at := ext.pending(); at != 0 {
@@ -552,8 +491,7 @@ func updateMultiplier(tok cas20Token, ext assetExt, newMul *uint256.Int) error {
 	if !tok.ctx.AddLog([]common.Hash{cas20TopicMultiplierUpdated}, mb[:]) {
 		return ErrOutOfGas
 	}
-	// ERC-8056's canonical event, emitted by both setters so one stream carries
-	// every change.
+	// Emitted by both setters so one stream carries every change.
 	if !tok.ctx.AddLog([]common.Hash{cas20TopicUIMultiplierUpdated},
 		append(append(wU256(previous).Bytes(), wU256(newMul).Bytes()...), wU256(uint256.NewInt(now)).Bytes()...)) {
 		return ErrOutOfGas
@@ -565,8 +503,6 @@ func batchMint(tok cas20Token, args []byte) error {
 	if tok.ctx.ReadOnly {
 		return ErrWriteProtection
 	}
-	// Decoded first, as Solidity's dispatcher does, so a payload that does not
-	// decode is reported as such rather than as a pause or a missing role.
 	recipients, err := readWordArray(args, 0)
 	if err != nil {
 		return err
@@ -589,11 +525,8 @@ func batchMint(tok cas20Token, args []byte) error {
 		return revCAS20("EmptyBatch()", errSelEmptyBatch)
 	}
 	for i := range recipients {
-		// chargeGas marks the frame out of gas and returns, so without this
-		// the loop would run to completion on an exhausted budget — the state is
-		// discarded either way, but the node has already done the work. A batch
-		// long enough to exhaust its gas on the first recipient measured the same
-		// wall-clock as one that paid for every one of them.
+		// chargeGas only marks the frame, so without this an exhausted batch would
+		// still run to completion before being discarded.
 		if tok.ctx.OutOfGas() {
 			return ErrOutOfGas
 		}
@@ -609,8 +542,6 @@ func batchMint(tok cas20Token, args []byte) error {
 	return nil
 }
 
-// readWordArray decodes an ABI dynamic array of 32-byte words (address[] /
-// uint256[]) at head word argIndex.
 func readWordArray(args []byte, argIndex int) ([]common.Hash, error) {
 	L := uint64(len(args))
 	base, ok := wordU64(args, uint64(argIndex)*32)
@@ -619,7 +550,7 @@ func readWordArray(args []byte, argIndex int) ([]common.Hash, error) {
 	}
 	n, ok2 := wordU64(args, base)
 	if !ok2 {
-		return nil, ErrExecutionReverted // malformed length word
+		return nil, ErrExecutionReverted
 	}
 	dataPos := base + 32
 	if n > (L-dataPos)/32 {

--- a/core/vm/cas20_asset.go
+++ b/core/vm/cas20_asset.go
@@ -357,9 +357,6 @@ func readStringArg(args []byte, argIndex int) (string, error) {
 }
 
 func announce(tok cas20Token, ext assetExt, args []byte) error {
-	if tok.ctx.ReadOnly {
-		return ErrWriteProtection
-	}
 	calls, err := readBytesArray(args, 0)
 	if err != nil {
 		return err
@@ -375,6 +372,9 @@ func announce(tok cas20Token, ext assetExt, args []byte) error {
 	uri, err := readStringArg(args, 3)
 	if err != nil {
 		return err
+	}
+	if tok.ctx.ReadOnly {
+		return ErrWriteProtection
 	}
 	if tok.inAnnounce {
 		return revCAS20("AnnouncementInProgress()", errSelAnnounceInProgress)
@@ -504,9 +504,6 @@ func updateMultiplier(tok cas20Token, ext assetExt, newMul *uint256.Int) error {
 }
 
 func batchMint(tok cas20Token, args []byte) error {
-	if tok.ctx.ReadOnly {
-		return ErrWriteProtection
-	}
 	recipients, err := readWordArray(args, 0)
 	if err != nil {
 		return err
@@ -514,6 +511,9 @@ func batchMint(tok cas20Token, args []byte) error {
 	amounts, err := readWordArray(args, 1)
 	if err != nil {
 		return err
+	}
+	if tok.ctx.ReadOnly {
+		return ErrWriteProtection
 	}
 	if tok.isPaused(cas20PauseMint) {
 		return revCAS20("ContractPaused(uint8)", errSelContractPaused, wU8(cas20PauseMint))

--- a/core/vm/cas20_asset.go
+++ b/core/vm/cas20_asset.go
@@ -399,7 +399,7 @@ func announce(tok cas20Token, ext assetExt, args []byte) error {
 
 	tok.inAnnounce = true
 	for _, c := range calls {
-		if tok.ctx.OutOfGas() {
+		if !tok.ctx.chargeInternalDispatch(c) {
 			return ErrOutOfGas
 		}
 		if len(c) < 4 {

--- a/core/vm/cas20_asset_test.go
+++ b/core/vm/cas20_asset_test.go
@@ -1,0 +1,487 @@
+package vm
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+func encodeBatchMint(recips []common.Address, amounts []uint64) []byte {
+	out := append([]byte{}, selBatchMint[:]...)
+	out = append(out, u256hash(0x40).Bytes()...)                            // offset arr1
+	out = append(out, u256hash(uint64(0x40+(1+len(recips))*32)).Bytes()...) // offset arr2
+	out = append(out, u256hash(uint64(len(recips))).Bytes()...)
+	for _, r := range recips {
+		out = append(out, addrKey(r).Bytes()...)
+	}
+	out = append(out, u256hash(uint64(len(amounts))).Bytes()...)
+	for _, a := range amounts {
+		out = append(out, u256hash(a).Bytes()...)
+	}
+	return out
+}
+
+func TestCAS20AssetExtension(t *testing.T) {
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := *cas20TestChainConfig()
+	bc := cas20BlockContext(1)
+	seedActivation(statedb, cas20TestCaller)
+	evm := NewEVM(bc, statedb, &cfg, Config{})
+
+	creator := common.HexToAddress("0xc4ea70")
+	minter := common.HexToAddress("0x33333")
+	operator := common.HexToAddress("0x09e4a704")
+	salt := common.HexToHash("0x0a")
+
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	u := func(ret []byte, err error) uint64 {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("call err: %v", err)
+		}
+		return new(uint256.Int).SetBytes(ret).Uint64()
+	}
+
+	// create an Asset token: minter=MINT, operator=OPERATOR, mint 1000 to alice.
+	initCalls := [][]byte{
+		cas20Call(selGrantRole, roleMint, addrKey(minter)),
+		cas20Call(selGrantRole, roleOperator, addrKey(operator)),
+		cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
+	}
+	ret, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, salt, creator, initCalls))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	// defaults from extension storage.
+	if got := u(call(creator, token, cas20Call(selDecimals))); got != 18 {
+		t.Errorf("decimals = %d, want 18", got)
+	}
+	if got := u(call(creator, token, cas20Call(selMultiplier))); got != 1e18 {
+		t.Errorf("multiplier = %d, want 1e18", got)
+	}
+	if got := u(call(creator, token, cas20Call(selWadPrecision))); got != 1e18 {
+		t.Errorf("WAD_PRECISION = %d, want 1e18", got)
+	}
+	if got := u(call(creator, token, cas20Call(selScaledBalanceOf, addrKey(cas20Alice)))); got != 1000 {
+		t.Errorf("scaledBalanceOf(alice) = %d, want 1000", got)
+	}
+
+	// non-operator updateMultiplier reverts.
+	if _, err := call(minter, token, cas20Call(selUpdateMultiplier, u256hash(2e18))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("non-operator updateMultiplier err = %v, want revert", err)
+	}
+	// operator sets multiplier to 1.5x.
+	if _, err := call(operator, token, cas20Call(selUpdateMultiplier, u256hash(1_500_000_000_000_000_000))); err != nil {
+		t.Fatalf("updateMultiplier: %v", err)
+	}
+	if got := u(call(creator, token, cas20Call(selMultiplier))); got != 1_500_000_000_000_000_000 {
+		t.Errorf("multiplier = %d, want 1.5e18", got)
+	}
+
+	// scaled views reflect the multiplier; raw balance is unchanged.
+	if got := u(call(creator, token, cas20Call(selScaledBalanceOf, addrKey(cas20Alice)))); got != 1500 {
+		t.Errorf("scaledBalanceOf(alice) = %d, want 1500", got)
+	}
+	if got := u(call(creator, token, cas20Call(selToScaledBalance, u256hash(1000)))); got != 1500 {
+		t.Errorf("toScaledBalance(1000) = %d, want 1500", got)
+	}
+	if got := u(call(creator, token, cas20Call(selToRawBalance, u256hash(1500)))); got != 1000 {
+		t.Errorf("toRawBalance(1500) = %d, want 1000", got)
+	}
+	if got := u(call(creator, token, cas20Call(selBalanceOf, addrKey(cas20Alice)))); got != 1000 {
+		t.Errorf("balanceOf(alice) = %d, want 1000 (raw unchanged)", got)
+	}
+	// updateMultiplier to 0 reverts.
+	if _, err := call(operator, token, cas20Call(selUpdateMultiplier, u256hash(0))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("zero multiplier err = %v, want revert", err)
+	}
+
+	// batchMint to bob and carol.
+	if _, err := call(minter, token, encodeBatchMint([]common.Address{cas20Bob, cas20Carol}, []uint64{10, 20})); err != nil {
+		t.Fatalf("batchMint: %v", err)
+	}
+	view := newUnmeteredCAS20Storage(statedb, token)
+	if view.balanceOf(cas20Bob).Uint64() != 10 || view.balanceOf(cas20Carol).Uint64() != 20 {
+		t.Errorf("batchMint balances bob %d carol %d, want 10/20", view.balanceOf(cas20Bob).Uint64(), view.balanceOf(cas20Carol).Uint64())
+	}
+	if view.totalSupply().Uint64() != 1030 {
+		t.Errorf("supply = %d, want 1030", view.totalSupply().Uint64())
+	}
+	// mismatched array lengths revert.
+	if _, err := call(minter, token, encodeBatchMint([]common.Address{cas20Bob}, []uint64{1, 2})); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("length-mismatch batchMint err = %v, want revert", err)
+	}
+}
+
+// abiStr encodes a string's tail: its length followed by the bytes padded up to
+// a word. An empty string is one zero word and nothing else.
+func abiStr(s string) []byte {
+	return append(u256hash(uint64(len(s))).Bytes(), rightPad32([]byte(s))...)
+}
+
+// encodeAnnounce ABI-encodes announce(bytes[],string,string,string) with the
+// bytes[] placed right after the head and empty description/uri strings. All
+// four arguments are dynamic, so the head is four offsets.
+func encodeAnnounce(calls [][]byte, id string) []byte {
+	return encodeAnnounceWith(calls, id, "", "")
+}
+
+func encodeAnnounceWith(calls [][]byte, id, description, uri string) []byte {
+	elems := make([][]byte, len(calls))
+	for i, c := range calls {
+		elems[i] = append(u256hash(uint64(len(c))).Bytes(), rightPad32(c)...)
+	}
+	arr := append([]byte{}, u256hash(uint64(len(calls))).Bytes()...)
+	cur := uint64(len(calls) * 32)
+	for _, e := range elems {
+		arr = append(arr, u256hash(cur).Bytes()...)
+		cur += uint64(len(e))
+	}
+	for _, e := range elems {
+		arr = append(arr, e...)
+	}
+	idEnc, descEnc, uriEnc := abiStr(id), abiStr(description), abiStr(uri)
+	idOff := uint64(0x80 + len(arr))
+	descOff := idOff + uint64(len(idEnc))
+	uriOff := descOff + uint64(len(descEnc))
+
+	out := append([]byte{}, selAnnounce[:]...)
+	out = append(out, u256hash(0x80).Bytes()...)    // w0 offset -> bytes[]
+	out = append(out, u256hash(idOff).Bytes()...)   // w1 offset -> id
+	out = append(out, u256hash(descOff).Bytes()...) // w2 offset -> description
+	out = append(out, u256hash(uriOff).Bytes()...)  // w3 offset -> uri
+	out = append(out, arr...)
+	out = append(out, idEnc...)
+	out = append(out, descEnc...)
+	out = append(out, uriEnc...)
+	return out
+}
+
+func TestCAS20Announce(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc4ea70")
+	operator := common.HexToAddress("0x09e4a704")
+	salt := common.HexToHash("0x0e")
+
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	initCalls := [][]byte{
+		cas20Call(selGrantRole, roleOperator, addrKey(operator)),
+		cas20Call(selGrantRole, roleMint, addrKey(operator)),
+		cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
+	}
+	ret, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, salt, creator, initCalls))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+	mul := func() uint64 {
+		r, err := call(creator, token, cas20Call(selMultiplier))
+		if err != nil {
+			t.Fatalf("multiplier(): %v", err)
+		}
+		return new(uint256.Int).SetBytes(r).Uint64()
+	}
+
+	const id1 = "2026-Q1-NAV"
+
+	// happy path: announce bundling an updateMultiplier runs atomically.
+	inner := [][]byte{cas20Call(selUpdateMultiplier, u256hash(1_200_000_000_000_000_000))}
+	if _, err := call(operator, token, encodeAnnounce(inner, id1)); err != nil {
+		t.Fatalf("announce: %v", err)
+	}
+	if got := mul(); got != 1_200_000_000_000_000_000 {
+		t.Fatalf("multiplier after announce = %d, want 1.2e18", got)
+	}
+	if r, _ := call(creator, token, encodeStringCall(selIsAnnouncementIdUsed, id1)); !bytes.Equal(r, encBool(true)) {
+		t.Fatal("id1 should be marked used")
+	}
+
+	// reusing the id reverts.
+	if _, err := call(operator, token, encodeAnnounce(nil, id1)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("reused id err = %v, want revert", err)
+	}
+	// non-operator reverts.
+	if _, err := call(creator, token, encodeAnnounce(nil, "2026-Q2-NAV")); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("non-operator announce err = %v, want revert", err)
+	}
+	// nesting announce inside announce reverts (and rolls back, id unused).
+	const nestedID = "2026-Q3-NAV"
+	nested := [][]byte{encodeAnnounce(nil, "2026-Q4-NAV")}
+	if _, err := call(operator, token, encodeAnnounce(nested, nestedID)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("nested announce err = %v, want revert", err)
+	}
+	if r, _ := call(creator, token, encodeStringCall(selIsAnnouncementIdUsed, nestedID)); !bytes.Equal(r, encBool(false)) {
+		t.Fatal("failed announce must not mark its id (atomic rollback)")
+	}
+
+	// a failing internal call rolls the whole announce back.
+	const badID = "2027-Q1-NAV"
+	bad := [][]byte{cas20Call(selUpdateMultiplier, u256hash(0))} // zero multiplier reverts
+	if _, err := call(operator, token, encodeAnnounce(bad, badID)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("failing internal call err = %v, want revert", err)
+	}
+	if got := mul(); got != 1_200_000_000_000_000_000 {
+		t.Fatalf("multiplier changed despite rollback = %d", got)
+	}
+	if r, _ := call(creator, token, encodeStringCall(selIsAnnouncementIdUsed, badID)); !bytes.Equal(r, encBool(false)) {
+		t.Fatal("badID must not be marked (rollback)")
+	}
+}
+
+func encodeStringCall(sel [4]byte, strs ...string) []byte {
+	out := append([]byte{}, sel[:]...)
+	bodies := make([][]byte, len(strs))
+	cur := uint64(len(strs) * 32)
+	offs := make([]uint64, len(strs))
+	for i, s := range strs {
+		offs[i] = cur
+		bodies[i] = append(u256hash(uint64(len(s))).Bytes(), rightPad32([]byte(s))...)
+		cur += uint64(len(bodies[i]))
+	}
+	for _, o := range offs {
+		out = append(out, u256hash(o).Bytes()...)
+	}
+	for _, b := range bodies {
+		out = append(out, b...)
+	}
+	return out
+}
+
+func TestCAS20ExtraMetadata(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc4ea70")
+	salt := common.HexToHash("0x0f")
+
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	readStr := func(to common.Address, input []byte) string {
+		t.Helper()
+		ret, err := call(creator, to, input)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		// decode ABI string: [offset][len][data]
+		n := new(uint256.Int).SetBytes(ret[32:64]).Uint64()
+		return string(ret[64 : 64+n])
+	}
+
+	initCalls := [][]byte{cas20Call(selGrantRole, roleMetadata, addrKey(creator))}
+	ret, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, salt, creator, initCalls))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	// unset key returns empty.
+	if got := readStr(token, encodeStringCall(selExtraMetadata, "category")); got != "" {
+		t.Fatalf("unset extraMetadata = %q, want empty", got)
+	}
+	// set + read a short value.
+	if _, err := call(creator, token, encodeStringCall(selUpdateExtraMetadata, "category", "fund")); err != nil {
+		t.Fatalf("updateExtraMetadata: %v", err)
+	}
+	if got := readStr(token, encodeStringCall(selExtraMetadata, "category")); got != "fund" {
+		t.Fatalf("extraMetadata(category) = %q, want fund", got)
+	}
+	// long value (> 32 bytes) exercises the long-string path at a mapping slot.
+	long := "an-international-securities-identification-number-XS1234567890"
+	if _, err := call(creator, token, encodeStringCall(selUpdateExtraMetadata, "isin", long)); err != nil {
+		t.Fatalf("updateExtraMetadata long: %v", err)
+	}
+	if got := readStr(token, encodeStringCall(selExtraMetadata, "isin")); got != long {
+		t.Fatalf("extraMetadata(isin) = %q, want %q", got, long)
+	}
+	// empty value deletes.
+	if _, err := call(creator, token, encodeStringCall(selUpdateExtraMetadata, "category", "")); err != nil {
+		t.Fatalf("delete extraMetadata: %v", err)
+	}
+	if got := readStr(token, encodeStringCall(selExtraMetadata, "category")); got != "" {
+		t.Fatalf("deleted extraMetadata = %q, want empty", got)
+	}
+	// empty key reverts.
+	if _, err := call(creator, token, encodeStringCall(selUpdateExtraMetadata, "", "x")); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("empty key err = %v, want revert", err)
+	}
+	// non-METADATA caller reverts.
+	if _, err := call(cas20Alice, token, encodeStringCall(selUpdateExtraMetadata, "k", "v")); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("unauthorized err = %v, want revert", err)
+	}
+}
+
+// TestCAS20AnnounceEncoderIsCanonical checks the hand-rolled encoder above against
+// go-ethereum's ABI packer.
+func TestCAS20AnnounceEncoderIsCanonical(t *testing.T) {
+	mustType := func(s string) abi.Type {
+		t.Helper()
+		ty, err := abi.NewType(s, "", nil)
+		if err != nil {
+			t.Fatalf("NewType(%s): %v", s, err)
+		}
+		return ty
+	}
+	args := abi.Arguments{
+		{Type: mustType("bytes[]")},
+		{Type: mustType("string")},
+		{Type: mustType("string")},
+		{Type: mustType("string")},
+	}
+
+	for _, tc := range []struct {
+		name          string
+		calls         [][]byte
+		id, desc, uri string
+	}{
+		{name: "all empty"},
+		{name: "no calls", id: "2026-Q1-NAV", desc: "d", uri: "u"},
+		{name: "one call", calls: [][]byte{{1, 2, 3, 4}}, id: "id", desc: "desc", uri: "uri"},
+		{
+			name:  "element of exactly one word",
+			calls: [][]byte{bytes.Repeat([]byte{9}, 32)},
+			id:    "id", desc: "d", uri: "u",
+		},
+		{
+			name:  "empty element among non-empty",
+			calls: [][]byte{{}, {1, 2, 3, 4}, {}},
+			id:    "id", desc: "d", uri: "u",
+		},
+		{
+			name:  "multi-word id and description",
+			calls: [][]byte{{1, 2, 3, 4}, bytes.Repeat([]byte{9}, 40)},
+			id:    strings.Repeat("L", 70), desc: strings.Repeat("d", 33), uri: "u",
+		},
+		// Either side of the word boundary, where a string's tail either fits
+		// exactly or spills into a second word and moves every later offset.
+		{name: "id of 31 bytes", id: strings.Repeat("L", 31), desc: "d", uri: "u"},
+		{name: "id of 32 bytes", id: strings.Repeat("L", 32), desc: "d", uri: "u"},
+		{name: "id of 33 bytes", id: strings.Repeat("L", 33), desc: "d", uri: "u"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			want, err := args.Pack(tc.calls, tc.id, tc.desc, tc.uri)
+			if err != nil {
+				t.Fatalf("Pack: %v", err)
+			}
+			if got := encodeAnnounceWith(tc.calls, tc.id, tc.desc, tc.uri)[4:]; !bytes.Equal(got, want) {
+				t.Errorf("encoder disagrees with abi.Pack:\n got  %x\n want %x", got, want)
+			}
+		})
+	}
+}
+
+// TestCAS20AnnouncementIDShapes covers the id lengths the fixed test ids do not.
+func TestCAS20AnnouncementIDShapes(t *testing.T) {
+	for _, id := range []string{
+		"",
+		"x",
+		strings.Repeat("L", 31),
+		strings.Repeat("L", 32),
+		strings.Repeat("L", 200),
+	} {
+		_, evm := newCAS20EVM(t)
+		creator := common.HexToAddress("0xc4ea70")
+		ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+			encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xbb"), creator,
+				[][]byte{cas20Call(selGrantRole, roleOperator, addrKey(creator))}),
+			NewGasBudget(9_000_000), uint256.NewInt(0))
+		if err != nil {
+			t.Fatalf("createCAS20: %v", err)
+		}
+		token := common.BytesToAddress(ret)
+
+		call := func(input []byte) ([]byte, error) {
+			out, _, err := evm.Call(creator, token, input, NewGasBudget(9_000_000), uint256.NewInt(0))
+			return out, err
+		}
+		used := func(id string) bool {
+			t.Helper()
+			out, err := call(encodeStringCall(selIsAnnouncementIdUsed, id))
+			if err != nil {
+				t.Fatalf("isAnnouncementIdUsed(len %d): %v", len(id), err)
+			}
+			return bytes.Equal(out, encBool(true))
+		}
+
+		if used(id) {
+			t.Fatalf("len %d: reported used before any announcement", len(id))
+		}
+		if _, err := call(encodeAnnounce(nil, id)); err != nil {
+			t.Fatalf("announce(len %d): %v", len(id), err)
+		}
+		if !used(id) {
+			t.Errorf("len %d: not marked used after announcing", len(id))
+		}
+		if _, err := call(encodeAnnounce(nil, id)); !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("len %d: reuse err = %v, want a revert", len(id), err)
+		}
+		if used(id + "z") {
+			t.Errorf("len %d: a one-character-longer id aliases onto it", len(id))
+		}
+	}
+}
+
+// TestCAS20MultiplierCeilingIsOneConstant pins the ceiling both setters enforce to
+// the one MAX_UI_MULTIPLIER() advertises. Nothing tested either bound, so the
+// instant setter had been expressing it with the supply-cap sentinel — the same
+// number today, and a silent divergence the moment that sentinel changes.
+func TestCAS20MultiplierCeilingIsOneConstant(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	operator := common.HexToAddress("0x09e7a70a")
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	ret, err := call(cas20TestCaller, CAS20FactoryAddress, encodeCreateCAS20(
+		cas20VariantAsset, common.HexToHash("0xce11"), cas20TestCaller,
+		[][]byte{cas20Call(selGrantRole, roleOperator, addrKey(operator))}))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	advertised, err := call(operator, token, cas20Call(selMaxUIMultiplier))
+	if err != nil {
+		t.Fatalf("MAX_UI_MULTIPLIER: %v", err)
+	}
+	ceiling := new(uint256.Int).SetBytes(advertised)
+	over := new(uint256.Int).AddUint64(ceiling, 1)
+	future := u256hash(evm.Context.Time + 3600)
+
+	for _, tc := range []struct {
+		name  string
+		input []byte
+		want  bool // accepted
+	}{
+		{"updateMultiplier at the ceiling", cas20Call(selUpdateMultiplier, ceiling.Bytes32()), true},
+		{"updateMultiplier above it", cas20Call(selUpdateMultiplier, over.Bytes32()), false},
+		{"updateUIMultiplier at the ceiling", cas20Call(selUpdateUIMultiplier, ceiling.Bytes32(), future), true},
+		{"updateUIMultiplier above it", cas20Call(selUpdateUIMultiplier, over.Bytes32(), future), false},
+	} {
+		_, err := call(operator, token, tc.input)
+		if tc.want && err != nil {
+			t.Errorf("%s: err = %v, want accepted — the setter is stricter than the value it advertises", tc.name, err)
+		}
+		if !tc.want && !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("%s: err = %v, want a revert — the setter accepts more than it advertises", tc.name, err)
+		}
+	}
+}

--- a/core/vm/cas20_asset_test.go
+++ b/core/vm/cas20_asset_test.go
@@ -72,6 +72,9 @@ func TestCAS20AssetExtension(t *testing.T) {
 	if got := u(call(creator, token, cas20Call(selMultiplier))); got != 1e18 {
 		t.Errorf("multiplier = %d, want 1e18", got)
 	}
+	if got := u(call(creator, token, cas20Call(selNewUIMultiplier))); got != 1e18 {
+		t.Errorf("newUIMultiplier with no schedule = %d, want the current multiplier 1e18", got)
+	}
 	if got := u(call(creator, token, cas20Call(selWadPrecision))); got != 1e18 {
 		t.Errorf("WAD_PRECISION = %d, want 1e18", got)
 	}
@@ -87,6 +90,9 @@ func TestCAS20AssetExtension(t *testing.T) {
 	}
 	if got := u(call(creator, token, cas20Call(selMultiplier))); got != 1_500_000_000_000_000_000 {
 		t.Errorf("multiplier = %d, want 1.5e18", got)
+	}
+	if got := u(call(creator, token, cas20Call(selNewUIMultiplier))); got != 1_500_000_000_000_000_000 {
+		t.Errorf("newUIMultiplier after an instant update = %d, want 1.5e18", got)
 	}
 
 	if got := u(call(creator, token, cas20Call(selScaledBalanceOf, addrKey(cas20Alice)))); got != 1500 {

--- a/core/vm/cas20_asset_test.go
+++ b/core/vm/cas20_asset_test.go
@@ -55,7 +55,6 @@ func TestCAS20AssetExtension(t *testing.T) {
 		return new(uint256.Int).SetBytes(ret).Uint64()
 	}
 
-	// create an Asset token: minter=MINT, operator=OPERATOR, mint 1000 to alice.
 	initCalls := [][]byte{
 		cas20Call(selGrantRole, roleMint, addrKey(minter)),
 		cas20Call(selGrantRole, roleOperator, addrKey(operator)),
@@ -67,7 +66,6 @@ func TestCAS20AssetExtension(t *testing.T) {
 	}
 	token := common.BytesToAddress(ret)
 
-	// defaults from extension storage.
 	if got := u(call(creator, token, cas20Call(selDecimals))); got != 18 {
 		t.Errorf("decimals = %d, want 18", got)
 	}
@@ -81,11 +79,9 @@ func TestCAS20AssetExtension(t *testing.T) {
 		t.Errorf("scaledBalanceOf(alice) = %d, want 1000", got)
 	}
 
-	// non-operator updateMultiplier reverts.
 	if _, err := call(minter, token, cas20Call(selUpdateMultiplier, u256hash(2e18))); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("non-operator updateMultiplier err = %v, want revert", err)
 	}
-	// operator sets multiplier to 1.5x.
 	if _, err := call(operator, token, cas20Call(selUpdateMultiplier, u256hash(1_500_000_000_000_000_000))); err != nil {
 		t.Fatalf("updateMultiplier: %v", err)
 	}
@@ -93,7 +89,6 @@ func TestCAS20AssetExtension(t *testing.T) {
 		t.Errorf("multiplier = %d, want 1.5e18", got)
 	}
 
-	// scaled views reflect the multiplier; raw balance is unchanged.
 	if got := u(call(creator, token, cas20Call(selScaledBalanceOf, addrKey(cas20Alice)))); got != 1500 {
 		t.Errorf("scaledBalanceOf(alice) = %d, want 1500", got)
 	}
@@ -106,12 +101,10 @@ func TestCAS20AssetExtension(t *testing.T) {
 	if got := u(call(creator, token, cas20Call(selBalanceOf, addrKey(cas20Alice)))); got != 1000 {
 		t.Errorf("balanceOf(alice) = %d, want 1000 (raw unchanged)", got)
 	}
-	// updateMultiplier to 0 reverts.
 	if _, err := call(operator, token, cas20Call(selUpdateMultiplier, u256hash(0))); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("zero multiplier err = %v, want revert", err)
 	}
 
-	// batchMint to bob and carol.
 	if _, err := call(minter, token, encodeBatchMint([]common.Address{cas20Bob, cas20Carol}, []uint64{10, 20})); err != nil {
 		t.Fatalf("batchMint: %v", err)
 	}
@@ -122,21 +115,15 @@ func TestCAS20AssetExtension(t *testing.T) {
 	if view.totalSupply().Uint64() != 1030 {
 		t.Errorf("supply = %d, want 1030", view.totalSupply().Uint64())
 	}
-	// mismatched array lengths revert.
 	if _, err := call(minter, token, encodeBatchMint([]common.Address{cas20Bob}, []uint64{1, 2})); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("length-mismatch batchMint err = %v, want revert", err)
 	}
 }
 
-// abiStr encodes a string's tail: its length followed by the bytes padded up to
-// a word. An empty string is one zero word and nothing else.
 func abiStr(s string) []byte {
 	return append(u256hash(uint64(len(s))).Bytes(), rightPad32([]byte(s))...)
 }
 
-// encodeAnnounce ABI-encodes announce(bytes[],string,string,string) with the
-// bytes[] placed right after the head and empty description/uri strings. All
-// four arguments are dynamic, so the head is four offsets.
 func encodeAnnounce(calls [][]byte, id string) []byte {
 	return encodeAnnounceWith(calls, id, "", "")
 }
@@ -203,7 +190,6 @@ func TestCAS20Announce(t *testing.T) {
 
 	const id1 = "2026-Q1-NAV"
 
-	// happy path: announce bundling an updateMultiplier runs atomically.
 	inner := [][]byte{cas20Call(selUpdateMultiplier, u256hash(1_200_000_000_000_000_000))}
 	if _, err := call(operator, token, encodeAnnounce(inner, id1)); err != nil {
 		t.Fatalf("announce: %v", err)
@@ -215,15 +201,12 @@ func TestCAS20Announce(t *testing.T) {
 		t.Fatal("id1 should be marked used")
 	}
 
-	// reusing the id reverts.
 	if _, err := call(operator, token, encodeAnnounce(nil, id1)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("reused id err = %v, want revert", err)
 	}
-	// non-operator reverts.
 	if _, err := call(creator, token, encodeAnnounce(nil, "2026-Q2-NAV")); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("non-operator announce err = %v, want revert", err)
 	}
-	// nesting announce inside announce reverts (and rolls back, id unused).
 	const nestedID = "2026-Q3-NAV"
 	nested := [][]byte{encodeAnnounce(nil, "2026-Q4-NAV")}
 	if _, err := call(operator, token, encodeAnnounce(nested, nestedID)); !errors.Is(err, ErrExecutionReverted) {
@@ -233,9 +216,8 @@ func TestCAS20Announce(t *testing.T) {
 		t.Fatal("failed announce must not mark its id (atomic rollback)")
 	}
 
-	// a failing internal call rolls the whole announce back.
 	const badID = "2027-Q1-NAV"
-	bad := [][]byte{cas20Call(selUpdateMultiplier, u256hash(0))} // zero multiplier reverts
+	bad := [][]byte{cas20Call(selUpdateMultiplier, u256hash(0))}
 	if _, err := call(operator, token, encodeAnnounce(bad, badID)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("failing internal call err = %v, want revert", err)
 	}
@@ -281,7 +263,6 @@ func TestCAS20ExtraMetadata(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read: %v", err)
 		}
-		// decode ABI string: [offset][len][data]
 		n := new(uint256.Int).SetBytes(ret[32:64]).Uint64()
 		return string(ret[64 : 64+n])
 	}
@@ -293,18 +274,15 @@ func TestCAS20ExtraMetadata(t *testing.T) {
 	}
 	token := common.BytesToAddress(ret)
 
-	// unset key returns empty.
 	if got := readStr(token, encodeStringCall(selExtraMetadata, "category")); got != "" {
 		t.Fatalf("unset extraMetadata = %q, want empty", got)
 	}
-	// set + read a short value.
 	if _, err := call(creator, token, encodeStringCall(selUpdateExtraMetadata, "category", "fund")); err != nil {
 		t.Fatalf("updateExtraMetadata: %v", err)
 	}
 	if got := readStr(token, encodeStringCall(selExtraMetadata, "category")); got != "fund" {
 		t.Fatalf("extraMetadata(category) = %q, want fund", got)
 	}
-	// long value (> 32 bytes) exercises the long-string path at a mapping slot.
 	long := "an-international-securities-identification-number-XS1234567890"
 	if _, err := call(creator, token, encodeStringCall(selUpdateExtraMetadata, "isin", long)); err != nil {
 		t.Fatalf("updateExtraMetadata long: %v", err)
@@ -312,25 +290,20 @@ func TestCAS20ExtraMetadata(t *testing.T) {
 	if got := readStr(token, encodeStringCall(selExtraMetadata, "isin")); got != long {
 		t.Fatalf("extraMetadata(isin) = %q, want %q", got, long)
 	}
-	// empty value deletes.
 	if _, err := call(creator, token, encodeStringCall(selUpdateExtraMetadata, "category", "")); err != nil {
 		t.Fatalf("delete extraMetadata: %v", err)
 	}
 	if got := readStr(token, encodeStringCall(selExtraMetadata, "category")); got != "" {
 		t.Fatalf("deleted extraMetadata = %q, want empty", got)
 	}
-	// empty key reverts.
 	if _, err := call(creator, token, encodeStringCall(selUpdateExtraMetadata, "", "x")); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("empty key err = %v, want revert", err)
 	}
-	// non-METADATA caller reverts.
 	if _, err := call(cas20Alice, token, encodeStringCall(selUpdateExtraMetadata, "k", "v")); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("unauthorized err = %v, want revert", err)
 	}
 }
 
-// TestCAS20AnnounceEncoderIsCanonical checks the hand-rolled encoder above against
-// go-ethereum's ABI packer.
 func TestCAS20AnnounceEncoderIsCanonical(t *testing.T) {
 	mustType := func(s string) abi.Type {
 		t.Helper()
@@ -370,8 +343,7 @@ func TestCAS20AnnounceEncoderIsCanonical(t *testing.T) {
 			calls: [][]byte{{1, 2, 3, 4}, bytes.Repeat([]byte{9}, 40)},
 			id:    strings.Repeat("L", 70), desc: strings.Repeat("d", 33), uri: "u",
 		},
-		// Either side of the word boundary, where a string's tail either fits
-		// exactly or spills into a second word and moves every later offset.
+		// Either side of the word boundary, where a spilled tail moves every later offset.
 		{name: "id of 31 bytes", id: strings.Repeat("L", 31), desc: "d", uri: "u"},
 		{name: "id of 32 bytes", id: strings.Repeat("L", 32), desc: "d", uri: "u"},
 		{name: "id of 33 bytes", id: strings.Repeat("L", 33), desc: "d", uri: "u"},
@@ -388,7 +360,6 @@ func TestCAS20AnnounceEncoderIsCanonical(t *testing.T) {
 	}
 }
 
-// TestCAS20AnnouncementIDShapes covers the id lengths the fixed test ids do not.
 func TestCAS20AnnouncementIDShapes(t *testing.T) {
 	for _, id := range []string{
 		"",
@@ -439,10 +410,8 @@ func TestCAS20AnnouncementIDShapes(t *testing.T) {
 	}
 }
 
-// TestCAS20MultiplierCeilingIsOneConstant pins the ceiling both setters enforce to
-// the one MAX_UI_MULTIPLIER() advertises. Nothing tested either bound, so the
-// instant setter had been expressing it with the supply-cap sentinel — the same
-// number today, and a silent divergence the moment that sentinel changes.
+// Both setters must enforce the ceiling MAX_UI_MULTIPLIER() advertises, not the
+// supply-cap sentinel that happens to equal it.
 func TestCAS20MultiplierCeilingIsOneConstant(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	operator := common.HexToAddress("0x09e7a70a")

--- a/core/vm/cas20_errors.go
+++ b/core/vm/cas20_errors.go
@@ -1,0 +1,179 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+)
+
+// Typed revert data for the CAS20 precompiles. Business-rule failures use ABI
+// custom errors; malformed calldata and unknown selectors revert with empty
+// returndata (BEP-702 3.2).
+
+// cas20ErrSigs accumulates every error signature the implementation registers, so
+// a test can read what the code actually raises rather than a list of it. That is
+// what keeps a newly added error from slipping past the overload check.
+var cas20ErrSigs = map[string][4]byte{}
+
+// eventTopic computes topic0 for an event signature.
+func eventTopic(sig string) common.Hash {
+	return crypto.Keccak256Hash([]byte(sig))
+}
+
+// cas20ErrorSel computes (and registers) the 4-byte selector of an error signature.
+func cas20ErrorSel(sig string) [4]byte {
+	var s [4]byte
+	copy(s[:], crypto.Keccak256([]byte(sig)))
+	cas20ErrSigs[sig] = s
+	return s
+}
+
+// cas20RevertError carries an ABI-encoded revert payload through the internal
+// call chain. It is never returned to the EVM directly; finishCAS20 converts it.
+type cas20RevertError struct {
+	sig  string
+	data []byte
+}
+
+func (e *cas20RevertError) Error() string { return fmt.Sprintf("cas20 revert: %s", e.sig) }
+
+// Is lets errors.Is(err, ErrExecutionReverted) hold before finishCAS20 converts
+// the typed revert at the precompile boundary.
+func (e *cas20RevertError) Is(target error) bool { return target == ErrExecutionReverted }
+
+// finishCAS20 converts a typed revert into (returndata, ErrExecutionReverted) at
+// the precompile boundary. All other results pass through unchanged.
+func finishCAS20(ret []byte, err error) ([]byte, error) {
+	// A refused call form is a revert, not an exceptional halt: BEP-702 3.2 says
+	// DELEGATECALL and CALLCODE MUST revert, and names both this and the
+	// write-protection failure as ABI errors. Returning the sentinels straight to
+	// the EVM would exhaust the caller's gas and hand back no returndata, so an
+	// integrator could neither decode the reason nor keep the gas — a footgun no
+	// contract at an ordinary address has. Converted here rather than at each of
+	// the twenty guard sites, which keep the plain sentinel internally.
+	switch {
+	case errors.Is(err, ErrCAS20DelegateCall):
+		err = revCAS20("DelegateCallNotAllowed()", errSelDelegateCallDenied)
+	case errors.Is(err, ErrWriteProtection):
+		err = revCAS20("StaticCallNotAllowed()", errSelStaticCallDenied)
+	}
+	var rev *cas20RevertError
+	if errors.As(err, &rev) {
+		return rev.data, ErrExecutionReverted
+	}
+	return ret, err
+}
+
+// finishCAS20Metered is finishCAS20 for a call that has already charged gas. An
+// exhausted budget outranks whatever the logic returned: a charge that could not
+// be covered is an out-of-gas exception, not a revert, however the handler
+// reported it. Guards that run before any charge — a delegated call, a
+// value-bearing one — can use finishCAS20 directly, since there is nothing to have
+// exhausted yet.
+func finishCAS20Metered(ctx *PrecompileContext, ret []byte, err error) ([]byte, error) {
+	if ctx.writeProtectionViolated() {
+		return finishCAS20(nil, ErrWriteProtection)
+	}
+	if ctx.OutOfGas() {
+		return nil, ErrOutOfGas
+	}
+	return finishCAS20(ret, err)
+}
+
+// revCAS20 builds a typed revert from a registered selector and static 32-byte words.
+func revCAS20(sig string, sel [4]byte, words ...common.Hash) error {
+	data := make([]byte, 4+32*len(words))
+	copy(data, sel[:])
+	for i := range words {
+		copy(data[4+i*32:], words[i][:])
+	}
+	return &cas20RevertError{sig: sig, data: data}
+}
+
+// revCAS20Bytes builds a typed revert for an error with a single dynamic
+// `bytes`/`string` argument.
+func revCAS20Bytes(sig string, sel [4]byte, payload []byte) error {
+	return &cas20RevertError{sig: sig, data: append(sel[:], encodeTuple(abiBytes(payload))...)}
+}
+
+// revCAS20StringBytes builds a revert carrying a string and a bytes argument, the
+// shape BSC's system contracts use to report a rejected parameter change.
+func revCAS20StringBytes(sig string, sel [4]byte, key string, value []byte) error {
+	return &cas20RevertError{sig: sig, data: append(sel[:], encodeTuple(abiString(key), abiBytes(value))...)}
+}
+
+func wU256(v *uint256.Int) common.Hash { return v.Bytes32() }
+func wU64(v uint64) common.Hash        { return uint256.NewInt(v).Bytes32() }
+func wU8(v byte) common.Hash           { var h common.Hash; h[31] = v; return h }
+
+// Registered error selectors (BEP-702 error surface).
+var (
+	errSelNonPayable          = cas20ErrorSel("NonPayable()")
+	errSelInvalidReceiver     = cas20ErrorSel("InvalidReceiver(address)")
+	errSelInvalidSender       = cas20ErrorSel("InvalidSender(address)")
+	errSelInvalidSpender      = cas20ErrorSel("InvalidSpender(address)")
+	errSelInvalidApprover     = cas20ErrorSel("InvalidApprover(address)")
+	errSelInsufficientBalance = cas20ErrorSel("InsufficientBalance(address,uint256,uint256)")
+	errSelInsufficientAllow   = cas20ErrorSel("InsufficientAllowance(address,uint256,uint256)")
+	errSelSupplyCapExceeded   = cas20ErrorSel("SupplyCapExceeded(uint256,uint256)")
+	errSelInvalidSupplyCap    = cas20ErrorSel("InvalidSupplyCap(uint256,uint256)")
+	errSelContractPaused      = cas20ErrorSel("ContractPaused(uint8)")
+	errSelExpiredSignature    = cas20ErrorSel("ExpiredSignature(uint256)")
+	errSelInvalidSigner       = cas20ErrorSel("InvalidSigner(address,address)")
+	errSelACUnauthorized      = cas20ErrorSel("AccessControlUnauthorizedAccount(address,bytes32)")
+	errSelACBadConfirmation   = cas20ErrorSel("AccessControlBadConfirmation()")
+	errSelLastAdminRenounce   = cas20ErrorSel("LastAdminCannotRenounce()")
+	errSelNotSoleAdmin        = cas20ErrorSel("NotSoleAdmin()")
+	errSelPolicyForbids       = cas20ErrorSel("PolicyForbids(bytes32,uint64)")
+	// Two forms: the registry answers about a policy the caller named, so the id
+	// adds nothing; a token binding one reports which id it could not find
+	// (IPolicyRegistry vs IB20).
+	errSelPolicyNotFound     = cas20ErrorSel("PolicyNotFound()")
+	errSelPolicyNotFoundID   = cas20ErrorSel("PolicyNotFound(uint64)")
+	errSelUnsupportedScope   = cas20ErrorSel("UnsupportedPolicyType(bytes32)")
+	errSelIncompatibleType   = cas20ErrorSel("IncompatiblePolicyType()")
+	errSelInvalidChildPolicy = cas20ErrorSel("InvalidChildPolicy(uint64)")
+	errSelChildrenOutOfRange = cas20ErrorSel("ChildPoliciesOutsideOfRange()")
+	errSelBatchTooLarge      = cas20ErrorSel("BatchSizeTooLarge(uint256)")
+	errSelEmptyBatch         = cas20ErrorSel("EmptyBatch()")
+	errSelLengthMismatch     = cas20ErrorSel("LengthMismatch(uint256,uint256)")
+	errSelEmptyFeatureSet    = cas20ErrorSel("EmptyFeatureSet()")
+	errSelInvalidMultiplier  = cas20ErrorSel("InvalidMultiplier()")
+	errSelEffectiveAtInPast  = cas20ErrorSel("EffectiveAtInPast(uint256)")
+	errSelEffectiveAtTooFar  = cas20ErrorSel("EffectiveAtTooFar(uint256)")
+	errSelUIMulExists        = cas20ErrorSel("UIMultiplierUpdateExists(uint256)")
+	errSelUIMulMissing       = cas20ErrorSel("UIMultiplierUpdateDoesNotExist()")
+	errSelInvalidMetadataKey = cas20ErrorSel("InvalidMetadataKey()")
+	errSelAnnounceInProgress = cas20ErrorSel("AnnouncementInProgress()")
+	errSelAnnounceIdUsed     = cas20ErrorSel("AnnouncementIdAlreadyUsed(string)")
+	errSelInternalMalformed  = cas20ErrorSel("InternalCallMalformed(bytes)")
+	errSelInternalFailed     = cas20ErrorSel("InternalCallFailed(bytes)")
+	errSelInvalidVariant     = cas20ErrorSel("InvalidVariant()")
+	errSelTokenExists        = cas20ErrorSel("TokenAlreadyExists(address)")
+	errSelInitCallFailed     = cas20ErrorSel("InitCallFailed(uint256)")
+	errSelUnauthorized       = cas20ErrorSel("Unauthorized()")
+	errSelNoPendingAdmin     = cas20ErrorSel("NoPendingAdmin()")
+	errSelZeroAddress        = cas20ErrorSel("ZeroAddress()")
+	errSelAccountNotSeizable = cas20ErrorSel("AccountNotSeizable(address)")
+	errSelPanic              = cas20ErrorSel("Panic(uint256)")
+	errSelFeatureNotActive   = cas20ErrorSel("FeatureNotActivated(bytes32)")
+	errSelAlreadyActivated   = cas20ErrorSel("AlreadyActivated(bytes32)")
+	errSelUnauthorizedAddr   = cas20ErrorSel("Unauthorized(address)")
+	errSelInvalidValue       = cas20ErrorSel("InvalidValue(string,bytes)")
+	errSelUnknownParam       = cas20ErrorSel("UnknownParam(string,bytes)")
+	errSelDelegateCallDenied = cas20ErrorSel("DelegateCallNotAllowed()")
+	errSelStaticCallDenied   = cas20ErrorSel("StaticCallNotAllowed()")
+	errSelUnsupportedVersion = cas20ErrorSel("UnsupportedVersion(uint8,uint8)")
+	errSelInvalidDecimals    = cas20ErrorSel("InvalidDecimals(uint8)")
+	errSelMissingField       = cas20ErrorSel("MissingRequiredField(string)")
+	errSelInvalidCurrency    = cas20ErrorSel("InvalidCurrency(string)")
+)
+
+// revPanic mirrors Solidity's Panic(code): 0x11 arithmetic over/underflow,
+// 0x21 invalid enum value.
+func revPanic(code byte) error {
+	return revCAS20("Panic(uint256)", errSelPanic, wU8(code))
+}

--- a/core/vm/cas20_errors.go
+++ b/core/vm/cas20_errors.go
@@ -172,8 +172,9 @@ var (
 	errSelInvalidCurrency    = cas20ErrorSel("InvalidCurrency(string)")
 )
 
-// revPanic mirrors Solidity's Panic(code): 0x11 arithmetic over/underflow,
-// 0x21 invalid enum value.
+// revPanic mirrors Solidity's Panic(code). Only 0x11, arithmetic overflow and
+// underflow, arises here: a malformed argument is a decode failure and reverts
+// with empty returndata, which is what Solidity's external decoder does.
 func revPanic(code byte) error {
 	return revCAS20("Panic(uint256)", errSelPanic, wU8(code))
 }

--- a/core/vm/cas20_errors.go
+++ b/core/vm/cas20_errors.go
@@ -18,12 +18,11 @@ import (
 // what keeps a newly added error from slipping past the overload check.
 var cas20ErrSigs = map[string][4]byte{}
 
-// eventTopic computes topic0 for an event signature.
 func eventTopic(sig string) common.Hash {
 	return crypto.Keccak256Hash([]byte(sig))
 }
 
-// cas20ErrorSel computes (and registers) the 4-byte selector of an error signature.
+// cas20ErrorSel also registers the signature, for revert-data assertions.
 func cas20ErrorSel(sig string) [4]byte {
 	var s [4]byte
 	copy(s[:], crypto.Keccak256([]byte(sig)))
@@ -83,7 +82,6 @@ func finishCAS20Metered(ctx *PrecompileContext, ret []byte, err error) ([]byte, 
 	return finishCAS20(ret, err)
 }
 
-// revCAS20 builds a typed revert from a registered selector and static 32-byte words.
 func revCAS20(sig string, sel [4]byte, words ...common.Hash) error {
 	data := make([]byte, 4+32*len(words))
 	copy(data, sel[:])
@@ -93,8 +91,6 @@ func revCAS20(sig string, sel [4]byte, words ...common.Hash) error {
 	return &cas20RevertError{sig: sig, data: data}
 }
 
-// revCAS20Bytes builds a typed revert for an error with a single dynamic
-// `bytes`/`string` argument.
 func revCAS20Bytes(sig string, sel [4]byte, payload []byte) error {
 	return &cas20RevertError{sig: sig, data: append(sel[:], encodeTuple(abiBytes(payload))...)}
 }

--- a/core/vm/cas20_errors.go
+++ b/core/vm/cas20_errors.go
@@ -102,7 +102,7 @@ var (
 	errSelLastAdminRenounce   = cas20ErrorSel("LastAdminCannotRenounce()")
 	errSelNotSoleAdmin        = cas20ErrorSel("NotSoleAdmin()")
 	errSelPolicyForbids       = cas20ErrorSel("PolicyForbids(bytes32,uint64)")
-	// IPolicyRegistry answers about the id the caller named; IB20 reports which one it could not find.
+	// IPolicyRegistry answers about the id the caller named; ICAS20 reports which one it could not find.
 	errSelPolicyNotFound     = cas20ErrorSel("PolicyNotFound()")
 	errSelPolicyNotFoundID   = cas20ErrorSel("PolicyNotFound(uint64)")
 	errSelUnsupportedScope   = cas20ErrorSel("UnsupportedPolicyType(bytes32)")

--- a/core/vm/cas20_errors.go
+++ b/core/vm/cas20_errors.go
@@ -142,6 +142,10 @@ var (
 	errSelInvalidDecimals    = cas20ErrorSel("InvalidDecimals(uint8)")
 	errSelMissingField       = cas20ErrorSel("MissingRequiredField(string)")
 	errSelInvalidCurrency    = cas20ErrorSel("InvalidCurrency(string)")
+	errSelFormatNotFound     = cas20ErrorSel("FormatNotFound(uint64)")
+	errSelInvalidCategory    = cas20ErrorSel("InvalidCategory()")
+	errSelInvalidFieldCount  = cas20ErrorSel("InvalidFieldCount(uint256)")
+	errSelInvalidFieldSpec   = cas20ErrorSel("InvalidFieldSpec(uint256)")
 )
 
 // Only 0x11 arises here: a malformed argument is a decode failure and reverts empty.

--- a/core/vm/cas20_errors.go
+++ b/core/vm/cas20_errors.go
@@ -9,20 +9,16 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// Typed revert data for the CAS20 precompiles. Business-rule failures use ABI
-// custom errors; malformed calldata and unknown selectors revert with empty
-// returndata (BEP-702 3.2).
+// Business-rule failures are ABI custom errors; malformed calldata and unknown
+// selectors revert with empty returndata (BEP-702 3.2).
 
-// cas20ErrSigs accumulates every error signature the implementation registers, so
-// a test can read what the code actually raises rather than a list of it. That is
-// what keeps a newly added error from slipping past the overload check.
+// cas20ErrSigs lets a test read what the code actually raises rather than a list of it.
 var cas20ErrSigs = map[string][4]byte{}
 
 func eventTopic(sig string) common.Hash {
 	return crypto.Keccak256Hash([]byte(sig))
 }
 
-// cas20ErrorSel also registers the signature, for revert-data assertions.
 func cas20ErrorSel(sig string) [4]byte {
 	var s [4]byte
 	copy(s[:], crypto.Keccak256([]byte(sig)))
@@ -30,8 +26,7 @@ func cas20ErrorSel(sig string) [4]byte {
 	return s
 }
 
-// cas20RevertError carries an ABI-encoded revert payload through the internal
-// call chain. It is never returned to the EVM directly; finishCAS20 converts it.
+// cas20RevertError never reaches the EVM directly; finishCAS20 converts it.
 type cas20RevertError struct {
 	sig  string
 	data []byte
@@ -39,20 +34,10 @@ type cas20RevertError struct {
 
 func (e *cas20RevertError) Error() string { return fmt.Sprintf("cas20 revert: %s", e.sig) }
 
-// Is lets errors.Is(err, ErrExecutionReverted) hold before finishCAS20 converts
-// the typed revert at the precompile boundary.
 func (e *cas20RevertError) Is(target error) bool { return target == ErrExecutionReverted }
 
-// finishCAS20 converts a typed revert into (returndata, ErrExecutionReverted) at
-// the precompile boundary. All other results pass through unchanged.
 func finishCAS20(ret []byte, err error) ([]byte, error) {
-	// A refused call form is a revert, not an exceptional halt: BEP-702 3.2 says
-	// DELEGATECALL and CALLCODE MUST revert, and names both this and the
-	// write-protection failure as ABI errors. Returning the sentinels straight to
-	// the EVM would exhaust the caller's gas and hand back no returndata, so an
-	// integrator could neither decode the reason nor keep the gas — a footgun no
-	// contract at an ordinary address has. Converted here rather than at each of
-	// the twenty guard sites, which keep the plain sentinel internally.
+	// A refused call form is an ABI error, not an exceptional halt (BEP-702 3.2).
 	switch {
 	case errors.Is(err, ErrCAS20DelegateCall):
 		err = revCAS20("DelegateCallNotAllowed()", errSelDelegateCallDenied)
@@ -66,12 +51,7 @@ func finishCAS20(ret []byte, err error) ([]byte, error) {
 	return ret, err
 }
 
-// finishCAS20Metered is finishCAS20 for a call that has already charged gas. An
-// exhausted budget outranks whatever the logic returned: a charge that could not
-// be covered is an out-of-gas exception, not a revert, however the handler
-// reported it. Guards that run before any charge — a delegated call, a
-// value-bearing one — can use finishCAS20 directly, since there is nothing to have
-// exhausted yet.
+// Write protection, then an exhausted budget, outrank whatever the logic returned.
 func finishCAS20Metered(ctx *PrecompileContext, ret []byte, err error) ([]byte, error) {
 	if ctx.writeProtectionViolated() {
 		return finishCAS20(nil, ErrWriteProtection)
@@ -95,8 +75,7 @@ func revCAS20Bytes(sig string, sel [4]byte, payload []byte) error {
 	return &cas20RevertError{sig: sig, data: append(sel[:], encodeTuple(abiBytes(payload))...)}
 }
 
-// revCAS20StringBytes builds a revert carrying a string and a bytes argument, the
-// shape BSC's system contracts use to report a rejected parameter change.
+// The shape BSC's system contracts use to report a rejected parameter change.
 func revCAS20StringBytes(sig string, sel [4]byte, key string, value []byte) error {
 	return &cas20RevertError{sig: sig, data: append(sel[:], encodeTuple(abiString(key), abiBytes(value))...)}
 }
@@ -105,7 +84,6 @@ func wU256(v *uint256.Int) common.Hash { return v.Bytes32() }
 func wU64(v uint64) common.Hash        { return uint256.NewInt(v).Bytes32() }
 func wU8(v byte) common.Hash           { var h common.Hash; h[31] = v; return h }
 
-// Registered error selectors (BEP-702 error surface).
 var (
 	errSelNonPayable          = cas20ErrorSel("NonPayable()")
 	errSelInvalidReceiver     = cas20ErrorSel("InvalidReceiver(address)")
@@ -124,9 +102,7 @@ var (
 	errSelLastAdminRenounce   = cas20ErrorSel("LastAdminCannotRenounce()")
 	errSelNotSoleAdmin        = cas20ErrorSel("NotSoleAdmin()")
 	errSelPolicyForbids       = cas20ErrorSel("PolicyForbids(bytes32,uint64)")
-	// Two forms: the registry answers about a policy the caller named, so the id
-	// adds nothing; a token binding one reports which id it could not find
-	// (IPolicyRegistry vs IB20).
+	// IPolicyRegistry answers about the id the caller named; IB20 reports which one it could not find.
 	errSelPolicyNotFound     = cas20ErrorSel("PolicyNotFound()")
 	errSelPolicyNotFoundID   = cas20ErrorSel("PolicyNotFound(uint64)")
 	errSelUnsupportedScope   = cas20ErrorSel("UnsupportedPolicyType(bytes32)")
@@ -168,9 +144,7 @@ var (
 	errSelInvalidCurrency    = cas20ErrorSel("InvalidCurrency(string)")
 )
 
-// revPanic mirrors Solidity's Panic(code). Only 0x11, arithmetic overflow and
-// underflow, arises here: a malformed argument is a decode failure and reverts
-// with empty returndata, which is what Solidity's external decoder does.
+// Only 0x11 arises here: a malformed argument is a decode failure and reverts empty.
 func revPanic(code byte) error {
 	return revCAS20("Panic(uint256)", errSelPanic, wU8(code))
 }

--- a/core/vm/cas20_factory.go
+++ b/core/vm/cas20_factory.go
@@ -1,0 +1,413 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+)
+
+// cas20ParamsVersion is the encoding version every create-params struct carries
+// as its leading field. A struct that does not match is rejected before any
+// field is looked at, so a version error always takes precedence.
+const cas20ParamsVersion = 1
+
+// Asset decimals bounds (BEP-702 section 4.10).
+const (
+	cas20MinDecimals = 6
+	cas20MaxDecimals = 18
+)
+
+var (
+	cas20TopicCAS20Created = eventTopic("CAS20Created(address,uint8,string,string,uint8,bytes)")
+
+	selCreateCAS20        = selector("createCAS20(uint8,bytes32,bytes,bytes[])")
+	selGetCAS20Address    = selector("getCAS20Address(uint8,address,bytes32)")
+	selIsCAS20            = selector("isCAS20(address)")
+	selVariantOf          = selector("variantOf(address)")
+	selIsCAS20Initialized = selector("isCAS20Initialized(address)")
+)
+
+// cas20VariantRecognized reports whether this variant reaches a handler.
+func cas20VariantRecognized(variant byte) bool {
+	_, ok := cas20Variants[variant]
+	return ok
+}
+
+// CAS20MarkerCode marks an initialized token, keeps the account clear of EIP-161
+// reaping, and uses EIP-3541's reserved 0xEF prefix so no deployment can forge
+// it (BEP-702 3.16). It is never executed. Exported so a genesis that starts
+// after the fork can pre-deploy it on the registries, the way the other system
+// accounts are.
+var CAS20MarkerCode = []byte{0xEF}
+
+// cas20NoSupplyCap is the "unlimited" sentinel: type(uint128).max.
+var cas20NoSupplyCap = new(uint256.Int).Sub(new(uint256.Int).Lsh(uint256.NewInt(1), 128), uint256.NewInt(1))
+
+// cas20DeriveAddress computes a token's deterministic address:
+// 0xCA50 ++ 8×0x00 ++ variant ++ keccak256(abi.encode(creator, salt))[:9].
+func cas20DeriveAddress(variant byte, creator common.Address, salt common.Hash) common.Address {
+	h := crypto.Keccak256(common.LeftPadBytes(creator.Bytes(), 32), salt.Bytes())
+	var a common.Address
+	a[0], a[1] = cas20MarkerPrefix[0], cas20MarkerPrefix[1]
+	a[10] = variant
+	copy(a[11:20], h[:9])
+	return a
+}
+
+func runCAS20Factory(ctx *PrecompileContext, input []byte) ([]byte, error) {
+	if len(input) < 4 {
+		return nil, ErrExecutionReverted
+	}
+	var sel [4]byte
+	copy(sel[:], input[:4])
+	args := input[4:]
+
+	switch sel {
+	case selGetCAS20Address:
+		variant, err := readWord(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		sender, err := readAddress(args, 1)
+		if err != nil {
+			return nil, err
+		}
+		salt, err := readWord(args, 2)
+		if err != nil {
+			return nil, err
+		}
+		// Decoded exactly as createCAS20 decodes the same argument. Prediction is
+		// only meaningful if the two agree on what the input means: truncating
+		// variant[31] answered for encodings creation rejects, and named
+		// addresses in unroutable variant spaces.
+		if !isEnumWord(variant, cas20VariantMax) {
+			return nil, revPanic(0x21)
+		}
+		if !ctx.chargeKeccak(64) {
+			return nil, ErrOutOfGas
+		}
+		addr := cas20DeriveAddress(variant[31], sender, salt)
+		return addrKey(addr).Bytes(), nil
+	case selIsCAS20:
+		a, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		return encBool(IsCAS20Address(a)), nil
+	case selVariantOf:
+		a, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		// Unlike isCAS20, this one validates the variant byte: the return type is
+		// an enum, so naming an unrecognized variant would hand the caller a
+		// value its own ABI decoder rejects.
+		if !IsCAS20Address(a) || !cas20VariantRecognized(a[10]) {
+			return nil, revCAS20("InvalidVariant()", errSelInvalidVariant)
+		}
+		return wU8(a[10]).Bytes(), nil
+	case selIsCAS20Initialized:
+		a, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		return encBool(IsCAS20Address(a) && cas20InitializedMetered(ctx, a)), nil
+	case selCreateCAS20:
+		return createCAS20(ctx, args)
+	}
+	return nil, ErrExecutionReverted
+}
+
+func createCAS20(ctx *PrecompileContext, args []byte) ([]byte, error) {
+	if ctx.ReadOnly {
+		return nil, ErrWriteProtection
+	}
+	variantWord, err := readWord(args, 0)
+	if err != nil {
+		return nil, err
+	}
+	salt, err := readWord(args, 1)
+	if err != nil {
+		return nil, err
+	}
+	params, err := readBytesArg(args, 2)
+	if err != nil {
+		return nil, err
+	}
+	initCalls, err := readBytesArray(args, 3)
+	if err != nil {
+		return nil, err
+	}
+
+	// Order follows BEP-702 3.4: the variant is resolved and its
+	// feature gate applied before the variant-specific params blob is decoded, so
+	// a closed feature is reported as such whatever the payload.
+	if !isEnumWord(variantWord, cas20VariantMax) {
+		return nil, revPanic(0x21)
+	}
+	variant := variantWord[31]
+	feature, ok := variantFeature(variant)
+	if !ok {
+		return nil, revCAS20("InvalidVariant()", errSelInvalidVariant)
+	}
+	if err := ensureFeatureActivated(ctx, feature); err != nil {
+		return nil, err
+	}
+	create, err := decodeCreateParams(variant, params)
+	if err != nil {
+		return nil, err
+	}
+	// Every field is validated before the address is derived, so a malformed
+	// currency is reported as such even when the salt is also taken.
+	if variant == cas20VariantStablecoin {
+		if err := validateCurrency(create.currency); err != nil {
+			return nil, err
+		}
+	}
+	creator := ctx.Caller
+	if !ctx.chargeKeccak(64) {
+		return nil, ErrOutOfGas
+	}
+	addr := cas20DeriveAddress(variant, creator, salt)
+
+	if cas20AddressOccupied(ctx, addr) {
+		return nil, revCAS20("TokenAlreadyExists(address)", errSelTokenExists, addrKey(addr))
+	}
+	if !ctx.chargeCodeWrite(addr, CAS20MarkerCode) {
+		return nil, ErrOutOfGas
+	}
+	ctx.StateDB.SetCode(addr, CAS20MarkerCode, tracing.CodeChangeContractCreation)
+
+	// Bootstrap context/token bound to the new address, privileged so initCalls
+	// can grant roles and mint before any role holder exists.
+	decimals := create.decimals
+	tokenCtx := ctx.spawnBootstrap(addr, creator)
+	tok := newCAS20TokenBootstrap(tokenCtx, decimals)
+
+	// Initial state: metadata, no supply cap, and the variant's own storage.
+	if !tok.s.setName(create.name) || !tok.s.setSymbol(create.symbol) {
+		return nil, ErrOutOfGas
+	}
+	tok.s.setSupplyCap(cas20NoSupplyCap)
+	if variant == cas20VariantAsset {
+		initAssetExtension(tokenCtx, create.decimals)
+	} else if !newStablecoinExt(tokenCtx).setCurrency(create.currency) {
+		return nil, ErrOutOfGas
+	}
+	initialAdmin := create.initialAdmin
+	if initialAdmin != (common.Address{}) {
+		tok.s.setRole(roleDefaultAdmin, initialAdmin, true)
+		tok.s.setAdminCount(uint256.NewInt(1))
+		if !tokenCtx.AddLog([]common.Hash{cas20TopicRoleGranted, roleDefaultAdmin, addrKey(initialAdmin), addrKey(creator)}, nil) {
+			return nil, ErrOutOfGas
+		}
+	}
+
+	// Each entry runs on the variant's full dispatcher, not the shared half: an
+	// Asset token has to be able to set its multiplier or batch its first
+	// distribution at creation. The bootstrap dispatched tok.dispatch directly
+	// from the commit that introduced it, when no variant layer existed yet, and
+	// was not revisited when one did.
+	dispatch := func(call []byte) ([]byte, error) { return stablecoinDispatch(tok, newStablecoinExt(tokenCtx), call) }
+	if variant == cas20VariantAsset {
+		dispatch = func(call []byte) ([]byte, error) { return assetDispatch(tok, newAssetExt(tokenCtx), call) }
+	}
+
+	// Privileged bootstrap: any initCall failure reverts the whole creation.
+	for i, call := range initCalls {
+		// Same shape as announce's bundle: each entry dispatches a full token
+		// call, so without this the whole array runs on an exhausted budget.
+		if ctx.OutOfGas() {
+			return nil, ErrOutOfGas
+		}
+		if len(call) < 4 {
+			return nil, revCAS20Bytes("InternalCallMalformed(bytes)", errSelInternalMalformed, call)
+		}
+		if _, err := dispatch(call); err != nil {
+			if _, isRev := err.(*cas20RevertError); !isRev && err != ErrExecutionReverted {
+				return nil, err // out-of-gas / write-protection propagate as-is
+			}
+			return nil, revCAS20("InitCallFailed(uint256)", errSelInitCallFailed, wU64(uint64(i)))
+		}
+	}
+	if ctx.OutOfGas() {
+		return nil, ErrOutOfGas
+	}
+	// CAS20Created is emitted by the factory, not the token, so an indexer can
+	// follow creation from one address. variantEventParams carries the
+	// variant's immutable identity data: empty for Asset, the versioned
+	// currency struct for Stablecoin.
+	if !ctx.AddLog(
+		[]common.Hash{cas20TopicCAS20Created, addrKey(addr), wU8(variant)},
+		encodeCAS20CreatedData(create),
+	) {
+		return nil, ErrOutOfGas
+	}
+	return addrKey(addr).Bytes(), nil
+}
+
+type cas20CreateParams struct {
+	variant      byte
+	name         string
+	symbol       string
+	initialAdmin common.Address
+	decimals     byte
+	currency     string // Stablecoin only
+}
+
+// decodeCreateParams decodes and validates the variant's create-params struct.
+// The version check precedes every field check, so an unsupported encoding is
+// always reported as such.
+func decodeCreateParams(variant byte, params []byte) (cas20CreateParams, error) {
+	out := cas20CreateParams{variant: variant}
+
+	// abi.encode of a single dynamic struct wraps it in a one-element tuple, so
+	// the blob opens with an offset to the struct's own encoding rather than
+	// with its first field. Read through it before touching any field.
+	off, ok := wordU64(params, 0)
+	if !ok || off > uint64(len(params)) {
+		return out, ErrExecutionReverted // malformed encoding
+	}
+	body := params[off:]
+
+	// A uint8 field with dirty high bits is a malformed encoding, which the
+	// decode reports as such — Panic(0x21) is for an out-of-range enum, and
+	// version and decimals are plain integers.
+	version, err := readStrictUint8(body, 0)
+	if err != nil {
+		return out, err
+	}
+	if version != cas20ParamsVersion {
+		return out, revCAS20("UnsupportedVersion(uint8,uint8)", errSelUnsupportedVersion,
+			wU8(version), wU8(variant))
+	}
+	if out.name, err = readStringArg(body, 1); err != nil {
+		return out, err
+	}
+	if out.symbol, err = readStringArg(body, 2); err != nil {
+		return out, err
+	}
+	if out.initialAdmin, err = readAddress(body, 3); err != nil {
+		return out, err
+	}
+
+	if variant == cas20VariantAsset {
+		if out.decimals, err = readStrictUint8(body, 4); err != nil {
+			return out, err
+		}
+		if out.decimals < cas20MinDecimals || out.decimals > cas20MaxDecimals {
+			return out, revCAS20("InvalidDecimals(uint8)", errSelInvalidDecimals, wU8(out.decimals))
+		}
+		return out, nil
+	}
+
+	// Stablecoin: decimals are fixed and not carried on the wire. The currency's
+	// content is checked by the caller before the address is derived, so a
+	// malformed one is reported ahead of TokenAlreadyExists.
+	out.decimals = 6
+	if out.currency, err = readStringArg(body, 4); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+// validateCurrency is the Stablecoin content check. Its caller runs it before
+// deriving the address, so it reports ahead of TokenAlreadyExists.
+func validateCurrency(code string) error {
+	if code == "" {
+		return revCAS20Bytes("MissingRequiredField(string)", errSelMissingField, []byte("currency"))
+	}
+	for i := 0; i < len(code); i++ {
+		if code[i] < 'A' || code[i] > 'Z' {
+			return revCAS20Bytes("InvalidCurrency(string)", errSelInvalidCurrency, []byte(code))
+		}
+	}
+	return nil
+}
+
+// readStrictUint8 decodes a uint8 field: every byte above the last must be
+// zero, or the encoding is malformed.
+func readStrictUint8(args []byte, i int) (byte, error) {
+	w, err := readWord(args, i)
+	if err != nil {
+		return 0, err
+	}
+	if !isEnumWord(w, 0xff) {
+		return 0, ErrExecutionReverted // malformed encoding
+	}
+	return w[31], nil
+}
+
+// encodeCAS20CreatedData ABI-encodes the non-indexed fields of CAS20Created:
+// (string name, string symbol, uint8 decimals, bytes variantEventParams).
+func encodeCAS20CreatedData(c cas20CreateParams) []byte {
+	var variantParams []byte
+	if c.variant == cas20VariantStablecoin {
+		// abi.encode(CAS20StablecoinEventParams{version, currency}) — a single
+		// dynamic struct, so it carries the same outer offset wrapper.
+		variantParams = abiEncodeStruct(
+			abiWord(wU8(cas20ParamsVersion)),
+			abiString(c.currency),
+		)
+	}
+	return encodeTuple(
+		abiString(c.name),
+		abiString(c.symbol),
+		abiWord(wU8(c.decimals)),
+		abiBytes(variantParams),
+	)
+}
+
+func readBytesArray(args []byte, argIndex int) ([][]byte, error) {
+	L := uint64(len(args))
+	base, ok := wordU64(args, uint64(argIndex)*32)
+	if !ok || base > L || L-base < 32 {
+		return nil, ErrExecutionReverted
+	}
+	n, ok2 := wordU64(args, base)
+	if !ok2 {
+		return nil, ErrExecutionReverted // malformed length word
+	}
+	arrData := base + 32
+	if n > (L-arrData)/32 {
+		return nil, ErrExecutionReverted
+	}
+	out := make([][]byte, n)
+	for i := uint64(0); i < n; i++ {
+		elemOff, ok2 := wordU64(args, arrData+i*32)
+		if !ok2 {
+			return nil, ErrExecutionReverted // malformed element offset
+		}
+		pos := arrData + elemOff
+		if elemOff > L-arrData || pos > L || L-pos < 32 {
+			return nil, ErrExecutionReverted
+		}
+		elemLen, ok3 := wordU64(args, pos)
+		if !ok3 {
+			return nil, ErrExecutionReverted // malformed element length
+		}
+		start := pos + 32
+		if elemLen > L-start {
+			return nil, ErrExecutionReverted
+		}
+		out[i] = args[start : start+elemLen]
+	}
+	return out, nil
+}
+
+// wordU64 reads the 32-byte word at byte position pos as a uint64. It reports
+// false when the word is out of range or does not fit a uint64: an offset or
+// length with dirty high bits is a malformed encoding, not a large number to
+// be truncated into something plausible.
+func wordU64(args []byte, pos uint64) (uint64, bool) {
+	if pos > uint64(len(args)) || uint64(len(args))-pos < 32 {
+		return 0, false
+	}
+	for _, b := range args[pos : pos+24] {
+		if b != 0 {
+			return 0, false
+		}
+	}
+	return new(uint256.Int).SetBytes(args[pos+24 : pos+32]).Uint64(), true
+}

--- a/core/vm/cas20_factory.go
+++ b/core/vm/cas20_factory.go
@@ -82,7 +82,7 @@ func runCAS20Factory(ctx *PrecompileContext, input []byte) ([]byte, error) {
 		// variant[31] answered for encodings creation rejects, and named
 		// addresses in unroutable variant spaces.
 		if !isEnumWord(variant, cas20VariantMax) {
-			return nil, revPanic(0x21)
+			return nil, ErrExecutionReverted
 		}
 		if !ctx.chargeKeccak(64) {
 			return nil, ErrOutOfGas
@@ -144,7 +144,7 @@ func createCAS20(ctx *PrecompileContext, args []byte) ([]byte, error) {
 	// feature gate applied before the variant-specific params blob is decoded, so
 	// a closed feature is reported as such whatever the payload.
 	if !isEnumWord(variantWord, cas20VariantMax) {
-		return nil, revPanic(0x21)
+		return nil, ErrExecutionReverted
 	}
 	variant := variantWord[31]
 	feature, ok := variantFeature(variant)
@@ -272,8 +272,8 @@ func decodeCreateParams(variant byte, params []byte) (cas20CreateParams, error) 
 	body := params[off:]
 
 	// A uint8 field with dirty high bits is a malformed encoding, which the
-	// decode reports as such — Panic(0x21) is for an out-of-range enum, and
-	// version and decimals are plain integers.
+	// decode reports as such: version and decimals are plain integers, so their
+	// range is a field check rather than a decode failure.
 	version, err := readStrictUint8(body, 0)
 	if err != nil {
 		return out, err

--- a/core/vm/cas20_factory.go
+++ b/core/vm/cas20_factory.go
@@ -45,7 +45,7 @@ var CAS20MarkerCode = []byte{0xEF}
 var cas20NoSupplyCap = new(uint256.Int).Sub(new(uint256.Int).Lsh(uint256.NewInt(1), 128), uint256.NewInt(1))
 
 // cas20DeriveAddress computes a token's deterministic address:
-// 0xCA50 ++ 8×0x00 ++ variant ++ keccak256(abi.encode(creator, salt))[:9].
+// 0xCA52 ++ 8×0x00 ++ variant ++ keccak256(abi.encode(creator, salt))[:9].
 func cas20DeriveAddress(variant byte, creator common.Address, salt common.Hash) common.Address {
 	h := crypto.Keccak256(common.LeftPadBytes(creator.Bytes(), 32), salt.Bytes())
 	var a common.Address

--- a/core/vm/cas20_factory.go
+++ b/core/vm/cas20_factory.go
@@ -193,9 +193,7 @@ func createCAS20(ctx *PrecompileContext, args []byte) ([]byte, error) {
 	}
 
 	for i, call := range initCalls {
-		// chargeGas only marks the frame; without this the whole array runs on an
-		// exhausted budget.
-		if ctx.OutOfGas() {
+		if !ctx.chargeInternalDispatch(call) {
 			return nil, ErrOutOfGas
 		}
 		if len(call) < 4 {

--- a/core/vm/cas20_factory.go
+++ b/core/vm/cas20_factory.go
@@ -7,12 +7,9 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// cas20ParamsVersion is the encoding version every create-params struct carries
-// as its leading field. A struct that does not match is rejected before any
-// field is looked at, so a version error always takes precedence.
 const cas20ParamsVersion = 1
 
-// Asset decimals bounds (BEP-702 section 4.10).
+// BEP-702 4.10.
 const (
 	cas20MinDecimals = 6
 	cas20MaxDecimals = 18
@@ -28,23 +25,17 @@ var (
 	selIsCAS20Initialized = selector("isCAS20Initialized(address)")
 )
 
-// cas20VariantRecognized reports whether this variant reaches a handler.
 func cas20VariantRecognized(variant byte) bool {
 	_, ok := cas20Variants[variant]
 	return ok
 }
 
-// CAS20MarkerCode marks an initialized token, keeps the account clear of EIP-161
-// reaping, and uses EIP-3541's reserved 0xEF prefix so no deployment can forge
-// it (BEP-702 3.16). It is never executed. Exported so a genesis that starts
-// after the fork can pre-deploy it on the registries, the way the other system
-// accounts are.
+// 0xEF cannot be deployed (EIP-3541), so nothing can forge the marker, and it
+// keeps the account clear of EIP-161 reaping (BEP-702 3.16). Exported for genesis.
 var CAS20MarkerCode = []byte{0xEF}
 
-// cas20NoSupplyCap is the "unlimited" sentinel: type(uint128).max.
 var cas20NoSupplyCap = new(uint256.Int).Sub(new(uint256.Int).Lsh(uint256.NewInt(1), 128), uint256.NewInt(1))
 
-// cas20DeriveAddress computes a token's deterministic address:
 // 0xCA52 ++ 8×0x00 ++ variant ++ keccak256(abi.encode(creator, salt))[:9].
 func cas20DeriveAddress(variant byte, creator common.Address, salt common.Hash) common.Address {
 	h := crypto.Keccak256(common.LeftPadBytes(creator.Bytes(), 32), salt.Bytes())
@@ -77,10 +68,7 @@ func runCAS20Factory(ctx *PrecompileContext, input []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Decoded exactly as createCAS20 decodes the same argument. Prediction is
-		// only meaningful if the two agree on what the input means: truncating
-		// variant[31] answered for encodings creation rejects, and named
-		// addresses in unroutable variant spaces.
+		// Decoded as createCAS20 decodes it, so prediction and creation agree.
 		if !isEnumWord(variant, cas20VariantMax) {
 			return nil, ErrExecutionReverted
 		}
@@ -100,9 +88,8 @@ func runCAS20Factory(ctx *PrecompileContext, input []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Unlike isCAS20, this one validates the variant byte: the return type is
-		// an enum, so naming an unrecognized variant would hand the caller a
-		// value its own ABI decoder rejects.
+		// The return type is an enum, so an unrecognized variant reverts rather than
+		// handing the caller a value its decoder rejects.
 		if !IsCAS20Address(a) || !cas20VariantRecognized(a[10]) {
 			return nil, revCAS20("InvalidVariant()", errSelInvalidVariant)
 		}
@@ -140,9 +127,8 @@ func createCAS20(ctx *PrecompileContext, args []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	// Order follows BEP-702 3.4: the variant is resolved and its
-	// feature gate applied before the variant-specific params blob is decoded, so
-	// a closed feature is reported as such whatever the payload.
+	// Variant and feature gate before the params blob (BEP-702 3.4): a closed
+	// feature is reported as such whatever the payload.
 	if !isEnumWord(variantWord, cas20VariantMax) {
 		return nil, ErrExecutionReverted
 	}
@@ -158,8 +144,6 @@ func createCAS20(ctx *PrecompileContext, args []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Every field is validated before the address is derived, so a malformed
-	// currency is reported as such even when the salt is also taken.
 	if variant == cas20VariantStablecoin {
 		if err := validateCurrency(create.currency); err != nil {
 			return nil, err
@@ -179,13 +163,10 @@ func createCAS20(ctx *PrecompileContext, args []byte) ([]byte, error) {
 	}
 	ctx.StateDB.SetCode(addr, CAS20MarkerCode, tracing.CodeChangeContractCreation)
 
-	// Bootstrap context/token bound to the new address, privileged so initCalls
-	// can grant roles and mint before any role holder exists.
 	decimals := create.decimals
 	tokenCtx := ctx.spawnBootstrap(addr, creator)
 	tok := newCAS20TokenBootstrap(tokenCtx, decimals)
 
-	// Initial state: metadata, no supply cap, and the variant's own storage.
 	if !tok.s.setName(create.name) || !tok.s.setSymbol(create.symbol) {
 		return nil, ErrOutOfGas
 	}
@@ -204,20 +185,16 @@ func createCAS20(ctx *PrecompileContext, args []byte) ([]byte, error) {
 		}
 	}
 
-	// Each entry runs on the variant's full dispatcher, not the shared half: an
-	// Asset token has to be able to set its multiplier or batch its first
-	// distribution at creation. The bootstrap dispatched tok.dispatch directly
-	// from the commit that introduced it, when no variant layer existed yet, and
-	// was not revisited when one did.
+	// The variant's full dispatcher, not the shared half: an Asset token has to be
+	// able to set its multiplier at creation.
 	dispatch := func(call []byte) ([]byte, error) { return stablecoinDispatch(tok, newStablecoinExt(tokenCtx), call) }
 	if variant == cas20VariantAsset {
 		dispatch = func(call []byte) ([]byte, error) { return assetDispatch(tok, newAssetExt(tokenCtx), call) }
 	}
 
-	// Privileged bootstrap: any initCall failure reverts the whole creation.
 	for i, call := range initCalls {
-		// Same shape as announce's bundle: each entry dispatches a full token
-		// call, so without this the whole array runs on an exhausted budget.
+		// chargeGas only marks the frame; without this the whole array runs on an
+		// exhausted budget.
 		if ctx.OutOfGas() {
 			return nil, ErrOutOfGas
 		}
@@ -226,7 +203,7 @@ func createCAS20(ctx *PrecompileContext, args []byte) ([]byte, error) {
 		}
 		if _, err := dispatch(call); err != nil {
 			if _, isRev := err.(*cas20RevertError); !isRev && err != ErrExecutionReverted {
-				return nil, err // out-of-gas / write-protection propagate as-is
+				return nil, err
 			}
 			return nil, revCAS20("InitCallFailed(uint256)", errSelInitCallFailed, wU64(uint64(i)))
 		}
@@ -234,10 +211,6 @@ func createCAS20(ctx *PrecompileContext, args []byte) ([]byte, error) {
 	if ctx.OutOfGas() {
 		return nil, ErrOutOfGas
 	}
-	// CAS20Created is emitted by the factory, not the token, so an indexer can
-	// follow creation from one address. variantEventParams carries the
-	// variant's immutable identity data: empty for Asset, the versioned
-	// currency struct for Stablecoin.
 	if !ctx.AddLog(
 		[]common.Hash{cas20TopicCAS20Created, addrKey(addr), wU8(variant)},
 		encodeCAS20CreatedData(create),
@@ -256,24 +229,16 @@ type cas20CreateParams struct {
 	currency     string // Stablecoin only
 }
 
-// decodeCreateParams decodes and validates the variant's create-params struct.
-// The version check precedes every field check, so an unsupported encoding is
-// always reported as such.
 func decodeCreateParams(variant byte, params []byte) (cas20CreateParams, error) {
 	out := cas20CreateParams{variant: variant}
 
-	// abi.encode of a single dynamic struct wraps it in a one-element tuple, so
-	// the blob opens with an offset to the struct's own encoding rather than
-	// with its first field. Read through it before touching any field.
+	// The single-struct offset word; see abiEncodeStruct.
 	off, ok := wordU64(params, 0)
 	if !ok || off > uint64(len(params)) {
-		return out, ErrExecutionReverted // malformed encoding
+		return out, ErrExecutionReverted
 	}
 	body := params[off:]
 
-	// A uint8 field with dirty high bits is a malformed encoding, which the
-	// decode reports as such: version and decimals are plain integers, so their
-	// range is a field check rather than a decode failure.
 	version, err := readStrictUint8(body, 0)
 	if err != nil {
 		return out, err
@@ -302,9 +267,7 @@ func decodeCreateParams(variant byte, params []byte) (cas20CreateParams, error) 
 		return out, nil
 	}
 
-	// Stablecoin: decimals are fixed and not carried on the wire. The currency's
-	// content is checked by the caller before the address is derived, so a
-	// malformed one is reported ahead of TokenAlreadyExists.
+	// Stablecoin decimals are fixed and not carried on the wire.
 	out.decimals = 6
 	if out.currency, err = readStringArg(body, 4); err != nil {
 		return out, err
@@ -312,8 +275,6 @@ func decodeCreateParams(variant byte, params []byte) (cas20CreateParams, error) 
 	return out, nil
 }
 
-// validateCurrency is the Stablecoin content check. Its caller runs it before
-// deriving the address, so it reports ahead of TokenAlreadyExists.
 func validateCurrency(code string) error {
 	if code == "" {
 		return revCAS20Bytes("MissingRequiredField(string)", errSelMissingField, []byte("currency"))
@@ -326,26 +287,20 @@ func validateCurrency(code string) error {
 	return nil
 }
 
-// readStrictUint8 decodes a uint8 field: every byte above the last must be
-// zero, or the encoding is malformed.
 func readStrictUint8(args []byte, i int) (byte, error) {
 	w, err := readWord(args, i)
 	if err != nil {
 		return 0, err
 	}
 	if !isEnumWord(w, 0xff) {
-		return 0, ErrExecutionReverted // malformed encoding
+		return 0, ErrExecutionReverted
 	}
 	return w[31], nil
 }
 
-// encodeCAS20CreatedData ABI-encodes the non-indexed fields of CAS20Created:
-// (string name, string symbol, uint8 decimals, bytes variantEventParams).
 func encodeCAS20CreatedData(c cas20CreateParams) []byte {
 	var variantParams []byte
 	if c.variant == cas20VariantStablecoin {
-		// abi.encode(CAS20StablecoinEventParams{version, currency}) — a single
-		// dynamic struct, so it carries the same outer offset wrapper.
 		variantParams = abiEncodeStruct(
 			abiWord(wU8(cas20ParamsVersion)),
 			abiString(c.currency),
@@ -367,7 +322,7 @@ func readBytesArray(args []byte, argIndex int) ([][]byte, error) {
 	}
 	n, ok2 := wordU64(args, base)
 	if !ok2 {
-		return nil, ErrExecutionReverted // malformed length word
+		return nil, ErrExecutionReverted
 	}
 	arrData := base + 32
 	if n > (L-arrData)/32 {
@@ -377,7 +332,7 @@ func readBytesArray(args []byte, argIndex int) ([][]byte, error) {
 	for i := uint64(0); i < n; i++ {
 		elemOff, ok2 := wordU64(args, arrData+i*32)
 		if !ok2 {
-			return nil, ErrExecutionReverted // malformed element offset
+			return nil, ErrExecutionReverted
 		}
 		pos := arrData + elemOff
 		if elemOff > L-arrData || pos > L || L-pos < 32 {
@@ -385,7 +340,7 @@ func readBytesArray(args []byte, argIndex int) ([][]byte, error) {
 		}
 		elemLen, ok3 := wordU64(args, pos)
 		if !ok3 {
-			return nil, ErrExecutionReverted // malformed element length
+			return nil, ErrExecutionReverted
 		}
 		start := pos + 32
 		if elemLen > L-start {
@@ -396,10 +351,7 @@ func readBytesArray(args []byte, argIndex int) ([][]byte, error) {
 	return out, nil
 }
 
-// wordU64 reads the 32-byte word at byte position pos as a uint64. It reports
-// false when the word is out of range or does not fit a uint64: an offset or
-// length with dirty high bits is a malformed encoding, not a large number to
-// be truncated into something plausible.
+// An offset or length with dirty high bits is a malformed encoding, not a large number.
 func wordU64(args []byte, pos uint64) (uint64, bool) {
 	if pos > uint64(len(args)) || uint64(len(args))-pos < 32 {
 		return 0, false

--- a/core/vm/cas20_factory_test.go
+++ b/core/vm/cas20_factory_test.go
@@ -445,17 +445,19 @@ func TestCAS20FieldValidationPrecedesOccupancy(t *testing.T) {
 	}
 }
 
-// TestCAS20OutOfEnumVariantPanics covers the variant word no enum member claims.
-func TestCAS20OutOfEnumVariantPanics(t *testing.T) {
+// TestCAS20OutOfEnumVariantRevertsEmpty covers the variant word no enum member
+// claims. Solidity's external decoder validates an enum argument and reverts with
+// empty returndata; Panic(0x21) comes from an internal uint-to-enum cast and is
+// not what a caller passing 2 to an enum parameter receives.
+func TestCAS20OutOfEnumVariantRevertsEmpty(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	caller := common.HexToAddress("0xca11e4")
-	wantData, _ := finishCAS20(nil, revPanic(0x21))
 
 	for _, tc := range []struct {
 		name  string
 		input []byte
 	}{
-		{"createCAS20", encodeCreateCAS20WithParams(0x02, common.HexToHash("0xbv"),
+		{"createCAS20", encodeCreateCAS20WithParams(0x02, common.HexToHash("0xb0a1"),
 			cas20AssetParams("T", "T", caller, 18), nil)},
 		{"getCAS20Address", cas20Call(selGetCAS20Address, u256hash(2), addrKey(caller), common.Hash{})},
 	} {
@@ -464,9 +466,9 @@ func TestCAS20OutOfEnumVariantPanics(t *testing.T) {
 		if !errors.Is(err, ErrExecutionReverted) {
 			t.Errorf("%s with variant 2: err = %v, want a revert", tc.name, err)
 		}
-		if !bytes.Equal(ret, wantData) {
-			t.Errorf("%s with variant 2: returndata = %x, want Panic(0x21) = %x. Both entry "+
-				"points must decode the variant identically", tc.name, ret, wantData)
+		if len(ret) != 0 {
+			t.Errorf("%s with variant 2: returndata = %x, want empty. Both entry points must "+
+				"decode the variant identically", tc.name, ret)
 		}
 	}
 

--- a/core/vm/cas20_factory_test.go
+++ b/core/vm/cas20_factory_test.go
@@ -1,0 +1,546 @@
+package vm
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+func rightPad32(b []byte) []byte {
+	out := make([]byte, (len(b)+31)/32*32)
+	copy(out, b)
+	return out
+}
+
+func cas20AssetParams(name, symbol string, admin common.Address, decimals byte) []byte {
+	return abiEncodeStruct(
+		abiWord(wU8(cas20ParamsVersion)),
+		abiString(name),
+		abiString(symbol),
+		abiWord(addrKey(admin)),
+		abiWord(wU8(decimals)),
+	)
+}
+
+func cas20StablecoinParams(name, symbol string, admin common.Address, currency string) []byte {
+	return abiEncodeStruct(
+		abiWord(wU8(cas20ParamsVersion)),
+		abiString(name),
+		abiString(symbol),
+		abiWord(addrKey(admin)),
+		abiString(currency),
+	)
+}
+
+// encodeCreateCAS20 ABI-encodes createCAS20(uint8,bytes32,bytes,bytes[]) with the
+// variant's default params, which is what most tests want.
+func encodeCreateCAS20(variant byte, salt common.Hash, admin common.Address, calls [][]byte) []byte {
+	params := cas20AssetParams("Test Token", "TT", admin, 18)
+	if variant == cas20VariantStablecoin {
+		params = cas20StablecoinParams("Test Stable", "TS", admin, "USD")
+	}
+	return encodeCreateCAS20WithParams(variant, salt, params, calls)
+}
+
+// encodeCreateCAS20WithParams is encodeCreateCAS20 with an explicit params blob,
+// for tests that exercise the validation paths.
+func encodeCreateCAS20WithParams(variant byte, salt common.Hash, params []byte, calls [][]byte) []byte {
+	elems := make([][]byte, len(calls))
+	for i, c := range calls {
+		elems[i] = append(u256hash(uint64(len(c))).Bytes(), rightPad32(c)...)
+	}
+	arr := append([]byte{}, u256hash(uint64(len(calls))).Bytes()...)
+	cur := uint64(len(calls) * 32) // element offsets are relative to just after the length word
+	for _, e := range elems {
+		arr = append(arr, u256hash(cur).Bytes()...)
+		cur += uint64(len(e))
+	}
+	for _, e := range elems {
+		arr = append(arr, e...)
+	}
+
+	out := append([]byte{}, selCreateCAS20[:]...)
+	return append(out, encodeTuple(
+		abiWord(u256hash(uint64(variant))),
+		abiWord(salt),
+		abiBytes(params),
+		abiPart{dynamic: true, tail: arr},
+	)...)
+}
+
+func TestCAS20Factory(t *testing.T) {
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := *cas20TestChainConfig()
+	bc := cas20BlockContext(1)
+	seedActivation(statedb, cas20TestCaller)
+	evm := NewEVM(bc, statedb, &cfg, Config{})
+
+	creator := common.HexToAddress("0xc4ea70")
+	minter := common.HexToAddress("0x33333")
+	salt := common.HexToHash("0x01")
+
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	// predict address.
+	predicted, err := call(creator, CAS20FactoryAddress, cas20Call(selGetCAS20Address, u256hash(cas20VariantAsset), addrKey(creator), salt))
+	if err != nil {
+		t.Fatalf("getCAS20Address: %v", err)
+	}
+	want := cas20DeriveAddress(cas20VariantAsset, creator, salt)
+	if common.BytesToAddress(predicted) != want {
+		t.Fatalf("getCAS20Address = %s, want %s", common.BytesToAddress(predicted).Hex(), want.Hex())
+	}
+
+	// create the token with bootstrap initCalls: grant MINT to minter, mint 1000 to alice.
+	initCalls := [][]byte{
+		cas20Call(selGrantRole, roleMint, addrKey(minter)),
+		cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
+	}
+	ret, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, salt, creator, initCalls))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+	if token != want {
+		t.Fatalf("createCAS20 returned %s, want %s", token.Hex(), want.Hex())
+	}
+
+	// isCAS20Initialized(token) == true.
+	if r, _ := call(creator, CAS20FactoryAddress, cas20Call(selIsCAS20Initialized, addrKey(token))); !bytes.Equal(r, encBool(true)) {
+		t.Fatal("token should be initialized")
+	}
+
+	// the created token is live: bootstrap state applied.
+	view := newUnmeteredCAS20Storage(statedb, token)
+	if view.totalSupply().Uint64() != 1000 || view.balanceOf(cas20Alice).Uint64() != 1000 {
+		t.Fatalf("supply %d aliceBal %d, want 1000/1000", view.totalSupply().Uint64(), view.balanceOf(cas20Alice).Uint64())
+	}
+	if !view.hasRole(roleDefaultAdmin, creator) || view.adminCount().Uint64() != 1 {
+		t.Fatal("creator should be sole DEFAULT_ADMIN")
+	}
+	if !view.hasRole(roleMint, minter) {
+		t.Fatal("minter should hold MINT_ROLE")
+	}
+
+	// and it behaves like a token through the EVM: alice transfers to bob.
+	if r, err := call(cas20Alice, token, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(400))); err != nil || !bytes.Equal(r, encBool(true)) {
+		t.Fatalf("transfer via created token: ret %x err %v", r, err)
+	}
+	if view.balanceOf(cas20Bob).Uint64() != 400 {
+		t.Fatalf("bob balance %d, want 400", view.balanceOf(cas20Bob).Uint64())
+	}
+
+	// re-creating at the same salt collides.
+	if _, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, salt, creator, nil)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("duplicate createCAS20 err = %v, want revert", err)
+	}
+}
+
+// TestCAS20FactoryOwnerless creates a token with initialAdmin == 0: roles are set
+// up during the privileged bootstrap and the token is then ungovernable.
+func TestCAS20FactoryOwnerless(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	cfg := *cas20TestChainConfig()
+	bc := cas20BlockContext(1)
+	seedActivation(statedb, cas20TestCaller)
+	evm := NewEVM(bc, statedb, &cfg, Config{})
+	creator := common.HexToAddress("0xc4ea70")
+	salt := common.HexToHash("0x02")
+
+	// initCalls grant MINT to creator despite no admin (privileged bootstrap).
+	initCalls := [][]byte{cas20Call(selGrantRole, roleMint, addrKey(creator))}
+	ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantStablecoin, salt, common.Address{}, initCalls),
+		NewGasBudget(5_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20 ownerless: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+	view := newUnmeteredCAS20Storage(statedb, token)
+	if !view.adminCount().IsZero() {
+		t.Fatalf("adminCount = %d, want 0 (ownerless)", view.adminCount().Uint64())
+	}
+	if !view.hasRole(roleMint, creator) {
+		t.Fatal("bootstrap should have granted MINT despite ownerless")
+	}
+	// post-creation, role mutations are impossible (no admin).
+	if _, _, err := evm.Call(creator, token, cas20Call(selGrantRole, roleBurn, addrKey(creator)),
+		NewGasBudget(1_000_000), uint256.NewInt(0)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("grant on ownerless token err = %v, want revert", err)
+	}
+}
+
+// TestCAS20CreateParams exercises the create-params blob: the version gate that
+// precedes every field check, the per-variant validation, and the metadata the
+// token ends up carrying.
+func TestCAS20CreateParams(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc4ea70")
+	call := func(input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(creator, CAS20FactoryAddress, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	salt := func(n uint64) common.Hash { return u256hash(n) }
+
+	// An unsupported version is reported before any field is looked at, so a
+	// blob that is also invalid downstream still fails on the version.
+	bad := abiEncodeStruct(abiWord(wU8(2)), abiString("N"), abiString("S"), abiWord(addrKey(creator)), abiWord(wU8(3)))
+	ret, err := call(encodeCreateCAS20WithParams(cas20VariantAsset, salt(1), bad, nil))
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("bad version err = %v, want revert", err)
+	}
+	want := append(append([]byte{}, errSelUnsupportedVersion[:]...), wU8(2).Bytes()...)
+	want = append(want, wU8(cas20VariantAsset).Bytes()...)
+	if !bytes.Equal(ret, want) {
+		t.Fatalf("revert data = %x, want UnsupportedVersion(2, ASSET) = %x", ret, want)
+	}
+
+	// Asset decimals are bounded.
+	for _, d := range []byte{5, 19} {
+		p := cas20AssetParams("N", "S", creator, d)
+		ret, err := call(encodeCreateCAS20WithParams(cas20VariantAsset, salt(uint64(d)), p, nil))
+		if !errors.Is(err, ErrExecutionReverted) {
+			t.Fatalf("decimals %d err = %v, want revert", d, err)
+		}
+		want := append(append([]byte{}, errSelInvalidDecimals[:]...), wU8(d).Bytes()...)
+		if !bytes.Equal(ret, want) {
+			t.Fatalf("decimals %d revert data = %x, want InvalidDecimals", d, ret)
+		}
+	}
+
+	// Stablecoin currency must be present and uppercase A-Z.
+	if _, err := call(encodeCreateCAS20WithParams(cas20VariantStablecoin, salt(20), cas20StablecoinParams("N", "S", creator, ""), nil)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("empty currency err = %v, want MissingRequiredField", err)
+	}
+	if _, err := call(encodeCreateCAS20WithParams(cas20VariantStablecoin, salt(21), cas20StablecoinParams("N", "S", creator, "usd"), nil)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("lowercase currency err = %v, want InvalidCurrency", err)
+	}
+
+	// A valid Asset carries its metadata and its chosen decimals.
+	ret, err = call(encodeCreateCAS20WithParams(cas20VariantAsset, salt(30), cas20AssetParams("Gold Fund", "GLD", creator, 8), nil))
+	if err != nil {
+		t.Fatalf("createCAS20 asset: %v", err)
+	}
+	asset := common.BytesToAddress(ret)
+	view := newUnmeteredCAS20Storage(statedb, asset)
+	if got := strOf(view.name()); got != "Gold Fund" {
+		t.Fatalf("name = %q, want Gold Fund", got)
+	}
+	if got := strOf(view.symbol()); got != "GLD" {
+		t.Fatalf("symbol = %q, want GLD", got)
+	}
+	dec, _, err := evm.Call(creator, asset, cas20Call(selDecimals), NewGasBudget(200_000), uint256.NewInt(0))
+	if err != nil || !bytes.Equal(dec, u256hash(8).Bytes()) {
+		t.Fatalf("decimals() = %x (err %v), want 8", dec, err)
+	}
+
+	// A valid Stablecoin exposes its immutable currency and fixed 6 decimals.
+	ret, err = call(encodeCreateCAS20WithParams(cas20VariantStablecoin, salt(31), cas20StablecoinParams("Euro Coin", "EURC", creator, "EUR"), nil))
+	if err != nil {
+		t.Fatalf("createCAS20 stablecoin: %v", err)
+	}
+	stable := common.BytesToAddress(ret)
+	cur, _, err := evm.Call(creator, stable, cas20Call(selCurrency), NewGasBudget(200_000), uint256.NewInt(0))
+	if err != nil || !bytes.Equal(cur, encString("EUR")) {
+		t.Fatalf("currency() = %x (err %v), want EUR", cur, err)
+	}
+	dec, _, err = evm.Call(creator, stable, cas20Call(selDecimals), NewGasBudget(200_000), uint256.NewInt(0))
+	if err != nil || !bytes.Equal(dec, u256hash(6).Bytes()) {
+		t.Fatalf("stablecoin decimals() = %x (err %v), want 6", dec, err)
+	}
+}
+
+// TestCAS20CreatedEvent pins the creation event's topics and payload: an indexer
+// must be able to build a token index from the factory address alone.
+func TestCAS20CreatedEvent(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xe7e17")
+	statedb.SetTxContext(common.HexToHash("0xbeef"), 0)
+
+	params := cas20StablecoinParams("Dollar Coin", "USDX", creator, "USD")
+	ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+		encodeCreateCAS20WithParams(cas20VariantStablecoin, common.HexToHash("0x77"), params, nil),
+		NewGasBudget(5_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	var created *types.Log
+	for _, l := range statedb.Logs() {
+		if len(l.Topics) > 0 && l.Topics[0] == cas20TopicCAS20Created {
+			created = l
+		}
+	}
+	if created == nil {
+		t.Fatal("no CAS20Created log emitted")
+	}
+	if created.Address != CAS20FactoryAddress {
+		t.Fatalf("emitted by %x, want the factory %x", created.Address, CAS20FactoryAddress)
+	}
+	if len(created.Topics) != 3 {
+		t.Fatalf("topics = %d, want 3 (signature, token, variant)", len(created.Topics))
+	}
+	if created.Topics[1] != addrKey(token) {
+		t.Fatalf("indexed token = %x, want %x", created.Topics[1], addrKey(token))
+	}
+	if created.Topics[2] != wU8(cas20VariantStablecoin) {
+		t.Fatalf("indexed variant = %x, want STABLECOIN", created.Topics[2])
+	}
+
+	// Data is (name, symbol, decimals, variantEventParams); the last carries
+	// the versioned currency struct for a Stablecoin.
+	wantParams := abiEncodeStruct(abiWord(wU8(cas20ParamsVersion)), abiString("USD"))
+	wantData := encodeTuple(
+		abiString("Dollar Coin"), abiString("USDX"), abiWord(wU8(6)), abiBytes(wantParams),
+	)
+	if !bytes.Equal(created.Data, wantData) {
+		t.Fatalf("event data = %x\nwant                = %x", created.Data, wantData)
+	}
+}
+
+// TestCAS20CreateParamsCanonicalEncoding decodes a params blob written out by
+// hand, byte for byte, as `abi.encode(CAS20AssetCreateParams{...})` would produce
+// it. The other tests build their input with the same helper the expected
+// output uses, so a shared mistake in that helper would pass unnoticed; this
+// vector is independent of it.
+func TestCAS20CreateParamsCanonicalEncoding(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	admin := common.HexToAddress("0xad3111")
+
+	word := func(v uint64) []byte { return u256hash(v).Bytes() }
+	var blob []byte
+	blob = append(blob, word(0x20)...)             // w0 outer offset
+	blob = append(blob, word(1)...)                // w1 version
+	blob = append(blob, word(0xa0)...)             // w2 name offset
+	blob = append(blob, word(0xe0)...)             // w3 symbol offset
+	blob = append(blob, addrKey(admin).Bytes()...) // w4 initialAdmin
+	blob = append(blob, word(18)...)               // w5 decimals
+	blob = append(blob, word(1)...)                // w6 name length
+	blob = append(blob, rightPad32([]byte("A"))...)
+	blob = append(blob, word(1)...) // w8 symbol length
+	blob = append(blob, rightPad32([]byte("B"))...)
+
+	// The helper must agree with the hand-written vector; if it does not, every
+	// other params test is measuring the helper against itself.
+	if got := cas20AssetParams("A", "B", admin, 18); !bytes.Equal(got, blob) {
+		t.Fatalf("cas20AssetParams disagrees with the canonical encoding:\n got %x\nwant %x", got, blob)
+	}
+
+	ret, _, err := evm.Call(admin, CAS20FactoryAddress,
+		encodeCreateCAS20WithParams(cas20VariantAsset, common.HexToHash("0xcafe"), blob, nil),
+		NewGasBudget(5_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20 with a canonically encoded blob: %v", err)
+	}
+	view := newUnmeteredCAS20Storage(statedb, common.BytesToAddress(ret))
+	if strOf(view.name()) != "A" || strOf(view.symbol()) != "B" {
+		t.Fatalf("name/symbol = %q/%q, want A/B", strOf(view.name()), strOf(view.symbol()))
+	}
+}
+
+// TestCAS20CreateParamsRejectsMalformed covers the decoder's strictness: dirty
+// high bits in a uint8 field or an out-of-range offset are malformed
+// encodings, reported as a bare revert rather than decoded into something
+// plausible.
+func TestCAS20CreateParamsRejectsMalformed(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	admin := common.HexToAddress("0xad3111")
+	call := func(salt common.Hash, blob []byte) error {
+		_, _, err := evm.Call(admin, CAS20FactoryAddress,
+			encodeCreateCAS20WithParams(cas20VariantAsset, salt, blob, nil),
+			NewGasBudget(5_000_000), uint256.NewInt(0))
+		return err
+	}
+
+	// A version word carrying dirty high bits.
+	dirty := cas20AssetParams("A", "B", admin, 18)
+	dirty[32] = 0xff // first byte of the version word, inside the struct
+	if err := call(common.HexToHash("0x1"), dirty); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("dirty version word err = %v, want revert", err)
+	}
+
+	// An outer offset pointing past the end of the blob.
+	bad := cas20AssetParams("A", "B", admin, 18)
+	copy(bad[:32], u256hash(uint64(len(bad)+32)).Bytes())
+	if err := call(common.HexToHash("0x2"), bad); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("out-of-range offset err = %v, want revert", err)
+	}
+
+	// A dirty length word on a dynamic field. Truncating it to uint64 would
+	// silently read a zero-length name; it must fail the decode instead.
+	// The name length sits at the start of the first string tail: outer offset
+	// (1 word) + 5 struct head words = word 6.
+	dirtyLen := cas20AssetParams("A", "B", admin, 18)
+	dirtyLen[6*32] = 0x01 // high byte of the length word
+	ret, _, err := evm.Call(admin, CAS20FactoryAddress,
+		encodeCreateCAS20WithParams(cas20VariantAsset, common.HexToHash("0x3"), dirtyLen, nil),
+		NewGasBudget(5_000_000), uint256.NewInt(0))
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("dirty length word err = %v, want revert", err)
+	}
+	// A malformed encoding reverts bare, the way an ABI decode failure does —
+	// it is not a business-rule error and carries no typed payload.
+	if len(ret) != 0 {
+		t.Fatalf("malformed encoding revert data = %x, want empty", ret)
+	}
+}
+
+// TestCAS20FieldValidationPrecedesOccupancy pins the precedence: an invalid
+// currency is reported as such even when the salt in the same call is already
+// taken, because every field is validated before the address is derived, which
+// puts MissingRequiredField and InvalidCurrency ahead of TokenAlreadyExists.
+func TestCAS20FieldValidationPrecedesOccupancy(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xdup)")
+	call := func(salt common.Hash, currency string) ([]byte, error) {
+		params := cas20StablecoinParams("N", "S", creator, currency)
+		ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+			encodeCreateCAS20WithParams(cas20VariantStablecoin, salt, params, nil),
+			NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	salt := common.HexToHash("0x5a17")
+
+	if _, err := call(salt, "USD"); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	// Same salt AND an invalid currency: the currency is what is reported.
+	ret, err := call(salt, "usd")
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("duplicate salt with a bad currency: err = %v, want revert", err)
+	}
+	if len(ret) < 4 || [4]byte(ret[:4]) != errSelInvalidCurrency {
+		t.Fatalf("revert selector = %x, want InvalidCurrency %x", ret[:min(4, len(ret))], errSelInvalidCurrency)
+	}
+	// An empty one likewise outranks the duplicate salt.
+	ret, err = call(salt, "")
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("empty currency: err = %v, want a revert", err)
+	}
+	if len(ret) < 4 || [4]byte(ret[:4]) != errSelMissingField {
+		t.Fatalf("empty currency: selector = %x, want MissingRequiredField %x",
+			ret[:min(4, len(ret))], errSelMissingField)
+	}
+	// And with a valid currency the duplicate salt is what binds, so the cases
+	// above had two failing conditions rather than one.
+	ret, err = call(salt, "EUR")
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("valid currency, duplicate salt: err = %v, want a revert", err)
+	}
+	if len(ret) < 4 || [4]byte(ret[:4]) != errSelTokenExists {
+		t.Fatalf("valid currency, duplicate salt: selector = %x, want TokenAlreadyExists %x",
+			ret[:min(4, len(ret))], errSelTokenExists)
+	}
+}
+
+// TestCAS20OutOfEnumVariantPanics covers the variant word no enum member claims.
+func TestCAS20OutOfEnumVariantPanics(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	caller := common.HexToAddress("0xca11e4")
+	wantData, _ := finishCAS20(nil, revPanic(0x21))
+
+	for _, tc := range []struct {
+		name  string
+		input []byte
+	}{
+		{"createCAS20", encodeCreateCAS20WithParams(0x02, common.HexToHash("0xbv"),
+			cas20AssetParams("T", "T", caller, 18), nil)},
+		{"getCAS20Address", cas20Call(selGetCAS20Address, u256hash(2), addrKey(caller), common.Hash{})},
+	} {
+		ret, _, err := evm.Call(caller, CAS20FactoryAddress, tc.input,
+			NewGasBudget(5_000_000), uint256.NewInt(0))
+		if !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("%s with variant 2: err = %v, want a revert", tc.name, err)
+		}
+		if !bytes.Equal(ret, wantData) {
+			t.Errorf("%s with variant 2: returndata = %x, want Panic(0x21) = %x. Both entry "+
+				"points must decode the variant identically", tc.name, ret, wantData)
+		}
+	}
+
+	// And a word inside the enum still routes, so the bound is not simply refusing
+	// everything.
+	ret, _, err := evm.Call(caller, CAS20FactoryAddress,
+		cas20Call(selGetCAS20Address, u256hash(uint64(cas20VariantStablecoin)), addrKey(caller), common.Hash{}),
+		NewGasBudget(5_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("getCAS20Address for the stablecoin variant: %v", err)
+	}
+	if want := addrKey(cas20DeriveAddress(cas20VariantStablecoin, caller, common.Hash{})); !bytes.Equal(ret, want.Bytes()) {
+		t.Errorf("getCAS20Address = %x, want %x", ret, want)
+	}
+}
+
+// TestCAS20BootstrapReachesTheVariant covers the six Asset write selectors that the
+// bootstrap could not reach.
+func TestCAS20BootstrapReachesTheVariant(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc4ea70")
+	call := func(input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(creator, common.Address{}, input, NewGasBudget(9_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	_ = call
+
+	at := func(to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(creator, to, input, NewGasBudget(9_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	u := func(ret []byte, err error) uint64 {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("call: %v", err)
+		}
+		return new(uint256.Int).SetBytes(ret).Uint64()
+	}
+
+	const oneAndAHalf = 1_500_000_000_000_000_000
+	ret, err := at(CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset,
+		common.HexToHash("0xb007"), creator, [][]byte{
+			cas20Call(selGrantRole, roleMint, addrKey(creator)),
+			cas20Call(selGrantRole, roleOperator, addrKey(creator)),
+			cas20Call(selGrantRole, roleMetadata, addrKey(creator)),
+			// Asset-only, every one an unknown selector before this fix.
+			cas20Call(selUpdateMultiplier, u256hash(oneAndAHalf)),
+			encodeBatchMint([]common.Address{cas20Alice, cas20Bob}, []uint64{10, 20}),
+			encodeStringCall(selUpdateExtraMetadata, "issuer", "acme"),
+		}))
+	if err != nil {
+		t.Fatalf("createCAS20 with Asset-only initCalls: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	if got := u(at(token, cas20Call(selMultiplier))); got != oneAndAHalf {
+		t.Errorf("multiplier = %d, want %d — updateMultiplier did not run", got, oneAndAHalf)
+	}
+	// Raw balances from batchMint, and the scaled views the multiplier drives.
+	if got := u(at(token, cas20Call(selBalanceOf, addrKey(cas20Alice)))); got != 10 {
+		t.Errorf("balanceOf(alice) = %d, want 10 — batchMint did not run", got)
+	}
+	if got := u(at(token, cas20Call(selScaledBalanceOf, addrKey(cas20Bob)))); got != 30 {
+		t.Errorf("scaledBalanceOf(bob) = %d, want 30 (raw 20 at 1.5x)", got)
+	}
+	if got, err := at(token, encodeStringCall(selExtraMetadata, "issuer")); err != nil {
+		t.Errorf("extraMetadata: %v", err)
+	} else if s := decodeString(t, got); s != "acme" {
+		t.Errorf("extraMetadata(issuer) = %q, want %q", s, "acme")
+	}
+
+	// The shared surface still reaches the same way, so the variant dispatcher's
+	// fallback is intact rather than having replaced it.
+	if got := u(at(token, cas20Call(selTotalSupply))); got != 30 {
+		t.Errorf("totalSupply = %d, want 30", got)
+	}
+}

--- a/core/vm/cas20_factory_test.go
+++ b/core/vm/cas20_factory_test.go
@@ -37,8 +37,6 @@ func cas20StablecoinParams(name, symbol string, admin common.Address, currency s
 	)
 }
 
-// encodeCreateCAS20 ABI-encodes createCAS20(uint8,bytes32,bytes,bytes[]) with the
-// variant's default params, which is what most tests want.
 func encodeCreateCAS20(variant byte, salt common.Hash, admin common.Address, calls [][]byte) []byte {
 	params := cas20AssetParams("Test Token", "TT", admin, 18)
 	if variant == cas20VariantStablecoin {
@@ -47,8 +45,6 @@ func encodeCreateCAS20(variant byte, salt common.Hash, admin common.Address, cal
 	return encodeCreateCAS20WithParams(variant, salt, params, calls)
 }
 
-// encodeCreateCAS20WithParams is encodeCreateCAS20 with an explicit params blob,
-// for tests that exercise the validation paths.
 func encodeCreateCAS20WithParams(variant byte, salt common.Hash, params []byte, calls [][]byte) []byte {
 	elems := make([][]byte, len(calls))
 	for i, c := range calls {
@@ -92,7 +88,6 @@ func TestCAS20Factory(t *testing.T) {
 		return ret, err
 	}
 
-	// predict address.
 	predicted, err := call(creator, CAS20FactoryAddress, cas20Call(selGetCAS20Address, u256hash(cas20VariantAsset), addrKey(creator), salt))
 	if err != nil {
 		t.Fatalf("getCAS20Address: %v", err)
@@ -102,7 +97,6 @@ func TestCAS20Factory(t *testing.T) {
 		t.Fatalf("getCAS20Address = %s, want %s", common.BytesToAddress(predicted).Hex(), want.Hex())
 	}
 
-	// create the token with bootstrap initCalls: grant MINT to minter, mint 1000 to alice.
 	initCalls := [][]byte{
 		cas20Call(selGrantRole, roleMint, addrKey(minter)),
 		cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
@@ -116,12 +110,10 @@ func TestCAS20Factory(t *testing.T) {
 		t.Fatalf("createCAS20 returned %s, want %s", token.Hex(), want.Hex())
 	}
 
-	// isCAS20Initialized(token) == true.
 	if r, _ := call(creator, CAS20FactoryAddress, cas20Call(selIsCAS20Initialized, addrKey(token))); !bytes.Equal(r, encBool(true)) {
 		t.Fatal("token should be initialized")
 	}
 
-	// the created token is live: bootstrap state applied.
 	view := newUnmeteredCAS20Storage(statedb, token)
 	if view.totalSupply().Uint64() != 1000 || view.balanceOf(cas20Alice).Uint64() != 1000 {
 		t.Fatalf("supply %d aliceBal %d, want 1000/1000", view.totalSupply().Uint64(), view.balanceOf(cas20Alice).Uint64())
@@ -133,7 +125,6 @@ func TestCAS20Factory(t *testing.T) {
 		t.Fatal("minter should hold MINT_ROLE")
 	}
 
-	// and it behaves like a token through the EVM: alice transfers to bob.
 	if r, err := call(cas20Alice, token, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(400))); err != nil || !bytes.Equal(r, encBool(true)) {
 		t.Fatalf("transfer via created token: ret %x err %v", r, err)
 	}
@@ -141,14 +132,11 @@ func TestCAS20Factory(t *testing.T) {
 		t.Fatalf("bob balance %d, want 400", view.balanceOf(cas20Bob).Uint64())
 	}
 
-	// re-creating at the same salt collides.
 	if _, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, salt, creator, nil)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("duplicate createCAS20 err = %v, want revert", err)
 	}
 }
 
-// TestCAS20FactoryOwnerless creates a token with initialAdmin == 0: roles are set
-// up during the privileged bootstrap and the token is then ungovernable.
 func TestCAS20FactoryOwnerless(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	cfg := *cas20TestChainConfig()
@@ -158,7 +146,6 @@ func TestCAS20FactoryOwnerless(t *testing.T) {
 	creator := common.HexToAddress("0xc4ea70")
 	salt := common.HexToHash("0x02")
 
-	// initCalls grant MINT to creator despite no admin (privileged bootstrap).
 	initCalls := [][]byte{cas20Call(selGrantRole, roleMint, addrKey(creator))}
 	ret, _, err := evm.Call(creator, CAS20FactoryAddress,
 		encodeCreateCAS20(cas20VariantStablecoin, salt, common.Address{}, initCalls),
@@ -174,16 +161,12 @@ func TestCAS20FactoryOwnerless(t *testing.T) {
 	if !view.hasRole(roleMint, creator) {
 		t.Fatal("bootstrap should have granted MINT despite ownerless")
 	}
-	// post-creation, role mutations are impossible (no admin).
 	if _, _, err := evm.Call(creator, token, cas20Call(selGrantRole, roleBurn, addrKey(creator)),
 		NewGasBudget(1_000_000), uint256.NewInt(0)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("grant on ownerless token err = %v, want revert", err)
 	}
 }
 
-// TestCAS20CreateParams exercises the create-params blob: the version gate that
-// precedes every field check, the per-variant validation, and the metadata the
-// token ends up carrying.
 func TestCAS20CreateParams(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xc4ea70")
@@ -193,8 +176,7 @@ func TestCAS20CreateParams(t *testing.T) {
 	}
 	salt := func(n uint64) common.Hash { return u256hash(n) }
 
-	// An unsupported version is reported before any field is looked at, so a
-	// blob that is also invalid downstream still fails on the version.
+	// Also invalid downstream, so the version is what must be reported.
 	bad := abiEncodeStruct(abiWord(wU8(2)), abiString("N"), abiString("S"), abiWord(addrKey(creator)), abiWord(wU8(3)))
 	ret, err := call(encodeCreateCAS20WithParams(cas20VariantAsset, salt(1), bad, nil))
 	if !errors.Is(err, ErrExecutionReverted) {
@@ -206,7 +188,6 @@ func TestCAS20CreateParams(t *testing.T) {
 		t.Fatalf("revert data = %x, want UnsupportedVersion(2, ASSET) = %x", ret, want)
 	}
 
-	// Asset decimals are bounded.
 	for _, d := range []byte{5, 19} {
 		p := cas20AssetParams("N", "S", creator, d)
 		ret, err := call(encodeCreateCAS20WithParams(cas20VariantAsset, salt(uint64(d)), p, nil))
@@ -219,7 +200,6 @@ func TestCAS20CreateParams(t *testing.T) {
 		}
 	}
 
-	// Stablecoin currency must be present and uppercase A-Z.
 	if _, err := call(encodeCreateCAS20WithParams(cas20VariantStablecoin, salt(20), cas20StablecoinParams("N", "S", creator, ""), nil)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("empty currency err = %v, want MissingRequiredField", err)
 	}
@@ -227,7 +207,6 @@ func TestCAS20CreateParams(t *testing.T) {
 		t.Fatalf("lowercase currency err = %v, want InvalidCurrency", err)
 	}
 
-	// A valid Asset carries its metadata and its chosen decimals.
 	ret, err = call(encodeCreateCAS20WithParams(cas20VariantAsset, salt(30), cas20AssetParams("Gold Fund", "GLD", creator, 8), nil))
 	if err != nil {
 		t.Fatalf("createCAS20 asset: %v", err)
@@ -245,7 +224,6 @@ func TestCAS20CreateParams(t *testing.T) {
 		t.Fatalf("decimals() = %x (err %v), want 8", dec, err)
 	}
 
-	// A valid Stablecoin exposes its immutable currency and fixed 6 decimals.
 	ret, err = call(encodeCreateCAS20WithParams(cas20VariantStablecoin, salt(31), cas20StablecoinParams("Euro Coin", "EURC", creator, "EUR"), nil))
 	if err != nil {
 		t.Fatalf("createCAS20 stablecoin: %v", err)
@@ -261,8 +239,6 @@ func TestCAS20CreateParams(t *testing.T) {
 	}
 }
 
-// TestCAS20CreatedEvent pins the creation event's topics and payload: an indexer
-// must be able to build a token index from the factory address alone.
 func TestCAS20CreatedEvent(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xe7e17")
@@ -299,8 +275,6 @@ func TestCAS20CreatedEvent(t *testing.T) {
 		t.Fatalf("indexed variant = %x, want STABLECOIN", created.Topics[2])
 	}
 
-	// Data is (name, symbol, decimals, variantEventParams); the last carries
-	// the versioned currency struct for a Stablecoin.
 	wantParams := abiEncodeStruct(abiWord(wU8(cas20ParamsVersion)), abiString("USD"))
 	wantData := encodeTuple(
 		abiString("Dollar Coin"), abiString("USDX"), abiWord(wU8(6)), abiBytes(wantParams),
@@ -310,11 +284,8 @@ func TestCAS20CreatedEvent(t *testing.T) {
 	}
 }
 
-// TestCAS20CreateParamsCanonicalEncoding decodes a params blob written out by
-// hand, byte for byte, as `abi.encode(CAS20AssetCreateParams{...})` would produce
-// it. The other tests build their input with the same helper the expected
-// output uses, so a shared mistake in that helper would pass unnoticed; this
-// vector is independent of it.
+// A hand-written vector, independent of the helper every other params test both
+// builds its input with and measures against.
 func TestCAS20CreateParamsCanonicalEncoding(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	admin := common.HexToAddress("0xad3111")
@@ -332,8 +303,6 @@ func TestCAS20CreateParamsCanonicalEncoding(t *testing.T) {
 	blob = append(blob, word(1)...) // w8 symbol length
 	blob = append(blob, rightPad32([]byte("B"))...)
 
-	// The helper must agree with the hand-written vector; if it does not, every
-	// other params test is measuring the helper against itself.
 	if got := cas20AssetParams("A", "B", admin, 18); !bytes.Equal(got, blob) {
 		t.Fatalf("cas20AssetParams disagrees with the canonical encoding:\n got %x\nwant %x", got, blob)
 	}
@@ -350,10 +319,6 @@ func TestCAS20CreateParamsCanonicalEncoding(t *testing.T) {
 	}
 }
 
-// TestCAS20CreateParamsRejectsMalformed covers the decoder's strictness: dirty
-// high bits in a uint8 field or an out-of-range offset are malformed
-// encodings, reported as a bare revert rather than decoded into something
-// plausible.
 func TestCAS20CreateParamsRejectsMalformed(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	admin := common.HexToAddress("0xad3111")
@@ -364,24 +329,19 @@ func TestCAS20CreateParamsRejectsMalformed(t *testing.T) {
 		return err
 	}
 
-	// A version word carrying dirty high bits.
 	dirty := cas20AssetParams("A", "B", admin, 18)
 	dirty[32] = 0xff // first byte of the version word, inside the struct
 	if err := call(common.HexToHash("0x1"), dirty); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("dirty version word err = %v, want revert", err)
 	}
 
-	// An outer offset pointing past the end of the blob.
 	bad := cas20AssetParams("A", "B", admin, 18)
 	copy(bad[:32], u256hash(uint64(len(bad)+32)).Bytes())
 	if err := call(common.HexToHash("0x2"), bad); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("out-of-range offset err = %v, want revert", err)
 	}
 
-	// A dirty length word on a dynamic field. Truncating it to uint64 would
-	// silently read a zero-length name; it must fail the decode instead.
-	// The name length sits at the start of the first string tail: outer offset
-	// (1 word) + 5 struct head words = word 6.
+	// The name length word: outer offset (1 word) + 5 struct head words = word 6.
 	dirtyLen := cas20AssetParams("A", "B", admin, 18)
 	dirtyLen[6*32] = 0x01 // high byte of the length word
 	ret, _, err := evm.Call(admin, CAS20FactoryAddress,
@@ -390,17 +350,11 @@ func TestCAS20CreateParamsRejectsMalformed(t *testing.T) {
 	if !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("dirty length word err = %v, want revert", err)
 	}
-	// A malformed encoding reverts bare, the way an ABI decode failure does —
-	// it is not a business-rule error and carries no typed payload.
 	if len(ret) != 0 {
 		t.Fatalf("malformed encoding revert data = %x, want empty", ret)
 	}
 }
 
-// TestCAS20FieldValidationPrecedesOccupancy pins the precedence: an invalid
-// currency is reported as such even when the salt in the same call is already
-// taken, because every field is validated before the address is derived, which
-// puts MissingRequiredField and InvalidCurrency ahead of TokenAlreadyExists.
 func TestCAS20FieldValidationPrecedesOccupancy(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xdup)")
@@ -416,7 +370,6 @@ func TestCAS20FieldValidationPrecedesOccupancy(t *testing.T) {
 	if _, err := call(salt, "USD"); err != nil {
 		t.Fatalf("first create: %v", err)
 	}
-	// Same salt AND an invalid currency: the currency is what is reported.
 	ret, err := call(salt, "usd")
 	if !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("duplicate salt with a bad currency: err = %v, want revert", err)
@@ -424,7 +377,6 @@ func TestCAS20FieldValidationPrecedesOccupancy(t *testing.T) {
 	if len(ret) < 4 || [4]byte(ret[:4]) != errSelInvalidCurrency {
 		t.Fatalf("revert selector = %x, want InvalidCurrency %x", ret[:min(4, len(ret))], errSelInvalidCurrency)
 	}
-	// An empty one likewise outranks the duplicate salt.
 	ret, err = call(salt, "")
 	if !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("empty currency: err = %v, want a revert", err)
@@ -433,8 +385,7 @@ func TestCAS20FieldValidationPrecedesOccupancy(t *testing.T) {
 		t.Fatalf("empty currency: selector = %x, want MissingRequiredField %x",
 			ret[:min(4, len(ret))], errSelMissingField)
 	}
-	// And with a valid currency the duplicate salt is what binds, so the cases
-	// above had two failing conditions rather than one.
+	// Shows the cases above had two failing conditions rather than one.
 	ret, err = call(salt, "EUR")
 	if !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("valid currency, duplicate salt: err = %v, want a revert", err)
@@ -445,10 +396,8 @@ func TestCAS20FieldValidationPrecedesOccupancy(t *testing.T) {
 	}
 }
 
-// TestCAS20OutOfEnumVariantRevertsEmpty covers the variant word no enum member
-// claims. Solidity's external decoder validates an enum argument and reverts with
-// empty returndata; Panic(0x21) comes from an internal uint-to-enum cast and is
-// not what a caller passing 2 to an enum parameter receives.
+// Solidity's external decoder rejects an out-of-range enum with empty returndata;
+// Panic(0x21) belongs to an internal uint-to-enum cast.
 func TestCAS20OutOfEnumVariantRevertsEmpty(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	caller := common.HexToAddress("0xca11e4")
@@ -472,8 +421,6 @@ func TestCAS20OutOfEnumVariantRevertsEmpty(t *testing.T) {
 		}
 	}
 
-	// And a word inside the enum still routes, so the bound is not simply refusing
-	// everything.
 	ret, _, err := evm.Call(caller, CAS20FactoryAddress,
 		cas20Call(selGetCAS20Address, u256hash(uint64(cas20VariantStablecoin)), addrKey(caller), common.Hash{}),
 		NewGasBudget(5_000_000), uint256.NewInt(0))
@@ -485,8 +432,6 @@ func TestCAS20OutOfEnumVariantRevertsEmpty(t *testing.T) {
 	}
 }
 
-// TestCAS20BootstrapReachesTheVariant covers the six Asset write selectors that the
-// bootstrap could not reach.
 func TestCAS20BootstrapReachesTheVariant(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xc4ea70")
@@ -514,7 +459,6 @@ func TestCAS20BootstrapReachesTheVariant(t *testing.T) {
 			cas20Call(selGrantRole, roleMint, addrKey(creator)),
 			cas20Call(selGrantRole, roleOperator, addrKey(creator)),
 			cas20Call(selGrantRole, roleMetadata, addrKey(creator)),
-			// Asset-only, every one an unknown selector before this fix.
 			cas20Call(selUpdateMultiplier, u256hash(oneAndAHalf)),
 			encodeBatchMint([]common.Address{cas20Alice, cas20Bob}, []uint64{10, 20}),
 			encodeStringCall(selUpdateExtraMetadata, "issuer", "acme"),
@@ -527,7 +471,6 @@ func TestCAS20BootstrapReachesTheVariant(t *testing.T) {
 	if got := u(at(token, cas20Call(selMultiplier))); got != oneAndAHalf {
 		t.Errorf("multiplier = %d, want %d — updateMultiplier did not run", got, oneAndAHalf)
 	}
-	// Raw balances from batchMint, and the scaled views the multiplier drives.
 	if got := u(at(token, cas20Call(selBalanceOf, addrKey(cas20Alice)))); got != 10 {
 		t.Errorf("balanceOf(alice) = %d, want 10 — batchMint did not run", got)
 	}
@@ -540,8 +483,6 @@ func TestCAS20BootstrapReachesTheVariant(t *testing.T) {
 		t.Errorf("extraMetadata(issuer) = %q, want %q", s, "acme")
 	}
 
-	// The shared surface still reaches the same way, so the variant dispatcher's
-	// fallback is intact rather than having replaced it.
 	if got := u(at(token, cas20Call(selTotalSupply))); got != 30 {
 		t.Errorf("totalSupply = %d, want 30", got)
 	}

--- a/core/vm/cas20_gas.go
+++ b/core/vm/cas20_gas.go
@@ -1,0 +1,160 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// CAS20 gas metering (BEP-702 3.14): mirror existing EVM cost functions so nothing
+// a CAS20 call does is cheaper than the same work through bytecode. That covers
+// state access and equally the calldata copy, the keccaks, the logs and permit's
+// ecrecover — every charge goes through chargeGas, which is why the counter it
+// feeds is not GasCosts.StateGas (see meteredGasUsed). Opcode, memory and call
+// overhead have no counterpart here and are not synthesized.
+
+// The EIP-2929 warm/cold policy is normative and lives in BEP-702 3.14: no CAS20
+// address starts warm, a transaction access list applies, warmth is keyed on
+// (address, slot), and a foreign slot read warms the foreign address too.
+//
+// None of those four clauses has a test. The addresses are absent from the
+// static precompile map today, which is what keeps the first of them true by
+// accident; a refactor that added them would start every call warm and reprice
+// it, with nothing here to notice.
+
+// cas20CalldataWordGas is the per-word part of bringing calldata into memory:
+// CALLDATACOPY's copy cost plus the linear part of the memory expansion that
+// receives it (3 + 3).
+const cas20CalldataWordGas = params.CopyGas + params.MemoryGas
+
+// chargeCalldata charges G_copy + G_memory per 32-byte word, which is what
+// BEP-702 3.14 specifies and all of it: the table there is exhaustive and forbids
+// synthesizing opcode or memory-expansion overhead. It used to add CALLDATACOPY's
+// base step and a quadratic memory term, making the implementation and the
+// specification two different consensus sources. Internal Go redispatches read no
+// calldata and are not charged again.
+func (ctx *PrecompileContext) chargeCalldata(input []byte) bool {
+	words := (uint64(len(input)) + 31) / 32
+	if words == 0 {
+		return true
+	}
+	return ctx.chargeGas(words * cas20CalldataWordGas)
+}
+
+// chargeKeccak meters a keccak256 over size bytes: the same base plus per-word
+// cost the KECCAK256 opcode pays. Slot derivation for a mapping hashes 64
+// bytes; leaving it unmetered would donate computation.
+func (ctx *PrecompileContext) chargeKeccak(size int) bool {
+	words := (uint64(size) + 31) / 32
+	return ctx.chargeGas(params.Keccak256Gas + params.Keccak256WordGas*words)
+}
+
+// chargeLog meters a log emission at LOG* prices: base, per topic, per data
+// byte.
+func (ctx *PrecompileContext) chargeLog(topics int, dataLen int) bool {
+	return ctx.chargeGas(params.LogGas +
+		params.LogTopicGas*uint64(topics) +
+		params.LogDataGas*uint64(dataLen))
+}
+
+// chargeAccountAccess meters reading an account's balance, nonce or code hash
+// at EIP-2929 prices: warm always, plus the cold surcharge on first touch of
+// the address in this transaction.
+func (ctx *PrecompileContext) chargeAccountAccess(addr common.Address) bool {
+	if ctx.StateDB.AddressInAccessList(addr) {
+		return ctx.chargeGas(params.WarmStorageReadCostEIP2929)
+	}
+	// Warming before the charge mirrors the interpreter's own order; the addition
+	// is journalled, so a refused charge leaves nothing behind once the frame
+	// reverts.
+	ctx.StateDB.AddAddressToAccessList(addr)
+	return ctx.chargeGas(params.ColdAccountAccessCostEIP2929)
+}
+
+// chargeCodeWrite meters writing account code: the per-byte deposit cost, the
+// keccak of the code, and — when the target had no code — the account-creation
+// cost. The creation cost is owed even at a prefunded address, since balance
+// alone does not make an account a contract.
+func (ctx *PrecompileContext) chargeCodeWrite(addr common.Address, code []byte) bool {
+	cost := params.CreateDataGas * uint64(len(code))
+	if hadNoCode(ctx.StateDB, addr) {
+		cost += params.CreateGas
+	}
+	return ctx.chargeGas(cost) && ctx.chargeKeccak(len(code))
+}
+
+// sstoreSentry enforces EIP-2200's reentrancy guard: an SSTORE is refused
+// whenever remaining gas is at or below the 2300-gas call stipend, however
+// cheap the write itself would be. That check, not the write's price, is what
+// makes Solidity's transfer()/send() safe — net metering prices a warm dirty
+// rewrite at roughly a hundred gas. A CAS20 token writes state without executing
+// SSTORE, so it has to apply the same check itself; omitting it would
+// retroactively invalidate the reentrancy assumption already-deployed,
+// unchangeable contracts were audited against.
+func (ctx *PrecompileContext) sstoreSentry() bool {
+	return ctx.gas.RegularGas > params.SstoreSentryGasEIP2200
+}
+
+// chargeStorageWrite meters an SSTORE against the same net-metering rules the
+// interpreter applies, including EIP-3529 refunds. It mirrors
+// makeGasSStoreFunc; the arms are kept in the same order and with the same
+// clause numbers so the two can be diffed.
+func (s cas20Storage) chargeStorageWrite(slot, value common.Hash) bool {
+	if s.ctx == nil {
+		return true
+	}
+	// First, as in gasSStoreEIP2200: a read-only frame may not write, whatever it
+	// could afford and whatever the net-metered price would have been.
+	if s.ctx.ReadOnly {
+		s.ctx.markWriteProtected()
+		return false
+	}
+	if !s.ctx.sstoreSentry() {
+		// Propagate, do not assign: the sentry refuses the write without
+		// draining the budget, so a spawner that only saw its own flag would
+		// still have gas in hand and report success over a write that never
+		// happened.
+		s.ctx.markOutOfGas()
+		return false
+	}
+	var (
+		current, original = s.state.GetStateAndCommittedState(s.token, slot)
+		clearingRefund    = params.SstoreClearsScheduleRefundEIP3529
+		cost              = uint64(0)
+	)
+	if _, slotPresent := s.state.SlotInAccessList(s.token, slot); !slotPresent {
+		cost = params.ColdSloadCostEIP2929
+		s.state.AddSlotToAccessList(s.token, slot)
+	}
+	switch {
+	case current == value: // noop (1)
+		return s.ctx.chargeGas(cost + params.WarmStorageReadCostEIP2929)
+
+	case original == current:
+		if original == (common.Hash{}) { // create slot (2.1.1)
+			return s.ctx.chargeGas(cost + params.SstoreSetGasEIP2200)
+		}
+		if value == (common.Hash{}) { // delete slot (2.1.2b)
+			s.state.AddRefund(clearingRefund)
+		}
+		// write existing slot (2.1.2)
+		return s.ctx.chargeGas(cost + (params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929))
+	}
+
+	// dirty slot (2.2)
+	if original != (common.Hash{}) {
+		if current == (common.Hash{}) { // recreate slot (2.2.1.1)
+			s.state.SubRefund(clearingRefund)
+		} else if value == (common.Hash{}) { // delete slot (2.2.1.2)
+			s.state.AddRefund(clearingRefund)
+		}
+	}
+	if original == value {
+		if original == (common.Hash{}) { // reset to original inexistent slot (2.2.2.1)
+			s.state.AddRefund(params.SstoreSetGasEIP2200 - params.WarmStorageReadCostEIP2929)
+		} else { // reset to original existing slot (2.2.2.2)
+			s.state.AddRefund((params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929) - params.WarmStorageReadCostEIP2929)
+		}
+	}
+	// dirty update (2.2)
+	return s.ctx.chargeGas(cost + params.WarmStorageReadCostEIP2929)
+}

--- a/core/vm/cas20_gas.go
+++ b/core/vm/cas20_gas.go
@@ -46,6 +46,10 @@ func (ctx *PrecompileContext) chargeAccountAccess(addr common.Address) bool {
 // The creation cost is owed even at a prefunded address: balance alone does not
 // make an account a contract.
 func (ctx *PrecompileContext) chargeCodeWrite(addr common.Address, code []byte) bool {
+	if ctx.ReadOnly {
+		ctx.markWriteProtected()
+		return false
+	}
 	cost := params.CreateDataGas * uint64(len(code))
 	if hadNoCode(ctx.StateDB, addr) {
 		cost += params.CreateGas

--- a/core/vm/cas20_gas.go
+++ b/core/vm/cas20_gas.go
@@ -5,33 +5,16 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// CAS20 gas metering (BEP-702 3.14): mirror existing EVM cost functions so nothing
-// a CAS20 call does is cheaper than the same work through bytecode. That covers
-// state access and equally the calldata copy, the keccaks, the logs and permit's
-// ecrecover — every charge goes through chargeGas, which is why the counter it
-// feeds is not GasCosts.StateGas (see meteredGasUsed). Opcode, memory and call
-// overhead have no counterpart here and are not synthesized.
-
-// The EIP-2929 warm/cold policy is normative and lives in BEP-702 3.14: no CAS20
-// address starts warm, a transaction access list applies, warmth is keyed on
-// (address, slot), and a foreign slot read warms the foreign address too.
+// Every charge mirrors an existing EVM cost function, so nothing a CAS20 call does
+// is cheaper than the same work through bytecode (BEP-702 3.14). Opcode, memory
+// and call overhead are not synthesized: the table there is exhaustive.
 //
-// None of those four clauses has a test. The addresses are absent from the
-// static precompile map today, which is what keeps the first of them true by
-// accident; a refactor that added them would start every call warm and reprice
-// it, with nothing here to notice.
+// No CAS20 address is warm by default (a transaction access list still applies).
+// That holds because they are absent from the static precompile map, and nothing
+// here would notice a refactor that added them.
 
-// cas20CalldataWordGas is the per-word part of bringing calldata into memory:
-// CALLDATACOPY's copy cost plus the linear part of the memory expansion that
-// receives it (3 + 3).
 const cas20CalldataWordGas = params.CopyGas + params.MemoryGas
 
-// chargeCalldata charges G_copy + G_memory per 32-byte word, which is what
-// BEP-702 3.14 specifies and all of it: the table there is exhaustive and forbids
-// synthesizing opcode or memory-expansion overhead. It used to add CALLDATACOPY's
-// base step and a quadratic memory term, making the implementation and the
-// specification two different consensus sources. Internal Go redispatches read no
-// calldata and are not charged again.
 func (ctx *PrecompileContext) chargeCalldata(input []byte) bool {
 	words := (uint64(len(input)) + 31) / 32
 	if words == 0 {
@@ -40,40 +23,28 @@ func (ctx *PrecompileContext) chargeCalldata(input []byte) bool {
 	return ctx.chargeGas(words * cas20CalldataWordGas)
 }
 
-// chargeKeccak meters a keccak256 over size bytes: the same base plus per-word
-// cost the KECCAK256 opcode pays. Slot derivation for a mapping hashes 64
-// bytes; leaving it unmetered would donate computation.
 func (ctx *PrecompileContext) chargeKeccak(size int) bool {
 	words := (uint64(size) + 31) / 32
 	return ctx.chargeGas(params.Keccak256Gas + params.Keccak256WordGas*words)
 }
 
-// chargeLog meters a log emission at LOG* prices: base, per topic, per data
-// byte.
 func (ctx *PrecompileContext) chargeLog(topics int, dataLen int) bool {
 	return ctx.chargeGas(params.LogGas +
 		params.LogTopicGas*uint64(topics) +
 		params.LogDataGas*uint64(dataLen))
 }
 
-// chargeAccountAccess meters reading an account's balance, nonce or code hash
-// at EIP-2929 prices: warm always, plus the cold surcharge on first touch of
-// the address in this transaction.
 func (ctx *PrecompileContext) chargeAccountAccess(addr common.Address) bool {
 	if ctx.StateDB.AddressInAccessList(addr) {
 		return ctx.chargeGas(params.WarmStorageReadCostEIP2929)
 	}
-	// Warming before the charge mirrors the interpreter's own order; the addition
-	// is journalled, so a refused charge leaves nothing behind once the frame
-	// reverts.
+	// Warmed before the charge, in the interpreter's order; the addition is journalled.
 	ctx.StateDB.AddAddressToAccessList(addr)
 	return ctx.chargeGas(params.ColdAccountAccessCostEIP2929)
 }
 
-// chargeCodeWrite meters writing account code: the per-byte deposit cost, the
-// keccak of the code, and — when the target had no code — the account-creation
-// cost. The creation cost is owed even at a prefunded address, since balance
-// alone does not make an account a contract.
+// The creation cost is owed even at a prefunded address: balance alone does not
+// make an account a contract.
 func (ctx *PrecompileContext) chargeCodeWrite(addr common.Address, code []byte) bool {
 	cost := params.CreateDataGas * uint64(len(code))
 	if hadNoCode(ctx.StateDB, addr) {
@@ -82,37 +53,22 @@ func (ctx *PrecompileContext) chargeCodeWrite(addr common.Address, code []byte) 
 	return ctx.chargeGas(cost) && ctx.chargeKeccak(len(code))
 }
 
-// sstoreSentry enforces EIP-2200's reentrancy guard: an SSTORE is refused
-// whenever remaining gas is at or below the 2300-gas call stipend, however
-// cheap the write itself would be. That check, not the write's price, is what
-// makes Solidity's transfer()/send() safe — net metering prices a warm dirty
-// rewrite at roughly a hundred gas. A CAS20 token writes state without executing
-// SSTORE, so it has to apply the same check itself; omitting it would
-// retroactively invalidate the reentrancy assumption already-deployed,
-// unchangeable contracts were audited against.
+// EIP-2200's reentrancy guard, which is what makes transfer()/send() safe: a CAS20
+// token writes state without SSTORE, so it applies the check itself.
 func (ctx *PrecompileContext) sstoreSentry() bool {
 	return ctx.gas.RegularGas > params.SstoreSentryGasEIP2200
 }
 
-// chargeStorageWrite meters an SSTORE against the same net-metering rules the
-// interpreter applies, including EIP-3529 refunds. It mirrors
-// makeGasSStoreFunc; the arms are kept in the same order and with the same
-// clause numbers so the two can be diffed.
+// Mirrors makeGasSStoreFunc, arms in the same order with the same clause numbers.
 func (s cas20Storage) chargeStorageWrite(slot, value common.Hash) bool {
 	if s.ctx == nil {
 		return true
 	}
-	// First, as in gasSStoreEIP2200: a read-only frame may not write, whatever it
-	// could afford and whatever the net-metered price would have been.
 	if s.ctx.ReadOnly {
 		s.ctx.markWriteProtected()
 		return false
 	}
 	if !s.ctx.sstoreSentry() {
-		// Propagate, do not assign: the sentry refuses the write without
-		// draining the budget, so a spawner that only saw its own flag would
-		// still have gas in hand and report success over a write that never
-		// happened.
 		s.ctx.markOutOfGas()
 		return false
 	}

--- a/core/vm/cas20_gas.go
+++ b/core/vm/cas20_gas.go
@@ -44,6 +44,7 @@ func (ctx *PrecompileContext) chargeLog(topics int, dataLen int) bool {
 }
 
 func (ctx *PrecompileContext) chargeAccountAccess(addr common.Address) bool {
+	ctx.traceAccountRead(addr)
 	if ctx.StateDB.AddressInAccessList(addr) {
 		return ctx.chargeGas(params.WarmStorageReadCostEIP2929)
 	}

--- a/core/vm/cas20_gas.go
+++ b/core/vm/cas20_gas.go
@@ -15,6 +15,15 @@ import (
 
 const cas20CalldataWordGas = params.CopyGas + params.MemoryGas
 
+// chargeInternalDispatch is what the reference contract pays to route one entry of
+// an announce bundle or an initCalls array: a warm CALL plus the copy of that
+// entry into the callee's input. Without it a shared tail could be dispatched N×M
+// times for the price of one.
+func (ctx *PrecompileContext) chargeInternalDispatch(call []byte) bool {
+	words := (uint64(len(call)) + 31) / 32
+	return ctx.chargeGas(params.WarmStorageReadCostEIP2929 + words*cas20CalldataWordGas)
+}
+
 func (ctx *PrecompileContext) chargeCalldata(input []byte) bool {
 	words := (uint64(len(input)) + 31) / 32
 	if words == 0 {

--- a/core/vm/cas20_gas.go
+++ b/core/vm/cas20_gas.go
@@ -85,6 +85,7 @@ func (s cas20Storage) chargeStorageWrite(slot, value common.Hash) bool {
 		s.ctx.markOutOfGas()
 		return false
 	}
+	s.ctx.traceStorageRead(s.token, slot)
 	var (
 		current, original = s.state.GetStateAndCommittedState(s.token, slot)
 		clearingRefund    = params.SstoreClearsScheduleRefundEIP3529

--- a/core/vm/cas20_genesis.go
+++ b/core/vm/cas20_genesis.go
@@ -1,0 +1,28 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+)
+
+// SeedCAS20Activation gives the two singleton registries their account sentinels.
+// They hold storage and no code, so EIP-161 would otherwise clear them — and the
+// storage with them (BEP-702 3.16). Every feature stays disabled.
+//
+// The sentinel is also what makes the registry reachable by governance at all:
+// GovHub refuses a target with no code (isContract) and swallows the refusal into
+// an event, so a registry without one could never be sent its first parameter
+// change, and the failed proposal would look like a successful one.
+func SeedCAS20Activation(state StateDB) {
+	seedCAS20Sentinel(state, CAS20ActivationRegistryAddress)
+	seedCAS20Sentinel(state, CAS20PolicyRegistryAddress)
+}
+
+// seedCAS20Sentinel gives a registry account the marker code that keeps it out of
+// reach of EIP-161 state clearing, unless it already carries code.
+func seedCAS20Sentinel(state StateDB, addr common.Address) {
+	if !hadNoCode(state, addr) {
+		return
+	}
+	state.SetCode(addr, CAS20MarkerCode, tracing.CodeChangeSystemContractUpgrade)
+}

--- a/core/vm/cas20_genesis.go
+++ b/core/vm/cas20_genesis.go
@@ -5,21 +5,15 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 )
 
-// SeedCAS20Activation gives the two singleton registries their account sentinels.
-// They hold storage and no code, so EIP-161 would otherwise clear them — and the
-// storage with them (BEP-702 3.16). Every feature stays disabled.
-//
-// The sentinel is also what makes the registry reachable by governance at all:
-// GovHub refuses a target with no code (isContract) and swallows the refusal into
-// an event, so a registry without one could never be sent its first parameter
-// change, and the failed proposal would look like a successful one.
+// SeedCAS20Activation plants the registries' account sentinels (BEP-702 3.16).
+// Without code, EIP-161 would clear the accounts and their storage, and GovHub
+// would refuse them as a target: it tests extcodesize before forwarding a
+// parameter change, and swallows the refusal into an event.
 func SeedCAS20Activation(state StateDB) {
 	seedCAS20Sentinel(state, CAS20ActivationRegistryAddress)
 	seedCAS20Sentinel(state, CAS20PolicyRegistryAddress)
 }
 
-// seedCAS20Sentinel gives a registry account the marker code that keeps it out of
-// reach of EIP-161 state clearing, unless it already carries code.
 func seedCAS20Sentinel(state StateDB, addr common.Address) {
 	if !hadNoCode(state, addr) {
 		return

--- a/core/vm/cas20_genesis.go
+++ b/core/vm/cas20_genesis.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // SeedCAS20Activation plants the registries' account sentinels (BEP-702 3.16).
@@ -16,6 +17,7 @@ func SeedCAS20Activation(state StateDB) {
 
 func seedCAS20Sentinel(state StateDB, addr common.Address) {
 	if !hadNoCode(state, addr) {
+		log.Error("CAS20 registry already carries code", "addr", addr)
 		return
 	}
 	state.SetCode(addr, CAS20MarkerCode, tracing.CodeChangeSystemContractUpgrade)

--- a/core/vm/cas20_genesis.go
+++ b/core/vm/cas20_genesis.go
@@ -13,6 +13,7 @@ import (
 func SeedCAS20Activation(state StateDB) {
 	seedCAS20Sentinel(state, CAS20ActivationRegistryAddress)
 	seedCAS20Sentinel(state, CAS20PolicyRegistryAddress)
+	seedCAS20Sentinel(state, CAS20MemoFormatRegistryAddress)
 }
 
 func seedCAS20Sentinel(state StateDB, addr common.Address) {

--- a/core/vm/cas20_guards_test.go
+++ b/core/vm/cas20_guards_test.go
@@ -1,0 +1,315 @@
+package vm
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// Guards that were correct and that nothing failed on when removed.
+
+// TestCAS20CreateRejectsStaticCall uses grantRole in a non-empty bootstrap bundle so
+// it covers both createCAS20's ReadOnly rejection and the flag spawnBootstrap
+// carries; with no initCalls the factory's own writes land regardless, since
+// StateDB and cas20Storage do not consult ReadOnly.
+func TestCAS20CreateRejectsStaticCall(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	caller := common.HexToAddress("0xc4ea70")
+	salt := common.HexToHash("0x51a71c")
+
+	minter := common.HexToAddress("0x33333")
+	bundle := [][]byte{cas20Call(selGrantRole, roleMint, addrKey(minter))}
+	input := encodeCreateCAS20(cas20VariantAsset, salt, caller, bundle)
+	// A refused write is a revert carrying StaticCallNotAllowed(), not an
+	// exceptional halt: the caller keeps its gas and can decode the reason.
+	budget := NewGasBudget(5_000_000)
+	ret, left, err := evm.StaticCall(caller, CAS20FactoryAddress, input, budget)
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("STATICCALL createCAS20 gave %v, want a revert", err)
+	}
+	wantData, _ := finishCAS20(nil, revCAS20("StaticCallNotAllowed()", errSelStaticCallDenied))
+	if !bytes.Equal(ret, wantData) {
+		t.Errorf("returndata = %x, want StaticCallNotAllowed() = %x", ret, wantData)
+	}
+	if left.RegularGas == 0 {
+		t.Error("the whole budget was consumed; a revert refunds what it did not spend")
+	}
+
+	// Nothing may have been written: no sentinel, so the address stays free.
+	addr := cas20DeriveAddress(cas20VariantAsset, caller, salt)
+	if code := evm.StateDB.GetCode(addr); len(code) != 0 {
+		t.Errorf("code at %s after a refused STATICCALL: %x", addr.Hex(), code)
+	}
+	if newUnmeteredCAS20Storage(evm.StateDB, addr).hasRole(roleMint, minter) {
+		t.Error("the bundle's grantRole took effect under STATICCALL")
+	}
+
+	// The registries' write paths under STATICCALL too, since they share the
+	// same class of guard.
+	for _, tc := range []struct {
+		name  string
+		to    common.Address
+		input []byte
+	}{
+		{"activate", CAS20ActivationRegistryAddress, cas20Call(selActivate, common.HexToHash("0xf2"))},
+		{"deactivate", CAS20ActivationRegistryAddress, cas20Call(selDeactivate, featureCAS20Asset)},
+		// The governance entry point is refused for the same reason. Note that this
+		// case cannot witness updateParam's own ReadOnly check: the metering layer
+		// refuses the write in a read-only frame and the exit reports the identical
+		// StaticCallNotAllowed, so removing the handler's guard changes no
+		// returndata. What that guard buys is refusing before the decode and the
+		// authorization, not the error itself.
+		{"updateParam", CAS20ActivationRegistryAddress, encodeSetAdmin(common.HexToAddress("0xad4152"))},
+		{"createPolicy", CAS20PolicyRegistryAddress, cas20Call(selCreatePolicy, addrKey(caller), u256hash(cas20PolicyBlocklist))},
+	} {
+		caller := cas20TestCaller
+		if tc.name == "updateParam" {
+			caller = params.CAS20GovHubAddress // the one caller authorization would admit
+		}
+		if _, _, err := evm.StaticCall(caller, tc.to, tc.input, NewGasBudget(5_000_000)); err == nil {
+			t.Errorf("%s succeeded under STATICCALL", tc.name)
+		}
+	}
+}
+
+// TestCAS20AdminCountGuards covers the two conditions that keep adminCount honest:
+// grant counts only a role that was absent, revoke only one that was present. An
+// inflated count makes the sole-admin protection see two admins where there is
+// one, so the last becomes revocable. The other tests walk 1 -> 2 -> 1 -> 0 and
+// never repeat a grant or remove an absent holder.
+func TestCAS20AdminCountGuards(t *testing.T) {
+	admin := common.HexToAddress("0xad4149")
+	second := common.HexToAddress("0x5ec0nd")
+
+	statedb, token, run := newTokenWithEVM(t, 1, func(s cas20Storage) {
+		s.setRole(roleDefaultAdmin, admin, true)
+		s.setAdminCount(uint256.NewInt(1))
+	})
+	view := func() *uint256.Int { return newUnmeteredCAS20Storage(statedb, token).adminCount() }
+
+	// Granting a role its holder already has must not count twice.
+	if _, err := run(admin, cas20Call(selGrantRole, roleDefaultAdmin, addrKey(admin))); err != nil {
+		t.Fatalf("re-granting DEFAULT_ADMIN to its holder: %v", err)
+	}
+	if got := view(); got.Uint64() != 1 {
+		t.Errorf("adminCount = %s after a duplicate grant, want 1", got)
+	}
+
+	// A real second admin does count.
+	if _, err := run(admin, cas20Call(selGrantRole, roleDefaultAdmin, addrKey(second))); err != nil {
+		t.Fatalf("granting DEFAULT_ADMIN to a new account: %v", err)
+	}
+	if got := view(); got.Uint64() != 2 {
+		t.Fatalf("adminCount = %s after a real grant, want 2", got)
+	}
+
+	// Revoking an account that does not hold the role must not decrement.
+	third := common.HexToAddress("0x7h1rd")
+	if _, err := run(admin, cas20Call(selRevokeRole, roleDefaultAdmin, addrKey(third))); err != nil {
+		t.Fatalf("revoking DEFAULT_ADMIN from a non-holder: %v", err)
+	}
+	if got := view(); got.Uint64() != 2 {
+		t.Errorf("adminCount = %s after revoking a non-holder, want 2", got)
+	}
+}
+
+// TestCAS20AnnounceKeepsInnerRoleChecks covers that an announcement does not lend
+// its bundle the announcer's absent roles. The other announce test grants its
+// operator MINT_ROLE too and bundles only updateMultiplier, which needs the same
+// role the outer check already required, so nothing there distinguished "roles
+// still apply" from "roles are skipped".
+func TestCAS20AnnounceKeepsInnerRoleChecks(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc4ea70")
+	operator := common.HexToAddress("0x09e4a704")
+	salt := common.HexToHash("0x0e2")
+
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	// OPERATOR_ROLE only — deliberately no MINT_ROLE.
+	ret, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, salt, creator,
+		[][]byte{cas20Call(selGrantRole, roleOperator, addrKey(operator))}))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	// Positive control: an announcement this operator IS entitled to make must
+	// succeed, so a failure below cannot be blamed on the setup.
+	if _, err := call(operator, token, encodeAnnounce(
+		[][]byte{cas20Call(selUpdateMultiplier, u256hash(2_000_000_000_000_000_000))}, "2026-Q1-NAV")); err != nil {
+		t.Fatalf("an OPERATOR_ROLE holder could not announce updateMultiplier: %v", err)
+	}
+
+	// And the bundle must not gain a role its announcer lacks.
+	inner := encodeBatchMint([]common.Address{cas20Alice}, []uint64{1000})
+	if _, err := call(operator, token, encodeAnnounce([][]byte{inner}, "2026-Q2-NAV")); err == nil {
+		t.Fatal("an announcer without MINT_ROLE ran batchMint inside its announcement")
+	}
+	if newUnmeteredCAS20Storage(evm.StateDB, token).balanceOf(cas20Alice).Sign() != 0 {
+		t.Error("batchMint took effect despite the announcement failing")
+	}
+}
+
+// TestCAS20NonDirectCallPlumbing drives the non-direct paths through the EVM's own
+// entry points rather than a hand-built context, so the DirectCall flag evm.go
+// sets is covered rather than assumed. It says nothing about the Caller and
+// Value evm.go passes alongside it — the guard fires before either is read, so
+// this test holds whatever they are; TestStatefulPrecompileCallContext pins
+// those. TestCAS20DelegateCallGuard covers the guard itself.
+func TestCAS20NonDirectCallPlumbing(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc4ea70")
+	ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0x9a11"), creator, nil),
+		NewGasBudget(5_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	caller := common.HexToAddress("0xca11e5")
+	origin := common.HexToAddress("0x0416019")
+
+	// Both revert with DelegateCallNotAllowed() and refund; see
+	// TestCAS20DelegateCallGuard for the payload.
+	wantDelegate, _ := finishCAS20(nil, revCAS20("DelegateCallNotAllowed()", errSelDelegateCallDenied))
+	for _, tc := range []struct {
+		name string
+		run  func() ([]byte, GasBudget, error)
+	}{
+		{"CALLCODE", func() ([]byte, GasBudget, error) {
+			return evm.CallCode(caller, token, cas20Call(selTotalSupply), NewGasBudget(100_000), uint256.NewInt(7))
+		}},
+		{"DELEGATECALL", func() ([]byte, GasBudget, error) {
+			return evm.DelegateCall(origin, caller, token, cas20Call(selTotalSupply), NewGasBudget(100_000), uint256.NewInt(0))
+		}},
+	} {
+		ret, left, err := tc.run()
+		if !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("%s err = %v, want a revert", tc.name, err)
+		}
+		if !bytes.Equal(ret, wantDelegate) {
+			t.Errorf("%s returndata = %x, want %x", tc.name, ret, wantDelegate)
+		}
+		if left.RegularGas == 0 {
+			t.Errorf("%s consumed the whole budget; a revert refunds the rest", tc.name)
+		}
+	}
+}
+
+// TestCAS20MeteringRefusesWritesInStaticFrames covers the backstop under the 25
+// hand-written ReadOnly guards. Removing any one of them used to let a
+// STATICCALL write: approve() with its guard deleted returned nil and left the
+// allowance slot holding the amount. The metering layer now refuses first, as
+// gasSStoreEIP2200 does, so a missing guard costs a revert rather than consensus.
+func TestCAS20MeteringRefusesWritesInStaticFrames(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	ret, _, err := evm.Call(cas20TestCaller, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0x5711"), cas20TestCaller, nil),
+		NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+	// Driven with readOnly set but reaching the handler directly, which is the
+	// state a frame is in when its own guard is missing.
+	tok := cas20Token{
+		ctx: &PrecompileContext{evm: evm, StateDB: statedb, Self: token, Caller: cas20Alice,
+			ReadOnly: true, DirectCall: true, Value: uint256.NewInt(0), gas: &GasBudget{RegularGas: 5_000_000}},
+	}
+	tok.s = newMeteredCAS20StorageAt(tok.ctx, token)
+
+	if ok := tok.s.setWord(tok.s.allowanceSlot(cas20Alice, cas20Bob), u256hash(4242)); ok {
+		t.Error("a metered write reported success in a read-only frame")
+	}
+	if got := statedb.GetState(token, tok.s.allowanceSlot(cas20Alice, cas20Bob)); got != (common.Hash{}) {
+		t.Errorf("the allowance slot holds %x, want empty — a read-only frame wrote state", got)
+	}
+	if !tok.ctx.writeProtectionViolated() {
+		t.Fatal("the refusal was not recorded, so the exit cannot report it")
+	}
+	if tok.ctx.OutOfGas() {
+		t.Error("the frame was marked out of gas; a static write is a protection failure, not exhaustion")
+	}
+
+	// And the exit turns it into the same typed revert a hand-written guard gives.
+	_, err = finishCAS20Metered(tok.ctx, nil, nil)
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("exit err = %v, want the StaticCallNotAllowed revert", err)
+	}
+
+	// A log is equally a write.
+	before := len(statedb.Logs())
+	if tok.ctx.AddLog([]common.Hash{cas20TopicApproval}, nil) {
+		t.Error("AddLog reported success in a read-only frame")
+	}
+	if n := len(statedb.Logs()) - before; n != 0 {
+		t.Errorf("a read-only frame emitted %d log(s)", n)
+	}
+}
+
+// TestCAS20PolicyWritesAllRefuseStaticFrames covers every write selector the
+// PolicyRegistry dispatches, because one guard now stands for all nine. The
+// handlers used to repeat the check; removing those left this switch as the only
+// place a write path consults ReadOnly, so a selector added to the switch without
+// the guard — or the guard removed — must fail here rather than in whichever
+// handler happened to keep a copy.
+//
+// The metering layer refuses the write in a read-only frame regardless, and the
+// exit reports the same error, so this cannot witness the guard by returndata
+// alone. What it witnesses is that no write path is missing from the switch and
+// that none of them mutates state under STATICCALL.
+func TestCAS20PolicyWritesAllRefuseStaticFrames(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	caller := cas20TestCaller
+	admin := addrKey(caller)
+	list := u256hash(cas20PolicyBlocklist)
+	id := u256hash(uint64(cas20PolicyBlocklist)<<56 | 2)
+
+	for _, tc := range []struct {
+		name  string
+		input []byte
+	}{
+		{"createPolicy", cas20Call(selCreatePolicy, admin, list)},
+		{"createPolicyWithAccounts", encodeCreatePolicyWithAccounts(caller, cas20PolicyBlocklist, []common.Address{caller})},
+		{"updateAllowlist", encodeUpdateList(selUpdateAllowlist, uint64(cas20PolicyAllowlist)<<56|2, true, []common.Address{caller})},
+		{"updateBlocklist", encodeUpdateList(selUpdateBlocklist, uint64(cas20PolicyBlocklist)<<56|2, true, []common.Address{caller})},
+		{"stageUpdateAdmin", cas20Call(selStageUpdateAdmin, id, admin)},
+		{"finalizeUpdateAdmin", cas20Call(selFinalizeUpdateAdmin, id)},
+		{"renounceAdmin", cas20Call(selRenounceAdmin, id)},
+		// The two composite selectors take a dynamic array; a bare selector is
+		// enough here, since the guard precedes decoding.
+		{"createCompositePolicy", selCreateComposite[:]},
+		{"updateComposite", selUpdateComposite[:]},
+	} {
+		before := statedb.IntermediateRoot(true)
+		_, _, err := evm.StaticCall(caller, CAS20PolicyRegistryAddress, tc.input, NewGasBudget(5_000_000))
+		if err == nil {
+			t.Errorf("%s succeeded under STATICCALL", tc.name)
+		}
+		if after := statedb.IntermediateRoot(true); after != before {
+			t.Errorf("%s changed state under STATICCALL: %x -> %x", tc.name, before, after)
+		}
+	}
+
+	// And the switch covers every write selector the registry declares: a new one
+	// added below the guard rather than inside the case list would be routed to
+	// the default arm and rejected as unknown, not silently let through.
+	for _, sel := range [][4]byte{
+		selCreatePolicy, selCreatePolicyWithAccounts, selUpdateAllowlist, selUpdateBlocklist,
+		selStageUpdateAdmin, selFinalizeUpdateAdmin, selRenounceAdmin,
+		selCreateComposite, selUpdateComposite,
+	} {
+		if _, _, err := evm.StaticCall(caller, CAS20PolicyRegistryAddress, sel[:], NewGasBudget(5_000_000)); err == nil {
+			t.Errorf("selector %x accepted a static frame", sel)
+		}
+	}
+}

--- a/core/vm/cas20_guards_test.go
+++ b/core/vm/cas20_guards_test.go
@@ -313,3 +313,111 @@ func TestCAS20PolicyWritesAllRefuseStaticFrames(t *testing.T) {
 		}
 	}
 }
+
+// TestCAS20MalformedArgsRevertEmpty pins the returndata of every decode failure,
+// not merely that one occurred.
+//
+// Solidity's external decoder validates each narrow argument and reverts with
+// `revert(0, 0)` — empty returndata — both for dirty padding and for a clean
+// value outside an enum's range. Panic(0x21) is what an *internal* uint-to-enum
+// cast produces and is not what a caller passing 2 to an enum parameter receives.
+// Asserting only that the call reverted cannot tell the two apart, so every case
+// here compares the returndata itself.
+func TestCAS20MalformedArgsRevertEmpty(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	caller := cas20TestCaller
+
+	assertEmpty := func(what string, ret []byte, err error) {
+		t.Helper()
+		if !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("%s: err = %v, want a revert", what, err)
+			return
+		}
+		if len(ret) != 0 {
+			t.Errorf("%s: returndata = %x, want empty. A decode failure is revert(0,0), "+
+				"never Panic(0x21)", what, ret)
+		}
+	}
+
+	// The registry's enum and bool arguments.
+	outOfEnum := u256hash(uint64(cas20PolicyIntersect) + 1)
+	for _, tc := range []struct {
+		name  string
+		input []byte
+	}{
+		{"createPolicy, policyType past the enum",
+			cas20Call(selCreatePolicy, addrKey(caller), outOfEnum)},
+		{"createPolicyWithAccounts, policyType past the enum",
+			encodeCreatePolicyWithAccountsRaw(addrKey(caller), outOfEnum, nil)},
+		{"createCompositePolicy, policyType past the enum",
+			encodeComposite(selCreateComposite,
+				[]common.Hash{addrKey(caller), outOfEnum}, []uint64{cas20PolicyAlwaysAllow})},
+	} {
+		ret, _, err := evm.Call(caller, CAS20PolicyRegistryAddress, tc.input,
+			NewGasBudget(5_000_000), uint256.NewInt(0))
+		assertEmpty(tc.name, ret, err)
+	}
+
+	// A live policy, so the bool below fails on its own encoding rather than on
+	// the policy's absence.
+	ret, _, err := evm.Call(caller, CAS20PolicyRegistryAddress,
+		cas20Call(selCreatePolicy, addrKey(caller), u256hash(cas20PolicyAllowlist)),
+		NewGasBudget(5_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createPolicy: %v", err)
+	}
+	id := new(uint256.Int).SetBytes(ret).Uint64()
+	ret, _, err = evm.Call(caller, CAS20PolicyRegistryAddress,
+		encodeUpdateListRaw(selUpdateAllowlist, id, u256hash(2), []common.Hash{addrKey(cas20Alice)}),
+		NewGasBudget(5_000_000), uint256.NewInt(0))
+	assertEmpty("updateAllowlist, allowed = 2", ret, err)
+
+	// The token's own narrow arguments. These go through evm.Call on a real token
+	// rather than a bare dispatch: a revert's data is materialized on the way out
+	// of the precompile, so a handler-level call returns nil returndata for every
+	// failure and an emptiness assertion over it would hold vacuously.
+	initCalls := [][]byte{cas20Call(selGrantRole, rolePause, addrKey(caller))}
+	ret, _, err = evm.Call(caller, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0x9174d5"), caller, initCalls),
+		NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	asset := common.BytesToAddress(ret)
+	onToken := func(input []byte) ([]byte, error) {
+		r, _, e := evm.Call(caller, asset, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return r, e
+	}
+
+	badFeature := uint64(cas20PauseSeize) + 1
+	assertEmpty2 := func(what string, input []byte) {
+		t.Helper()
+		r, e := onToken(input)
+		assertEmpty(what, r, e)
+	}
+	assertEmpty2("isPaused, feature past the enum", cas20Call(selIsPaused, u256hash(badFeature)))
+	assertEmpty2("pause, element past the enum", cas20CallU8Array(selPause, byte(badFeature)))
+
+	if _, err := onToken(cas20Call(selIsPaused, u256hash(uint64(cas20PauseSeize)))); err != nil {
+		t.Errorf("isPaused with a valid feature: %v", err)
+	}
+	if _, err := onToken(cas20CallU8Array(selPause, byte(cas20PauseTransfer))); err != nil {
+		t.Errorf("pause with a valid feature: %v", err)
+	}
+
+	dirtyID := common.Hash{}
+	copy(dirtyID[:4], selIsPaused[:])
+	dirtyID[31] = 1 // a nonzero byte outside the bytes4 value
+	assertEmpty2("supportsInterface, bytes4 with nonzero padding",
+		cas20Call(selSupportsInterface, dirtyID))
+
+	// The clean form answers rather than reverting, so the guard above is not
+	// simply refusing every bytes4.
+	clean := common.Hash{}
+	copy(clean[:4], selIsPaused[:])
+	if ret, err := onToken(cas20Call(selSupportsInterface, clean)); err != nil {
+		t.Errorf("supportsInterface with a clean bytes4: %v", err)
+	} else if !bytes.Equal(ret, encBool(false)) {
+		t.Errorf("supportsInterface(unknown id) = %x, want false", ret)
+	}
+}

--- a/core/vm/cas20_guards_test.go
+++ b/core/vm/cas20_guards_test.go
@@ -207,6 +207,9 @@ func TestCAS20MeteringRefusesWritesInStaticFrames(t *testing.T) {
 	}
 
 	before := len(statedb.Logs())
+	if tok.ctx.chargeCodeWrite(tok.ctx.Self, CAS20MarkerCode) {
+		t.Error("chargeCodeWrite reported success in a read-only frame")
+	}
 	if tok.ctx.AddLog([]common.Hash{cas20TopicApproval}, nil) {
 		t.Error("AddLog reported success in a read-only frame")
 	}

--- a/core/vm/cas20_guards_test.go
+++ b/core/vm/cas20_guards_test.go
@@ -10,12 +10,7 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// Guards that were correct and that nothing failed on when removed.
-
-// TestCAS20CreateRejectsStaticCall uses grantRole in a non-empty bootstrap bundle so
-// it covers both createCAS20's ReadOnly rejection and the flag spawnBootstrap
-// carries; with no initCalls the factory's own writes land regardless, since
-// StateDB and cas20Storage do not consult ReadOnly.
+// A non-empty bootstrap bundle, so the ReadOnly flag spawnBootstrap carries is covered too.
 func TestCAS20CreateRejectsStaticCall(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	caller := common.HexToAddress("0xc4ea70")
@@ -24,8 +19,6 @@ func TestCAS20CreateRejectsStaticCall(t *testing.T) {
 	minter := common.HexToAddress("0x33333")
 	bundle := [][]byte{cas20Call(selGrantRole, roleMint, addrKey(minter))}
 	input := encodeCreateCAS20(cas20VariantAsset, salt, caller, bundle)
-	// A refused write is a revert carrying StaticCallNotAllowed(), not an
-	// exceptional halt: the caller keeps its gas and can decode the reason.
 	budget := NewGasBudget(5_000_000)
 	ret, left, err := evm.StaticCall(caller, CAS20FactoryAddress, input, budget)
 	if !errors.Is(err, ErrExecutionReverted) {
@@ -39,7 +32,6 @@ func TestCAS20CreateRejectsStaticCall(t *testing.T) {
 		t.Error("the whole budget was consumed; a revert refunds what it did not spend")
 	}
 
-	// Nothing may have been written: no sentinel, so the address stays free.
 	addr := cas20DeriveAddress(cas20VariantAsset, caller, salt)
 	if code := evm.StateDB.GetCode(addr); len(code) != 0 {
 		t.Errorf("code at %s after a refused STATICCALL: %x", addr.Hex(), code)
@@ -48,8 +40,6 @@ func TestCAS20CreateRejectsStaticCall(t *testing.T) {
 		t.Error("the bundle's grantRole took effect under STATICCALL")
 	}
 
-	// The registries' write paths under STATICCALL too, since they share the
-	// same class of guard.
 	for _, tc := range []struct {
 		name  string
 		to    common.Address
@@ -57,12 +47,6 @@ func TestCAS20CreateRejectsStaticCall(t *testing.T) {
 	}{
 		{"activate", CAS20ActivationRegistryAddress, cas20Call(selActivate, common.HexToHash("0xf2"))},
 		{"deactivate", CAS20ActivationRegistryAddress, cas20Call(selDeactivate, featureCAS20Asset)},
-		// The governance entry point is refused for the same reason. Note that this
-		// case cannot witness updateParam's own ReadOnly check: the metering layer
-		// refuses the write in a read-only frame and the exit reports the identical
-		// StaticCallNotAllowed, so removing the handler's guard changes no
-		// returndata. What that guard buys is refusing before the decode and the
-		// authorization, not the error itself.
 		{"updateParam", CAS20ActivationRegistryAddress, encodeSetAdmin(common.HexToAddress("0xad4152"))},
 		{"createPolicy", CAS20PolicyRegistryAddress, cas20Call(selCreatePolicy, addrKey(caller), u256hash(cas20PolicyBlocklist))},
 	} {
@@ -76,11 +60,8 @@ func TestCAS20CreateRejectsStaticCall(t *testing.T) {
 	}
 }
 
-// TestCAS20AdminCountGuards covers the two conditions that keep adminCount honest:
-// grant counts only a role that was absent, revoke only one that was present. An
-// inflated count makes the sole-admin protection see two admins where there is
-// one, so the last becomes revocable. The other tests walk 1 -> 2 -> 1 -> 0 and
-// never repeat a grant or remove an absent holder.
+// An inflated adminCount makes the sole-admin protection see two admins where
+// there is one, so the last becomes revocable.
 func TestCAS20AdminCountGuards(t *testing.T) {
 	admin := common.HexToAddress("0xad4149")
 	second := common.HexToAddress("0x5ec0nd")
@@ -91,7 +72,6 @@ func TestCAS20AdminCountGuards(t *testing.T) {
 	})
 	view := func() *uint256.Int { return newUnmeteredCAS20Storage(statedb, token).adminCount() }
 
-	// Granting a role its holder already has must not count twice.
 	if _, err := run(admin, cas20Call(selGrantRole, roleDefaultAdmin, addrKey(admin))); err != nil {
 		t.Fatalf("re-granting DEFAULT_ADMIN to its holder: %v", err)
 	}
@@ -99,7 +79,6 @@ func TestCAS20AdminCountGuards(t *testing.T) {
 		t.Errorf("adminCount = %s after a duplicate grant, want 1", got)
 	}
 
-	// A real second admin does count.
 	if _, err := run(admin, cas20Call(selGrantRole, roleDefaultAdmin, addrKey(second))); err != nil {
 		t.Fatalf("granting DEFAULT_ADMIN to a new account: %v", err)
 	}
@@ -107,7 +86,6 @@ func TestCAS20AdminCountGuards(t *testing.T) {
 		t.Fatalf("adminCount = %s after a real grant, want 2", got)
 	}
 
-	// Revoking an account that does not hold the role must not decrement.
 	third := common.HexToAddress("0x7h1rd")
 	if _, err := run(admin, cas20Call(selRevokeRole, roleDefaultAdmin, addrKey(third))); err != nil {
 		t.Fatalf("revoking DEFAULT_ADMIN from a non-holder: %v", err)
@@ -117,11 +95,6 @@ func TestCAS20AdminCountGuards(t *testing.T) {
 	}
 }
 
-// TestCAS20AnnounceKeepsInnerRoleChecks covers that an announcement does not lend
-// its bundle the announcer's absent roles. The other announce test grants its
-// operator MINT_ROLE too and bundles only updateMultiplier, which needs the same
-// role the outer check already required, so nothing there distinguished "roles
-// still apply" from "roles are skipped".
 func TestCAS20AnnounceKeepsInnerRoleChecks(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xc4ea70")
@@ -133,7 +106,6 @@ func TestCAS20AnnounceKeepsInnerRoleChecks(t *testing.T) {
 		return ret, err
 	}
 
-	// OPERATOR_ROLE only — deliberately no MINT_ROLE.
 	ret, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, salt, creator,
 		[][]byte{cas20Call(selGrantRole, roleOperator, addrKey(operator))}))
 	if err != nil {
@@ -141,14 +113,12 @@ func TestCAS20AnnounceKeepsInnerRoleChecks(t *testing.T) {
 	}
 	token := common.BytesToAddress(ret)
 
-	// Positive control: an announcement this operator IS entitled to make must
-	// succeed, so a failure below cannot be blamed on the setup.
+	// Positive control, so a failure below cannot be blamed on the setup.
 	if _, err := call(operator, token, encodeAnnounce(
 		[][]byte{cas20Call(selUpdateMultiplier, u256hash(2_000_000_000_000_000_000))}, "2026-Q1-NAV")); err != nil {
 		t.Fatalf("an OPERATOR_ROLE holder could not announce updateMultiplier: %v", err)
 	}
 
-	// And the bundle must not gain a role its announcer lacks.
 	inner := encodeBatchMint([]common.Address{cas20Alice}, []uint64{1000})
 	if _, err := call(operator, token, encodeAnnounce([][]byte{inner}, "2026-Q2-NAV")); err == nil {
 		t.Fatal("an announcer without MINT_ROLE ran batchMint inside its announcement")
@@ -158,12 +128,8 @@ func TestCAS20AnnounceKeepsInnerRoleChecks(t *testing.T) {
 	}
 }
 
-// TestCAS20NonDirectCallPlumbing drives the non-direct paths through the EVM's own
-// entry points rather than a hand-built context, so the DirectCall flag evm.go
-// sets is covered rather than assumed. It says nothing about the Caller and
-// Value evm.go passes alongside it — the guard fires before either is read, so
-// this test holds whatever they are; TestStatefulPrecompileCallContext pins
-// those. TestCAS20DelegateCallGuard covers the guard itself.
+// Through the EVM's own entry points, so the DirectCall flag evm.go sets is
+// covered rather than assumed.
 func TestCAS20NonDirectCallPlumbing(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xc4ea70")
@@ -178,8 +144,6 @@ func TestCAS20NonDirectCallPlumbing(t *testing.T) {
 	caller := common.HexToAddress("0xca11e5")
 	origin := common.HexToAddress("0x0416019")
 
-	// Both revert with DelegateCallNotAllowed() and refund; see
-	// TestCAS20DelegateCallGuard for the payload.
 	wantDelegate, _ := finishCAS20(nil, revCAS20("DelegateCallNotAllowed()", errSelDelegateCallDenied))
 	for _, tc := range []struct {
 		name string
@@ -205,11 +169,8 @@ func TestCAS20NonDirectCallPlumbing(t *testing.T) {
 	}
 }
 
-// TestCAS20MeteringRefusesWritesInStaticFrames covers the backstop under the 25
-// hand-written ReadOnly guards. Removing any one of them used to let a
-// STATICCALL write: approve() with its guard deleted returned nil and left the
-// allowance slot holding the amount. The metering layer now refuses first, as
-// gasSStoreEIP2200 does, so a missing guard costs a revert rather than consensus.
+// The backstop under the hand-written ReadOnly guards: a missing one costs a
+// revert rather than consensus.
 func TestCAS20MeteringRefusesWritesInStaticFrames(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	ret, _, err := evm.Call(cas20TestCaller, CAS20FactoryAddress,
@@ -219,8 +180,8 @@ func TestCAS20MeteringRefusesWritesInStaticFrames(t *testing.T) {
 		t.Fatalf("createCAS20: %v", err)
 	}
 	token := common.BytesToAddress(ret)
-	// Driven with readOnly set but reaching the handler directly, which is the
-	// state a frame is in when its own guard is missing.
+	// Reaching the handler directly with readOnly set is the state of a frame whose
+	// own guard is missing.
 	tok := cas20Token{
 		ctx: &PrecompileContext{evm: evm, StateDB: statedb, Self: token, Caller: cas20Alice,
 			ReadOnly: true, DirectCall: true, Value: uint256.NewInt(0), gas: &GasBudget{RegularGas: 5_000_000}},
@@ -240,13 +201,11 @@ func TestCAS20MeteringRefusesWritesInStaticFrames(t *testing.T) {
 		t.Error("the frame was marked out of gas; a static write is a protection failure, not exhaustion")
 	}
 
-	// And the exit turns it into the same typed revert a hand-written guard gives.
 	_, err = finishCAS20Metered(tok.ctx, nil, nil)
 	if !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("exit err = %v, want the StaticCallNotAllowed revert", err)
 	}
 
-	// A log is equally a write.
 	before := len(statedb.Logs())
 	if tok.ctx.AddLog([]common.Hash{cas20TopicApproval}, nil) {
 		t.Error("AddLog reported success in a read-only frame")
@@ -256,17 +215,8 @@ func TestCAS20MeteringRefusesWritesInStaticFrames(t *testing.T) {
 	}
 }
 
-// TestCAS20PolicyWritesAllRefuseStaticFrames covers every write selector the
-// PolicyRegistry dispatches, because one guard now stands for all nine. The
-// handlers used to repeat the check; removing those left this switch as the only
-// place a write path consults ReadOnly, so a selector added to the switch without
-// the guard — or the guard removed — must fail here rather than in whichever
-// handler happened to keep a copy.
-//
-// The metering layer refuses the write in a read-only frame regardless, and the
-// exit reports the same error, so this cannot witness the guard by returndata
-// alone. What it witnesses is that no write path is missing from the switch and
-// that none of them mutates state under STATICCALL.
+// One guard stands for every registry write selector, so a selector added outside
+// it must fail here.
 func TestCAS20PolicyWritesAllRefuseStaticFrames(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	caller := cas20TestCaller
@@ -285,8 +235,6 @@ func TestCAS20PolicyWritesAllRefuseStaticFrames(t *testing.T) {
 		{"stageUpdateAdmin", cas20Call(selStageUpdateAdmin, id, admin)},
 		{"finalizeUpdateAdmin", cas20Call(selFinalizeUpdateAdmin, id)},
 		{"renounceAdmin", cas20Call(selRenounceAdmin, id)},
-		// The two composite selectors take a dynamic array; a bare selector is
-		// enough here, since the guard precedes decoding.
 		{"createCompositePolicy", selCreateComposite[:]},
 		{"updateComposite", selUpdateComposite[:]},
 	} {
@@ -300,9 +248,6 @@ func TestCAS20PolicyWritesAllRefuseStaticFrames(t *testing.T) {
 		}
 	}
 
-	// And the switch covers every write selector the registry declares: a new one
-	// added below the guard rather than inside the case list would be routed to
-	// the default arm and rejected as unknown, not silently let through.
 	for _, sel := range [][4]byte{
 		selCreatePolicy, selCreatePolicyWithAccounts, selUpdateAllowlist, selUpdateBlocklist,
 		selStageUpdateAdmin, selFinalizeUpdateAdmin, selRenounceAdmin,
@@ -314,15 +259,8 @@ func TestCAS20PolicyWritesAllRefuseStaticFrames(t *testing.T) {
 	}
 }
 
-// TestCAS20MalformedArgsRevertEmpty pins the returndata of every decode failure,
-// not merely that one occurred.
-//
-// Solidity's external decoder validates each narrow argument and reverts with
-// `revert(0, 0)` — empty returndata — both for dirty padding and for a clean
-// value outside an enum's range. Panic(0x21) is what an *internal* uint-to-enum
-// cast produces and is not what a caller passing 2 to an enum parameter receives.
-// Asserting only that the call reverted cannot tell the two apart, so every case
-// here compares the returndata itself.
+// Every case compares the returndata: a bare revert cannot be told from Panic(0x21)
+// by the error alone.
 func TestCAS20MalformedArgsRevertEmpty(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	caller := cas20TestCaller
@@ -339,7 +277,6 @@ func TestCAS20MalformedArgsRevertEmpty(t *testing.T) {
 		}
 	}
 
-	// The registry's enum and bool arguments.
 	outOfEnum := u256hash(uint64(cas20PolicyIntersect) + 1)
 	for _, tc := range []struct {
 		name  string
@@ -358,8 +295,7 @@ func TestCAS20MalformedArgsRevertEmpty(t *testing.T) {
 		assertEmpty(tc.name, ret, err)
 	}
 
-	// A live policy, so the bool below fails on its own encoding rather than on
-	// the policy's absence.
+	// A live policy, so the bool fails on its own encoding rather than on the policy's absence.
 	ret, _, err := evm.Call(caller, CAS20PolicyRegistryAddress,
 		cas20Call(selCreatePolicy, addrKey(caller), u256hash(cas20PolicyAllowlist)),
 		NewGasBudget(5_000_000), uint256.NewInt(0))
@@ -372,10 +308,8 @@ func TestCAS20MalformedArgsRevertEmpty(t *testing.T) {
 		NewGasBudget(5_000_000), uint256.NewInt(0))
 	assertEmpty("updateAllowlist, allowed = 2", ret, err)
 
-	// The token's own narrow arguments. These go through evm.Call on a real token
-	// rather than a bare dispatch: a revert's data is materialized on the way out
-	// of the precompile, so a handler-level call returns nil returndata for every
-	// failure and an emptiness assertion over it would hold vacuously.
+	// Through evm.Call, not a bare dispatch: revert data is materialized on the way
+	// out of the precompile, so an emptiness assertion over dispatch would hold vacuously.
 	initCalls := [][]byte{cas20Call(selGrantRole, rolePause, addrKey(caller))}
 	ret, _, err = evm.Call(caller, CAS20FactoryAddress,
 		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0x9174d5"), caller, initCalls),
@@ -411,13 +345,65 @@ func TestCAS20MalformedArgsRevertEmpty(t *testing.T) {
 	assertEmpty2("supportsInterface, bytes4 with nonzero padding",
 		cas20Call(selSupportsInterface, dirtyID))
 
-	// The clean form answers rather than reverting, so the guard above is not
-	// simply refusing every bytes4.
 	clean := common.Hash{}
 	copy(clean[:4], selIsPaused[:])
 	if ret, err := onToken(cas20Call(selSupportsInterface, clean)); err != nil {
 		t.Errorf("supportsInterface with a clean bytes4: %v", err)
 	} else if !bytes.Equal(ret, encBool(false)) {
 		t.Errorf("supportsInterface(unknown id) = %x, want false", ret)
+	}
+}
+
+// Solidity decodes before any modifier runs, so an undecodable payload is reported
+// as such whoever sends it and whatever the token's state.
+func TestCAS20DecodePrecedesBusinessChecks(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	creator := cas20TestCaller
+	// Both business checks would fire if they ran first.
+	ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xde0de"), creator,
+			[][]byte{
+				cas20Call(selGrantRole, rolePause, addrKey(creator)),
+				cas20CallU8Array(selPause, byte(cas20PauseMint)),
+			}),
+		NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	stranger := common.HexToAddress("0x57ra9e")
+	for _, tc := range []struct {
+		name string
+		sel  [4]byte
+	}{
+		{"announce, no role and no arguments", selAnnounce},
+		{"batchMint, mint paused and no arguments", selBatchMint},
+	} {
+		ret, _, err := evm.Call(stranger, token, tc.sel[:], NewGasBudget(5_000_000), uint256.NewInt(0))
+		if !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("%s: err = %v, want a revert", tc.name, err)
+			continue
+		}
+		if len(ret) != 0 {
+			t.Errorf("%s: returndata = %x, want empty. Arguments are decoded before "+
+				"the caller or the token's state is looked at", tc.name, ret)
+		}
+	}
+
+	if ret, _, _ := evm.Call(stranger, token,
+		encodeAnnounceWith(nil, "id", "d", "u"), NewGasBudget(5_000_000), uint256.NewInt(0)); len(ret) < 4 ||
+		[4]byte(ret[:4]) != errSelACUnauthorized {
+		t.Errorf("announce with valid args: revert data %x, want AccessControlUnauthorizedAccount", ret)
+	}
+	emptyPair := append([]byte{}, selBatchMint[:]...)
+	emptyPair = append(emptyPair, u256hash(0x40).Bytes()...) // offset to recipients
+	emptyPair = append(emptyPair, u256hash(0x60).Bytes()...) // offset to amounts
+	emptyPair = append(emptyPair, u256hash(0).Bytes()...)    // len(recipients)
+	emptyPair = append(emptyPair, u256hash(0).Bytes()...)    // len(amounts)
+	if ret, _, _ := evm.Call(stranger, token, emptyPair,
+		NewGasBudget(5_000_000), uint256.NewInt(0)); len(ret) < 4 ||
+		[4]byte(ret[:4]) != errSelContractPaused {
+		t.Errorf("batchMint with valid args: revert data %x, want ContractPaused", ret)
 	}
 }

--- a/core/vm/cas20_info.go
+++ b/core/vm/cas20_info.go
@@ -1,0 +1,139 @@
+package vm
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/holiman/uint256"
+)
+
+// ErrNotCAS20Token is returned for an address outside the CAS20 space or one
+// no createCAS20 has initialized.
+var ErrNotCAS20Token = errors.New("not an initialized CAS20 token")
+
+// ErrCAS20StringTooLong bounds what one unmetered read will walk. No single
+// transaction can store a string this long, so it is only ever met on state
+// that did not come from the precompile.
+var ErrCAS20StringTooLong = errors.New("CAS20 string exceeds the RPC read bound")
+
+const cas20RPCMaxStringLen = 256 << 10
+
+// CAS20TokenInfo is a token's whole configuration read from one state, the way a
+// sequence of eth_calls at one block would read it. It is the cas20_getTokenInfo
+// RPC result, off the consensus path. Variant-specific fields are omitted for the
+// other variant, and PendingMultiplier is omitted unless a schedule is live at
+// the block; Multiplier is the effective value, a matured schedule folded in.
+type CAS20TokenInfo struct {
+	Address         common.Address      `json:"address"`
+	Variant         string              `json:"variant"`
+	Name            string              `json:"name"`
+	Symbol          string              `json:"symbol"`
+	Decimals        hexutil.Uint        `json:"decimals"`
+	ContractURI     string              `json:"contractURI"`
+	TotalSupply     *hexutil.Big        `json:"totalSupply"`
+	SupplyCap       *hexutil.Big        `json:"supplyCap"`
+	PausedFeatures  []hexutil.Uint      `json:"pausedFeatures"`
+	Policies        CAS20PolicyBindings `json:"policies"`
+	DomainSeparator common.Hash         `json:"domainSeparator"`
+
+	// Asset only.
+	Multiplier        *hexutil.Big            `json:"multiplier,omitempty"`
+	PendingMultiplier *CAS20PendingMultiplier `json:"pendingMultiplier,omitempty"`
+	TotalSupplyUI     *hexutil.Big            `json:"totalSupplyUI,omitempty"`
+
+	// Stablecoin only.
+	Currency string `json:"currency,omitempty"`
+}
+
+type CAS20PolicyBindings struct {
+	TransferSender   hexutil.Uint64 `json:"transferSender"`
+	TransferReceiver hexutil.Uint64 `json:"transferReceiver"`
+	TransferExecutor hexutil.Uint64 `json:"transferExecutor"`
+	MintReceiver     hexutil.Uint64 `json:"mintReceiver"`
+	SeizeHolder      hexutil.Uint64 `json:"seizeHolder"`
+	SeizeReceiver    hexutil.Uint64 `json:"seizeReceiver"`
+}
+
+type CAS20PendingMultiplier struct {
+	Value       *hexutil.Big   `json:"value"`
+	EffectiveAt hexutil.Uint64 `json:"effectiveAt"`
+}
+
+var cas20VariantNames = map[byte]string{
+	cas20VariantAsset:      "asset",
+	cas20VariantStablecoin: "stablecoin",
+}
+
+// CAS20TokenInfoAt reads addr's configuration from state as of a block with the
+// given time. Unmetered: it is for RPC, never for a precompile frame.
+func CAS20TokenInfoAt(state StateDB, chainID *big.Int, addr common.Address, blockTime uint64) (*CAS20TokenInfo, error) {
+	variant, ok := cas20VariantNames[addr[10]]
+	if !ok || !IsCAS20Address(addr) || state.GetCodeHash(addr) != cas20MarkerCodeHash {
+		return nil, ErrNotCAS20Token
+	}
+	if chainID == nil {
+		return nil, errors.New("chain config has no chain id")
+	}
+	s := newUnmeteredCAS20Storage(state, addr)
+	strings := []common.Hash{slotAt(cas20SlotName), slotAt(cas20SlotSymbol), slotAt(cas20SlotContractURI)}
+	if addr[10] == cas20VariantStablecoin {
+		strings = append(strings, stablecoinSlot(cas20StablecoinSlotCurrency))
+	}
+	for _, slot := range strings {
+		if s.stringChunks(slot) > cas20RPCMaxStringLen/32 {
+			return nil, ErrCAS20StringTooLong
+		}
+	}
+
+	info := &CAS20TokenInfo{
+		Address:        addr,
+		Variant:        variant,
+		TotalSupply:    u256Big(s.totalSupply()),
+		SupplyCap:      u256Big(s.supplyCap()),
+		PausedFeatures: []hexutil.Uint{},
+	}
+	info.Name, _ = s.name()
+	info.Symbol, _ = s.symbol()
+	info.ContractURI, _ = s.contractURI()
+
+	paused := s.paused()
+	for f := uint(0); f <= cas20PauseSeize; f++ {
+		if new(uint256.Int).Rsh(paused, f).Uint64()&1 == 1 {
+			info.PausedFeatures = append(info.PausedFeatures, hexutil.Uint(f))
+		}
+	}
+	sender, receiver, executor := s.transferPolicies()
+	holder, seizeTo := s.seizePolicies()
+	info.Policies = CAS20PolicyBindings{
+		TransferSender:   hexutil.Uint64(sender),
+		TransferReceiver: hexutil.Uint64(receiver),
+		TransferExecutor: hexutil.Uint64(executor),
+		MintReceiver:     hexutil.Uint64(s.mintReceiverPolicy()),
+		SeizeHolder:      hexutil.Uint64(holder),
+		SeizeReceiver:    hexutil.Uint64(seizeTo),
+	}
+	id, _ := uint256.FromBig(chainID)
+	info.DomainSeparator = cas20DomainSeparator(info.Name, id, addr)
+
+	switch addr[10] {
+	case cas20VariantAsset:
+		ext := assetExt{s: s}
+		info.Decimals = hexutil.Uint(ext.decimals())
+		mul := ext.effectiveMultiplier(blockTime)
+		info.Multiplier = u256Big(mul)
+		if pending, at := ext.pending(); at > blockTime {
+			info.PendingMultiplier = &CAS20PendingMultiplier{Value: u256Big(pending), EffectiveAt: hexutil.Uint64(at)}
+		}
+		// Both factors are bounded by type(uint128).max, so this cannot overflow.
+		ui, _ := applyMultiplier(s.totalSupply(), mul)
+		info.TotalSupplyUI = u256Big(ui)
+	case cas20VariantStablecoin:
+		info.Decimals = 6
+		info.Currency, _ = stablecoinExt{s: s}.currency()
+	}
+	return info, nil
+}
+
+func u256Big(v *uint256.Int) *hexutil.Big { return (*hexutil.Big)(v.ToBig()) }

--- a/core/vm/cas20_info.go
+++ b/core/vm/cas20_info.go
@@ -37,6 +37,8 @@ type CAS20TokenInfo struct {
 	PausedFeatures  []hexutil.Uint      `json:"pausedFeatures"`
 	Policies        CAS20PolicyBindings `json:"policies"`
 	DomainSeparator common.Hash         `json:"domainSeparator"`
+	// The formats the issuer expects transfers to declare; advisory.
+	ExpectedMemoFormats []hexutil.Uint64 `json:"expectedMemoFormats"`
 
 	// Asset only.
 	Multiplier        *hexutil.Big            `json:"multiplier,omitempty"`
@@ -116,6 +118,10 @@ func CAS20TokenInfoAt(state StateDB, chainID *big.Int, addr common.Address, bloc
 	}
 	id, _ := uint256.FromBig(chainID)
 	info.DomainSeparator = cas20DomainSeparator(info.Name, id, addr)
+	info.ExpectedMemoFormats = []hexutil.Uint64{}
+	for _, f := range s.u64ArrayAt(slotAt(cas20SlotExpectedMemoFormats), cas20MemoMaxFields) {
+		info.ExpectedMemoFormats = append(info.ExpectedMemoFormats, hexutil.Uint64(f))
+	}
 
 	switch addr[10] {
 	case cas20VariantAsset:

--- a/core/vm/cas20_info.go
+++ b/core/vm/cas20_info.go
@@ -21,8 +21,8 @@ var ErrCAS20StringTooLong = errors.New("CAS20 string exceeds the RPC read bound"
 const cas20RPCMaxStringLen = 256 << 10
 
 // CAS20TokenInfo is a token's whole configuration read from one state, the way a
-// sequence of eth_calls at one block would read it. It is the cas20_getTokenInfo
-// RPC result, off the consensus path. Variant-specific fields are omitted for the
+// sequence of eth_calls at one block would read it. It is the eth_getCAS20TokenInfo
+// result, off the consensus path. Variant-specific fields are omitted for the
 // other variant, and PendingMultiplier is omitted unless a schedule is live at
 // the block; Multiplier is the effective value, a matured schedule folded in.
 type CAS20TokenInfo struct {

--- a/core/vm/cas20_info_test.go
+++ b/core/vm/cas20_info_test.go
@@ -1,0 +1,178 @@
+package vm
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/holiman/uint256"
+)
+
+// The facade must answer exactly what the selectors answer at the same block.
+func TestCAS20TokenInfoMatchesTheSelectors(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xdec0de")
+	now := evm.Context.Time
+	future := now + 3600
+	call := func(to common.Address, input []byte) []byte {
+		t.Helper()
+		ret, _, err := evm.Call(creator, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		if err != nil {
+			t.Fatalf("call %x: %v", input[:4], err)
+		}
+		return ret
+	}
+	word := func(to common.Address, input []byte) uint64 {
+		return new(uint256.Int).SetBytes(call(to, input)).Uint64()
+	}
+	big := func(v *hexutil.Big) uint64 { return v.ToInt().Uint64() }
+
+	ret := call(CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0x1f0"), creator, [][]byte{
+		cas20Call(selGrantRole, roleMint, addrKey(creator)),
+		cas20Call(selGrantRole, roleOperator, addrKey(creator)),
+		cas20Call(selGrantRole, rolePause, addrKey(creator)),
+		cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
+		cas20CallU8Array(selPause, byte(cas20PauseBurn)),
+		cas20Call(selUpdateUIMultiplier, u256hash(2e18), u256hash(future)),
+		cas20Call(selUpdatePolicy, scopeTransferReceiver, u256hash(cas20PolicyAlwaysBlock)),
+	}))
+	token := common.BytesToAddress(ret)
+
+	info, err := CAS20TokenInfoAt(statedb, evm.chainConfig.ChainID, token, now)
+	if err != nil {
+		t.Fatalf("CAS20TokenInfoAt: %v", err)
+	}
+	if info.Variant != "asset" || info.Address != token {
+		t.Errorf("variant %q address %x, want asset %x", info.Variant, info.Address, token)
+	}
+	if got := call(token, cas20Call(selName)); info.Name != "Test Token" || !containsString(got, info.Name) {
+		t.Errorf("name = %q, want Test Token", info.Name)
+	}
+	if info.Symbol != "TT" || info.ContractURI != "" {
+		t.Errorf("symbol %q uri %q, want TT and empty", info.Symbol, info.ContractURI)
+	}
+	for _, tc := range []struct {
+		name string
+		sel  [4]byte
+		got  uint64
+	}{
+		{"decimals", selDecimals, uint64(info.Decimals)},
+		{"totalSupply", selTotalSupply, big(info.TotalSupply)},
+		{"supplyCap", selSupplyCap, big(info.SupplyCap)},
+		{"multiplier", selMultiplier, big(info.Multiplier)},
+		{"totalSupplyUI", selTotalSupplyUI, big(info.TotalSupplyUI)},
+		{"newUIMultiplier", selNewUIMultiplier, big(info.PendingMultiplier.Value)},
+		{"effectiveAt", selEffectiveAt, uint64(info.PendingMultiplier.EffectiveAt)},
+	} {
+		if want := word(token, cas20Call(tc.sel)); tc.got != want {
+			t.Errorf("%s = %d, selector %d", tc.name, tc.got, want)
+		}
+	}
+	if info.Decimals != 18 || big(info.TotalSupply) != 1000 || big(info.Multiplier) != 1e18 || big(info.TotalSupplyUI) != 1000 {
+		t.Errorf("literals: decimals %d supply %d multiplier %d ui %d", info.Decimals, big(info.TotalSupply), big(info.Multiplier), big(info.TotalSupplyUI))
+	}
+	if len(info.PausedFeatures) != 1 || info.PausedFeatures[0] != cas20PauseBurn {
+		t.Errorf("pausedFeatures = %v, want [BURN]", info.PausedFeatures)
+	}
+	for _, tc := range []struct {
+		scope common.Hash
+		got   hexutil.Uint64
+	}{
+		{scopeTransferSender, info.Policies.TransferSender},
+		{scopeTransferReceiver, info.Policies.TransferReceiver},
+		{scopeTransferExecutor, info.Policies.TransferExecutor},
+		{scopeMintReceiver, info.Policies.MintReceiver},
+		{scopeSeizeHolder, info.Policies.SeizeHolder},
+		{scopeSeizeReceiver, info.Policies.SeizeReceiver},
+	} {
+		if want := word(token, cas20Call(selPolicyId, tc.scope)); uint64(tc.got) != want {
+			t.Errorf("policy %x = %d, selector %d", tc.scope[:4], tc.got, want)
+		}
+	}
+	if uint64(info.Policies.TransferReceiver) != cas20PolicyAlwaysBlock {
+		t.Errorf("transferReceiver = %d, want the bound ALWAYS_BLOCK", info.Policies.TransferReceiver)
+	}
+	if got := common.BytesToHash(call(token, cas20Call(selDomainSeparator))); got != info.DomainSeparator {
+		t.Errorf("domainSeparator = %x, selector %x", info.DomainSeparator, got)
+	}
+	if info.Currency != "" {
+		t.Errorf("an Asset reports currency %q", info.Currency)
+	}
+
+	// Past the schedule, with no transaction in between: the pending value is
+	// the multiplier and nothing is pending, for the selectors and the facade alike.
+	evm.Context.Time = future
+	matured, err := CAS20TokenInfoAt(statedb, evm.chainConfig.ChainID, token, future)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := word(token, cas20Call(selMultiplier)); got != big(matured.Multiplier) || got != 2e18 {
+		t.Errorf("matured multiplier = %d, selector %d, want 2e18", big(matured.Multiplier), got)
+	}
+	if got := word(token, cas20Call(selNewUIMultiplier)); got != big(matured.Multiplier) || matured.PendingMultiplier != nil {
+		t.Errorf("matured: newUIMultiplier %d pending %+v, want the multiplier and nil", got, matured.PendingMultiplier)
+	}
+	if got := word(token, cas20Call(selTotalSupplyUI)); got != big(matured.TotalSupplyUI) || got != 2000 {
+		t.Errorf("matured totalSupplyUI = %d, selector %d, want 2000", big(matured.TotalSupplyUI), got)
+	}
+	evm.Context.Time = now
+
+	// Stablecoin: fixed decimals, a currency, no multiplier surface.
+	ret = call(CAS20FactoryAddress, encodeCreateCAS20(cas20VariantStablecoin, common.HexToHash("0x1f1"), creator, nil))
+	stable, err := CAS20TokenInfoAt(statedb, evm.chainConfig.ChainID, common.BytesToAddress(ret), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stable.Variant != "stablecoin" || stable.Decimals != 6 || stable.Currency != "USD" {
+		t.Errorf("stablecoin: variant %q decimals %d currency %q", stable.Variant, stable.Decimals, stable.Currency)
+	}
+	if stable.Multiplier != nil || stable.PendingMultiplier != nil || stable.TotalSupplyUI != nil {
+		t.Error("a Stablecoin reports a multiplier surface")
+	}
+
+	// The JSON shape: hex quantities, an empty list rather than null, and the
+	// other variant's fields absent.
+	assetJSON, _ := json.Marshal(info)
+	for _, want := range []string{`"decimals":"0x12"`, `"totalSupply":"0x3e8"`, `"pausedFeatures":["0x2"]`, `"pendingMultiplier":{"value":"0x1bc16d674ec80000","effectiveAt":"0x`} {
+		if !strings.Contains(string(assetJSON), want) {
+			t.Errorf("asset JSON lacks %s: %s", want, assetJSON)
+		}
+	}
+	if strings.Contains(string(assetJSON), "currency") {
+		t.Errorf("asset JSON carries currency: %s", assetJSON)
+	}
+	stableJSON, _ := json.Marshal(stable)
+	if !strings.Contains(string(stableJSON), `"currency":"USD"`) || !strings.Contains(string(stableJSON), `"pausedFeatures":[]`) {
+		t.Errorf("stablecoin JSON: %s", stableJSON)
+	}
+	for _, absent := range []string{"multiplier", "totalSupplyUI", "pendingMultiplier"} {
+		if strings.Contains(string(stableJSON), absent) {
+			t.Errorf("stablecoin JSON carries %s: %s", absent, stableJSON)
+		}
+	}
+
+	// Not tokens: outside the space, the factory, an address never created.
+	for _, addr := range []common.Address{creator, CAS20FactoryAddress, cas20Addr(cas20VariantAsset, 0xee)} {
+		if _, err := CAS20TokenInfoAt(statedb, evm.chainConfig.ChainID, addr, now); !errors.Is(err, ErrNotCAS20Token) {
+			t.Errorf("%x: err = %v, want ErrNotCAS20Token", addr, err)
+		}
+	}
+
+	// A length word no transaction could have paid for is refused, not walked.
+	view := newUnmeteredCAS20Storage(statedb, token)
+	view.setWord(slotAt(cas20SlotContractURI), uint256.NewInt(2*(cas20RPCMaxStringLen+32)+1).Bytes32())
+	if _, err := CAS20TokenInfoAt(statedb, evm.chainConfig.ChainID, token, now); !errors.Is(err, ErrCAS20StringTooLong) {
+		t.Errorf("oversized contractURI: err = %v, want ErrCAS20StringTooLong", err)
+	}
+}
+
+func containsString(abiRet []byte, s string) bool {
+	if len(abiRet) < 64 {
+		return false
+	}
+	n := new(uint256.Int).SetBytes(abiRet[32:64]).Uint64()
+	return uint64(len(abiRet)) >= 64+n && string(abiRet[64:64+n]) == s
+}

--- a/core/vm/cas20_layout_fixture_test.go
+++ b/core/vm/cas20_layout_fixture_test.go
@@ -1,0 +1,119 @@
+package vm
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestCAS20LayoutFixtureFollowsTheCode keeps testdata/cas20_layout.json in step with
+// the constants, because BEP-702 3.17 is generated from that fixture and is what a
+// second implementation builds from.
+//
+// It pins agreement, not values. The namespace strings are still undecided — a
+// rename of a namespace moves its ERC-7201 root and with it the absolute
+// position of every field — so nothing here asserts what they are. It asserts that
+// whatever the code says, the fixture says too: rename a namespace or renumber a
+// slot and this fails, telling you to regenerate the fixture, which regenerates the
+// spec section in the same commit.
+func TestCAS20LayoutFixtureFollowsTheCode(t *testing.T) {
+	// Derived from the code, never transcribed.
+	live := map[string]map[string]uint64{
+		cas20Namespace: {
+			"name": cas20SlotName, "symbol": cas20SlotSymbol, "contractURI": cas20SlotContractURI,
+			"totalSupply": cas20SlotTotalSupply, "balances": cas20SlotBalances,
+			"allowances": cas20SlotAllowances, "roles": cas20SlotRoles,
+			"roleAdmins": cas20SlotRoleAdmins, "adminCount": cas20SlotAdminCount,
+			"transferPolicies": cas20SlotTransferPolicies, "mintPolicy": cas20SlotMintPolicy,
+			"paused": cas20SlotPaused, "supplyCap": cas20SlotSupplyCap,
+			"nonces": cas20SlotNonces, "seizePolicies": cas20SlotSeizePolicies,
+		},
+		cas20AssetNamespace: {
+			"decimals": cas20AssetSlotDecimals, "multiplier": cas20AssetSlotMultiplier,
+			"announcements": cas20AssetSlotAnnouncements, "extraMetadata": cas20AssetSlotExtraMeta,
+			"pendingMultiplier": cas20AssetSlotPending,
+		},
+		cas20StablecoinNamespace: {"currency": cas20StablecoinSlotCurrency},
+		cas20PolicyNamespace: {
+			"policies": polSlotPolicies, "members": polSlotMembers,
+			"pendingAdmins": polSlotPendingAdmins, "counter": polSlotCounter,
+			"children": polSlotChildren,
+		},
+		cas20ActivationNamespace: {"features": actSlotFeatures, "admin": actSlotAdmin},
+	}
+
+	var ref struct {
+		Namespaces []struct {
+			Name   string `json:"name"`
+			Root   string `json:"root"`
+			Fields []struct {
+				Slot uint64 `json:"slot"`
+				Name string `json:"name"`
+			} `json:"fields"`
+		} `json:"namespaces"`
+		Derivation struct {
+			StringMaxLen uint64 `json:"string_max_len"`
+		} `json:"derivation"`
+	}
+	raw, err := os.ReadFile("testdata/cas20_layout.json")
+	if err != nil {
+		t.Fatalf("read the layout fixture: %v", err)
+	}
+	if err := json.Unmarshal(raw, &ref); err != nil {
+		t.Fatalf("parse the layout fixture: %v", err)
+	}
+
+	const regen = "update the fixture, and BEP-702 3.17 with it"
+
+	seenNS := map[string]bool{}
+	for _, ns := range ref.Namespaces {
+		fields, known := live[ns.Name]
+		if !known {
+			t.Errorf("the fixture names namespace %q, which no constant declares — %s",
+				ns.Name, regen)
+			continue
+		}
+		seenNS[ns.Name] = true
+		// Recomputed from the code's own string: a rename moves every slot in the
+		// namespace, so a stale root here would reach the spec unnoticed.
+		if want := erc7201Root(ns.Name).Hex(); ns.Root != want {
+			t.Errorf("namespace %q: fixture root %s, the code derives %s — %s",
+				ns.Name, ns.Root, want, regen)
+		}
+		seen := map[string]bool{}
+		for _, f := range ns.Fields {
+			seen[f.Name] = true
+			slot, ok := fields[f.Name]
+			if !ok {
+				t.Errorf("%s: the fixture names field %q, which no constant declares — %s",
+					ns.Name, f.Name, regen)
+			} else if slot != f.Slot {
+				t.Errorf("%s.%s is slot %d in the fixture and %d in the code — %s",
+					ns.Name, f.Name, f.Slot, slot, regen)
+			}
+		}
+		var missing []string
+		for name := range fields {
+			if !seen[name] {
+				missing = append(missing, name)
+			}
+		}
+		sort.Strings(missing)
+		if len(missing) > 0 {
+			t.Errorf("%s: the fixture does not document %s. An undocumented slot is one a "+
+				"reimplementation cannot place — %s", ns.Name, strings.Join(missing, ", "), regen)
+		}
+	}
+	for ns := range live {
+		if !seenNS[ns] {
+			t.Errorf("namespace %q is absent from the fixture, so BEP-702 3.17 will not "+
+				"mention it — %s", ns, regen)
+		}
+	}
+	if ref.Derivation.StringMaxLen != cas20MaxStringLen {
+		t.Errorf("the fixture caps a string at %d, the code at %d — %s",
+			ref.Derivation.StringMaxLen, cas20MaxStringLen, regen)
+	}
+}

--- a/core/vm/cas20_layout_fixture_test.go
+++ b/core/vm/cas20_layout_fixture_test.go
@@ -21,6 +21,7 @@ func TestCAS20LayoutFixtureFollowsTheCode(t *testing.T) {
 			"transferPolicies": cas20SlotTransferPolicies, "mintPolicy": cas20SlotMintPolicy,
 			"paused": cas20SlotPaused, "supplyCap": cas20SlotSupplyCap,
 			"nonces": cas20SlotNonces, "seizePolicies": cas20SlotSeizePolicies,
+			"expectedMemoFormats": cas20SlotExpectedMemoFormats,
 		},
 		cas20AssetNamespace: {
 			"decimals": cas20AssetSlotDecimals, "multiplier": cas20AssetSlotMultiplier,
@@ -34,6 +35,7 @@ func TestCAS20LayoutFixtureFollowsTheCode(t *testing.T) {
 			"children": polSlotChildren,
 		},
 		cas20ActivationNamespace: {"features": actSlotFeatures, "admin": actSlotAdmin},
+		cas20MemoNamespace:       {"formats": memoSlotFormats, "fields": memoSlotFields, "counters": memoSlotCounters},
 	}
 
 	var ref struct {

--- a/core/vm/cas20_layout_fixture_test.go
+++ b/core/vm/cas20_layout_fixture_test.go
@@ -8,18 +8,10 @@ import (
 	"testing"
 )
 
-// TestCAS20LayoutFixtureFollowsTheCode keeps testdata/cas20_layout.json in step with
-// the constants, because BEP-702 3.17 is generated from that fixture and is what a
-// second implementation builds from.
-//
-// It pins agreement, not values. The namespace strings are still undecided — a
-// rename of a namespace moves its ERC-7201 root and with it the absolute
-// position of every field — so nothing here asserts what they are. It asserts that
-// whatever the code says, the fixture says too: rename a namespace or renumber a
-// slot and this fails, telling you to regenerate the fixture, which regenerates the
-// spec section in the same commit.
+// BEP-702 3.17 is generated from testdata/cas20_layout.json. This pins agreement
+// with the code, not values: a rename or renumbering fails here and says to
+// regenerate the fixture.
 func TestCAS20LayoutFixtureFollowsTheCode(t *testing.T) {
-	// Derived from the code, never transcribed.
 	live := map[string]map[string]uint64{
 		cas20Namespace: {
 			"name": cas20SlotName, "symbol": cas20SlotSymbol, "contractURI": cas20SlotContractURI,
@@ -76,8 +68,6 @@ func TestCAS20LayoutFixtureFollowsTheCode(t *testing.T) {
 			continue
 		}
 		seenNS[ns.Name] = true
-		// Recomputed from the code's own string: a rename moves every slot in the
-		// namespace, so a stale root here would reach the spec unnoticed.
 		if want := erc7201Root(ns.Name).Hex(); ns.Root != want {
 			t.Errorf("namespace %q: fixture root %s, the code derives %s — %s",
 				ns.Name, ns.Root, want, regen)

--- a/core/vm/cas20_layout_test.go
+++ b/core/vm/cas20_layout_test.go
@@ -1,0 +1,296 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+)
+
+// Storage-layout pins. Expectations are spelled out from Solidity's rules, not
+// obtained from the accessor under test: a test that asks mapSlot where a slot
+// lives agrees with mapSlot whatever mapSlot does, which is why each case below
+// could be changed in reader and writer together without failing anything.
+
+// solMap is Solidity's mapping slot: keccak256(h(key) . slot), with the key
+// left-padded to a word for value types.
+func solMap(slot common.Hash, key common.Hash) common.Hash {
+	return crypto.Keccak256Hash(key.Bytes(), slot.Bytes())
+}
+
+// solSlot is base + offset, as Solidity numbers consecutive fields.
+func solSlot(base common.Hash, offset uint64) common.Hash {
+	s := new(uint256.Int).SetBytes(base.Bytes())
+	s.AddUint64(s, offset)
+	return common.Hash(s.Bytes32())
+}
+
+// TestCAS20PolicyMemberSlot pins members[id][account] at
+// keccak256(account . keccak256(id . slot)) — id first. The token's own nested
+// mappings are covered against this; the registry's was not.
+func TestCAS20PolicyMemberSlot(t *testing.T) {
+	s := newTestStorage(t)
+	reg := policyReg{s: s}
+
+	const id = uint64(0x0100000000002a) // allowlist type, counter 42
+	account := common.HexToAddress("0xbeef")
+
+	reg.setMember(id, account, true)
+
+	inner := solMap(solSlot(cas20PolicyRoot, polSlotMembers), idKey(id))
+	want := solMap(inner, addrKey(account))
+	if got := s.getWord(want); got == (common.Hash{}) {
+		t.Errorf("members[%#x][%s] is not at %s", id, account.Hex(), want.Hex())
+	}
+
+	// The swapped order must be empty, which is what makes this an assertion
+	// about ordering rather than about reachability.
+	swappedInner := solMap(solSlot(cas20PolicyRoot, polSlotMembers), addrKey(account))
+	if got := s.getWord(solMap(swappedInner, idKey(id))); got != (common.Hash{}) {
+		t.Error("the account-then-id ordering also holds a value; the keys are interchangeable")
+	}
+}
+
+// TestCAS20StringKeyedSlots pins both string-keyed mappings: a dynamic key is
+// hashed unpadded, keccak256(bytes(key) . slot). Padding it to a word instead —
+// the rule for value-typed keys — would put every entry somewhere else.
+func TestCAS20StringKeyedSlots(t *testing.T) {
+	ext := assetExt{s: newUnmeteredCAS20Storage(nil, common.Address{})}
+	for _, tc := range []struct {
+		name string
+		slot uint64
+		got  func(string) common.Hash
+	}{
+		{"extraMetadata", cas20AssetSlotExtraMeta, ext.extraMetaSlot},
+		{"announcements", cas20AssetSlotAnnouncements, ext.announcementSlot},
+	} {
+		const key = "category"
+		base := solSlot(cas20AssetRoot, tc.slot)
+		if want, got := crypto.Keccak256Hash([]byte(key), base.Bytes()), tc.got(key); got != want {
+			t.Errorf("%s slot for %q = %s, want keccak256(key . slot) = %s",
+				tc.name, key, got.Hex(), want.Hex())
+		}
+		// And the reversed preimage must differ, or the assertion above is vacuous.
+		if reversed := crypto.Keccak256Hash(base.Bytes(), []byte(key)); tc.got(key) == reversed {
+			t.Errorf("%s: slot . key and key . slot agree; the order is not pinned", tc.name)
+		}
+	}
+
+	// The two mappings must not answer the same slot for the same key, which is
+	// what keeps a metadata key from marking an announcement id used.
+	if ext.extraMetaSlot("x") == ext.announcementSlot("x") {
+		t.Error("extraMetadata and announcements collide on a shared key")
+	}
+}
+
+// TestCAS20ComplianceLanes pins which slot each compliance id lands in and where
+// inside it. Swapping the seize holder and receiver offsets would apply the
+// wrong policy to a seizure; putting a seize id back in the mint slot would
+// take a lane reserved for future mint-side policy types.
+func TestCAS20ComplianceLanes(t *testing.T) {
+	s := newTestStorage(t)
+	const (
+		mintRecv  = uint64(0x11)
+		seizeHold = uint64(0x22)
+		seizeRecv = uint64(0x33)
+	)
+	s.setMintReceiverPolicy(mintRecv)
+	s.setSeizeHolderPolicy(seizeHold)
+	s.setSeizeReceiverPolicy(seizeRecv)
+
+	// Distinct values, so a swapped pair cannot pass by coincidence.
+	if mintRecv == seizeHold || seizeHold == seizeRecv || mintRecv == seizeRecv {
+		t.Fatal("the lane values must differ for a swap to be detectable")
+	}
+
+	// Raw words, read straight from their slots, with each lane at its own byte
+	// offset from the low end.
+	lane := func(slot uint64, off int) uint64 {
+		word := s.getU256At(slotAt(slot)).Bytes32()
+		// bytes are big-endian in the word, so lane n occupies [31-off-7 : 31-off]
+		var got uint64
+		for _, b := range word[32-off-8 : 32-off] {
+			got = got<<8 | uint64(b)
+		}
+		return got
+	}
+	for _, tc := range []struct {
+		name string
+		slot uint64
+		off  int
+		want uint64
+	}{
+		{"mintReceiver", cas20SlotMintPolicy, 0, mintRecv},
+		{"seizeHolder", cas20SlotSeizePolicies, 0, seizeHold},
+		{"seizeReceiver", cas20SlotSeizePolicies, 8, seizeRecv},
+	} {
+		if got := lane(tc.slot, tc.off); got != tc.want {
+			t.Errorf("%s at slot %d byte offset %d = %#x, want %#x",
+				tc.name, tc.slot, tc.off, got, tc.want)
+		}
+	}
+
+	// And the mint slot holds nothing but its one id: the rest of that word is
+	// reserved for mint-side policy types a later revision adds, so a seize id
+	// straying back into it is a divergence even though both still read back.
+	if word := s.getU256At(slotAt(cas20SlotMintPolicy)).Bytes32(); word != mintOnly(mintRecv) {
+		t.Errorf("mint slot = %s, want only the receiver id in the low lane",
+			common.Hash(word).Hex())
+	}
+}
+
+// mintOnly is the mint slot's expected word: one id in the low lane, the rest
+// zero.
+func mintOnly(id uint64) [32]byte {
+	var w [32]byte
+	for i := 0; i < 8; i++ {
+		w[31-i] = byte(id >> (8 * i))
+	}
+	return w
+}
+
+// TestCAS20SlotNumbers pins every field's slot number as a literal. The accessors
+// agree with themselves whatever the numbers say, so without this a renumbering
+// is invisible. Slots are consensus constants and append-only.
+func TestCAS20SlotNumbers(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  uint64
+		want uint64
+	}{
+		{"core.name", cas20SlotName, 0},
+		{"core.symbol", cas20SlotSymbol, 1},
+		{"core.contractURI", cas20SlotContractURI, 2},
+		{"core.totalSupply", cas20SlotTotalSupply, 3},
+		{"core.balances", cas20SlotBalances, 4},
+		{"core.allowances", cas20SlotAllowances, 5},
+		{"core.roles", cas20SlotRoles, 6},
+		{"core.roleAdmins", cas20SlotRoleAdmins, 7},
+		{"core.adminCount", cas20SlotAdminCount, 8},
+		{"core.transferPolicies", cas20SlotTransferPolicies, 9},
+		{"core.mintPolicy", cas20SlotMintPolicy, 10},
+		{"core.paused", cas20SlotPaused, 11},
+		{"core.supplyCap", cas20SlotSupplyCap, 12},
+		{"core.nonces", cas20SlotNonces, 13},
+		{"core.seizePolicies", cas20SlotSeizePolicies, 14},
+
+		{"activation.features", actSlotFeatures, 0},
+		{"activation.admin", actSlotAdmin, 1},
+
+		{"policy.policies", polSlotPolicies, 0},
+		{"policy.members", polSlotMembers, 1},
+		{"policy.pendingAdmins", polSlotPendingAdmins, 2},
+		{"policy.counter", polSlotCounter, 3},
+
+		{"asset.decimals", cas20AssetSlotDecimals, 0},
+		{"asset.multiplier", cas20AssetSlotMultiplier, 1},
+		{"asset.announcements", cas20AssetSlotAnnouncements, 2},
+		{"asset.extraMeta", cas20AssetSlotExtraMeta, 3},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %d, want %d", tc.name, tc.got, tc.want)
+		}
+	}
+
+	// The packed lane offsets too, since a swap there is invisible to the
+	// accessors.
+	for _, tc := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"transferSender", cas20OffTransferSender, 0},
+		{"transferReceiver", cas20OffTransferReceiver, 8},
+		{"transferExecutor", cas20OffTransferExecutor, 16},
+		{"mintReceiver", cas20OffMintReceiver, 0},
+		{"seizeHolder", cas20OffSeizeHolder, 0},
+		{"seizeReceiver", cas20OffSeizeReceiver, 8},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("offset %s = %d, want %d", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// TestCAS20PolicyWordReservedBits pins that byte 0 is exactly 0x80. Bits 254:248
+// were unchecked, and they are where a later revision would add a flag.
+func TestCAS20PolicyWordReservedBits(t *testing.T) {
+	admin := common.HexToAddress("0xad4149")
+	w := packPolicy(admin)
+
+	if w[0] != 0x80 {
+		t.Errorf("byte 0 = %#02x, want exactly 0x80: bit 255 set, bits 254:248 clear", w[0])
+	}
+	for i := 1; i < 12; i++ {
+		if w[i] != 0 {
+			t.Errorf("byte %d = %#02x, want zero (bits 247:160 are reserved)", i, w[i])
+		}
+	}
+	if got := polWordAdmin(w); got != admin {
+		t.Errorf("admin round-trip = %s, want %s", got.Hex(), admin.Hex())
+	}
+	if !polWordExists(w) {
+		t.Error("packPolicy must set the existence bit")
+	}
+}
+
+// TestCAS20PolicyLanePositions checks every entry of cas20PolicyLanes against the byte
+// the id actually lands on, for all six scopes.
+func TestCAS20PolicyLanePositions(t *testing.T) {
+	if len(cas20PolicyLanes) != 6 {
+		t.Fatalf("cas20PolicyLanes has %d entries, want the six scopes", len(cas20PolicyLanes))
+	}
+	tok := cas20Token{s: newTestStorage(t)}
+
+	// A distinct id per scope, so no pair can pass by coincidence.
+	ids := map[common.Hash]uint64{
+		scopeTransferSender:   0x11,
+		scopeTransferReceiver: 0x22,
+		scopeTransferExecutor: 0x33,
+		scopeMintReceiver:     0x44,
+		scopeSeizeHolder:      0x55,
+		scopeSeizeReceiver:    0x66,
+	}
+	if len(ids) != len(cas20PolicyLanes) {
+		t.Fatalf("this test names %d scopes, the table has %d", len(ids), len(cas20PolicyLanes))
+	}
+	seen := map[uint64]common.Hash{}
+	for scope, lane := range cas20PolicyLanes {
+		id, named := ids[scope]
+		if !named {
+			t.Fatalf("the table holds a scope this test does not name: %s", scope.Hex())
+		}
+		tok.s.setPackedU64(lane.slot, lane.byteOff, id)
+		// Two scopes on the same byte of the same slot would overwrite each other.
+		key := lane.slot<<8 | uint64(lane.byteOff)
+		if other, dup := seen[key]; dup {
+			t.Errorf("%s and %s share slot %d byte %d", scope.Hex(), other.Hex(),
+				lane.slot, lane.byteOff)
+		}
+		seen[key] = scope
+	}
+
+	// Read back through the dispatcher's own path, then straight from the word, so
+	// a table entry that is wrong in a self-consistent way still fails.
+	for scope, want := range ids {
+		got, ok := tok.policyIdByScope(scope)
+		if !ok {
+			t.Errorf("policyIdByScope(%s) reports unknown", scope.Hex())
+			continue
+		}
+		if got != want {
+			t.Errorf("policyIdByScope(%s) = %#x, want %#x", scope.Hex(), got, want)
+		}
+		lane := cas20PolicyLanes[scope]
+		word := tok.s.getU256At(slotAt(lane.slot)).Bytes32()
+		var raw uint64
+		for _, b := range word[32-int(lane.byteOff)-8 : 32-int(lane.byteOff)] {
+			raw = raw<<8 | uint64(b)
+		}
+		if raw != want {
+			t.Errorf("%s: slot %d byte %d holds %#x, want %#x", scope.Hex(),
+				lane.slot, lane.byteOff, raw, want)
+		}
+	}
+}

--- a/core/vm/cas20_layout_test.go
+++ b/core/vm/cas20_layout_test.go
@@ -8,27 +8,19 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// Storage-layout pins. Expectations are spelled out from Solidity's rules, not
-// obtained from the accessor under test: a test that asks mapSlot where a slot
-// lives agrees with mapSlot whatever mapSlot does, which is why each case below
-// could be changed in reader and writer together without failing anything.
+// Expectations are spelled out from Solidity's rules, not obtained from the
+// accessor under test, which would agree with itself whatever it did.
 
-// solMap is Solidity's mapping slot: keccak256(h(key) . slot), with the key
-// left-padded to a word for value types.
 func solMap(slot common.Hash, key common.Hash) common.Hash {
 	return crypto.Keccak256Hash(key.Bytes(), slot.Bytes())
 }
 
-// solSlot is base + offset, as Solidity numbers consecutive fields.
 func solSlot(base common.Hash, offset uint64) common.Hash {
 	s := new(uint256.Int).SetBytes(base.Bytes())
 	s.AddUint64(s, offset)
 	return common.Hash(s.Bytes32())
 }
 
-// TestCAS20PolicyMemberSlot pins members[id][account] at
-// keccak256(account . keccak256(id . slot)) — id first. The token's own nested
-// mappings are covered against this; the registry's was not.
 func TestCAS20PolicyMemberSlot(t *testing.T) {
 	s := newTestStorage(t)
 	reg := policyReg{s: s}
@@ -44,17 +36,14 @@ func TestCAS20PolicyMemberSlot(t *testing.T) {
 		t.Errorf("members[%#x][%s] is not at %s", id, account.Hex(), want.Hex())
 	}
 
-	// The swapped order must be empty, which is what makes this an assertion
-	// about ordering rather than about reachability.
+	// The swapped order must be empty, or this asserts reachability rather than ordering.
 	swappedInner := solMap(solSlot(cas20PolicyRoot, polSlotMembers), addrKey(account))
 	if got := s.getWord(solMap(swappedInner, idKey(id))); got != (common.Hash{}) {
 		t.Error("the account-then-id ordering also holds a value; the keys are interchangeable")
 	}
 }
 
-// TestCAS20StringKeyedSlots pins both string-keyed mappings: a dynamic key is
-// hashed unpadded, keccak256(bytes(key) . slot). Padding it to a word instead —
-// the rule for value-typed keys — would put every entry somewhere else.
+// A dynamic key is hashed unpadded; padding it as a value-typed key would move every entry.
 func TestCAS20StringKeyedSlots(t *testing.T) {
 	ext := assetExt{s: newUnmeteredCAS20Storage(nil, common.Address{})}
 	for _, tc := range []struct {
@@ -71,23 +60,17 @@ func TestCAS20StringKeyedSlots(t *testing.T) {
 			t.Errorf("%s slot for %q = %s, want keccak256(key . slot) = %s",
 				tc.name, key, got.Hex(), want.Hex())
 		}
-		// And the reversed preimage must differ, or the assertion above is vacuous.
 		if reversed := crypto.Keccak256Hash(base.Bytes(), []byte(key)); tc.got(key) == reversed {
 			t.Errorf("%s: slot . key and key . slot agree; the order is not pinned", tc.name)
 		}
 	}
 
-	// The two mappings must not answer the same slot for the same key, which is
-	// what keeps a metadata key from marking an announcement id used.
+	// Otherwise a metadata key could mark an announcement id used.
 	if ext.extraMetaSlot("x") == ext.announcementSlot("x") {
 		t.Error("extraMetadata and announcements collide on a shared key")
 	}
 }
 
-// TestCAS20ComplianceLanes pins which slot each compliance id lands in and where
-// inside it. Swapping the seize holder and receiver offsets would apply the
-// wrong policy to a seizure; putting a seize id back in the mint slot would
-// take a lane reserved for future mint-side policy types.
 func TestCAS20ComplianceLanes(t *testing.T) {
 	s := newTestStorage(t)
 	const (
@@ -99,16 +82,12 @@ func TestCAS20ComplianceLanes(t *testing.T) {
 	s.setSeizeHolderPolicy(seizeHold)
 	s.setSeizeReceiverPolicy(seizeRecv)
 
-	// Distinct values, so a swapped pair cannot pass by coincidence.
 	if mintRecv == seizeHold || seizeHold == seizeRecv || mintRecv == seizeRecv {
 		t.Fatal("the lane values must differ for a swap to be detectable")
 	}
 
-	// Raw words, read straight from their slots, with each lane at its own byte
-	// offset from the low end.
 	lane := func(slot uint64, off int) uint64 {
 		word := s.getU256At(slotAt(slot)).Bytes32()
-		// bytes are big-endian in the word, so lane n occupies [31-off-7 : 31-off]
 		var got uint64
 		for _, b := range word[32-off-8 : 32-off] {
 			got = got<<8 | uint64(b)
@@ -131,17 +110,14 @@ func TestCAS20ComplianceLanes(t *testing.T) {
 		}
 	}
 
-	// And the mint slot holds nothing but its one id: the rest of that word is
-	// reserved for mint-side policy types a later revision adds, so a seize id
-	// straying back into it is a divergence even though both still read back.
+	// The rest of the mint word is reserved, so a seize id straying into it is a
+	// divergence even though both still read back.
 	if word := s.getU256At(slotAt(cas20SlotMintPolicy)).Bytes32(); word != mintOnly(mintRecv) {
 		t.Errorf("mint slot = %s, want only the receiver id in the low lane",
 			common.Hash(word).Hex())
 	}
 }
 
-// mintOnly is the mint slot's expected word: one id in the low lane, the rest
-// zero.
 func mintOnly(id uint64) [32]byte {
 	var w [32]byte
 	for i := 0; i < 8; i++ {
@@ -150,9 +126,8 @@ func mintOnly(id uint64) [32]byte {
 	return w
 }
 
-// TestCAS20SlotNumbers pins every field's slot number as a literal. The accessors
-// agree with themselves whatever the numbers say, so without this a renumbering
-// is invisible. Slots are consensus constants and append-only.
+// Slots are consensus constants and append-only; the accessors would agree with
+// themselves whatever the numbers said.
 func TestCAS20SlotNumbers(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -193,8 +168,6 @@ func TestCAS20SlotNumbers(t *testing.T) {
 		}
 	}
 
-	// The packed lane offsets too, since a swap there is invisible to the
-	// accessors.
 	for _, tc := range []struct {
 		name string
 		got  int
@@ -213,8 +186,7 @@ func TestCAS20SlotNumbers(t *testing.T) {
 	}
 }
 
-// TestCAS20PolicyWordReservedBits pins that byte 0 is exactly 0x80. Bits 254:248
-// were unchecked, and they are where a later revision would add a flag.
+// Bits 254:248 are where a later revision would add a flag.
 func TestCAS20PolicyWordReservedBits(t *testing.T) {
 	admin := common.HexToAddress("0xad4149")
 	w := packPolicy(admin)
@@ -235,15 +207,12 @@ func TestCAS20PolicyWordReservedBits(t *testing.T) {
 	}
 }
 
-// TestCAS20PolicyLanePositions checks every entry of cas20PolicyLanes against the byte
-// the id actually lands on, for all six scopes.
 func TestCAS20PolicyLanePositions(t *testing.T) {
 	if len(cas20PolicyLanes) != 6 {
 		t.Fatalf("cas20PolicyLanes has %d entries, want the six scopes", len(cas20PolicyLanes))
 	}
 	tok := cas20Token{s: newTestStorage(t)}
 
-	// A distinct id per scope, so no pair can pass by coincidence.
 	ids := map[common.Hash]uint64{
 		scopeTransferSender:   0x11,
 		scopeTransferReceiver: 0x22,
@@ -262,7 +231,6 @@ func TestCAS20PolicyLanePositions(t *testing.T) {
 			t.Fatalf("the table holds a scope this test does not name: %s", scope.Hex())
 		}
 		tok.s.setPackedU64(lane.slot, lane.byteOff, id)
-		// Two scopes on the same byte of the same slot would overwrite each other.
 		key := lane.slot<<8 | uint64(lane.byteOff)
 		if other, dup := seen[key]; dup {
 			t.Errorf("%s and %s share slot %d byte %d", scope.Hex(), other.Hex(),
@@ -271,8 +239,8 @@ func TestCAS20PolicyLanePositions(t *testing.T) {
 		seen[key] = scope
 	}
 
-	// Read back through the dispatcher's own path, then straight from the word, so
-	// a table entry that is wrong in a self-consistent way still fails.
+	// Through the dispatcher and then straight from the word, so a self-consistently
+	// wrong table entry still fails.
 	for scope, want := range ids {
 		got, ok := tok.policyIdByScope(scope)
 		if !ok {

--- a/core/vm/cas20_layout_test.go
+++ b/core/vm/cas20_layout_test.go
@@ -157,6 +157,10 @@ func TestCAS20SlotNumbers(t *testing.T) {
 		{"policy.members", polSlotMembers, 1},
 		{"policy.pendingAdmins", polSlotPendingAdmins, 2},
 		{"policy.counter", polSlotCounter, 3},
+		{"core.expectedMemoFormats", cas20SlotExpectedMemoFormats, 15},
+		{"memo.formats", memoSlotFormats, 0},
+		{"memo.fields", memoSlotFields, 1},
+		{"memo.counters", memoSlotCounters, 2},
 
 		{"asset.decimals", cas20AssetSlotDecimals, 0},
 		{"asset.multiplier", cas20AssetSlotMultiplier, 1},

--- a/core/vm/cas20_memo.go
+++ b/core/vm/cas20_memo.go
@@ -1,0 +1,469 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+)
+
+// The MemoFormatRegistry is the third singleton: a permissionless catalogue of
+// memo layouts, so a transfer can say which format(s) the payload behind its
+// 32-byte memo hash follows. The chain records the claim and checks only that
+// the formats exist; it never sees the payload, so it never verifies the claim.
+
+var CAS20MemoFormatRegistryAddress = common.HexToAddress("0x7020000000000000000000000000000000000003")
+
+const cas20MemoNamespace = "bsc.memo_registry"
+
+var cas20MemoRoot = erc7201Root(cas20MemoNamespace)
+
+var featureMemoRegistry = crypto.Keccak256Hash([]byte(cas20MemoNamespace))
+
+const (
+	memoSlotFormats  = 0 // mapping(uint64 => packed word)
+	memoSlotFields   = 1 // mapping(uint64 => uint64[]), one packed FieldSpec per lane
+	memoSlotCounters = 2 // mapping(uint8 category => uint64)
+)
+
+// A formatId is self-describing: the high byte is the category, the low 56 bits a
+// counter within it. Format 0, UNSTRUCTURED, is the plain memo of today.
+const (
+	memoCategoryInternal   = 0
+	memoCategoryISO        = 1
+	memoCategoryTravelRule = 2
+	memoCategoryGov        = 3
+	memoCategoryMax        = memoCategoryGov
+
+	memoFormatUnstructured = uint64(0)
+	memoCounterMax         = uint64(1)<<56 - 1
+
+	memoKindBytes = 4 // ASCII_UPPER, ASCII_ALNUM, NUMERIC, FIXED_ENUM, BYTES
+
+	// cas20MemoMaxFields bounds a format's field list, as the policy batch is bounded.
+	cas20MemoMaxFields = 64
+)
+
+// Packed format word: bit 255 exists, creator in bits 0..160, category 160..168,
+// field count 168..184, total length 184..200.
+var memoExistsBit = new(uint256.Int).Lsh(uint256.NewInt(1), 255)
+
+// A FieldSpec packs into one uint64 lane: offset 0..16, length 16..32, kind 32..40,
+// required 40..48.
+type memoFieldSpec struct {
+	offset, length uint16
+	kind           byte
+	required       bool
+}
+
+func (f memoFieldSpec) pack() uint64 {
+	v := uint64(f.offset) | uint64(f.length)<<16 | uint64(f.kind)<<32
+	if f.required {
+		v |= 1 << 40
+	}
+	return v
+}
+
+func unpackMemoField(v uint64) memoFieldSpec {
+	return memoFieldSpec{offset: uint16(v), length: uint16(v >> 16), kind: byte(v >> 32), required: v>>40&1 == 1}
+}
+
+var (
+	selCreateMemoFormat = selector("createMemoFormat(uint8,(uint16,uint16,uint8,bool)[])")
+	selFormatExists     = selector("formatExists(uint64)")
+	selGetMemoFormat    = selector("getMemoFormat(uint64)")
+	selFormatCount      = selector("formatCount(uint8)")
+
+	cas20TopicMemoFormatCreated = eventTopic("MemoFormatCreated(uint64,address,uint8)")
+
+	// Token side.
+	selTransferWithMemoFormats     = selector("transferWithMemoFormats(address,uint256,bytes32,uint64[])")
+	selTransferFromWithMemoFormats = selector("transferFromWithMemoFormats(address,address,uint256,bytes32,uint64[])")
+	selUpdateExpectedMemoFormats   = selector("updateExpectedMemoFormats(uint64[])")
+	selExpectedMemoFormats         = selector("expectedMemoFormats()")
+
+	cas20TopicMemoFormatsDeclared        = eventTopic("MemoFormatsDeclared(bytes32,uint64[])")
+	cas20TopicExpectedMemoFormatsUpdated = eventTopic("ExpectedMemoFormatsUpdated(address,uint64[])")
+)
+
+type memoReg struct{ s cas20Storage }
+
+func newMemoReg(ctx *PrecompileContext) memoReg {
+	return memoReg{s: newMeteredCAS20StorageAt(ctx, CAS20MemoFormatRegistryAddress)}
+}
+
+func memoSlot(offset uint64) common.Hash { return offsetSlot(cas20MemoRoot, offset) }
+
+func memoCategory(id uint64) byte { return byte(id >> 56) }
+
+func (r memoReg) formatWord(id uint64) *uint256.Int {
+	return new(uint256.Int).SetBytes(r.s.getWord(r.s.mapSlot(memoSlot(memoSlotFormats), idKey(id))).Bytes())
+}
+
+// formatExists answers for UNSTRUCTURED from the id alone, so it holds before any
+// format has been created.
+func (r memoReg) formatExists(id uint64) bool {
+	if id == memoFormatUnstructured {
+		return true
+	}
+	if memoCategory(id) > memoCategoryMax {
+		return false
+	}
+	return new(uint256.Int).And(r.formatWord(id), memoExistsBit).Sign() != 0
+}
+
+func (r memoReg) setFormat(id uint64, creator common.Address, category byte, fieldCount, totalLen uint16) {
+	w := new(uint256.Int).SetBytes(addrKey(creator).Bytes())
+	w.Or(w, new(uint256.Int).Lsh(uint256.NewInt(uint64(category)), 160))
+	w.Or(w, new(uint256.Int).Lsh(uint256.NewInt(uint64(fieldCount)), 168))
+	w.Or(w, new(uint256.Int).Lsh(uint256.NewInt(uint64(totalLen)), 184))
+	w.Or(w, memoExistsBit)
+	r.s.setWord(r.s.mapSlot(memoSlot(memoSlotFormats), idKey(id)), w.Bytes32())
+}
+
+func (r memoReg) counter(category byte) uint64 {
+	return new(uint256.Int).SetBytes(r.s.getWord(r.s.mapSlot(memoSlot(memoSlotCounters), wU8(category))).Bytes()).Uint64()
+}
+
+func (r memoReg) setCounter(category byte, n uint64) {
+	r.s.setWord(r.s.mapSlot(memoSlot(memoSlotCounters), wU8(category)), wU64(n))
+}
+
+func (r memoReg) fieldsSlot(id uint64) common.Hash {
+	return r.s.mapSlot(memoSlot(memoSlotFields), idKey(id))
+}
+
+type cas20MemoPrecompile struct{ cas20StatefulBase }
+
+func (p *cas20MemoPrecompile) Name() string { return "CAS20MemoFormatRegistry" }
+
+func (p *cas20MemoPrecompile) RunStateful(ctx *PrecompileContext, input []byte) ([]byte, error) {
+	if err := cas20EnterCall(ctx, input); err != nil {
+		return finishCAS20(nil, err)
+	}
+	ret, err := runCAS20Memo(ctx, input)
+	return finishCAS20Metered(ctx, ret, err)
+}
+
+func runCAS20Memo(ctx *PrecompileContext, input []byte) ([]byte, error) {
+	if len(input) < 4 {
+		return nil, ErrExecutionReverted
+	}
+	var sel [4]byte
+	copy(sel[:], input[:4])
+	args := input[4:]
+	reg := newMemoReg(ctx)
+
+	switch sel {
+	case selFormatExists:
+		id, err := readU64(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		return encBool(reg.formatExists(id)), nil
+	case selFormatCount:
+		w, err := readWord(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		if !isEnumWord(w, memoCategoryMax) {
+			return nil, ErrExecutionReverted
+		}
+		return encU256(uint256.NewInt(reg.counter(w[31]))), nil
+	case selGetMemoFormat:
+		id, err := readU64(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		return getMemoFormat(reg, id)
+	case selCreateMemoFormat:
+		// Static frame, then the feature gate, before decoding: the registries' order.
+		if ctx.ReadOnly {
+			return nil, ErrWriteProtection
+		}
+		if err := ensureFeatureActivated(ctx, featureMemoRegistry); err != nil {
+			return nil, err
+		}
+		return createMemoFormat(ctx, reg, args)
+	}
+	return nil, ErrExecutionReverted
+}
+
+// getMemoFormat returns (FieldSpec[] fields, uint16 totalLen, address creator).
+func getMemoFormat(reg memoReg, id uint64) ([]byte, error) {
+	if !reg.formatExists(id) {
+		return nil, revCAS20("FormatNotFound(uint64)", errSelFormatNotFound, wU64(id))
+	}
+	var fields []memoFieldSpec
+	var totalLen uint64
+	var creator common.Hash
+	if id != memoFormatUnstructured {
+		w := reg.formatWord(id)
+		creator = common.BytesToHash(common.BytesToAddress(w.Bytes()).Bytes())
+		count := new(uint256.Int).Rsh(w, 168).Uint64() & 0xffff
+		totalLen = new(uint256.Int).Rsh(w, 184).Uint64() & 0xffff
+		for _, lane := range reg.s.u64ArrayAt(reg.fieldsSlot(id), count) {
+			fields = append(fields, unpackMemoField(lane))
+		}
+	}
+	tail := make([]byte, 0, 32*(1+4*len(fields)))
+	tail = append(tail, wU64(uint64(len(fields))).Bytes()...)
+	for _, f := range fields {
+		tail = append(tail, wU64(uint64(f.offset)).Bytes()...)
+		tail = append(tail, wU64(uint64(f.length)).Bytes()...)
+		tail = append(tail, wU8(f.kind).Bytes()...)
+		tail = append(tail, encBool(f.required)...)
+	}
+	return encodeTuple(abiPart{dynamic: true, tail: tail}, abiWord(wU64(totalLen)), abiWord(creator)), nil
+}
+
+// createMemoFormat(uint8 category, FieldSpec[] fields) -> uint64 formatId.
+// Order: category, then each field in array order, then the counter bound.
+func createMemoFormat(ctx *PrecompileContext, reg memoReg, args []byte) ([]byte, error) {
+	catWord, err := readWord(args, 0)
+	if err != nil {
+		return nil, err
+	}
+	if !isEnumWord(catWord, 0xff) {
+		return nil, ErrExecutionReverted
+	}
+	fields, err := readFieldSpecs(args, 1)
+	if err != nil {
+		return nil, err
+	}
+	category := catWord[31]
+	if category > memoCategoryMax {
+		return nil, revCAS20("InvalidCategory()", errSelInvalidCategory)
+	}
+	if len(fields) == 0 || len(fields) > cas20MemoMaxFields {
+		return nil, revCAS20("InvalidFieldCount(uint256)", errSelInvalidFieldCount, wU64(uint64(len(fields))))
+	}
+	var totalLen uint64
+	for i, f := range fields {
+		end := uint64(f.offset) + uint64(f.length)
+		if f.length == 0 || end > 0xffff || f.kind > memoKindBytes {
+			return nil, revCAS20("InvalidFieldSpec(uint256)", errSelInvalidFieldSpec, wU64(uint64(i)))
+		}
+		if end > totalLen {
+			totalLen = end
+		}
+	}
+
+	c := reg.counter(category) + 1
+	if c > memoCounterMax {
+		return nil, revPanic(0x11)
+	}
+	id := uint64(category)<<56 | c
+	reg.setCounter(category, c)
+	lanes := make([]uint64, len(fields))
+	for i, f := range fields {
+		lanes[i] = f.pack()
+	}
+	reg.s.setU64ArrayAt(reg.fieldsSlot(id), lanes)
+	reg.setFormat(id, ctx.Caller, category, uint16(len(fields)), uint16(totalLen))
+	if !ctx.AddLog([]common.Hash{cas20TopicMemoFormatCreated, wU64(id), addrKey(ctx.Caller)}, wU8(category).Bytes()) {
+		return nil, ErrOutOfGas
+	}
+	return encU256(uint256.NewInt(id)), nil
+}
+
+// readFieldSpecs decodes a (uint16,uint16,uint8,bool)[]: a dynamic array of
+// static four-word tuples, every narrow member decoded strictly.
+func readFieldSpecs(args []byte, argIndex int) ([]memoFieldSpec, error) {
+	L := uint64(len(args))
+	base, ok := wordU64(args, uint64(argIndex)*32)
+	if !ok || base > L || L-base < 32 {
+		return nil, ErrExecutionReverted
+	}
+	n, ok := wordU64(args, base)
+	if !ok {
+		return nil, ErrExecutionReverted
+	}
+	dataPos := base + 32
+	if n > (L-dataPos)/(4*32) {
+		return nil, ErrExecutionReverted
+	}
+	out := make([]memoFieldSpec, n)
+	for i := uint64(0); i < n; i++ {
+		elem := args[dataPos+i*128 : dataPos+(i+1)*128]
+		var w [4]common.Hash
+		for j := range w {
+			w[j] = common.BytesToHash(elem[j*32 : (j+1)*32])
+		}
+		if !wordFitsIn(w[0], 2) || !wordFitsIn(w[1], 2) || !isEnumWord(w[2], 0xff) || !isEnumWord(w[3], 1) {
+			return nil, ErrExecutionReverted
+		}
+		out[i] = memoFieldSpec{
+			offset:   uint16(new(uint256.Int).SetBytes(w[0].Bytes()).Uint64()),
+			length:   uint16(new(uint256.Int).SetBytes(w[1].Bytes()).Uint64()),
+			kind:     w[2][31],
+			required: w[3][31] == 1,
+		}
+	}
+	return out, nil
+}
+
+// --- Token side ------------------------------------------------------------
+
+// dispatchMemoFormats handles the format-declaring transfers and the issuer's
+// advisory list. ok is false when sel is none of them.
+func (t cas20Token) dispatchMemoFormats(sel [4]byte, args []byte) (ret []byte, err error, ok bool) {
+	switch sel {
+	case selExpectedMemoFormats:
+		ids := t.s.u64ArrayAt(slotAt(cas20SlotExpectedMemoFormats), cas20MemoMaxFields)
+		return encodeTuple(abiWordArray(u64Words(ids))), nil, true
+	case selUpdateExpectedMemoFormats:
+		ids, err := readU64Array(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, t.updateExpectedMemoFormats(ids), true
+	case selTransferWithMemoFormats:
+		to, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		amount, err := readU256(args, 1)
+		if err != nil {
+			return nil, err, true
+		}
+		memo, err := readWord(args, 2)
+		if err != nil {
+			return nil, err, true
+		}
+		ids, err := readU64Array(args, 3)
+		if err != nil {
+			return nil, err, true
+		}
+		ret, err := t.transferWithMemoFormats(t.ctx.Caller, t.ctx.Caller, to, amount, memo, ids)
+		return ret, err, true
+	case selTransferFromWithMemoFormats:
+		from, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		to, err := readAddress(args, 1)
+		if err != nil {
+			return nil, err, true
+		}
+		amount, err := readU256(args, 2)
+		if err != nil {
+			return nil, err, true
+		}
+		memo, err := readWord(args, 3)
+		if err != nil {
+			return nil, err, true
+		}
+		ids, err := readU64Array(args, 4)
+		if err != nil {
+			return nil, err, true
+		}
+		ret, err := t.transferWithMemoFormats(t.ctx.Caller, from, to, amount, memo, ids)
+		return ret, err, true
+	}
+	return nil, nil, false
+}
+
+// transferWithMemoFormats is the memo transfer plus a self-declared claim. Order:
+// static frame, the feature gate, every id's existence, then the transfer's own
+// sequence; the claim is emitted after Memo.
+func (t cas20Token) transferWithMemoFormats(spender, from, to common.Address, amount *uint256.Int, memo common.Hash, ids []uint64) ([]byte, error) {
+	if t.ctx.ReadOnly {
+		return nil, ErrWriteProtection
+	}
+	if err := t.ensureMemoFormats(ids); err != nil {
+		return nil, err
+	}
+	var ret []byte
+	var err error
+	if spender == from {
+		ret, err = t.transfer(from, to, amount)
+	} else {
+		ret, err = t.transferFrom(spender, from, to, amount)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !t.emitMemo(memo) || !t.emitMemoFormats(memo, ids) {
+		return nil, ErrOutOfGas
+	}
+	return ret, nil
+}
+
+// ensureMemoFormats is the whole of what the chain checks about a claim: the
+// feature is open and every id names a format that exists.
+func (t cas20Token) ensureMemoFormats(ids []uint64) error {
+	if err := ensureFeatureActivated(t.ctx, featureMemoRegistry); err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return revCAS20("EmptyBatch()", errSelEmptyBatch)
+	}
+	reg := newMemoReg(t.ctx)
+	for _, id := range ids {
+		if t.ctx.OutOfGas() {
+			return ErrOutOfGas
+		}
+		if !reg.formatExists(id) {
+			return revCAS20("FormatNotFound(uint64)", errSelFormatNotFound, wU64(id))
+		}
+	}
+	return nil
+}
+
+// updateExpectedMemoFormats publishes the formats an issuer expects transfers to
+// declare. Advisory: a transfer omitting one still succeeds.
+func (t cas20Token) updateExpectedMemoFormats(ids []uint64) error {
+	if t.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	if err := t.ensureRole(roleDefaultAdmin); err != nil {
+		return err
+	}
+	if err := ensureFeatureActivated(t.ctx, featureMemoRegistry); err != nil {
+		return err
+	}
+	if len(ids) > cas20MemoMaxFields {
+		return revCAS20("BatchSizeTooLarge(uint256)", errSelBatchTooLarge, wU64(cas20MemoMaxFields))
+	}
+	reg := newMemoReg(t.ctx)
+	for _, id := range ids {
+		if !reg.formatExists(id) {
+			return revCAS20("FormatNotFound(uint64)", errSelFormatNotFound, wU64(id))
+		}
+	}
+	t.s.setU64ArrayAt(slotAt(cas20SlotExpectedMemoFormats), ids)
+	if !t.ctx.AddLog([]common.Hash{cas20TopicExpectedMemoFormatsUpdated, addrKey(t.ctx.Caller)},
+		encodeTuple(abiWordArray(u64Words(ids)))) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func (t cas20Token) emitMemoFormats(memo common.Hash, ids []uint64) bool {
+	return t.ctx.AddLog([]common.Hash{cas20TopicMemoFormatsDeclared, memo}, encodeTuple(abiWordArray(u64Words(ids))))
+}
+
+func u64Words(ids []uint64) []common.Hash {
+	words := make([]common.Hash, len(ids))
+	for i, id := range ids {
+		words[i] = wU64(id)
+	}
+	return words
+}
+
+// readU64Array decodes a uint64[] strictly: every element's high 24 bytes must be zero.
+func readU64Array(args []byte, argIndex int) ([]uint64, error) {
+	words, err := readWordArray(args, argIndex)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]uint64, len(words))
+	for i, w := range words {
+		v, ok := u64FromWord(w)
+		if !ok {
+			return nil, ErrExecutionReverted
+		}
+		out[i] = v
+	}
+	return out, nil
+}

--- a/core/vm/cas20_memo_test.go
+++ b/core/vm/cas20_memo_test.go
@@ -1,0 +1,279 @@
+package vm
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/holiman/uint256"
+)
+
+// selector ++ static words ++ one trailing uint64[] (offset, length, elements).
+func withU64Array(sel [4]byte, static []common.Hash, ids []uint64) []byte {
+	out := append([]byte{}, sel[:]...)
+	for _, w := range static {
+		out = append(out, w.Bytes()...)
+	}
+	out = append(out, u256hash(uint64(32*(len(static)+1))).Bytes()...)
+	out = append(out, u256hash(uint64(len(ids))).Bytes()...)
+	for _, id := range ids {
+		out = append(out, u256hash(id).Bytes()...)
+	}
+	return out
+}
+
+// createMemoFormat(uint8 category, (uint16,uint16,uint8,bool)[] fields).
+func encodeCreateMemoFormat(category uint64, fields []memoFieldSpec) []byte {
+	out := append([]byte{}, selCreateMemoFormat[:]...)
+	out = append(out, u256hash(category).Bytes()...)
+	out = append(out, u256hash(0x40).Bytes()...)
+	out = append(out, u256hash(uint64(len(fields))).Bytes()...)
+	for _, f := range fields {
+		out = append(out, u256hash(uint64(f.offset)).Bytes()...)
+		out = append(out, u256hash(uint64(f.length)).Bytes()...)
+		out = append(out, u256hash(uint64(f.kind)).Bytes()...)
+		out = append(out, encBool(f.required)...)
+	}
+	return out
+}
+
+// The Travel Rule layout from the proposal: four fields, 164 bytes.
+var travelRuleFields = []memoFieldSpec{
+	{0, 70, 0, true}, {70, 20, 1, true}, {90, 70, 0, true}, {160, 4, 3, false},
+}
+
+func TestCAS20MemoFormatRegistry(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	reg := CAS20MemoFormatRegistryAddress
+	creator := common.HexToAddress("0xc0ffee")
+	call := func(caller common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, reg, input, NewGasBudget(2_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	sel := func(input []byte, want [4]byte) bool { return len(input) >= 4 && [4]byte(input[:4]) == want }
+
+	// UNSTRUCTURED exists before anything is created, and reads as an empty layout.
+	if ret, _ := call(creator, cas20Call(selFormatExists, u256hash(0))); !bytes.Equal(ret, encBool(true)) {
+		t.Fatal("format 0 must exist from the start")
+	}
+	if ret, err := call(creator, cas20Call(selGetMemoFormat, u256hash(0))); err != nil ||
+		!bytes.Equal(ret, encodeTuple(abiPart{dynamic: true, tail: u256hash(0).Bytes()}, abiWord(common.Hash{}), abiWord(common.Hash{}))) {
+		t.Fatalf("getMemoFormat(0) = %x, %v; want an empty layout", ret, err)
+	}
+	if ret, _ := call(creator, cas20Call(selFormatExists, u256hash(1))); !bytes.Equal(ret, encBool(false)) {
+		t.Fatal("INTERNAL#1 must not exist before creation")
+	}
+
+	// Creation mints TRAVEL_RULE#1 and records the layout.
+	statedb.SetTxContext(common.HexToHash("0x7a"), 0)
+	ret, err := call(creator, encodeCreateMemoFormat(memoCategoryTravelRule, travelRuleFields))
+	if err != nil {
+		t.Fatalf("createMemoFormat: %v", err)
+	}
+	want := uint64(memoCategoryTravelRule)<<56 | 1
+	if got := new(uint256.Int).SetBytes(ret).Uint64(); got != want {
+		t.Fatalf("formatId = %x, want %x", got, want)
+	}
+	logs := statedb.GetLogs(common.HexToHash("0x7a"), 1, common.Hash{}, 1)
+	if len(logs) != 1 || logs[0].Topics[0] != cas20TopicMemoFormatCreated || logs[0].Topics[1] != wU64(want) ||
+		logs[0].Topics[2] != addrKey(creator) || !bytes.Equal(logs[0].Data, wU8(memoCategoryTravelRule).Bytes()) {
+		t.Errorf("MemoFormatCreated log = %+v", logs)
+	}
+	if ret, _ := call(creator, cas20Call(selFormatCount, u256hash(memoCategoryTravelRule))); new(uint256.Int).SetBytes(ret).Uint64() != 1 {
+		t.Errorf("formatCount(TRAVEL_RULE) = %x, want 1", ret)
+	}
+	ret, err = call(creator, cas20Call(selGetMemoFormat, u256hash(want)))
+	if err != nil {
+		t.Fatalf("getMemoFormat: %v", err)
+	}
+	// (fields, totalLen, creator): head offset, totalLen 164, creator; tail 4 fields.
+	if got := new(uint256.Int).SetBytes(ret[32:64]).Uint64(); got != 164 {
+		t.Errorf("totalLen = %d, want 164", got)
+	}
+	if got := common.BytesToAddress(ret[64:96]); got != creator {
+		t.Errorf("creator = %s, want %s", got, creator)
+	}
+	if n := new(uint256.Int).SetBytes(ret[96:128]).Uint64(); n != 4 {
+		t.Fatalf("field count = %d, want 4", n)
+	}
+	for i, f := range travelRuleFields {
+		e := ret[128+i*128:]
+		if new(uint256.Int).SetBytes(e[:32]).Uint64() != uint64(f.offset) || new(uint256.Int).SetBytes(e[32:64]).Uint64() != uint64(f.length) ||
+			e[95] != f.kind || (e[127] == 1) != f.required {
+			t.Errorf("field %d = %x, want %+v", i, e[:128], f)
+		}
+	}
+
+	// Ids are sequential within a category, and INTERNAL starts at 1 because 0 is taken.
+	ret, _ = call(creator, encodeCreateMemoFormat(memoCategoryTravelRule, travelRuleFields[:1]))
+	if got := new(uint256.Int).SetBytes(ret).Uint64(); got != want+1 {
+		t.Errorf("second TRAVEL_RULE id = %x, want %x", got, want+1)
+	}
+	ret, _ = call(creator, encodeCreateMemoFormat(memoCategoryInternal, travelRuleFields[:1]))
+	if got := new(uint256.Int).SetBytes(ret).Uint64(); got != 1 {
+		t.Errorf("first INTERNAL id = %x, want 1", got)
+	}
+
+	// Errors, in check order: category, then the fields.
+	for _, tc := range []struct {
+		name  string
+		input []byte
+		want  [4]byte
+	}{
+		{"category past GOV", encodeCreateMemoFormat(4, travelRuleFields), errSelInvalidCategory},
+		{"no fields", encodeCreateMemoFormat(memoCategoryISO, nil), errSelInvalidFieldCount},
+		{"zero-length field", encodeCreateMemoFormat(memoCategoryISO, []memoFieldSpec{{0, 0, 0, true}}), errSelInvalidFieldSpec},
+		{"field past 65535", encodeCreateMemoFormat(memoCategoryISO, []memoFieldSpec{{0xfff0, 0x20, 0, true}}), errSelInvalidFieldSpec},
+		{"kind past BYTES", encodeCreateMemoFormat(memoCategoryISO, []memoFieldSpec{{0, 1, 5, true}}), errSelInvalidFieldSpec},
+		{"unknown id", cas20Call(selGetMemoFormat, u256hash(1<<56|9)), errSelFormatNotFound},
+	} {
+		ret, err := call(creator, tc.input)
+		if !errors.Is(err, ErrExecutionReverted) || !sel(ret, tc.want) {
+			t.Errorf("%s: ret %x err %v, want %x", tc.name, ret, err, tc.want)
+		}
+	}
+	// A dirty bool word is a decode failure: empty returndata.
+	dirty := encodeCreateMemoFormat(memoCategoryISO, travelRuleFields[:1])
+	dirty[len(dirty)-1] = 2
+	if ret, err := call(creator, dirty); !errors.Is(err, ErrExecutionReverted) || len(ret) != 0 {
+		t.Errorf("dirty required word: ret %x err %v, want an empty revert", ret, err)
+	}
+	// A static frame is refused before decoding.
+	if ret, _, err := evm.StaticCall(creator, reg, encodeCreateMemoFormat(memoCategoryISO, travelRuleFields), NewGasBudget(2_000_000)); !sel(ret, errSelStaticCallDenied) {
+		t.Errorf("STATICCALL createMemoFormat: ret %x err %v, want StaticCallNotAllowed", ret, err)
+	}
+	// And the feature gate precedes decoding too.
+	act := cas20Storage{state: statedb, token: CAS20ActivationRegistryAddress}
+	act.setWord(mappingSlot(actSlot(actSlotFeatures), featureMemoRegistry), common.Hash{})
+	if ret, err := call(creator, encodeCreateMemoFormat(memoCategoryISO, nil)); !sel(ret, errSelFeatureNotActive) {
+		t.Errorf("closed feature: ret %x err %v, want FeatureNotActivated before InvalidFieldCount", ret, err)
+	}
+}
+
+func TestCAS20TransferWithMemoFormats(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xdec0de")
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(3_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	sel := func(ret []byte, want [4]byte) bool { return len(ret) >= 4 && [4]byte(ret[:4]) == want }
+
+	ret, err := call(creator, CAS20MemoFormatRegistryAddress, encodeCreateMemoFormat(memoCategoryISO, travelRuleFields[:2]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	iso := new(uint256.Int).SetBytes(ret).Uint64()
+	ret, err = call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantStablecoin, common.HexToHash("0x3e0"), creator, [][]byte{
+		cas20Call(selGrantRole, roleMint, addrKey(creator)),
+		cas20Call(selGrantRole, rolePause, addrKey(creator)),
+		cas20Call(selGrantRole, roleUnpause, addrKey(creator)),
+		cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
+	}))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+	view := newUnmeteredCAS20Storage(statedb, token)
+	memo := common.HexToHash("0x1234")
+
+	// The declared transfer: Transfer, Memo, MemoFormatsDeclared, in that order.
+	statedb.SetTxContext(common.HexToHash("0x7b"), 0)
+	if ret, err := call(cas20Alice, token, withU64Array(selTransferWithMemoFormats, []common.Hash{addrKey(cas20Bob), u256hash(40), memo}, []uint64{0, iso})); err != nil || !bytes.Equal(ret, encBool(true)) {
+		t.Fatalf("transferWithMemoFormats: ret %x err %v", ret, err)
+	}
+	if view.balanceOf(cas20Bob).Uint64() != 40 {
+		t.Errorf("bob = %d, want 40", view.balanceOf(cas20Bob).Uint64())
+	}
+	logs := statedb.GetLogs(common.HexToHash("0x7b"), 1, common.Hash{}, 1)
+	if len(logs) != 3 || logs[0].Topics[0] != cas20TopicTransfer || logs[1].Topics[0] != cas20TopicMemo || logs[2].Topics[0] != cas20TopicMemoFormatsDeclared {
+		t.Fatalf("logs = %+v, want Transfer, Memo, MemoFormatsDeclared", logs)
+	}
+	if logs[2].Topics[1] != memo || !bytes.Equal(logs[2].Data, encodeTuple(abiWordArray(u64Words([]uint64{0, iso})))) {
+		t.Errorf("MemoFormatsDeclared = topics %v data %x", logs[2].Topics, logs[2].Data)
+	}
+
+	// The claim is checked for existence and nothing else, before the transfer's own checks.
+	for _, tc := range []struct {
+		name string
+		ids  []uint64
+		want [4]byte
+	}{
+		{"unknown format", []uint64{iso + 7}, errSelFormatNotFound},
+		{"no formats", nil, errSelEmptyBatch},
+	} {
+		ret, err := call(cas20Alice, token, withU64Array(selTransferWithMemoFormats, []common.Hash{addrKey(cas20Bob), u256hash(1), memo}, tc.ids))
+		if !errors.Is(err, ErrExecutionReverted) || !sel(ret, tc.want) {
+			t.Errorf("%s: ret %x err %v, want %x", tc.name, ret, err, tc.want)
+		}
+	}
+	if _, err := call(creator, token, cas20CallU8Array(selPause, byte(cas20PauseTransfer))); err != nil {
+		t.Fatal(err)
+	}
+	if ret, _ := call(cas20Alice, token, withU64Array(selTransferWithMemoFormats, []common.Hash{addrKey(cas20Bob), u256hash(1), memo}, []uint64{iso + 7})); !sel(ret, errSelFormatNotFound) {
+		t.Errorf("paused + unknown format: ret %x, want FormatNotFound (the claim is checked first)", ret)
+	}
+	if ret, _ := call(cas20Alice, token, withU64Array(selTransferWithMemoFormats, []common.Hash{addrKey(cas20Bob), u256hash(1), memo}, []uint64{iso})); !sel(ret, errSelContractPaused) {
+		t.Errorf("paused + known format: ret %x, want ContractPaused", ret)
+	}
+	if _, err := call(creator, token, cas20CallU8Array(selUnpause, byte(cas20PauseTransfer))); err != nil {
+		t.Fatal(err)
+	}
+
+	// transferFrom spends the allowance like its memo counterpart.
+	if _, err := call(cas20Alice, token, cas20Call(selApprove, addrKey(cas20Carol), u256hash(10))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := call(cas20Carol, token, withU64Array(selTransferFromWithMemoFormats, []common.Hash{addrKey(cas20Alice), addrKey(cas20Bob), u256hash(6), memo}, []uint64{iso})); err != nil {
+		t.Fatalf("transferFromWithMemoFormats: %v", err)
+	}
+	if view.allowance(cas20Alice, cas20Carol).Uint64() != 4 || view.balanceOf(cas20Bob).Uint64() != 46 {
+		t.Errorf("allowance %d bob %d, want 4 and 46", view.allowance(cas20Alice, cas20Carol).Uint64(), view.balanceOf(cas20Bob).Uint64())
+	}
+
+	// The issuer's advisory list: admin-gated, existence-checked, shrink clears the tail.
+	if ret, _ := call(cas20Alice, token, withU64Array(selUpdateExpectedMemoFormats, nil, []uint64{iso})); !sel(ret, errSelACUnauthorized) {
+		t.Errorf("stranger updateExpectedMemoFormats: %x, want AccessControlUnauthorizedAccount", ret)
+	}
+	if ret, _ := call(creator, token, withU64Array(selUpdateExpectedMemoFormats, nil, []uint64{iso + 7})); !sel(ret, errSelFormatNotFound) {
+		t.Errorf("unknown expected format: %x, want FormatNotFound", ret)
+	}
+	statedb.SetTxContext(common.HexToHash("0x7c"), 0)
+	five := []uint64{iso, 0, iso, 0, iso}
+	if _, err := call(creator, token, withU64Array(selUpdateExpectedMemoFormats, nil, five)); err != nil {
+		t.Fatal(err)
+	}
+	logs = statedb.GetLogs(common.HexToHash("0x7c"), 1, common.Hash{}, 1)
+	if len(logs) != 1 || logs[0].Topics[0] != cas20TopicExpectedMemoFormatsUpdated || logs[0].Topics[1] != addrKey(creator) {
+		t.Errorf("ExpectedMemoFormatsUpdated log = %+v", logs)
+	}
+	if ret, _ := call(cas20Alice, token, cas20Call(selExpectedMemoFormats)); !bytes.Equal(ret, encodeTuple(abiWordArray(u64Words(five)))) {
+		t.Errorf("expectedMemoFormats = %x, want the five", ret)
+	}
+	if _, err := call(creator, token, withU64Array(selUpdateExpectedMemoFormats, nil, []uint64{iso})); err != nil {
+		t.Fatal(err)
+	}
+	slot := slotAt(cas20SlotExpectedMemoFormats)
+	second := new(uint256.Int).AddUint64(view.stringDataRoot(slot), 1).Bytes32()
+	if got := view.u64ArrayAt(slot, cas20MemoMaxFields); len(got) != 1 || got[0] != iso {
+		t.Errorf("after shrink = %v, want [iso]", got)
+	}
+	if statedb.GetState(token, second) != (common.Hash{}) {
+		t.Error("the second data word survived the shrink")
+	}
+	info, err := CAS20TokenInfoAt(statedb, evm.chainConfig.ChainID, token, evm.Context.Time)
+	if err != nil || len(info.ExpectedMemoFormats) != 1 || uint64(info.ExpectedMemoFormats[0]) != iso {
+		t.Errorf("token info expectedMemoFormats = %v, %v", info.ExpectedMemoFormats, err)
+	}
+}
+
+// The fork hook plants the third sentinel beside the other two.
+func TestCAS20MemoRegistrySentinelPlanted(t *testing.T) {
+	statedb, _ := state.New(common.Hash{}, state.NewDatabaseForTesting())
+	SeedCAS20Activation(statedb)
+	if statedb.GetCodeHash(CAS20MemoFormatRegistryAddress) != cas20MarkerCodeHash {
+		t.Fatal("the MemoFormatRegistry has no sentinel after seeding")
+	}
+}

--- a/core/vm/cas20_metadata.go
+++ b/core/vm/cas20_metadata.go
@@ -1,0 +1,152 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+// CAS20 mutable metadata and the remaining IB20 views. Metadata writes are not
+// pause-gated, and a rename changes the live EIP-712 domain — it emits
+// EIP712DomainChanged and invalidates outstanding permits (BEP-702 3.6).
+
+var (
+	selContractURI       = selector("contractURI()")
+	selUpdateName        = selector("updateName(string)")
+	selUpdateSymbol      = selector("updateSymbol(string)")
+	selUpdateContractURI = selector("updateContractURI(string)")
+	selPausedFeatures    = selector("pausedFeatures()")
+	selSupplyCap         = selector("supplyCap()")
+	selEIP712Domain      = selector("eip712Domain()")
+
+	cas20TopicNameUpdated         = eventTopic("NameUpdated(address,string)")
+	cas20TopicSymbolUpdated       = eventTopic("SymbolUpdated(address,string)")
+	cas20TopicContractURIUpdated  = eventTopic("ContractURIUpdated()")
+	cas20TopicEIP712DomainChanged = eventTopic("EIP712DomainChanged()")
+)
+
+// dispatchMetadata handles the metadata writers and the views that report
+// configuration rather than balances. ok is false when sel is none of them.
+func (t cas20Token) dispatchMetadata(sel [4]byte, args []byte) (ret []byte, err error, ok bool) {
+	switch sel {
+	case selContractURI:
+		v, ok := t.s.contractURI()
+		if !ok {
+			return nil, ErrOutOfGas, true
+		}
+		return encString(v), nil, true
+	case selSupplyCap:
+		return encU256(t.s.supplyCap()), nil, true
+	case selPausedFeatures:
+		return encodeTuple(abiWordArray(t.pausedFeatures())), nil, true
+	case selEIP712Domain:
+		d, ok := t.eip712Domain()
+		if !ok {
+			return nil, ErrOutOfGas, true
+		}
+		return d, nil, true
+
+	// writes (METADATA_ROLE)
+	case selUpdateName:
+		v, err := readStringArg(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, t.updateName(v), true
+	case selUpdateSymbol:
+		v, err := readStringArg(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, t.updateSymbol(v), true
+	case selUpdateContractURI:
+		v, err := readStringArg(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		return nil, t.updateContractURI(v), true
+	}
+	return nil, nil, false
+}
+
+func (t cas20Token) ensureMetadataWrite() error {
+	if t.ctx.ReadOnly {
+		return ErrWriteProtection
+	}
+	return t.ensureRole(roleMetadata)
+}
+
+func (t cas20Token) updateName(v string) error {
+	if err := t.ensureMetadataWrite(); err != nil {
+		return err
+	}
+	if !t.s.setName(v) {
+		return ErrOutOfGas
+	}
+	if !t.ctx.AddLog([]common.Hash{cas20TopicNameUpdated, addrKey(t.ctx.Caller)}, encString(v)) {
+		return ErrOutOfGas
+	}
+	if !t.ctx.AddLog([]common.Hash{cas20TopicEIP712DomainChanged}, nil) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func (t cas20Token) updateSymbol(v string) error {
+	if err := t.ensureMetadataWrite(); err != nil {
+		return err
+	}
+	if !t.s.setSymbol(v) {
+		return ErrOutOfGas
+	}
+	if !t.ctx.AddLog([]common.Hash{cas20TopicSymbolUpdated, addrKey(t.ctx.Caller)}, encString(v)) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func (t cas20Token) updateContractURI(v string) error {
+	if err := t.ensureMetadataWrite(); err != nil {
+		return err
+	}
+	if !t.s.setContractURI(v) {
+		return ErrOutOfGas
+	}
+	if !t.ctx.AddLog([]common.Hash{cas20TopicContractURIUpdated}, nil) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// pausedFeatures lists the set pause bits in ascending order. The bitmask is
+// read once: reporting four features must not cost four SLOADs.
+func (t cas20Token) pausedFeatures() []common.Hash {
+	p := t.s.paused()
+	out := make([]common.Hash, 0, cas20PauseSeize+1)
+	for f := uint(0); f <= cas20PauseSeize; f++ {
+		if new(uint256.Int).Rsh(p, f).Uint64()&1 == 1 {
+			out = append(out, wU8(byte(f)))
+		}
+	}
+	return out
+}
+
+// eip712Domain implements ERC-5267. fields is 0x0f — name, version, chainId
+// and verifyingContract are in use, salt and extensions are not — and matches
+// the four fields domainSeparator actually hashes.
+func (t cas20Token) eip712Domain() ([]byte, bool) {
+	name, ok := t.s.name()
+	if !ok {
+		return nil, false
+	}
+	var fields common.Hash
+	fields[0] = 0x0f // bytes1 sits at the high end of its word
+	return encodeTuple(
+		abiWord(fields),
+		abiString(name),
+		abiString(cas20EIP712Version),
+		abiWord(wU256(t.ctx.ChainID())),
+		abiWord(addrKey(t.ctx.Self)),
+		abiWord(common.Hash{}), // salt: unused
+		abiWordArray(nil),      // extensions: none
+	), true
+}

--- a/core/vm/cas20_metadata.go
+++ b/core/vm/cas20_metadata.go
@@ -5,9 +5,7 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// CAS20 mutable metadata and the remaining IB20 views. Metadata writes are not
-// pause-gated, and a rename changes the live EIP-712 domain — it emits
-// EIP712DomainChanged and invalidates outstanding permits (BEP-702 3.6).
+// Metadata writes are not pause-gated (BEP-702 3.6).
 
 var (
 	selContractURI       = selector("contractURI()")
@@ -24,8 +22,6 @@ var (
 	cas20TopicEIP712DomainChanged = eventTopic("EIP712DomainChanged()")
 )
 
-// dispatchMetadata handles the metadata writers and the views that report
-// configuration rather than balances. ok is false when sel is none of them.
 func (t cas20Token) dispatchMetadata(sel [4]byte, args []byte) (ret []byte, err error, ok bool) {
 	switch sel {
 	case selContractURI:
@@ -45,7 +41,6 @@ func (t cas20Token) dispatchMetadata(sel [4]byte, args []byte) (ret []byte, err 
 		}
 		return d, nil, true
 
-	// writes (METADATA_ROLE)
 	case selUpdateName:
 		v, err := readStringArg(args, 0)
 		if err != nil {
@@ -117,8 +112,6 @@ func (t cas20Token) updateContractURI(v string) error {
 	return nil
 }
 
-// pausedFeatures lists the set pause bits in ascending order. The bitmask is
-// read once: reporting four features must not cost four SLOADs.
 func (t cas20Token) pausedFeatures() []common.Hash {
 	p := t.s.paused()
 	out := make([]common.Hash, 0, cas20PauseSeize+1)
@@ -130,23 +123,21 @@ func (t cas20Token) pausedFeatures() []common.Hash {
 	return out
 }
 
-// eip712Domain implements ERC-5267. fields is 0x0f — name, version, chainId
-// and verifyingContract are in use, salt and extensions are not — and matches
-// the four fields domainSeparator actually hashes.
+// ERC-5267. fields 0x0f names the four members domainSeparator hashes.
 func (t cas20Token) eip712Domain() ([]byte, bool) {
 	name, ok := t.s.name()
 	if !ok {
 		return nil, false
 	}
 	var fields common.Hash
-	fields[0] = 0x0f // bytes1 sits at the high end of its word
+	fields[0] = 0x0f
 	return encodeTuple(
 		abiWord(fields),
 		abiString(name),
 		abiString(cas20EIP712Version),
 		abiWord(wU256(t.ctx.ChainID())),
 		abiWord(addrKey(t.ctx.Self)),
-		abiWord(common.Hash{}), // salt: unused
-		abiWordArray(nil),      // extensions: none
+		abiWord(common.Hash{}),
+		abiWordArray(nil),
 	), true
 }

--- a/core/vm/cas20_metadata_test.go
+++ b/core/vm/cas20_metadata_test.go
@@ -1,0 +1,470 @@
+package vm
+
+import (
+	"bytes"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+func cas20CallString(sel [4]byte, s string) []byte {
+	return append(append([]byte{}, sel[:]...), encString(s)...)
+}
+
+// decodeString reads an ABI-encoded single string return value. It follows the
+// head offset rather than assuming it, and requires the tail to be padded to a
+// word boundary — a helper that skipped those checks would accept payloads a
+// real ABI consumer rejects, and would hide exactly the encoder bugs these
+// tests exist to catch.
+func decodeString(t *testing.T, ret []byte) string {
+	t.Helper()
+	if len(ret) < 64 {
+		t.Fatalf("string return too short: %x", ret)
+	}
+	off := new(uint256.Int).SetBytes(ret[0:32])
+	if !off.Eq(uint256.NewInt(32)) {
+		t.Fatalf("string head offset = %s, want 32: %x", off, ret)
+	}
+	n := new(uint256.Int).SetBytes(ret[32:64]).Uint64()
+	if uint64(len(ret)) != 64+(n+31)/32*32 {
+		t.Fatalf("string tail is %d bytes, want %d for a %d-byte string: %x",
+			len(ret)-64, (n+31)/32*32, n, ret)
+	}
+	return string(ret[64 : 64+n])
+}
+
+func TestCAS20MetadataUpdates(t *testing.T) {
+	admin := common.HexToAddress("0xad4149")
+	editor := common.HexToAddress("0xed170r")
+
+	statedb, token, run := newTokenWithEVM(t, 1, func(s cas20Storage) {
+		s.setName("Test Token")
+		s.setSymbol("TT")
+		s.setRole(roleDefaultAdmin, admin, true)
+		s.setAdminCount(uint256.NewInt(1))
+	})
+	view := newUnmeteredCAS20Storage(statedb, token)
+
+	// A caller without METADATA_ROLE cannot touch any of the three fields.
+	for _, input := range [][]byte{
+		cas20CallString(selUpdateName, "Hijacked"),
+		cas20CallString(selUpdateSymbol, "HJK"),
+		cas20CallString(selUpdateContractURI, "ipfs://hijacked"),
+	} {
+		if _, err := run(editor, input); !errors.Is(err, ErrExecutionReverted) {
+			t.Fatalf("unauthorized metadata write err = %v, want revert", err)
+		}
+	}
+	if got := strOf(view.name()); got != "Test Token" {
+		t.Fatalf("name after refused update = %q, want unchanged", got)
+	}
+
+	if _, err := run(admin, cas20Call(selGrantRole, roleMetadata, addrKey(editor))); err != nil {
+		t.Fatalf("grant METADATA_ROLE: %v", err)
+	}
+
+	// DOMAIN_SEPARATOR is derived from the live name, so renaming must roll it.
+	before, err := run(editor, cas20Call(selDomainSeparator))
+	if err != nil {
+		t.Fatalf("DOMAIN_SEPARATOR: %v", err)
+	}
+
+	if _, err := run(editor, cas20CallString(selUpdateName, "Renamed Token")); err != nil {
+		t.Fatalf("updateName: %v", err)
+	}
+	if _, err := run(editor, cas20CallString(selUpdateSymbol, "RNT")); err != nil {
+		t.Fatalf("updateSymbol: %v", err)
+	}
+	if _, err := run(editor, cas20CallString(selUpdateContractURI, "ipfs://cid")); err != nil {
+		t.Fatalf("updateContractURI: %v", err)
+	}
+
+	if got := strOf(view.name()); got != "Renamed Token" {
+		t.Errorf("name = %q, want Renamed Token", got)
+	}
+	if got := strOf(view.symbol()); got != "RNT" {
+		t.Errorf("symbol = %q, want RNT", got)
+	}
+	ret, err := run(editor, cas20Call(selContractURI))
+	if err != nil {
+		t.Fatalf("contractURI: %v", err)
+	}
+	if got := decodeString(t, ret); got != "ipfs://cid" {
+		t.Errorf("contractURI() = %q, want ipfs://cid", got)
+	}
+
+	after, err := run(editor, cas20Call(selDomainSeparator))
+	if err != nil {
+		t.Fatalf("DOMAIN_SEPARATOR: %v", err)
+	}
+	if bytes.Equal(before, after) {
+		t.Error("DOMAIN_SEPARATOR unchanged after updateName — outstanding permits would stay valid")
+	}
+
+	// A metadata write is still a write: every one is refused in a read-only
+	// frame, not just the first.
+	for _, c := range []struct {
+		what  string
+		input []byte
+	}{
+		{"updateName", cas20CallString(selUpdateName, "Static")},
+		{"updateSymbol", cas20CallString(selUpdateSymbol, "STC")},
+		{"updateContractURI", cas20CallString(selUpdateContractURI, "ipfs://static")},
+	} {
+		gas := NewGasBudget(1_000_000)
+		roCtx := &PrecompileContext{StateDB: statedb, Self: token, Caller: editor, DirectCall: true, ReadOnly: true, gas: &gas}
+		if _, err := newCAS20Token(roCtx, 18).dispatch(c.input); !errors.Is(err, ErrWriteProtection) {
+			t.Errorf("read-only %s err = %v, want write protection", c.what, err)
+		}
+	}
+}
+
+// TestCAS20MetadataDuringBootstrap pins that the metadata writers are reachable
+// from createCAS20's privileged init calls without METADATA_ROLE, which is what
+// lets a creator finish configuring a token before any role holder exists.
+func TestCAS20MetadataDuringBootstrap(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xdec0de")
+
+	input := encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xc0"), creator,
+		[][]byte{cas20CallString(selUpdateName, "Configured")})
+	ret, _, err := evm.Call(creator, CAS20FactoryAddress, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20 with updateName init call: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	view := newUnmeteredCAS20Storage(statedb, token)
+	if got := strOf(view.name()); got != "Configured" {
+		t.Errorf("name = %q, want Configured", got)
+	}
+	// The bypass is the bootstrap window only: it must not outlive creation.
+	if view.hasRole(roleMetadata, creator) {
+		t.Error("creator holds METADATA_ROLE after bootstrap — the bypass leaked into stored state")
+	}
+	gas := NewGasBudget(1_000_000)
+	ctx := &PrecompileContext{evm: evm, StateDB: statedb, Self: token, Caller: creator, DirectCall: true, gas: &gas}
+	if _, err := newCAS20Token(ctx, 18).dispatch(cas20CallString(selUpdateName, "After")); !errors.Is(err, ErrExecutionReverted) {
+		t.Errorf("post-creation updateName err = %v, want revert", err)
+	}
+}
+
+// TestCAS20MetadataEvents pins the log shape of the metadata writers: updateName
+// must also signal the EIP-712 domain change, and updateContractURI carries no
+// argument at all.
+func TestCAS20MetadataEvents(t *testing.T) {
+	editor := common.HexToAddress("0xed170r")
+	statedb, token, run := newTokenWithEVM(t, 1, func(s cas20Storage) {
+		s.setRole(roleMetadata, editor, true)
+	})
+	txHash := common.HexToHash("0xbeef")
+	statedb.SetTxContext(txHash, 0)
+
+	// A name long enough to spill into the string's keccak-derived data region,
+	// so the encoders are exercised past the single-word case.
+	longName := strings.Repeat("Renamed ", 6) // 48 bytes
+	for _, c := range []struct {
+		what  string
+		input []byte
+	}{
+		{"updateName", cas20CallString(selUpdateName, longName)},
+		{"updateSymbol", cas20CallString(selUpdateSymbol, "RNT")},
+		{"updateContractURI", cas20CallString(selUpdateContractURI, "ipfs://cid")},
+	} {
+		if _, err := run(editor, c.input); err != nil {
+			t.Fatalf("%s: %v", c.what, err)
+		}
+	}
+
+	logs := statedb.GetLogs(txHash, 1, common.Hash{}, 1)
+	// Only updateName touches the EIP-712 domain, so exactly four logs in this
+	// order. A spurious EIP712DomainChanged from updateSymbol would break both
+	// the count and the sequence.
+	wantTopics := []common.Hash{
+		cas20TopicNameUpdated, cas20TopicEIP712DomainChanged,
+		cas20TopicSymbolUpdated, cas20TopicContractURIUpdated,
+	}
+	if len(logs) != len(wantTopics) {
+		t.Fatalf("got %d logs, want %d (NameUpdated, EIP712DomainChanged, SymbolUpdated, ContractURIUpdated)",
+			len(logs), len(wantTopics))
+	}
+	// NameUpdated and SymbolUpdated index the account that made the change; the
+	// other two take no arguments.
+	wantIndexed := map[common.Hash]bool{cas20TopicNameUpdated: true, cas20TopicSymbolUpdated: true}
+	for i, want := range wantTopics {
+		if logs[i].Address != token {
+			t.Errorf("log %d address = %s, want the token", i, logs[i].Address.Hex())
+		}
+		topics := 1
+		if wantIndexed[want] {
+			topics = 2
+		}
+		if len(logs[i].Topics) != topics || logs[i].Topics[0] != want {
+			t.Errorf("log %d topics = %v, want %d starting with %s", i, logs[i].Topics, topics, want.Hex())
+			continue
+		}
+		if topics == 2 && logs[i].Topics[1] != addrKey(editor) {
+			t.Errorf("log %d updater = %s, want %s", i, logs[i].Topics[1].Hex(), addrKey(editor).Hex())
+		}
+	}
+	if got := decodeString(t, logs[0].Data); got != longName {
+		t.Errorf("NameUpdated data = %q, want %q", got, longName)
+	}
+	if len(logs[1].Data) != 0 {
+		t.Errorf("EIP712DomainChanged data = %x, want empty", logs[1].Data)
+	}
+	if got := decodeString(t, logs[2].Data); got != "RNT" {
+		t.Errorf("SymbolUpdated data = %q, want RNT", got)
+	}
+	if len(logs[3].Data) != 0 {
+		t.Errorf("ContractURIUpdated data = %x, want empty", logs[3].Data)
+	}
+}
+
+// TestCAS20PausedFeaturesAndSupplyCap covers the two configuration views and the
+// SupplyCapUpdated / Paused log payloads. The uint8[] encodings are written out
+// word by word rather than produced by the encoder under test.
+func TestCAS20PausedFeaturesAndSupplyCap(t *testing.T) {
+	admin := common.HexToAddress("0xad4149")
+	statedb, _, run := newTokenWithEVM(t, 1, func(s cas20Storage) {
+		s.setRole(roleDefaultAdmin, admin, true)
+		s.setRole(rolePause, admin, true)
+		s.setRole(roleUnpause, admin, true)
+		s.setAdminCount(uint256.NewInt(1))
+		s.setSupplyCap(uint256.NewInt(1000))
+	})
+	txHash := common.HexToHash("0xfeed")
+	statedb.SetTxContext(txHash, 0)
+
+	ret, err := run(admin, cas20Call(selSupplyCap))
+	if err != nil {
+		t.Fatalf("supplyCap: %v", err)
+	}
+	if got := new(uint256.Int).SetBytes(ret).Uint64(); got != 1000 {
+		t.Errorf("supplyCap() = %d, want 1000", got)
+	}
+
+	// No feature paused yet: an empty uint8[] is offset ++ zero length.
+	ret, err = run(admin, cas20Call(selPausedFeatures))
+	if err != nil {
+		t.Fatalf("pausedFeatures: %v", err)
+	}
+	wantEmpty := append(u256hash(0x20).Bytes(), u256hash(0).Bytes()...)
+	if !bytes.Equal(ret, wantEmpty) {
+		t.Errorf("pausedFeatures() = %x, want %x", ret, wantEmpty)
+	}
+
+	// Pause SEIZE, BURN and TRANSFER. SEIZE is the highest feature id, so
+	// including it pins the scan's upper bound; the report comes back ordered by
+	// feature id, not in the order they were requested.
+	if _, err := run(admin, cas20CallU8Array(selPause, byte(cas20PauseSeize), byte(cas20PauseBurn), byte(cas20PauseTransfer))); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	ret, err = run(admin, cas20Call(selPausedFeatures))
+	if err != nil {
+		t.Fatalf("pausedFeatures: %v", err)
+	}
+	want := append([]byte{}, u256hash(0x20).Bytes()...)
+	want = append(want, u256hash(3).Bytes()...)
+	want = append(want, u256hash(uint64(cas20PauseTransfer)).Bytes()...)
+	want = append(want, u256hash(uint64(cas20PauseBurn)).Bytes()...)
+	want = append(want, u256hash(uint64(cas20PauseSeize)).Bytes()...)
+	if !bytes.Equal(ret, want) {
+		t.Errorf("pausedFeatures() = %x, want %x", ret, want)
+	}
+
+	// Unpause SEIZE only: the remaining two must stay set, and the log must be
+	// Unpaused rather than Paused.
+	if _, err := run(admin, cas20CallU8Array(selUnpause, byte(cas20PauseSeize))); err != nil {
+		t.Fatalf("unpause: %v", err)
+	}
+	ret, err = run(admin, cas20Call(selPausedFeatures))
+	if err != nil {
+		t.Fatalf("pausedFeatures: %v", err)
+	}
+	want = append([]byte{}, u256hash(0x20).Bytes()...)
+	want = append(want, u256hash(2).Bytes()...)
+	want = append(want, u256hash(uint64(cas20PauseTransfer)).Bytes()...)
+	want = append(want, u256hash(uint64(cas20PauseBurn)).Bytes()...)
+	if !bytes.Equal(ret, want) {
+		t.Errorf("pausedFeatures() after unpause = %x, want %x", ret, want)
+	}
+
+	if _, err := run(admin, cas20Call(selUpdateSupplyCap, u256hash(5000))); err != nil {
+		t.Fatalf("updateSupplyCap: %v", err)
+	}
+	// Read the cap back: emitting SupplyCapUpdated is not evidence the cap moved.
+	ret, err = run(admin, cas20Call(selSupplyCap))
+	if err != nil {
+		t.Fatalf("supplyCap: %v", err)
+	}
+	if got := new(uint256.Int).SetBytes(ret).Uint64(); got != 5000 {
+		t.Errorf("supplyCap() after update = %d, want 5000", got)
+	}
+
+	// ALWAYS_BLOCK is a sentinel id, so binding it needs no registry entry.
+	if _, err := run(admin, cas20Call(selUpdatePolicy, scopeTransferSender, wU64(cas20PolicyAlwaysBlock))); err != nil {
+		t.Fatalf("updatePolicy: %v", err)
+	}
+	// Same again: the binding must be observable, not just logged.
+	ret, err = run(admin, cas20Call(selPolicyId, scopeTransferSender))
+	if err != nil {
+		t.Fatalf("policyId: %v", err)
+	}
+	if got := new(uint256.Int).SetBytes(ret).Uint64(); got != cas20PolicyAlwaysBlock {
+		t.Errorf("policyId(TRANSFER_SENDER) = %d, want %d", got, cas20PolicyAlwaysBlock)
+	}
+
+	logs := statedb.GetLogs(txHash, 1, common.Hash{}, 1)
+	if len(logs) != 4 {
+		t.Fatalf("got %d logs, want 4 (Paused, Unpaused, SupplyCapUpdated, PolicyUpdated)", len(logs))
+	}
+	// Paused(address indexed updater, uint8[] features): the payload echoes the
+	// requested order, so it stays a record of the action rather than of state.
+	if len(logs[0].Topics) != 2 || logs[0].Topics[0] != cas20TopicPaused || logs[0].Topics[1] != addrKey(admin) {
+		t.Errorf("Paused topics = %v, want [Paused, admin]", logs[0].Topics)
+	}
+	wantPaused := append([]byte{}, u256hash(0x20).Bytes()...)
+	wantPaused = append(wantPaused, u256hash(3).Bytes()...)
+	wantPaused = append(wantPaused, u256hash(uint64(cas20PauseSeize)).Bytes()...)
+	wantPaused = append(wantPaused, u256hash(uint64(cas20PauseBurn)).Bytes()...)
+	wantPaused = append(wantPaused, u256hash(uint64(cas20PauseTransfer)).Bytes()...)
+	if !bytes.Equal(logs[0].Data, wantPaused) {
+		t.Errorf("Paused data = %x, want %x", logs[0].Data, wantPaused)
+	}
+	// Unpaused carries its own topic0 and the single feature it released.
+	if len(logs[1].Topics) != 2 || logs[1].Topics[0] != cas20TopicUnpaused || logs[1].Topics[1] != addrKey(admin) {
+		t.Errorf("Unpaused topics = %v, want [Unpaused, admin]", logs[1].Topics)
+	}
+	wantUnpaused := append([]byte{}, u256hash(0x20).Bytes()...)
+	wantUnpaused = append(wantUnpaused, u256hash(1).Bytes()...)
+	wantUnpaused = append(wantUnpaused, u256hash(uint64(cas20PauseSeize)).Bytes()...)
+	if !bytes.Equal(logs[1].Data, wantUnpaused) {
+		t.Errorf("Unpaused data = %x, want %x", logs[1].Data, wantUnpaused)
+	}
+	// SupplyCapUpdated(address indexed updater, uint256 previousCap, uint256 newCap).
+	if len(logs[2].Topics) != 2 || logs[2].Topics[0] != cas20TopicSupplyCapUpdated ||
+		logs[2].Topics[1] != addrKey(admin) {
+		t.Errorf("SupplyCapUpdated topics = %v, want [sig, updater %s]", logs[2].Topics, admin.Hex())
+	}
+	wantCap := append(u256hash(1000).Bytes(), u256hash(5000).Bytes()...)
+	if !bytes.Equal(logs[2].Data, wantCap) {
+		t.Errorf("SupplyCapUpdated data = %x, want %x", logs[2].Data, wantCap)
+	}
+	// PolicyUpdated(bytes32 indexed scope, uint64 oldPolicyId, uint64 newPolicyId).
+	// The old id is what lets an indexer reconstruct a scope's binding history
+	// without replaying every block since creation.
+	if len(logs[3].Topics) != 2 || logs[3].Topics[0] != cas20TopicPolicyUpdated || logs[3].Topics[1] != scopeTransferSender {
+		t.Errorf("PolicyUpdated topics = %v, want [PolicyUpdated, TRANSFER_SENDER]", logs[3].Topics)
+	}
+	wantPolicy := append(wU64(0).Bytes(), wU64(cas20PolicyAlwaysBlock).Bytes()...)
+	if !bytes.Equal(logs[3].Data, wantPolicy) {
+		t.Errorf("PolicyUpdated data = %x, want %x (unbound -> ALWAYS_BLOCK)", logs[3].Data, wantPolicy)
+	}
+}
+
+// TestCAS20EIP712DomainEncoding pins eip712Domain() against a byte vector built
+// by hand. The return is a 7-member tuple with three dynamic members, and an
+// encoder mistake in the head/tail split would be invisible to a test that
+// produced the expectation with the same encoder.
+func TestCAS20EIP712DomainEncoding(t *testing.T) {
+	_, token, run := newTokenWithEVM(t, 1, func(s cas20Storage) {
+		s.setName("Tok")
+	})
+
+	ret, err := run(cas20Alice, cas20Call(selEIP712Domain))
+	if err != nil {
+		t.Fatalf("eip712Domain: %v", err)
+	}
+
+	chainID, _ := uint256.FromBig(params.TestChainConfig.ChainID)
+	pad := func(s string) []byte {
+		out := make([]byte, 32)
+		copy(out, s)
+		return out
+	}
+	// Head is 7 words (224 bytes); the tails follow in declaration order:
+	// name at 224, version at 224+64=288, extensions at 288+64=352.
+	var want []byte
+	want = append(want, common.Hash{0: 0x0f}.Bytes()...) // bytes1 fields, left-aligned
+	want = append(want, u256hash(224).Bytes()...)        // -> name
+	want = append(want, u256hash(288).Bytes()...)        // -> version
+	want = append(want, common.Hash(chainID.Bytes32()).Bytes()...)
+	want = append(want, addrKey(token).Bytes()...)
+	want = append(want, common.Hash{}.Bytes()...)   // salt: unused
+	want = append(want, u256hash(352).Bytes()...)   // -> extensions
+	want = append(want, u256hash(3).Bytes()...)     // len("Tok")
+	want = append(want, pad("Tok")...)              //
+	want = append(want, u256hash(1).Bytes()...)     // len("1")
+	want = append(want, pad(cas20EIP712Version)...) //
+	want = append(want, u256hash(0).Bytes()...)     // extensions: empty
+
+	if !bytes.Equal(ret, want) {
+		t.Fatalf("eip712Domain() =\n%x\nwant\n%x", ret, want)
+	}
+}
+
+// TestCAS20ABIEncodingOracle re-checks the two non-trivial new encodings against
+// go-ethereum's own ABI packer. The hand-built vectors above pin the layout and
+// this pins conformance: a shared mistake between the CAS20 encoder and my
+// reading of the spec survives the first check but not the second.
+func TestCAS20ABIEncodingOracle(t *testing.T) {
+	mustType := func(s string) abi.Type {
+		t.Helper()
+		ty, err := abi.NewType(s, "", nil)
+		if err != nil {
+			t.Fatalf("NewType(%s): %v", s, err)
+		}
+		return ty
+	}
+
+	// eip712Domain(): a 7-member tuple with three dynamic members. Both a
+	// single-word name and one spanning several words, since a name longer than
+	// 32 bytes moves the version and extensions tails — a fixed-size tail
+	// assumption survives the short case.
+	domainArgs := abi.Arguments{
+		{Type: mustType("bytes1")}, {Type: mustType("string")}, {Type: mustType("string")},
+		{Type: mustType("uint256")}, {Type: mustType("address")}, {Type: mustType("bytes32")},
+		{Type: mustType("uint256[]")},
+	}
+	for _, name := range []string{"Tok", strings.Repeat("Long Name ", 7)} {
+		_, token, run := newTokenWithEVM(t, 1, func(s cas20Storage) { s.setName(name) })
+		got, err := run(cas20Alice, cas20Call(selEIP712Domain))
+		if err != nil {
+			t.Fatalf("eip712Domain(%d-byte name): %v", len(name), err)
+		}
+		want, err := domainArgs.Pack([1]byte{0x0f}, name, cas20EIP712Version,
+			params.TestChainConfig.ChainID, token, [32]byte{}, []*big.Int{})
+		if err != nil {
+			t.Fatalf("pack domain: %v", err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("eip712Domain(%d-byte name)\n got = %x\nwant = %x", len(name), got, want)
+		}
+	}
+
+	// pausedFeatures(): a bare dynamic uint8[].
+	admin := common.HexToAddress("0xad4149")
+	_, _, runPause := newTokenWithEVM(t, 1, func(s cas20Storage) { s.setRole(rolePause, admin, true) })
+	if _, err := runPause(admin, cas20CallU8Array(selPause, byte(cas20PauseSeize), byte(cas20PauseTransfer))); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	got, err := runPause(admin, cas20Call(selPausedFeatures))
+	if err != nil {
+		t.Fatalf("pausedFeatures: %v", err)
+	}
+	arrayArgs := abi.Arguments{{Type: mustType("uint8[]")}}
+	want, err := arrayArgs.Pack([]uint8{uint8(cas20PauseTransfer), uint8(cas20PauseSeize)})
+	if err != nil {
+		t.Fatalf("pack uint8[]: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("pausedFeatures()\n got = %x\nwant = %x", got, want)
+	}
+}

--- a/core/vm/cas20_metadata_test.go
+++ b/core/vm/cas20_metadata_test.go
@@ -17,11 +17,8 @@ func cas20CallString(sel [4]byte, s string) []byte {
 	return append(append([]byte{}, sel[:]...), encString(s)...)
 }
 
-// decodeString reads an ABI-encoded single string return value. It follows the
-// head offset rather than assuming it, and requires the tail to be padded to a
-// word boundary — a helper that skipped those checks would accept payloads a
-// real ABI consumer rejects, and would hide exactly the encoder bugs these
-// tests exist to catch.
+// decodeString follows the head offset and requires word padding, as a real ABI
+// consumer would; a laxer helper would hide the encoder bugs these tests exist for.
 func decodeString(t *testing.T, ret []byte) string {
 	t.Helper()
 	if len(ret) < 64 {
@@ -51,7 +48,6 @@ func TestCAS20MetadataUpdates(t *testing.T) {
 	})
 	view := newUnmeteredCAS20Storage(statedb, token)
 
-	// A caller without METADATA_ROLE cannot touch any of the three fields.
 	for _, input := range [][]byte{
 		cas20CallString(selUpdateName, "Hijacked"),
 		cas20CallString(selUpdateSymbol, "HJK"),
@@ -69,7 +65,6 @@ func TestCAS20MetadataUpdates(t *testing.T) {
 		t.Fatalf("grant METADATA_ROLE: %v", err)
 	}
 
-	// DOMAIN_SEPARATOR is derived from the live name, so renaming must roll it.
 	before, err := run(editor, cas20Call(selDomainSeparator))
 	if err != nil {
 		t.Fatalf("DOMAIN_SEPARATOR: %v", err)
@@ -107,8 +102,6 @@ func TestCAS20MetadataUpdates(t *testing.T) {
 		t.Error("DOMAIN_SEPARATOR unchanged after updateName — outstanding permits would stay valid")
 	}
 
-	// A metadata write is still a write: every one is refused in a read-only
-	// frame, not just the first.
 	for _, c := range []struct {
 		what  string
 		input []byte
@@ -125,9 +118,6 @@ func TestCAS20MetadataUpdates(t *testing.T) {
 	}
 }
 
-// TestCAS20MetadataDuringBootstrap pins that the metadata writers are reachable
-// from createCAS20's privileged init calls without METADATA_ROLE, which is what
-// lets a creator finish configuring a token before any role holder exists.
 func TestCAS20MetadataDuringBootstrap(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xdec0de")
@@ -144,7 +134,6 @@ func TestCAS20MetadataDuringBootstrap(t *testing.T) {
 	if got := strOf(view.name()); got != "Configured" {
 		t.Errorf("name = %q, want Configured", got)
 	}
-	// The bypass is the bootstrap window only: it must not outlive creation.
 	if view.hasRole(roleMetadata, creator) {
 		t.Error("creator holds METADATA_ROLE after bootstrap — the bypass leaked into stored state")
 	}
@@ -155,9 +144,6 @@ func TestCAS20MetadataDuringBootstrap(t *testing.T) {
 	}
 }
 
-// TestCAS20MetadataEvents pins the log shape of the metadata writers: updateName
-// must also signal the EIP-712 domain change, and updateContractURI carries no
-// argument at all.
 func TestCAS20MetadataEvents(t *testing.T) {
 	editor := common.HexToAddress("0xed170r")
 	statedb, token, run := newTokenWithEVM(t, 1, func(s cas20Storage) {
@@ -166,8 +152,7 @@ func TestCAS20MetadataEvents(t *testing.T) {
 	txHash := common.HexToHash("0xbeef")
 	statedb.SetTxContext(txHash, 0)
 
-	// A name long enough to spill into the string's keccak-derived data region,
-	// so the encoders are exercised past the single-word case.
+	// Long enough to spill past the single-word case.
 	longName := strings.Repeat("Renamed ", 6) // 48 bytes
 	for _, c := range []struct {
 		what  string
@@ -183,9 +168,6 @@ func TestCAS20MetadataEvents(t *testing.T) {
 	}
 
 	logs := statedb.GetLogs(txHash, 1, common.Hash{}, 1)
-	// Only updateName touches the EIP-712 domain, so exactly four logs in this
-	// order. A spurious EIP712DomainChanged from updateSymbol would break both
-	// the count and the sequence.
 	wantTopics := []common.Hash{
 		cas20TopicNameUpdated, cas20TopicEIP712DomainChanged,
 		cas20TopicSymbolUpdated, cas20TopicContractURIUpdated,
@@ -194,8 +176,6 @@ func TestCAS20MetadataEvents(t *testing.T) {
 		t.Fatalf("got %d logs, want %d (NameUpdated, EIP712DomainChanged, SymbolUpdated, ContractURIUpdated)",
 			len(logs), len(wantTopics))
 	}
-	// NameUpdated and SymbolUpdated index the account that made the change; the
-	// other two take no arguments.
 	wantIndexed := map[common.Hash]bool{cas20TopicNameUpdated: true, cas20TopicSymbolUpdated: true}
 	for i, want := range wantTopics {
 		if logs[i].Address != token {
@@ -227,9 +207,7 @@ func TestCAS20MetadataEvents(t *testing.T) {
 	}
 }
 
-// TestCAS20PausedFeaturesAndSupplyCap covers the two configuration views and the
-// SupplyCapUpdated / Paused log payloads. The uint8[] encodings are written out
-// word by word rather than produced by the encoder under test.
+// The uint8[] expectations are written out word by word, not produced by the encoder under test.
 func TestCAS20PausedFeaturesAndSupplyCap(t *testing.T) {
 	admin := common.HexToAddress("0xad4149")
 	statedb, _, run := newTokenWithEVM(t, 1, func(s cas20Storage) {
@@ -250,7 +228,6 @@ func TestCAS20PausedFeaturesAndSupplyCap(t *testing.T) {
 		t.Errorf("supplyCap() = %d, want 1000", got)
 	}
 
-	// No feature paused yet: an empty uint8[] is offset ++ zero length.
 	ret, err = run(admin, cas20Call(selPausedFeatures))
 	if err != nil {
 		t.Fatalf("pausedFeatures: %v", err)
@@ -260,9 +237,7 @@ func TestCAS20PausedFeaturesAndSupplyCap(t *testing.T) {
 		t.Errorf("pausedFeatures() = %x, want %x", ret, wantEmpty)
 	}
 
-	// Pause SEIZE, BURN and TRANSFER. SEIZE is the highest feature id, so
-	// including it pins the scan's upper bound; the report comes back ordered by
-	// feature id, not in the order they were requested.
+	// SEIZE pins the scan's upper bound; the report is ordered by id, not by request.
 	if _, err := run(admin, cas20CallU8Array(selPause, byte(cas20PauseSeize), byte(cas20PauseBurn), byte(cas20PauseTransfer))); err != nil {
 		t.Fatalf("pause: %v", err)
 	}
@@ -279,8 +254,6 @@ func TestCAS20PausedFeaturesAndSupplyCap(t *testing.T) {
 		t.Errorf("pausedFeatures() = %x, want %x", ret, want)
 	}
 
-	// Unpause SEIZE only: the remaining two must stay set, and the log must be
-	// Unpaused rather than Paused.
 	if _, err := run(admin, cas20CallU8Array(selUnpause, byte(cas20PauseSeize))); err != nil {
 		t.Fatalf("unpause: %v", err)
 	}
@@ -299,7 +272,6 @@ func TestCAS20PausedFeaturesAndSupplyCap(t *testing.T) {
 	if _, err := run(admin, cas20Call(selUpdateSupplyCap, u256hash(5000))); err != nil {
 		t.Fatalf("updateSupplyCap: %v", err)
 	}
-	// Read the cap back: emitting SupplyCapUpdated is not evidence the cap moved.
 	ret, err = run(admin, cas20Call(selSupplyCap))
 	if err != nil {
 		t.Fatalf("supplyCap: %v", err)
@@ -308,11 +280,9 @@ func TestCAS20PausedFeaturesAndSupplyCap(t *testing.T) {
 		t.Errorf("supplyCap() after update = %d, want 5000", got)
 	}
 
-	// ALWAYS_BLOCK is a sentinel id, so binding it needs no registry entry.
 	if _, err := run(admin, cas20Call(selUpdatePolicy, scopeTransferSender, wU64(cas20PolicyAlwaysBlock))); err != nil {
 		t.Fatalf("updatePolicy: %v", err)
 	}
-	// Same again: the binding must be observable, not just logged.
 	ret, err = run(admin, cas20Call(selPolicyId, scopeTransferSender))
 	if err != nil {
 		t.Fatalf("policyId: %v", err)
@@ -325,8 +295,7 @@ func TestCAS20PausedFeaturesAndSupplyCap(t *testing.T) {
 	if len(logs) != 4 {
 		t.Fatalf("got %d logs, want 4 (Paused, Unpaused, SupplyCapUpdated, PolicyUpdated)", len(logs))
 	}
-	// Paused(address indexed updater, uint8[] features): the payload echoes the
-	// requested order, so it stays a record of the action rather than of state.
+	// The payload echoes the requested order: a record of the action, not of state.
 	if len(logs[0].Topics) != 2 || logs[0].Topics[0] != cas20TopicPaused || logs[0].Topics[1] != addrKey(admin) {
 		t.Errorf("Paused topics = %v, want [Paused, admin]", logs[0].Topics)
 	}
@@ -338,7 +307,6 @@ func TestCAS20PausedFeaturesAndSupplyCap(t *testing.T) {
 	if !bytes.Equal(logs[0].Data, wantPaused) {
 		t.Errorf("Paused data = %x, want %x", logs[0].Data, wantPaused)
 	}
-	// Unpaused carries its own topic0 and the single feature it released.
 	if len(logs[1].Topics) != 2 || logs[1].Topics[0] != cas20TopicUnpaused || logs[1].Topics[1] != addrKey(admin) {
 		t.Errorf("Unpaused topics = %v, want [Unpaused, admin]", logs[1].Topics)
 	}
@@ -348,7 +316,6 @@ func TestCAS20PausedFeaturesAndSupplyCap(t *testing.T) {
 	if !bytes.Equal(logs[1].Data, wantUnpaused) {
 		t.Errorf("Unpaused data = %x, want %x", logs[1].Data, wantUnpaused)
 	}
-	// SupplyCapUpdated(address indexed updater, uint256 previousCap, uint256 newCap).
 	if len(logs[2].Topics) != 2 || logs[2].Topics[0] != cas20TopicSupplyCapUpdated ||
 		logs[2].Topics[1] != addrKey(admin) {
 		t.Errorf("SupplyCapUpdated topics = %v, want [sig, updater %s]", logs[2].Topics, admin.Hex())
@@ -357,9 +324,6 @@ func TestCAS20PausedFeaturesAndSupplyCap(t *testing.T) {
 	if !bytes.Equal(logs[2].Data, wantCap) {
 		t.Errorf("SupplyCapUpdated data = %x, want %x", logs[2].Data, wantCap)
 	}
-	// PolicyUpdated(bytes32 indexed scope, uint64 oldPolicyId, uint64 newPolicyId).
-	// The old id is what lets an indexer reconstruct a scope's binding history
-	// without replaying every block since creation.
 	if len(logs[3].Topics) != 2 || logs[3].Topics[0] != cas20TopicPolicyUpdated || logs[3].Topics[1] != scopeTransferSender {
 		t.Errorf("PolicyUpdated topics = %v, want [PolicyUpdated, TRANSFER_SENDER]", logs[3].Topics)
 	}
@@ -369,10 +333,8 @@ func TestCAS20PausedFeaturesAndSupplyCap(t *testing.T) {
 	}
 }
 
-// TestCAS20EIP712DomainEncoding pins eip712Domain() against a byte vector built
-// by hand. The return is a 7-member tuple with three dynamic members, and an
-// encoder mistake in the head/tail split would be invisible to a test that
-// produced the expectation with the same encoder.
+// A hand-built vector: a head/tail mistake would be invisible to an expectation
+// produced by the same encoder.
 func TestCAS20EIP712DomainEncoding(t *testing.T) {
 	_, token, run := newTokenWithEVM(t, 1, func(s cas20Storage) {
 		s.setName("Tok")
@@ -389,8 +351,7 @@ func TestCAS20EIP712DomainEncoding(t *testing.T) {
 		copy(out, s)
 		return out
 	}
-	// Head is 7 words (224 bytes); the tails follow in declaration order:
-	// name at 224, version at 224+64=288, extensions at 288+64=352.
+	// Head 7 words; tails at 224 (name), 288 (version), 352 (extensions).
 	var want []byte
 	want = append(want, common.Hash{0: 0x0f}.Bytes()...) // bytes1 fields, left-aligned
 	want = append(want, u256hash(224).Bytes()...)        // -> name
@@ -410,10 +371,7 @@ func TestCAS20EIP712DomainEncoding(t *testing.T) {
 	}
 }
 
-// TestCAS20ABIEncodingOracle re-checks the two non-trivial new encodings against
-// go-ethereum's own ABI packer. The hand-built vectors above pin the layout and
-// this pins conformance: a shared mistake between the CAS20 encoder and my
-// reading of the spec survives the first check but not the second.
+// Against go-ethereum's packer: the hand-built vectors pin the layout, this pins conformance.
 func TestCAS20ABIEncodingOracle(t *testing.T) {
 	mustType := func(s string) abi.Type {
 		t.Helper()
@@ -424,10 +382,7 @@ func TestCAS20ABIEncodingOracle(t *testing.T) {
 		return ty
 	}
 
-	// eip712Domain(): a 7-member tuple with three dynamic members. Both a
-	// single-word name and one spanning several words, since a name longer than
-	// 32 bytes moves the version and extensions tails — a fixed-size tail
-	// assumption survives the short case.
+	// A name past 32 bytes moves the later tails; a fixed-size assumption survives the short case.
 	domainArgs := abi.Arguments{
 		{Type: mustType("bytes1")}, {Type: mustType("string")}, {Type: mustType("string")},
 		{Type: mustType("uint256")}, {Type: mustType("address")}, {Type: mustType("bytes32")},
@@ -449,7 +404,6 @@ func TestCAS20ABIEncodingOracle(t *testing.T) {
 		}
 	}
 
-	// pausedFeatures(): a bare dynamic uint8[].
 	admin := common.HexToAddress("0xad4149")
 	_, _, runPause := newTokenWithEVM(t, 1, func(s cas20Storage) { s.setRole(rolePause, admin, true) })
 	if _, err := runPause(admin, cas20CallU8Array(selPause, byte(cas20PauseSeize), byte(cas20PauseTransfer))); err != nil {

--- a/core/vm/cas20_oog_test.go
+++ b/core/vm/cas20_oog_test.go
@@ -1,0 +1,384 @@
+package vm
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// TestCAS20ExhaustedBudgetStopsWork covers what chargeGas does not do: it marks
+// the frame out of gas and returns, leaving the caller to continue. Every
+// individual charge was correct, and the dispatcher failed the call at the end, so
+// the state was always discarded — but the node had already done all the work.
+func TestCAS20ExhaustedBudgetStopsWork(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc4ea70")
+	ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0x0c9"), creator,
+			[][]byte{cas20Call(selGrantRole, roleMint, addrKey(creator))}),
+		NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	const n = 4000
+	recips := make([]common.Address, n)
+	amts := make([]uint64, n)
+	for i := range recips {
+		recips[i] = common.BigToAddress(uint256.NewInt(uint64(0x400000 + i)).ToBig())
+		amts[i] = 1
+	}
+	input := encodeBatchMint(recips, amts)
+
+	// Best of several runs, so a scheduling hiccup cannot fail the test.
+	best := func(budget uint64, wantErr bool) time.Duration {
+		t.Helper()
+		out := time.Hour
+		for rep := 0; rep < 5; rep++ {
+			sdb := statedb.Copy()
+			e := NewEVM(cas20BlockContext(1), sdb, cas20TestChainConfig(), Config{})
+			start := time.Now()
+			_, _, err := e.Call(creator, token, input, NewGasBudget(budget), uint256.NewInt(0))
+			if d := time.Since(start); d < out {
+				out = d
+			}
+			if wantErr && err == nil {
+				t.Fatalf("a %d-recipient batch on %d gas should not succeed", n, budget)
+			}
+			if !wantErr && err != nil {
+				t.Fatalf("a %d-recipient batch on %d gas should succeed: %v", n, budget, err)
+			}
+		}
+		return out
+	}
+
+	// 25,000 gas cannot even pay the calldata charge for this payload, so the
+	// batch must abandon immediately rather than mint 4000 times.
+	// The funded run is the baseline for what all 4000 mints actually cost.
+	starved, funded := best(25_000, true), best(200_000_000, false)
+	if starved*3 > funded {
+		t.Errorf("a starved batch took %v against %v for one that could pay — the loop "+
+			"is still running past exhaustion", starved, funded)
+	}
+}
+
+// TestCAS20BootstrapStopsOnExhaustion is the same property for the factory's
+// initCalls loop, which the first pass missed: each entry dispatches a whole
+// token call, making it the most expensive per iteration of all the
+// caller-sized loops. Found by sweeping for the shape, not by a failing test.
+func TestCAS20BootstrapStopsOnExhaustion(t *testing.T) {
+	creator := common.HexToAddress("0xc4ea70")
+
+	// A long bundle of real grants, so every iteration writes storage.
+	const n = 1500
+	calls := make([][]byte, 0, n+1)
+	for i := 0; i < n; i++ {
+		who := common.BigToAddress(uint256.NewInt(uint64(0x500000 + i)).ToBig())
+		calls = append(calls, cas20Call(selGrantRole, roleMint, addrKey(who)))
+	}
+	input := encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xb007"), creator, calls)
+
+	best := func(budget uint64, wantErr bool) time.Duration {
+		t.Helper()
+		out := time.Hour
+		for rep := 0; rep < 5; rep++ {
+			_, e := newCAS20EVM(t)
+			start := time.Now()
+			_, _, err := e.Call(creator, CAS20FactoryAddress, input, NewGasBudget(budget), uint256.NewInt(0))
+			if d := time.Since(start); d < out {
+				out = d
+			}
+			if wantErr && err == nil {
+				t.Fatalf("a %d-call bootstrap on %d gas should not succeed", n, budget)
+			}
+			if !wantErr && err != nil {
+				t.Fatalf("a %d-call bootstrap on %d gas should succeed: %v", n, budget, err)
+			}
+		}
+		return out
+	}
+
+	starved, funded := best(60_000, true), best(400_000_000, false)
+	if starved*3 > funded {
+		t.Errorf("a starved bootstrap took %v against %v for one that could pay — the "+
+			"initCalls loop is still running past exhaustion", starved, funded)
+	}
+}
+
+// TestCAS20OldTailReleaseStopsOnExhaustion covers the one loop whose bound comes
+// from state rather than from the call's own calldata: replacing a long stored
+// string with a short one releases the old tail, and the old length is whatever a
+// previous caller paid to store.
+func TestCAS20OldTailReleaseStopsOnExhaustion(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc4ea70")
+	ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xta11"), creator,
+			[][]byte{cas20Call(selGrantRole, roleMetadata, addrKey(creator))}),
+		NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	// A name long enough that clearing its tail is measurable, stored and paid for.
+	long := strings.Repeat("N", 40_000)
+	if _, _, err := evm.Call(creator, token, encodeStringCall(selUpdateName, long),
+		NewGasBudget(500_000_000), uint256.NewInt(0)); err != nil {
+		t.Fatalf("storing the long name: %v", err)
+	}
+	chunks := newUnmeteredCAS20Storage(statedb, token).stringChunks(slotAt(cas20SlotName))
+	if chunks < 1000 {
+		t.Fatalf("the long name occupies %d chunks, too few for this to measure", chunks)
+	}
+
+	short := encodeStringCall(selUpdateName, "x")
+	best := func(budget uint64, wantErr bool) time.Duration {
+		t.Helper()
+		out := time.Hour
+		for rep := 0; rep < 5; rep++ {
+			sdb := statedb.Copy()
+			e := NewEVM(cas20BlockContext(1), sdb, cas20TestChainConfig(), Config{})
+			start := time.Now()
+			_, _, err := e.Call(creator, token, short, NewGasBudget(budget), uint256.NewInt(0))
+			if d := time.Since(start); d < out {
+				out = d
+			}
+			if wantErr && err == nil {
+				t.Fatalf("a starved updateName should not succeed")
+			}
+			if !wantErr && err != nil {
+				t.Fatalf("a funded updateName should succeed: %v", err)
+			}
+			// The long name surviving a failed attempt is what makes the work
+			// re-buyable, so assert it rather than assuming it.
+			if wantErr {
+				if got := newUnmeteredCAS20Storage(sdb, token).stringChunks(slotAt(cas20SlotName)); got != chunks {
+					t.Fatalf("after a reverted attempt the name occupies %d chunks, want %d", got, chunks)
+				}
+			}
+		}
+		return out
+	}
+
+	starved, funded := best(30_000, true), best(200_000_000, false)
+	if starved*3 > funded {
+		t.Errorf("a starved release took %v against %v for one that could pay — the "+
+			"old-tail loop is still running past exhaustion", starved, funded)
+	}
+}
+
+// TestCAS20UnaffordableCallDoesNoWork covers the DoS shape RequiredGas() == 0 opens.
+// warmed reports whether an (address, slot) pair is in the access list.
+func warmed(db *state.StateDB, addr common.Address, slot common.Hash) bool {
+	_, ok := db.SlotInAccessList(addr, slot)
+	return ok
+}
+
+func TestCAS20UnaffordableCallDoesNoWork(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xdec0de")
+	ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0x006"), creator, [][]byte{
+			cas20Call(selGrantRole, roleMint, addrKey(creator)),
+			cas20Call(selMint, addrKey(cas20Alice), u256hash(100)),
+		}), NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	// A slot no earlier call touched, which balanceOf would warm.
+	slot := cas20Storage{token: token}.balanceSlot(cas20Carol)
+	if warmed(statedb, token, slot) {
+		t.Fatal("carol's slot is already warm; the fixture cannot show a skipped read")
+	}
+
+	// Driven without evm.Call's snapshot: it reverts on error, and the access list
+	// reverts with it, so through evm.Call the slot reads cold whether or not the
+	// handler touched it. Asserting the end state there would prove nothing.
+	p, ok := resolveCAS20(token)
+	if !ok {
+		t.Fatal("the token address does not resolve to a precompile")
+	}
+	// One gas: enough for the call frame, not for the calldata charge.
+	input := cas20Call(selBalanceOf, addrKey(cas20Carol))
+	out, left, err := runStatefulPrecompiledContract(evm, p.(StatefulPrecompiledContract),
+		creator, token, input, NewGasBudget(1), false, true, uint256.NewInt(0))
+	if !errors.Is(err, ErrOutOfGas) {
+		t.Errorf("an unaffordable call err = %v, want ErrOutOfGas", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("returndata = %x, want empty", out)
+	}
+	if left.RegularGas != 0 {
+		t.Errorf("gas left = %d, want 0", left.RegularGas)
+	}
+	if warmed(statedb, token, slot) {
+		t.Error("the handler read state it could not pay for: carol's slot is warm after a " +
+			"call that could not afford its calldata. RequiredGas is zero, so the entry check " +
+			"is the only thing standing between a ~100-gas CALL and a handler's worth of work")
+	}
+}
+
+// TestCAS20CalldataGasMatchesTheBEP pins the calldata charge to BEP-702 3.14's
+// formula: G_copy + G_memory per 32-byte word, and nothing else.
+func TestCAS20CalldataGasMatchesTheBEP(t *testing.T) {
+	charged := func(words int) uint64 {
+		statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+		if err != nil {
+			t.Fatal(err)
+		}
+		gas := NewGasBudget(10_000_000)
+		ctx := &PrecompileContext{StateDB: statedb, Self: cas20Addr(cas20VariantAsset, 1), gas: &gas}
+		before := gas.RegularGas
+		ctx.chargeCalldata(make([]byte, words*32))
+		return before - gas.RegularGas
+	}
+	for _, words := range []int{0, 1, 2, 10, 1000} {
+		want := uint64(words) * (params.CopyGas + params.MemoryGas)
+		if got := charged(words); got != want {
+			t.Errorf("%d words charged %d, want %d — the table in BEP-702 3.14 is exhaustive "+
+				"and forbids synthesizing opcode or memory-expansion overhead", words, got, want)
+		}
+	}
+	// Linear, so the difference between sizes is the per-word price. A quadratic
+	// term would show up here even if the absolute values were adjusted to match.
+	if d := charged(1000) - charged(999); d != params.CopyGas+params.MemoryGas {
+		t.Errorf("the 1000th word costs %d, want %d — the charge is not linear",
+			d, params.CopyGas+params.MemoryGas)
+	}
+}
+
+// TestCAS20AnnounceStopsAtTheUnpaidRead is the regression Codex named as the proof
+// that a failed read must be reported, not silently zeroed.
+//
+// A zero read made announcementUsed report "unused", so announce went on to
+// ABI-encode the id, description and uri into an Announcement log and — with an
+// empty calls array, where the loop's own guard never runs — encode the id again
+// for EndAnnouncement. Both insertions happened on a frame whose charge had
+// already been refused, so a failing call still published a complete, balanced
+// disclosure. Reaching EndAnnouncement is the observable: it is the last write in
+// the function, and nothing after the refusal should execute at all.
+func TestCAS20AnnounceStopsAtTheUnpaidRead(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	admin := cas20TestCaller
+	ret, _, err := evm.Call(admin, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xaa11"), admin, [][]byte{
+			cas20Call(selGrantRole, roleOperator, addrKey(admin)),
+		}), NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+	p, ok := resolveCAS20(token)
+	if !ok {
+		t.Fatal("the token does not resolve")
+	}
+
+	// Long strings, so the skipped work is proportional to calldata, and an empty
+	// calls array so the loop guard never gets a turn. A fresh id per probe, so each
+	// meets a cold slot rather than the previous probe's AnnouncementIdAlreadyUsed.
+	long := strings.Repeat("x", 600)
+
+	probes, refused, zero := 0, 0, 0
+	for g := uint64(2_000); g <= 320_000; g += 2_000 {
+		before := len(statedb.Logs())
+		_, _, err := runStatefulPrecompiledContract(evm, p.(StatefulPrecompiledContract),
+			admin, token, encodeAnnounceWith(nil, fmt.Sprintf("announcement-%d", g), long, long),
+			NewGasBudget(g), false, true, uint256.NewInt(0))
+		added := statedb.Logs()[before:]
+		probes++
+		if err == nil {
+			continue
+		}
+		refused++
+		if !errors.Is(err, ErrOutOfGas) {
+			t.Fatalf("budget %d: err = %v, want ErrOutOfGas", g, err)
+		}
+		if len(added) == 0 {
+			zero++
+		}
+		// A log the frame did pay for may be here — the caller's revert removes it.
+		// EndAnnouncement may not: it is emitted after the refusal point, so its
+		// presence in a failing call means execution carried on past the refusal.
+		for _, l := range added {
+			if l.Topics[0] == cas20TopicEndAnnouncement {
+				t.Fatalf("budget %d: the call ran out of gas yet reached EndAnnouncement, "+
+					"so it kept executing after a charge was refused", g)
+			}
+		}
+	}
+	if refused == 0 || refused == probes {
+		t.Fatalf("%d of %d probes were refused; the sweep needs both outcomes to be "+
+			"straddling the boundary", refused, probes)
+	}
+	if zero == 0 {
+		t.Error("no probe was refused before its first log, so the sweep never reached " +
+			"the unpaid read this test is named for")
+	}
+}
+
+// TestCAS20AnnouncementViewNeverAnswersFromAnUnpaidRead pins the end-to-end
+// property rather than either mechanism that provides it. Two independent
+// barriers stand between an unpaid read and a wrong answer: announcementUsed
+// reports that it could not read, and finishCAS20Metered overrides the returned
+// error whenever the frame's out-of-gas flag is set. Remove either alone and
+// the other still holds, so no single-mutation test can witness this; remove
+// both and the view returns false for an id that was announced, with a nil
+// error and gas still in hand. That combination is what this test refuses.
+func TestCAS20AnnouncementViewNeverAnswersFromAnUnpaidRead(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	admin := cas20TestCaller
+	ret, _, err := evm.Call(admin, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xbb22"), admin, [][]byte{
+			cas20Call(selGrantRole, roleOperator, addrKey(admin)),
+		}), NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+	p, ok := resolveCAS20(token)
+	if !ok {
+		t.Fatal("the token does not resolve")
+	}
+
+	const id = "disclosure-1"
+	if _, _, err := evm.Call(admin, token, encodeAnnounceWith(nil, id, "d", "u"),
+		NewGasBudget(1_000_000), uint256.NewInt(0)); err != nil {
+		t.Fatalf("announce: %v", err)
+	}
+
+	input := encodeStringCall(selIsAnnouncementIdUsed, id)
+	answered, refused := 0, 0
+	for g := uint64(20); g <= 2_000; g += 20 {
+		out, _, err := runStatefulPrecompiledContract(evm, p.(StatefulPrecompiledContract),
+			admin, token, input, NewGasBudget(g), true, true, uint256.NewInt(0))
+		if err != nil {
+			if !errors.Is(err, ErrOutOfGas) {
+				t.Fatalf("budget %d: err = %v, want ErrOutOfGas", g, err)
+			}
+			refused++
+			continue
+		}
+		answered++
+		if !bytes.Equal(out, encBool(true)) {
+			t.Fatalf("budget %d: the view answered %x for an id that was announced. A read "+
+				"that could not be paid for must fail the call, never default to zero", g, out)
+		}
+	}
+	if answered == 0 || refused == 0 {
+		t.Fatalf("%d answered, %d refused; the sweep needs both to straddle the read's price",
+			answered, refused)
+	}
+}

--- a/core/vm/cas20_oog_test.go
+++ b/core/vm/cas20_oog_test.go
@@ -15,10 +15,8 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// TestCAS20ExhaustedBudgetStopsWork covers what chargeGas does not do: it marks
-// the frame out of gas and returns, leaving the caller to continue. Every
-// individual charge was correct, and the dispatcher failed the call at the end, so
-// the state was always discarded — but the node had already done all the work.
+// chargeGas only marks the frame; the state is discarded either way, but the node
+// must not do the work first.
 func TestCAS20ExhaustedBudgetStopsWork(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xc4ea70")
@@ -40,7 +38,6 @@ func TestCAS20ExhaustedBudgetStopsWork(t *testing.T) {
 	}
 	input := encodeBatchMint(recips, amts)
 
-	// Best of several runs, so a scheduling hiccup cannot fail the test.
 	best := func(budget uint64, wantErr bool) time.Duration {
 		t.Helper()
 		out := time.Hour
@@ -62,9 +59,7 @@ func TestCAS20ExhaustedBudgetStopsWork(t *testing.T) {
 		return out
 	}
 
-	// 25,000 gas cannot even pay the calldata charge for this payload, so the
-	// batch must abandon immediately rather than mint 4000 times.
-	// The funded run is the baseline for what all 4000 mints actually cost.
+	// 25,000 gas cannot pay the calldata charge, so the batch must abandon at once.
 	starved, funded := best(25_000, true), best(200_000_000, false)
 	if starved*3 > funded {
 		t.Errorf("a starved batch took %v against %v for one that could pay — the loop "+
@@ -72,14 +67,10 @@ func TestCAS20ExhaustedBudgetStopsWork(t *testing.T) {
 	}
 }
 
-// TestCAS20BootstrapStopsOnExhaustion is the same property for the factory's
-// initCalls loop, which the first pass missed: each entry dispatches a whole
-// token call, making it the most expensive per iteration of all the
-// caller-sized loops. Found by sweeping for the shape, not by a failing test.
+// The same property for the initCalls loop, the most expensive per iteration.
 func TestCAS20BootstrapStopsOnExhaustion(t *testing.T) {
 	creator := common.HexToAddress("0xc4ea70")
 
-	// A long bundle of real grants, so every iteration writes storage.
 	const n = 1500
 	calls := make([][]byte, 0, n+1)
 	for i := 0; i < n; i++ {
@@ -115,10 +106,8 @@ func TestCAS20BootstrapStopsOnExhaustion(t *testing.T) {
 	}
 }
 
-// TestCAS20OldTailReleaseStopsOnExhaustion covers the one loop whose bound comes
-// from state rather than from the call's own calldata: replacing a long stored
-// string with a short one releases the old tail, and the old length is whatever a
-// previous caller paid to store.
+// The one loop whose bound comes from state, not calldata: the old tail's length
+// is whatever a previous caller paid to store.
 func TestCAS20OldTailReleaseStopsOnExhaustion(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xc4ea70")
@@ -131,7 +120,6 @@ func TestCAS20OldTailReleaseStopsOnExhaustion(t *testing.T) {
 	}
 	token := common.BytesToAddress(ret)
 
-	// A name long enough that clearing its tail is measurable, stored and paid for.
 	long := strings.Repeat("N", 40_000)
 	if _, _, err := evm.Call(creator, token, encodeStringCall(selUpdateName, long),
 		NewGasBudget(500_000_000), uint256.NewInt(0)); err != nil {
@@ -160,8 +148,7 @@ func TestCAS20OldTailReleaseStopsOnExhaustion(t *testing.T) {
 			if !wantErr && err != nil {
 				t.Fatalf("a funded updateName should succeed: %v", err)
 			}
-			// The long name surviving a failed attempt is what makes the work
-			// re-buyable, so assert it rather than assuming it.
+			// The surviving long name is what makes the work re-buyable.
 			if wantErr {
 				if got := newUnmeteredCAS20Storage(sdb, token).stringChunks(slotAt(cas20SlotName)); got != chunks {
 					t.Fatalf("after a reverted attempt the name occupies %d chunks, want %d", got, chunks)
@@ -178,8 +165,6 @@ func TestCAS20OldTailReleaseStopsOnExhaustion(t *testing.T) {
 	}
 }
 
-// TestCAS20UnaffordableCallDoesNoWork covers the DoS shape RequiredGas() == 0 opens.
-// warmed reports whether an (address, slot) pair is in the access list.
 func warmed(db *state.StateDB, addr common.Address, slot common.Hash) bool {
 	_, ok := db.SlotInAccessList(addr, slot)
 	return ok
@@ -198,20 +183,17 @@ func TestCAS20UnaffordableCallDoesNoWork(t *testing.T) {
 	}
 	token := common.BytesToAddress(ret)
 
-	// A slot no earlier call touched, which balanceOf would warm.
 	slot := cas20Storage{token: token}.balanceSlot(cas20Carol)
 	if warmed(statedb, token, slot) {
 		t.Fatal("carol's slot is already warm; the fixture cannot show a skipped read")
 	}
 
-	// Driven without evm.Call's snapshot: it reverts on error, and the access list
-	// reverts with it, so through evm.Call the slot reads cold whether or not the
-	// handler touched it. Asserting the end state there would prove nothing.
+	// Without evm.Call's snapshot, which would revert the access list and read the
+	// slot cold whether or not the handler touched it.
 	p, ok := resolveCAS20(token)
 	if !ok {
 		t.Fatal("the token address does not resolve to a precompile")
 	}
-	// One gas: enough for the call frame, not for the calldata charge.
 	input := cas20Call(selBalanceOf, addrKey(cas20Carol))
 	out, left, err := runStatefulPrecompiledContract(evm, p.(StatefulPrecompiledContract),
 		creator, token, input, NewGasBudget(1), false, true, uint256.NewInt(0))
@@ -231,8 +213,6 @@ func TestCAS20UnaffordableCallDoesNoWork(t *testing.T) {
 	}
 }
 
-// TestCAS20CalldataGasMatchesTheBEP pins the calldata charge to BEP-702 3.14's
-// formula: G_copy + G_memory per 32-byte word, and nothing else.
 func TestCAS20CalldataGasMatchesTheBEP(t *testing.T) {
 	charged := func(words int) uint64 {
 		statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
@@ -252,24 +232,15 @@ func TestCAS20CalldataGasMatchesTheBEP(t *testing.T) {
 				"and forbids synthesizing opcode or memory-expansion overhead", words, got, want)
 		}
 	}
-	// Linear, so the difference between sizes is the per-word price. A quadratic
-	// term would show up here even if the absolute values were adjusted to match.
+	// A quadratic term would show up in the differences even if the absolute values matched.
 	if d := charged(1000) - charged(999); d != params.CopyGas+params.MemoryGas {
 		t.Errorf("the 1000th word costs %d, want %d — the charge is not linear",
 			d, params.CopyGas+params.MemoryGas)
 	}
 }
 
-// TestCAS20AnnounceStopsAtTheUnpaidRead is the regression Codex named as the proof
-// that a failed read must be reported, not silently zeroed.
-//
-// A zero read made announcementUsed report "unused", so announce went on to
-// ABI-encode the id, description and uri into an Announcement log and — with an
-// empty calls array, where the loop's own guard never runs — encode the id again
-// for EndAnnouncement. Both insertions happened on a frame whose charge had
-// already been refused, so a failing call still published a complete, balanced
-// disclosure. Reaching EndAnnouncement is the observable: it is the last write in
-// the function, and nothing after the refusal should execute at all.
+// A read zeroed for want of gas once let announce publish a complete disclosure on
+// a refused frame. EndAnnouncement is the observable: it is the last write.
 func TestCAS20AnnounceStopsAtTheUnpaidRead(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	admin := cas20TestCaller
@@ -286,9 +257,8 @@ func TestCAS20AnnounceStopsAtTheUnpaidRead(t *testing.T) {
 		t.Fatal("the token does not resolve")
 	}
 
-	// Long strings, so the skipped work is proportional to calldata, and an empty
-	// calls array so the loop guard never gets a turn. A fresh id per probe, so each
-	// meets a cold slot rather than the previous probe's AnnouncementIdAlreadyUsed.
+	// An empty calls array so the loop guard never gets a turn; a fresh id per probe
+	// so each meets a cold slot.
 	long := strings.Repeat("x", 600)
 
 	probes, refused, zero := 0, 0, 0
@@ -309,9 +279,8 @@ func TestCAS20AnnounceStopsAtTheUnpaidRead(t *testing.T) {
 		if len(added) == 0 {
 			zero++
 		}
-		// A log the frame did pay for may be here — the caller's revert removes it.
-		// EndAnnouncement may not: it is emitted after the refusal point, so its
-		// presence in a failing call means execution carried on past the refusal.
+		// A log the frame paid for may be here; EndAnnouncement, emitted after the
+		// refusal point, may not.
 		for _, l := range added {
 			if l.Topics[0] == cas20TopicEndAnnouncement {
 				t.Fatalf("budget %d: the call ran out of gas yet reached EndAnnouncement, "+
@@ -329,14 +298,8 @@ func TestCAS20AnnounceStopsAtTheUnpaidRead(t *testing.T) {
 	}
 }
 
-// TestCAS20AnnouncementViewNeverAnswersFromAnUnpaidRead pins the end-to-end
-// property rather than either mechanism that provides it. Two independent
-// barriers stand between an unpaid read and a wrong answer: announcementUsed
-// reports that it could not read, and finishCAS20Metered overrides the returned
-// error whenever the frame's out-of-gas flag is set. Remove either alone and
-// the other still holds, so no single-mutation test can witness this; remove
-// both and the view returns false for an id that was announced, with a nil
-// error and gas still in hand. That combination is what this test refuses.
+// Two independent barriers stand between an unpaid read and a wrong answer, so no
+// single-mutation test can witness this; the end-to-end property is what is pinned.
 func TestCAS20AnnouncementViewNeverAnswersFromAnUnpaidRead(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	admin := cas20TestCaller

--- a/core/vm/cas20_oog_test.go
+++ b/core/vm/cas20_oog_test.go
@@ -345,3 +345,55 @@ func TestCAS20AnnouncementViewNeverAnswersFromAnUnpaidRead(t *testing.T) {
 			answered, refused)
 	}
 }
+
+// One entry of an announce bundle or an initCalls array costs what the reference
+// contract pays to route it: a warm CALL plus the copy of the entry. Aliased
+// offsets are accepted, so without this a shared tail could be dispatched N×M
+// times for the price of one.
+func TestCAS20InternalDispatchIsCharged(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xdec0de")
+	ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0xd15"), creator, [][]byte{
+			cas20Call(selGrantRole, roleOperator, addrKey(creator)),
+		}), NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	// A constant getter reads no state, so the difference between announcing n
+	// and n+1 of them is the dispatch charge alone, once the id's own cost is out.
+	used := func(n int, id string) uint64 {
+		calls := make([][]byte, n)
+		for i := range calls {
+			calls[i] = cas20Call(selWadPrecision)
+		}
+		gas := NewGasBudget(5_000_000)
+		_, left, err := evm.Call(creator, token, encodeAnnounce(calls, id), gas, uint256.NewInt(0))
+		if err != nil {
+			t.Fatalf("announce with %d calls: %v", n, err)
+		}
+		return gas.RegularGas - left.RegularGas
+	}
+	one, two := used(1, "id-1"), used(2, "id-2")
+	// The second announce also carries three more words of outer calldata: the
+	// entry's offset, its length and its data.
+	want := params.WarmStorageReadCostEIP2929 + cas20CalldataWordGas + 3*cas20CalldataWordGas
+	if two-one != want {
+		t.Errorf("one more constant getter cost %d, want %d (warm CALL + its input word + three calldata words)", two-one, want)
+	}
+
+	// The charge is taken before the entry runs: a bundle the budget cannot pay
+	// for is out of gas, not executed and then reverted.
+	many := make([][]byte, 200)
+	for i := range many {
+		many[i] = cas20Call(selWadPrecision)
+	}
+	input := encodeAnnounce(many, "id-many")
+	words := (uint64(len(input)) + 31) / 32
+	budget := words*cas20CalldataWordGas + 200*(params.WarmStorageReadCostEIP2929+cas20CalldataWordGas)/2
+	if _, _, err := evm.Call(creator, token, input, NewGasBudget(budget), uint256.NewInt(0)); !errors.Is(err, ErrOutOfGas) {
+		t.Errorf("200 dispatches on half their price: err = %v, want out of gas", err)
+	}
+}

--- a/core/vm/cas20_oog_test.go
+++ b/core/vm/cas20_oog_test.go
@@ -384,16 +384,20 @@ func TestCAS20InternalDispatchIsCharged(t *testing.T) {
 		t.Errorf("one more constant getter cost %d, want %d (warm CALL + its input word + three calldata words)", two-one, want)
 	}
 
-	// The charge is taken before the entry runs: a bundle the budget cannot pay
-	// for is out of gas, not executed and then reverted.
+	// The charge is taken before each entry runs, so the budget decides how far
+	// into the bundle execution gets. Budget for the announcement itself plus
+	// exactly 200 dispatches succeeds; the same budget short of the last 100
+	// dispatches is out of gas — and only the dispatch charges separate the two.
 	many := make([][]byte, 200)
 	for i := range many {
 		many[i] = cas20Call(selWadPrecision)
 	}
-	input := encodeAnnounce(many, "id-many")
-	words := (uint64(len(input)) + 31) / 32
-	budget := words*cas20CalldataWordGas + 200*(params.WarmStorageReadCostEIP2929+cas20CalldataWordGas)/2
-	if _, _, err := evm.Call(creator, token, input, NewGasBudget(budget), uint256.NewInt(0)); !errors.Is(err, ErrOutOfGas) {
-		t.Errorf("200 dispatches on half their price: err = %v, want out of gas", err)
+	perEntry := params.WarmStorageReadCostEIP2929 + cas20CalldataWordGas + 3*cas20CalldataWordGas
+	enough := one + 199*perEntry
+	if _, _, err := evm.Call(creator, token, encodeAnnounce(many, "id-200"), NewGasBudget(enough), uint256.NewInt(0)); err != nil {
+		t.Fatalf("200 dispatches on their exact price: %v", err)
+	}
+	if _, _, err := evm.Call(creator, token, encodeAnnounce(many, "id-200-short"), NewGasBudget(enough-100*perEntry), uint256.NewInt(0)); !errors.Is(err, ErrOutOfGas) {
+		t.Errorf("200 dispatches short of the last hundred: err = %v, want out of gas", err)
 	}
 }

--- a/core/vm/cas20_permit.go
+++ b/core/vm/cas20_permit.go
@@ -1,0 +1,295 @@
+package vm
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// CAS20 EIP-2612 permit (gasless approvals) and the memo transfer/mint/burn
+// family. The EIP-712 domain is derived from the live token name, so any
+// updateName automatically invalidates outstanding permit signatures — there
+// is no cached separator to roll.
+
+// cas20EIP712Version is the domain's version field. DOMAIN_SEPARATOR() hashes it
+// and eip712Domain() reports it, so the two cannot drift apart.
+const cas20EIP712Version = "1"
+
+var (
+	selDomainSeparator      = selector("DOMAIN_SEPARATOR()")
+	selNonces               = selector("nonces(address)")
+	selPermit               = selector("permit(address,address,uint256,uint256,uint8,bytes32,bytes32)")
+	selTransferWithMemo     = selector("transferWithMemo(address,uint256,bytes32)")
+	selTransferFromWithMemo = selector("transferFromWithMemo(address,address,uint256,bytes32)")
+	selMintWithMemo         = selector("mintWithMemo(address,uint256,bytes32)")
+	selBurnWithMemo         = selector("burnWithMemo(uint256,bytes32)")
+
+	cas20DomainTypehash = crypto.Keccak256Hash([]byte("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"))
+	cas20PermitTypehash = crypto.Keccak256Hash([]byte("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"))
+	cas20TopicMemo      = eventTopic("Memo(address,bytes32)")
+)
+
+// dispatchPermitMemo handles the permit and *WithMemo selectors. ok is false
+// when sel matches none of them.
+func (t cas20Token) dispatchPermitMemo(sel [4]byte, args []byte) (ret []byte, err error, ok bool) {
+	switch sel {
+	case selDomainSeparator:
+		d, ok := t.domainSeparator()
+		if !ok {
+			return nil, ErrOutOfGas, true
+		}
+		return d.Bytes(), nil, true
+	case selNonces:
+		owner, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		return encU256(t.s.nonce(owner)), nil, true
+	case selPermit:
+		ret, err := t.decodePermit(args)
+		return ret, err, true
+
+	case selTransferWithMemo:
+		to, amount, memo, err := readToAmountMemo(args)
+		if err != nil {
+			return nil, err, true
+		}
+		ret, err := t.transfer(t.ctx.Caller, to, amount)
+		if err == nil {
+			if !t.emitMemo(memo) {
+				return nil, ErrOutOfGas, true
+			}
+		}
+		return ret, err, true
+	case selTransferFromWithMemo:
+		from, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		to, err := readAddress(args, 1)
+		if err != nil {
+			return nil, err, true
+		}
+		amount, err := readU256(args, 2)
+		if err != nil {
+			return nil, err, true
+		}
+		memo, err := readWord(args, 3)
+		if err != nil {
+			return nil, err, true
+		}
+		ret, err := t.transferFrom(t.ctx.Caller, from, to, amount)
+		if err == nil {
+			if !t.emitMemo(memo) {
+				return nil, ErrOutOfGas, true
+			}
+		}
+		return ret, err, true
+	case selMintWithMemo:
+		to, amount, memo, err := readToAmountMemo(args)
+		if err != nil {
+			return nil, err, true
+		}
+		if err := t.mint(to, amount); err != nil {
+			return nil, err, true
+		}
+		if !t.emitMemo(memo) {
+			return nil, ErrOutOfGas, true
+		}
+		return nil, nil, true
+	case selBurnWithMemo:
+		amount, err := readU256(args, 0)
+		if err != nil {
+			return nil, err, true
+		}
+		memo, err := readWord(args, 1)
+		if err != nil {
+			return nil, err, true
+		}
+		if err := t.burn(t.ctx.Caller, amount); err != nil {
+			return nil, err, true
+		}
+		if !t.emitMemo(memo) {
+			return nil, ErrOutOfGas, true
+		}
+		return nil, nil, true
+	}
+	return nil, nil, false
+}
+
+// emitMemo emits Memo(caller, memo) immediately after a primary op.
+func (t cas20Token) emitMemo(memo common.Hash) bool {
+	return t.ctx.AddLog([]common.Hash{cas20TopicMemo, addrKey(t.ctx.Caller), memo}, nil)
+}
+
+func readToAmountMemo(args []byte) (common.Address, *uint256.Int, common.Hash, error) {
+	to, err := readAddress(args, 0)
+	if err != nil {
+		return common.Address{}, nil, common.Hash{}, err
+	}
+	amount, err := readU256(args, 1)
+	if err != nil {
+		return common.Address{}, nil, common.Hash{}, err
+	}
+	memo, err := readWord(args, 2)
+	if err != nil {
+		return common.Address{}, nil, common.Hash{}, err
+	}
+	return to, amount, memo, nil
+}
+
+// --- EIP-2612 permit --------------------------------------------------------
+
+// domainSeparator computes the EIP-712 domain hash from the live token name,
+// version "1", chain id and the token address, and reports false when a charge on
+// the way could not be covered. A Solidity ERC-2612 pays for the same three
+// hashes, so leaving them free would make the native path cheaper than bytecode
+// (BEP-702 3.14).
+func (t cas20Token) domainSeparator() (common.Hash, bool) {
+	name, ok := t.s.name()
+	if !ok {
+		return common.Hash{}, false
+	}
+	if !t.ctx.chargeKeccak(len(name)) ||
+		!t.ctx.chargeKeccak(len(cas20EIP712Version)) ||
+		!t.ctx.chargeKeccak(160) {
+		return common.Hash{}, false
+	}
+	nameHash := crypto.Keccak256Hash([]byte(name))
+	versionHash := crypto.Keccak256Hash([]byte(cas20EIP712Version))
+	chainID := t.ctx.ChainID().Bytes32()
+
+	enc := make([]byte, 0, 160)
+	enc = append(enc, cas20DomainTypehash.Bytes()...)
+	enc = append(enc, nameHash.Bytes()...)
+	enc = append(enc, versionHash.Bytes()...)
+	enc = append(enc, chainID[:]...)
+	enc = append(enc, addrKey(t.ctx.Self).Bytes()...)
+	return crypto.Keccak256Hash(enc), true
+}
+
+func (t cas20Token) decodePermit(args []byte) ([]byte, error) {
+	owner, err := readAddress(args, 0)
+	if err != nil {
+		return nil, err
+	}
+	spender, err := readAddress(args, 1)
+	if err != nil {
+		return nil, err
+	}
+	value, err := readU256(args, 2)
+	if err != nil {
+		return nil, err
+	}
+	deadline, err := readU256(args, 3)
+	if err != nil {
+		return nil, err
+	}
+	// v is a uint8: a word with dirty high bytes is a malformed encoding, not a
+	// signature to be truncated and then blamed on the signer.
+	v, err := readStrictUint8(args, 4)
+	if err != nil {
+		return nil, err
+	}
+	r, err := readWord(args, 5)
+	if err != nil {
+		return nil, err
+	}
+	s, err := readWord(args, 6)
+	if err != nil {
+		return nil, err
+	}
+	return t.permit(owner, spender, value, deadline, v, r, s)
+}
+
+func (t cas20Token) permit(owner, spender common.Address, value, deadline *uint256.Int, v byte, r, s common.Hash) ([]byte, error) {
+	if t.ctx.ReadOnly {
+		return nil, ErrWriteProtection
+	}
+	if owner == (common.Address{}) {
+		return nil, revCAS20("InvalidApprover(address)", errSelInvalidApprover, addrKey(owner))
+	}
+	// Deadline is inclusive: now > deadline is expired.
+	if deadline.LtUint64(t.ctx.BlockTime()) {
+		return nil, revCAS20("ExpiredSignature(uint256)", errSelExpiredSignature, wU256(deadline))
+	}
+	nonce := t.s.nonce(owner)
+
+	structHash := make([]byte, 0, 192)
+	structHash = append(structHash, cas20PermitTypehash.Bytes()...)
+	structHash = append(structHash, addrKey(owner).Bytes()...)
+	structHash = append(structHash, addrKey(spender).Bytes()...)
+	vb := value.Bytes32()
+	structHash = append(structHash, vb[:]...)
+	nb := nonce.Bytes32()
+	structHash = append(structHash, nb[:]...)
+	db := deadline.Bytes32()
+	structHash = append(structHash, db[:]...)
+
+	dom, paid := t.domainSeparator()
+	if !paid {
+		return nil, ErrOutOfGas
+	}
+	// The struct hash, the final digest, and the signature recovery. ECRECOVER is
+	// its own precompile at a flat 3000 gas; a native permit doing the same
+	// secp256k1 work owes the same, and owes it whether or not the signature turns
+	// out to be valid.
+	if !t.ctx.chargeKeccak(len(structHash)) ||
+		!t.ctx.chargeKeccak(66) ||
+		!t.ctx.chargeGas(params.EcrecoverGas) {
+		return nil, ErrOutOfGas
+	}
+	digest := crypto.Keccak256([]byte{0x19, 0x01}, dom.Bytes(), crypto.Keccak256(structHash))
+
+	signer, ok := ecrecoverAddress(digest, v, r, s)
+	if !ok || signer != owner {
+		return nil, revCAS20("InvalidSigner(address,address)", errSelInvalidSigner,
+			addrKey(signer), addrKey(owner))
+	}
+
+	// A signature over the zero spender is a valid signature for an approval that
+	// must still be refused; without this check permit would set an allowance
+	// approve() rejects. Its position decides which error a request that is wrong
+	// twice receives: a bad signature naming the zero spender is reported as
+	// InvalidSigner, and the caller pays the two keccaks and the ecrecover before
+	// the free comparison runs.
+	if spender == (common.Address{}) {
+		return nil, revCAS20("InvalidSpender(address)", errSelInvalidSpender, addrKey(spender))
+	}
+	t.s.setNonce(owner, new(uint256.Int).AddUint64(nonce, 1))
+	t.s.setAllowance(owner, spender, value)
+	if !t.emit(cas20TopicApproval, owner, spender, value) {
+		return nil, ErrOutOfGas
+	}
+	// Empty returndata: EIP-2612 declares `permit(...) external` with no return
+	// value, so returning an ABI true would make a caller that decodes a bool
+	// succeed here and fail against every other implementation.
+	return nil, nil
+}
+
+// ecrecoverAddress recovers the signer of an EIP-712 digest. It enforces
+// EIP-2 low-s and v ∈ {27,28}; ERC-1271 contract signatures are not supported.
+func ecrecoverAddress(hash []byte, v byte, r, s common.Hash) (common.Address, bool) {
+	if v != 27 && v != 28 {
+		return common.Address{}, false
+	}
+	rBig := new(big.Int).SetBytes(r[:])
+	sBig := new(big.Int).SetBytes(s[:])
+	if !crypto.ValidateSignatureValues(v-27, rBig, sBig, true) {
+		return common.Address{}, false
+	}
+	sig := make([]byte, 65)
+	copy(sig[0:32], r[:])
+	copy(sig[32:64], s[:])
+	sig[64] = v - 27
+	pub, err := crypto.Ecrecover(hash, sig)
+	if err != nil || len(pub) == 0 {
+		return common.Address{}, false
+	}
+	var addr common.Address
+	copy(addr[:], crypto.Keccak256(pub[1:])[12:])
+	return addr, true
+}

--- a/core/vm/cas20_permit.go
+++ b/core/vm/cas20_permit.go
@@ -146,17 +146,21 @@ func (t cas20Token) domainSeparator() (common.Hash, bool) {
 		!t.ctx.chargeKeccak(160) {
 		return common.Hash{}, false
 	}
+	return cas20DomainSeparator(name, t.ctx.ChainID(), t.ctx.Self), true
+}
+
+func cas20DomainSeparator(name string, chainID *uint256.Int, self common.Address) common.Hash {
 	nameHash := crypto.Keccak256Hash([]byte(name))
 	versionHash := crypto.Keccak256Hash([]byte(cas20EIP712Version))
-	chainID := t.ctx.ChainID().Bytes32()
+	id := chainID.Bytes32()
 
 	enc := make([]byte, 0, 160)
 	enc = append(enc, cas20DomainTypehash.Bytes()...)
 	enc = append(enc, nameHash.Bytes()...)
 	enc = append(enc, versionHash.Bytes()...)
-	enc = append(enc, chainID[:]...)
-	enc = append(enc, addrKey(t.ctx.Self).Bytes()...)
-	return crypto.Keccak256Hash(enc), true
+	enc = append(enc, id[:]...)
+	enc = append(enc, addrKey(self).Bytes()...)
+	return crypto.Keccak256Hash(enc)
 }
 
 func (t cas20Token) decodePermit(args []byte) ([]byte, error) {

--- a/core/vm/cas20_permit.go
+++ b/core/vm/cas20_permit.go
@@ -9,13 +9,9 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// CAS20 EIP-2612 permit (gasless approvals) and the memo transfer/mint/burn
-// family. The EIP-712 domain is derived from the live token name, so any
-// updateName automatically invalidates outstanding permit signatures — there
-// is no cached separator to roll.
+// The EIP-712 domain is derived from the live token name, so updateName
+// invalidates outstanding permits; there is no cached separator to roll.
 
-// cas20EIP712Version is the domain's version field. DOMAIN_SEPARATOR() hashes it
-// and eip712Domain() reports it, so the two cannot drift apart.
 const cas20EIP712Version = "1"
 
 var (
@@ -32,8 +28,6 @@ var (
 	cas20TopicMemo      = eventTopic("Memo(address,bytes32)")
 )
 
-// dispatchPermitMemo handles the permit and *WithMemo selectors. ok is false
-// when sel matches none of them.
 func (t cas20Token) dispatchPermitMemo(sel [4]byte, args []byte) (ret []byte, err error, ok bool) {
 	switch sel {
 	case selDomainSeparator:
@@ -120,7 +114,6 @@ func (t cas20Token) dispatchPermitMemo(sel [4]byte, args []byte) (ret []byte, er
 	return nil, nil, false
 }
 
-// emitMemo emits Memo(caller, memo) immediately after a primary op.
 func (t cas20Token) emitMemo(memo common.Hash) bool {
 	return t.ctx.AddLog([]common.Hash{cas20TopicMemo, addrKey(t.ctx.Caller), memo}, nil)
 }
@@ -143,11 +136,6 @@ func readToAmountMemo(args []byte) (common.Address, *uint256.Int, common.Hash, e
 
 // --- EIP-2612 permit --------------------------------------------------------
 
-// domainSeparator computes the EIP-712 domain hash from the live token name,
-// version "1", chain id and the token address, and reports false when a charge on
-// the way could not be covered. A Solidity ERC-2612 pays for the same three
-// hashes, so leaving them free would make the native path cheaper than bytecode
-// (BEP-702 3.14).
 func (t cas20Token) domainSeparator() (common.Hash, bool) {
 	name, ok := t.s.name()
 	if !ok {
@@ -188,8 +176,6 @@ func (t cas20Token) decodePermit(args []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// v is a uint8: a word with dirty high bytes is a malformed encoding, not a
-	// signature to be truncated and then blamed on the signer.
 	v, err := readStrictUint8(args, 4)
 	if err != nil {
 		return nil, err
@@ -212,7 +198,6 @@ func (t cas20Token) permit(owner, spender common.Address, value, deadline *uint2
 	if owner == (common.Address{}) {
 		return nil, revCAS20("InvalidApprover(address)", errSelInvalidApprover, addrKey(owner))
 	}
-	// Deadline is inclusive: now > deadline is expired.
 	if deadline.LtUint64(t.ctx.BlockTime()) {
 		return nil, revCAS20("ExpiredSignature(uint256)", errSelExpiredSignature, wU256(deadline))
 	}
@@ -233,10 +218,7 @@ func (t cas20Token) permit(owner, spender common.Address, value, deadline *uint2
 	if !paid {
 		return nil, ErrOutOfGas
 	}
-	// The struct hash, the final digest, and the signature recovery. ECRECOVER is
-	// its own precompile at a flat 3000 gas; a native permit doing the same
-	// secp256k1 work owes the same, and owes it whether or not the signature turns
-	// out to be valid.
+	// Charged whether or not the signature turns out to be valid, as ECRECOVER would be.
 	if !t.ctx.chargeKeccak(len(structHash)) ||
 		!t.ctx.chargeKeccak(66) ||
 		!t.ctx.chargeGas(params.EcrecoverGas) {
@@ -250,12 +232,7 @@ func (t cas20Token) permit(owner, spender common.Address, value, deadline *uint2
 			addrKey(signer), addrKey(owner))
 	}
 
-	// A signature over the zero spender is a valid signature for an approval that
-	// must still be refused; without this check permit would set an allowance
-	// approve() rejects. Its position decides which error a request that is wrong
-	// twice receives: a bad signature naming the zero spender is reported as
-	// InvalidSigner, and the caller pays the two keccaks and the ecrecover before
-	// the free comparison runs.
+	// After the signature, so a bad signature naming the zero spender is InvalidSigner.
 	if spender == (common.Address{}) {
 		return nil, revCAS20("InvalidSpender(address)", errSelInvalidSpender, addrKey(spender))
 	}
@@ -264,13 +241,9 @@ func (t cas20Token) permit(owner, spender common.Address, value, deadline *uint2
 	if !t.emit(cas20TopicApproval, owner, spender, value) {
 		return nil, ErrOutOfGas
 	}
-	// Empty returndata: EIP-2612 declares `permit(...) external` with no return
-	// value, so returning an ABI true would make a caller that decodes a bool
-	// succeed here and fail against every other implementation.
 	return nil, nil
 }
 
-// ecrecoverAddress recovers the signer of an EIP-712 digest. It enforces
 // EIP-2 low-s and v ∈ {27,28}; ERC-1271 contract signatures are not supported.
 func ecrecoverAddress(hash []byte, v byte, r, s common.Hash) (common.Address, bool) {
 	if v != 27 && v != 28 {

--- a/core/vm/cas20_permit_test.go
+++ b/core/vm/cas20_permit_test.go
@@ -1,0 +1,150 @@
+package vm
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+)
+
+// newTokenWithEVM builds a token bound to a real EVM so ChainID()/BlockTime()
+// resolve (permit needs both). Any caller can submit; the seed callback runs
+// against the unmetered view.
+func newTokenWithEVM(t *testing.T, now uint64, seed func(cas20Storage)) (*state.StateDB, common.Address, func(caller common.Address, input []byte) ([]byte, error)) {
+	t.Helper()
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := cas20Addr(cas20VariantAsset, 1)
+	if seed != nil {
+		seed(newUnmeteredCAS20Storage(statedb, token))
+	}
+	bc := cas20BlockContext(now)
+	evm := NewEVM(bc, statedb, cas20TestChainConfig(), Config{})
+	run := func(caller common.Address, input []byte) ([]byte, error) {
+		gas := NewGasBudget(2_000_000)
+		ctx := &PrecompileContext{evm: evm, StateDB: statedb, Self: token, Caller: caller, DirectCall: true, gas: &gas}
+		return newCAS20Token(ctx, 18).dispatch(input)
+	}
+	return statedb, token, run
+}
+
+func TestCAS20Permit(t *testing.T) {
+	const now = 100
+	statedb, token, run := newTokenWithEVM(t, now, func(s cas20Storage) {
+		s.setName("Test Token")
+	})
+	view := newUnmeteredCAS20Storage(statedb, token)
+
+	// Build the token used only to compute the domain separator (same EVM cfg).
+	evm := NewEVM(BlockContext{BlockNumber: big.NewInt(1), Time: now}, statedb, cas20TestChainConfig(), Config{})
+	// A real budget: this token only computes the domain separator, but a read whose
+	// charge fails now returns zero rather than the stored value, so a 1-gas context
+	// would hash an empty name and sign against the wrong domain.
+	gas := NewGasBudget(2_000_000)
+	domTok := newCAS20Token(&PrecompileContext{evm: evm, StateDB: statedb, Self: token, gas: &gas}, 18)
+
+	sign := func(key *ecdsa.PrivateKey, owner, spender common.Address, value, deadline, nonce uint64) (byte, common.Hash, common.Hash) {
+		sh := append([]byte{}, cas20PermitTypehash.Bytes()...)
+		sh = append(sh, addrKey(owner).Bytes()...)
+		sh = append(sh, addrKey(spender).Bytes()...)
+		sh = append(sh, u256hash(value).Bytes()...)
+		sh = append(sh, u256hash(nonce).Bytes()...)
+		sh = append(sh, u256hash(deadline).Bytes()...)
+		dom, paid := domTok.domainSeparator()
+		if !paid {
+			t.Fatal("the reference domain separator could not be paid for")
+		}
+		digest := crypto.Keccak256([]byte{0x19, 0x01}, dom.Bytes(), crypto.Keccak256(sh))
+		sig, err := crypto.Sign(digest, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return sig[64] + 27, common.BytesToHash(sig[0:32]), common.BytesToHash(sig[32:64])
+	}
+	permitCall := func(owner, spender common.Address, value, deadline uint64, v byte, r, s common.Hash) []byte {
+		return cas20Call(selPermit, addrKey(owner), addrKey(spender), u256hash(value), u256hash(deadline), u256hash(uint64(v)), r, s)
+	}
+
+	key, _ := crypto.GenerateKey()
+	owner := crypto.PubkeyToAddress(key.PublicKey)
+	spender := cas20Carol
+	relayer := cas20Bob // anyone may submit
+
+	// happy path: valid signature sets the allowance and bumps the nonce.
+	v, r, s := sign(key, owner, spender, 777, 200, 0)
+	// Empty returndata: EIP-2612's `permit(...) external` returns nothing, so a
+	// caller decoding a bool must fail here.
+	if ret, err := run(relayer, permitCall(owner, spender, 777, 200, v, r, s)); err != nil || len(ret) != 0 {
+		t.Fatalf("permit ret %x err %v, want empty returndata", ret, err)
+	}
+	if got := view.allowance(owner, spender).Uint64(); got != 777 {
+		t.Fatalf("allowance = %d, want 777", got)
+	}
+	if got := view.nonce(owner).Uint64(); got != 1 {
+		t.Fatalf("nonce = %d, want 1", got)
+	}
+
+	// replay of the same signature now fails (nonce consumed).
+	if _, err := run(relayer, permitCall(owner, spender, 777, 200, v, r, s)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("replay err = %v, want revert", err)
+	}
+
+	// expired deadline reverts.
+	v, r, s = sign(key, owner, spender, 1, 50, 1) // deadline 50 < now 100
+	if _, err := run(relayer, permitCall(owner, spender, 1, 50, v, r, s)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("expired err = %v, want revert", err)
+	}
+
+	// signature by a different key (claiming owner) reverts.
+	other, _ := crypto.GenerateKey()
+	v, r, s = sign(other, owner, spender, 5, 200, 1)
+	if _, err := run(relayer, permitCall(owner, spender, 5, 200, v, r, s)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("wrong-signer err = %v, want revert", err)
+	}
+
+	// DOMAIN_SEPARATOR() and nonces() views.
+	want, paid := domTok.domainSeparator()
+	if !paid {
+		t.Fatal("the reference domain separator could not be paid for")
+	}
+	if ret, err := run(relayer, cas20Call(selDomainSeparator)); err != nil || !bytes.Equal(ret, want.Bytes()) {
+		t.Fatalf("DOMAIN_SEPARATOR mismatch: %x err %v", ret, err)
+	}
+	if ret, _ := run(relayer, cas20Call(selNonces, addrKey(owner))); new(uint256.Int).SetBytes(ret).Uint64() != 1 {
+		t.Fatalf("nonces(owner) = %x, want 1", ret)
+	}
+}
+
+func TestCAS20Memo(t *testing.T) {
+	statedb, _, run := newTokenWithEVM(t, 1, func(s cas20Storage) {
+		s.setBalance(cas20Alice, uint256.NewInt(1000))
+	})
+	txHash := common.HexToHash("0xabc")
+	statedb.SetTxContext(txHash, 0)
+
+	memo := common.HexToHash("0xdeadbeef")
+	ret, err := run(cas20Alice, cas20Call(selTransferWithMemo, addrKey(cas20Bob), u256hash(100), memo))
+	if err != nil || !bytes.Equal(ret, encBool(true)) {
+		t.Fatalf("transferWithMemo ret %x err %v", ret, err)
+	}
+
+	logs := statedb.GetLogs(txHash, 1, common.Hash{}, 1)
+	if len(logs) != 2 {
+		t.Fatalf("got %d logs, want 2 (Transfer + Memo)", len(logs))
+	}
+	if logs[0].Topics[0] != cas20TopicTransfer {
+		t.Errorf("first log should be Transfer, got %s", logs[0].Topics[0].Hex())
+	}
+	if logs[1].Topics[0] != cas20TopicMemo || logs[1].Topics[1] != addrKey(cas20Alice) || logs[1].Topics[2] != memo {
+		t.Errorf("second log should be Memo(alice, memo)")
+	}
+}

--- a/core/vm/cas20_permit_test.go
+++ b/core/vm/cas20_permit_test.go
@@ -14,9 +14,6 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// newTokenWithEVM builds a token bound to a real EVM so ChainID()/BlockTime()
-// resolve (permit needs both). Any caller can submit; the seed callback runs
-// against the unmetered view.
 func newTokenWithEVM(t *testing.T, now uint64, seed func(cas20Storage)) (*state.StateDB, common.Address, func(caller common.Address, input []byte) ([]byte, error)) {
 	t.Helper()
 	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
@@ -44,11 +41,9 @@ func TestCAS20Permit(t *testing.T) {
 	})
 	view := newUnmeteredCAS20Storage(statedb, token)
 
-	// Build the token used only to compute the domain separator (same EVM cfg).
 	evm := NewEVM(BlockContext{BlockNumber: big.NewInt(1), Time: now}, statedb, cas20TestChainConfig(), Config{})
-	// A real budget: this token only computes the domain separator, but a read whose
-	// charge fails now returns zero rather than the stored value, so a 1-gas context
-	// would hash an empty name and sign against the wrong domain.
+	// A real budget: a read whose charge fails returns zero, and a 1-gas context
+	// would sign against an empty name.
 	gas := NewGasBudget(2_000_000)
 	domTok := newCAS20Token(&PrecompileContext{evm: evm, StateDB: statedb, Self: token, gas: &gas}, 18)
 
@@ -79,10 +74,8 @@ func TestCAS20Permit(t *testing.T) {
 	spender := cas20Carol
 	relayer := cas20Bob // anyone may submit
 
-	// happy path: valid signature sets the allowance and bumps the nonce.
 	v, r, s := sign(key, owner, spender, 777, 200, 0)
-	// Empty returndata: EIP-2612's `permit(...) external` returns nothing, so a
-	// caller decoding a bool must fail here.
+	// EIP-2612's permit returns nothing, so a caller decoding a bool must fail here.
 	if ret, err := run(relayer, permitCall(owner, spender, 777, 200, v, r, s)); err != nil || len(ret) != 0 {
 		t.Fatalf("permit ret %x err %v, want empty returndata", ret, err)
 	}
@@ -93,25 +86,21 @@ func TestCAS20Permit(t *testing.T) {
 		t.Fatalf("nonce = %d, want 1", got)
 	}
 
-	// replay of the same signature now fails (nonce consumed).
 	if _, err := run(relayer, permitCall(owner, spender, 777, 200, v, r, s)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("replay err = %v, want revert", err)
 	}
 
-	// expired deadline reverts.
 	v, r, s = sign(key, owner, spender, 1, 50, 1) // deadline 50 < now 100
 	if _, err := run(relayer, permitCall(owner, spender, 1, 50, v, r, s)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("expired err = %v, want revert", err)
 	}
 
-	// signature by a different key (claiming owner) reverts.
 	other, _ := crypto.GenerateKey()
 	v, r, s = sign(other, owner, spender, 5, 200, 1)
 	if _, err := run(relayer, permitCall(owner, spender, 5, 200, v, r, s)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("wrong-signer err = %v, want revert", err)
 	}
 
-	// DOMAIN_SEPARATOR() and nonces() views.
 	want, paid := domTok.domainSeparator()
 	if !paid {
 		t.Fatal("the reference domain separator could not be paid for")

--- a/core/vm/cas20_policy.go
+++ b/core/vm/cas20_policy.go
@@ -184,8 +184,9 @@ func (p policyReg) setMember(id uint64, account common.Address, in bool) {
 }
 
 // isAuthorized never reverts: it sits on every transfer's path. A malformed or
-// absent policy takes empty-set semantics, and the sentinel ids answer before the
-// registry is initialized.
+// absent policy takes empty-set semantics — which authorizes everyone for a
+// BLOCKLIST or an INTERSECT and no one for an ALLOWLIST or a UNION — and the
+// sentinel ids answer before the registry is initialized.
 func (p policyReg) isAuthorized(id uint64, account common.Address) bool {
 	if !polIDWellFormed(id) {
 		return false
@@ -208,11 +209,11 @@ func (p policyReg) isAuthorized(id uint64, account common.Address) bool {
 		}
 		return false
 	case cas20PolicyIntersect:
-		kids := p.children(id)
-		if len(kids) == 0 {
-			return false
-		}
-		for _, child := range kids {
+		// An AND over no children is vacuously true, so a well-formed INTERSECT id
+		// that names no policy authorizes everyone — the same tolerance a
+		// never-created BLOCKLIST already gets, and for the same reason: binding
+		// checks existence, so no token can reference one (BEP-702 3.8).
+		for _, child := range p.children(id) {
 			if !p.isAuthorized(child, account) {
 				return false
 			}
@@ -454,8 +455,10 @@ func runCAS20Policy(ctx *PrecompileContext, input []byte) ([]byte, error) {
 }
 
 // validateChildren checks a proposed child set: the count, then that every entry
-// exists, then that none is itself a composite. The no-nesting rule keeps
-// evaluation one level deep so isAuthorized cannot recurse without bound.
+// exists, then that every entry is eligible — neither a composite nor a sentinel.
+// The no-nesting rule keeps evaluation one level deep so isAuthorized cannot
+// recurse without bound; a sentinel is refused because it stores no membership
+// for a composite to consult.
 func validateChildren(reg policyReg, kids []common.Hash) ([]uint64, error) {
 	if len(kids) < cas20CompositeMinChildren || len(kids) > cas20CompositeMaxChildren {
 		return nil, revCAS20("ChildPoliciesOutsideOfRange()", errSelChildrenOutOfRange)
@@ -470,13 +473,23 @@ func validateChildren(reg policyReg, kids []common.Hash) ([]uint64, error) {
 		if !ok {
 			return nil, ErrExecutionReverted
 		}
+		out = append(out, id)
+	}
+	// Two passes over the whole set, not one interleaved pass per child: a set
+	// holding both a missing child and an ineligible one owes PolicyNotFound,
+	// whichever comes first in the array. The order decides which error the
+	// caller receives, so it is consensus (BEP-702 3.9).
+	for _, id := range out {
 		if !reg.policyExists(id) {
-			return nil, revCAS20("PolicyNotFound(uint64)", errSelPolicyNotFoundID, wU64(id))
+			return nil, revCAS20("PolicyNotFound()", errSelPolicyNotFound)
 		}
-		if polIsComposite(id) {
+	}
+	// A sentinel is refused alongside a composite: only a simple policy the
+	// registry actually minted can be a child.
+	for _, id := range out {
+		if isSentinelPolicy(id) || polIsComposite(id) {
 			return nil, revCAS20("InvalidChildPolicy(uint64)", errSelInvalidChildPolicy, wU64(id))
 		}
-		out = append(out, id)
 	}
 	return out, nil
 }
@@ -493,8 +506,9 @@ func emitCompositeUpdated(ctx *PrecompileContext, id uint64, admin common.Addres
 }
 
 // createCompositePolicy mints a UNION or INTERSECT over existing simple policies.
-// The type is checked first, before the zero-admin guard — the reverse of the
-// simple constructors, which check the admin first and then refuse composites.
+// The zero-admin guard comes first, as it does in the simple constructors: all
+// three agree on the order, and it is observable through which error a caller
+// receives (BEP-702 3.9).
 func createCompositePolicy(ctx *PrecompileContext, reg policyReg, args []byte) ([]byte, error) {
 	admin, err := readAddress(args, 0)
 	if err != nil {
@@ -505,14 +519,14 @@ func createCompositePolicy(ctx *PrecompileContext, reg policyReg, args []byte) (
 		return nil, err
 	}
 	if !isEnumWord(ptypeWord, cas20PolicyIntersect) {
-		return nil, revPanic(0x21)
+		return nil, ErrExecutionReverted
 	}
 	ptype := ptypeWord[31]
-	if !polIsComposite(uint64(ptype) << 56) {
-		return nil, revCAS20("IncompatiblePolicyType()", errSelIncompatibleType)
-	}
 	if admin == (common.Address{}) {
 		return nil, revCAS20("ZeroAddress()", errSelZeroAddress)
+	}
+	if !polIsComposite(uint64(ptype) << 56) {
+		return nil, revCAS20("IncompatiblePolicyType()", errSelIncompatibleType)
 	}
 	rawKids, err := readWordArray(args, 2)
 	if err != nil {
@@ -551,7 +565,7 @@ func updateComposite(ctx *PrecompileContext, reg policyReg, args []byte) error {
 		return err
 	}
 	if !reg.policyExists(id) {
-		return revCAS20("PolicyNotFound(uint64)", errSelPolicyNotFoundID, wU64(id))
+		return revCAS20("PolicyNotFound()", errSelPolicyNotFound)
 	}
 	if !polIsComposite(id) {
 		return revCAS20("IncompatiblePolicyType()", errSelIncompatibleType)
@@ -588,7 +602,7 @@ func createPolicy(ctx *PrecompileContext, reg policyReg, args []byte, withAccoun
 	// refused by the logic instead, after the zero-admin check and before the batch
 	// bound — a composite is minted only through createCompositePolicy.
 	if !isEnumWord(ptypeWord, cas20PolicyIntersect) {
-		return nil, revPanic(0x21)
+		return nil, ErrExecutionReverted
 	}
 	if admin == (common.Address{}) {
 		return nil, revCAS20("ZeroAddress()", errSelZeroAddress)
@@ -656,7 +670,7 @@ func updateMembers(ctx *PrecompileContext, reg policyReg, args []byte, wantType 
 		return err
 	}
 	if !isEnumWord(inWord, 1) { // strict ABI bool
-		return revPanic(0x21)
+		return ErrExecutionReverted
 	}
 	accounts, err := readWordArray(args, 2)
 	if err != nil {

--- a/core/vm/cas20_policy.go
+++ b/core/vm/cas20_policy.go
@@ -340,7 +340,6 @@ func (p policyReg) ensureInitialized() uint64 {
 	return cas20PolicyFirstID
 }
 
-// cas20PolicyPrecompile is the singleton registry precompile.
 type cas20PolicyPrecompile struct{ cas20StatefulBase }
 
 func (p *cas20PolicyPrecompile) Name() string { return "CAS20PolicyRegistry" }

--- a/core/vm/cas20_policy.go
+++ b/core/vm/cas20_policy.go
@@ -1,0 +1,786 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+// PolicyRegistry: a chain-shared allow/block-list registry. A policy is a set
+// of addresses plus a type, referenced by tokens via a self-describing uint64
+// id (high byte = type, low 56 bits = global counter). Reads never revert (they
+// sit on every transfer's hot path); writes are admin-gated.
+
+// CAS20PolicyRegistryAddress is the singleton registry precompile (BEP-702 §3.1).
+var CAS20PolicyRegistryAddress = common.HexToAddress("0x7020000000000000000000000000000000000002")
+
+const cas20PolicyNamespace = "bsc.policy_registry"
+
+const (
+	cas20PolicyBlocklist = 0
+	cas20PolicyAllowlist = 1
+	cas20PolicyUnion     = 2 // authorized by ANY child (Cobalt)
+	cas20PolicyIntersect = 3 // authorized by EVERY child (Cobalt)
+	cas20PolicyBatchMax  = 64
+
+	// A composite references between two and four simple policies, inclusive.
+	cas20CompositeMinChildren = 2
+	cas20CompositeMaxChildren = 4
+	cas20PolicyFirstID        = 2 // counters 0 and 1 belong to the two sentinels
+
+	// Sentinel policy ids, seeded at initialization and always valid to bind.
+	cas20PolicyAlwaysAllow = 0                 // blocklist type, empty -> allow all
+	cas20PolicyAlwaysBlock = uint64(1)<<56 | 1 // allowlist type, empty -> block all
+
+	// cas20PolicyCounterMax bounds the 56-bit counter space. Creation is refused at
+	// the boundary rather than allowed to carry into the type byte, where it
+	// would collide ids across types and could reach a sentinel.
+	cas20PolicyCounterMax = uint64(1)<<56 - 1
+)
+
+// Storage layout (BEP-702 3.17). Slots are append-only: never reorder them
+// across forks.
+const (
+	polSlotPolicies      = 0 // mapping(uint64 => packed word)
+	polSlotMembers       = 1 // mapping(uint64 => mapping(address => bool))
+	polSlotPendingAdmins = 2 // mapping(uint64 => address)
+	polSlotCounter       = 3 // uint64
+	polSlotChildren      = 4 // mapping(uint64 => uint64[]) (Cobalt)
+)
+
+// A policy's existence and admin share one word: bit 255 exists, bits 159:0 the
+// admin. That keeps a policy whose admin was renounced to zero distinct from an
+// unwritten slot.
+var polExistsBit = new(uint256.Int).Lsh(uint256.NewInt(1), 255)
+
+func packPolicy(admin common.Address) common.Hash {
+	w := new(uint256.Int).SetBytes(admin.Bytes())
+	return w.Or(w, polExistsBit).Bytes32()
+}
+
+func polWordExists(w common.Hash) bool          { return w[0]&0x80 != 0 }
+func polWordAdmin(w common.Hash) common.Address { return common.BytesToAddress(w[12:]) }
+
+func polIDType(id uint64) byte { return byte(id >> 56) }
+
+// polIDWellFormed reports whether an id's type byte names a real policy type.
+func polIDWellFormed(id uint64) bool { return polIDType(id) <= cas20PolicyIntersect }
+
+func isSentinelPolicy(id uint64) bool {
+	return id == cas20PolicyAlwaysAllow || id == cas20PolicyAlwaysBlock
+}
+
+var cas20PolicyRoot = erc7201Root(cas20PolicyNamespace)
+
+var (
+	selCreatePolicy             = selector("createPolicy(address,uint8)")
+	selCreatePolicyWithAccounts = selector("createPolicyWithAccounts(address,uint8,address[])")
+	selCreateComposite          = selector("createCompositePolicy(address,uint8,uint64[])")
+	selUpdateComposite          = selector("updateComposite(uint64,uint64[])")
+	selCompositeChildIds        = selector("compositePolicyChildIds(uint64)")
+	selMinCompositeChildren     = selector("MIN_COMPOSITE_CHILD_POLICIES()")
+	selMaxCompositeChildren     = selector("MAX_COMPOSITE_CHILD_POLICIES()")
+	selUpdateAllowlist          = selector("updateAllowlist(uint64,bool,address[])")
+	selUpdateBlocklist          = selector("updateBlocklist(uint64,bool,address[])")
+	selStageUpdateAdmin         = selector("stageUpdateAdmin(uint64,address)")
+	selFinalizeUpdateAdmin      = selector("finalizeUpdateAdmin(uint64)")
+	selRenounceAdmin            = selector("renounceAdmin(uint64)")
+	selIsAuthorized             = selector("isAuthorized(uint64,address)")
+	selPolicyExists             = selector("policyExists(uint64)")
+	selPolicyAdmin              = selector("policyAdmin(uint64)")
+	selPendingPolicyAdmin       = selector("pendingPolicyAdmin(uint64)")
+
+	cas20TopicPolicyCreated      = eventTopic("PolicyCreated(uint64,address,uint8)")
+	cas20TopicPolicyAdminStaged  = eventTopic("PolicyAdminStaged(uint64,address,address)")
+	cas20TopicPolicyAdminUpdated = eventTopic("PolicyAdminUpdated(uint64,address,address)")
+	cas20TopicCompositeUpdated   = eventTopic("CompositePolicyUpdated(uint64,address,uint64[])")
+	cas20TopicAllowlistUpdated   = eventTopic("AllowlistUpdated(uint64,address,bool,address[])")
+	cas20TopicBlocklistUpdated   = eventTopic("BlocklistUpdated(uint64,address,bool,address[])")
+)
+
+// emitPolicyAdminUpdated reports creation, handover and renunciation through one
+// event, so a policy's whole admin history is a single filter.
+func emitPolicyAdminUpdated(ctx *PrecompileContext, id uint64, previous, next common.Address) bool {
+	return ctx.AddLog([]common.Hash{
+		cas20TopicPolicyAdminUpdated, idKey(id), addrKey(previous), addrKey(next),
+	}, nil)
+}
+
+// emitMembersUpdated reports under the event belonging to the policy's own type,
+// so a consumer can subscribe to just the list it cares about.
+func emitMembersUpdated(ctx *PrecompileContext, ptype byte, id uint64, updater common.Address, included bool, accounts []common.Hash) bool {
+	topic := cas20TopicBlocklistUpdated
+	if ptype == cas20PolicyAllowlist {
+		topic = cas20TopicAllowlistUpdated
+	}
+	return ctx.AddLog(
+		[]common.Hash{topic, idKey(id), addrKey(updater)},
+		encodeTuple(abiWord(boolWord(included)), abiWordArray(accounts)),
+	)
+}
+
+func boolWord(b bool) common.Hash {
+	var w common.Hash
+	if b {
+		w[31] = 1
+	}
+	return w
+}
+
+// policyReg is a gas-metered view over the registry's storage.
+type policyReg struct{ s cas20Storage }
+
+func newPolicyReg(ctx *PrecompileContext) policyReg {
+	return policyReg{s: newMeteredCAS20StorageAt(ctx, CAS20PolicyRegistryAddress)}
+}
+
+func polSlot(offset uint64) common.Hash { return offsetSlot(cas20PolicyRoot, offset) }
+
+func idKey(id uint64) common.Hash { return uint256.NewInt(id).Bytes32() }
+
+// isEnumWord reports whether an ABI word strictly encodes an enum/bool value
+// in [0, max]: every byte above the last must be zero.
+func isEnumWord(w common.Hash, max byte) bool {
+	return wordFitsIn(w, 1) && w[31] <= max
+}
+
+func (p policyReg) counter() uint64 {
+	return new(uint256.Int).SetBytes(p.s.getWord(polSlot(polSlotCounter)).Bytes()).Uint64()
+}
+func (p policyReg) setCounter(v uint64) {
+	p.s.setWord(polSlot(polSlotCounter), uint256.NewInt(v).Bytes32())
+}
+
+func (p policyReg) policyWord(id uint64) common.Hash {
+	return p.s.getWord(p.s.mapSlot(polSlot(polSlotPolicies), idKey(id)))
+}
+
+// setPolicyAdmin writes the packed word, which marks the policy as existing.
+// Renouncing goes through here too, with the zero address: the exists bit stays
+// set, so a renounced policy remains distinguishable from one never created.
+func (p policyReg) setPolicyAdmin(id uint64, a common.Address) {
+	p.s.setWord(p.s.mapSlot(polSlot(polSlotPolicies), idKey(id)), packPolicy(a))
+}
+
+func (p policyReg) exists(id uint64) bool          { return polWordExists(p.policyWord(id)) }
+func (p policyReg) admin(id uint64) common.Address { return polWordAdmin(p.policyWord(id)) }
+
+func (p policyReg) pending(id uint64) common.Address {
+	return common.BytesToAddress(p.s.getWord(p.s.mapSlot(polSlot(polSlotPendingAdmins), idKey(id))).Bytes())
+}
+func (p policyReg) setPending(id uint64, a common.Address) {
+	p.s.setWord(p.s.mapSlot(polSlot(polSlotPendingAdmins), idKey(id)), addrKey(a))
+}
+func (p policyReg) member(id uint64, account common.Address) bool {
+	inner := p.s.mapSlot(polSlot(polSlotMembers), idKey(id))
+	return p.s.getWord(p.s.mapSlot(inner, addrKey(account))) != (common.Hash{})
+}
+func (p policyReg) setMember(id uint64, account common.Address, in bool) {
+	inner := p.s.mapSlot(polSlot(polSlotMembers), idKey(id))
+	var v common.Hash
+	if in {
+		v[31] = 1
+	}
+	p.s.setWord(p.s.mapSlot(inner, addrKey(account)), v)
+}
+
+// isAuthorized never reverts: it sits on every transfer's path. A malformed or
+// absent policy takes empty-set semantics, and the sentinel ids answer before the
+// registry is initialized.
+func (p policyReg) isAuthorized(id uint64, account common.Address) bool {
+	if !polIDWellFormed(id) {
+		return false
+	}
+	switch id {
+	case cas20PolicyAlwaysAllow:
+		return true
+	case cas20PolicyAlwaysBlock:
+		return false
+	}
+	// A composite has no members of its own: it asks its children, every time, so
+	// mutating a child's membership changes the composite's verdict with no call on
+	// the composite itself.
+	switch polIDType(id) {
+	case cas20PolicyUnion:
+		for _, child := range p.children(id) {
+			if p.isAuthorized(child, account) {
+				return true
+			}
+		}
+		return false
+	case cas20PolicyIntersect:
+		kids := p.children(id)
+		if len(kids) == 0 {
+			return false
+		}
+		for _, child := range kids {
+			if !p.isAuthorized(child, account) {
+				return false
+			}
+		}
+		return true
+	}
+	member := p.member(id, account)
+	if polIDType(id) == cas20PolicyAllowlist {
+		return member
+	}
+	return !member
+}
+
+// polIsComposite reports whether an id names a UNION or INTERSECT policy.
+func polIsComposite(id uint64) bool {
+	t := polIDType(id)
+	return t == cas20PolicyUnion || t == cas20PolicyIntersect
+}
+
+// children reads a composite's child set. Solidity stores a uint64[] as a length
+// word at the mapping slot with the elements packed four per word from
+// keccak256(slot), which is what the factory and a reference contract must agree
+// on byte for byte.
+func (p policyReg) childrenSlot(id uint64) common.Hash {
+	return p.s.mapSlot(polSlot(polSlotChildren), idKey(id))
+}
+
+func (p policyReg) children(id uint64) []uint64 {
+	slot := p.childrenSlot(id)
+	n := new(uint256.Int).SetBytes(p.s.getWord(slot).Bytes()).Uint64()
+	if n == 0 || n > cas20CompositeMaxChildren {
+		return nil
+	}
+	base := p.s.stringDataRoot(slot)
+	out := make([]uint64, 0, n)
+	for i := uint64(0); i < n; i++ {
+		if p.s.ctx != nil && p.s.ctx.OutOfGas() {
+			return nil
+		}
+		w := p.s.getWord(new(uint256.Int).AddUint64(base, i/4).Bytes32())
+		// Four uint64 lanes per word, LSB-first as Solidity packs them.
+		lane := uint((i % 4) * 8)
+		out = append(out, new(uint256.Int).Rsh(new(uint256.Int).SetBytes(w.Bytes()), lane*8).Uint64())
+	}
+	return out
+}
+
+func (p policyReg) setChildren(id uint64, kids []uint64) {
+	slot := p.childrenSlot(id)
+	p.s.setWord(slot, uint256.NewInt(uint64(len(kids))).Bytes32())
+	base := p.s.stringDataRoot(slot)
+	// Each word is built from scratch and written whole, so lanes past the new
+	// length are zeroed rather than left behind. The loop then runs to the word
+	// count the *maximum* set would need, not the new one, which clears any tail a
+	// shrink orphaned — Solidity's array assignment does the same, and without it
+	// the state root would diverge from a reference contract even though every read
+	// agreed. Today the cap of four is exactly one word so the tail is empty; this
+	// is what keeps that from being load-bearing.
+	maxWords := (cas20CompositeMaxChildren + 3) / 4
+	for w := 0; w < maxWords; w++ {
+		packed := new(uint256.Int)
+		for lane := 0; lane < 4 && w*4+lane < len(kids); lane++ {
+			packed.Or(packed, new(uint256.Int).Lsh(uint256.NewInt(kids[w*4+lane]), uint(lane)*64))
+		}
+		slotW := new(uint256.Int).AddUint64(base, uint64(w)).Bytes32()
+		if packed.IsZero() && w*4 >= len(kids) {
+			// Nothing to store here; only write if something is already there, so a
+			// fresh composite does not pay for clearing empty slots.
+			if p.s.getWord(slotW) == (common.Hash{}) {
+				continue
+			}
+		}
+		p.s.setWord(slotW, packed.Bytes32())
+	}
+}
+
+// policyExists is the ABI view. A malformed id never exists; the sentinels
+// always do, before initialization included.
+func (p policyReg) policyExists(id uint64) bool {
+	if !polIDWellFormed(id) {
+		return false
+	}
+	if isSentinelPolicy(id) {
+		return true
+	}
+	return p.exists(id)
+}
+
+// policyAdminOf is the ABI view: zero for a malformed id and for any policy that
+// does not exist, so a caller cannot mistake an unwritten slot for an admin.
+func (p policyReg) policyAdminOf(id uint64) common.Address {
+	if !polIDWellFormed(id) {
+		return common.Address{}
+	}
+	w := p.policyWord(id)
+	if !polWordExists(w) {
+		return common.Address{}
+	}
+	return polWordAdmin(w)
+}
+
+// pendingPolicyAdminOf is the ABI view. The sentinels can never have a pending
+// admin, so their slot is never even read.
+func (p policyReg) pendingPolicyAdminOf(id uint64) common.Address {
+	if !polIDWellFormed(id) || isSentinelPolicy(id) {
+		return common.Address{}
+	}
+	return p.pending(id)
+}
+
+// ensureInitialized seeds the two sentinel policies and leaves the counter on
+// the first id available to callers. It gates on the counter, not on the sentinel
+// words, so a harness that pre-warms the account's bytecode cannot cause the
+// seeding to be skipped.
+func (p policyReg) ensureInitialized() uint64 {
+	c := p.counter()
+	if c >= cas20PolicyFirstID {
+		return c
+	}
+	// Both sentinels are born renounced: they exist, and nobody administers them.
+	p.setPolicyAdmin(cas20PolicyAlwaysAllow, common.Address{})
+	p.setPolicyAdmin(cas20PolicyAlwaysBlock, common.Address{})
+	p.setCounter(cas20PolicyFirstID)
+	return cas20PolicyFirstID
+}
+
+// cas20PolicyPrecompile is the singleton registry precompile.
+type cas20PolicyPrecompile struct{ cas20StatefulBase }
+
+func (p *cas20PolicyPrecompile) Name() string { return "CAS20PolicyRegistry" }
+
+func (p *cas20PolicyPrecompile) RunStateful(ctx *PrecompileContext, input []byte) ([]byte, error) {
+	if err := cas20EnterCall(ctx, input); err != nil {
+		return finishCAS20(nil, err)
+	}
+	ret, err := runCAS20Policy(ctx, input)
+	return finishCAS20Metered(ctx, ret, err)
+}
+
+func runCAS20Policy(ctx *PrecompileContext, input []byte) ([]byte, error) {
+	if len(input) < 4 {
+		return nil, ErrExecutionReverted
+	}
+	var sel [4]byte
+	copy(sel[:], input[:4])
+	args := input[4:]
+	reg := newPolicyReg(ctx)
+
+	switch sel {
+	// reads (allowed in read-only frames, never revert on lookup)
+	case selIsAuthorized:
+		id, err := readU64(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		acct, err := readAddress(args, 1)
+		if err != nil {
+			return nil, err
+		}
+		return encBool(reg.isAuthorized(id, acct)), nil
+	case selPolicyExists:
+		id, err := readU64(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		return encBool(reg.policyExists(id)), nil
+	case selPolicyAdmin:
+		id, err := readU64(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		return addrKey(reg.policyAdminOf(id)).Bytes(), nil
+	case selPendingPolicyAdmin:
+		id, err := readU64(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		return addrKey(reg.pendingPolicyAdminOf(id)).Bytes(), nil
+	case selMinCompositeChildren:
+		return encU256(uint256.NewInt(cas20CompositeMinChildren)), nil
+	case selMaxCompositeChildren:
+		return encU256(uint256.NewInt(cas20CompositeMaxChildren)), nil
+	case selCompositeChildIds:
+		id, err := readU64(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		kids := reg.children(id)
+		words := make([]common.Hash, len(kids))
+		for i, k := range kids {
+			words[i] = wU64(k)
+		}
+		return encodeTuple(abiWordArray(words)), nil
+	}
+
+	// Writes: unknown selector, then static frame, then inactive feature, before
+	// decoding arguments. The order is consensus-visible (BEP-702 3.15).
+	//
+	// This is the only place a write path checks ReadOnly. The handlers below used
+	// to repeat it, which the reference implementation does not — it enforces the
+	// call-frame invariants in the frame machinery, not per method — and repeating
+	// it here bought nothing: none of them is reachable except through this switch.
+	switch sel {
+	case selCreatePolicy, selCreatePolicyWithAccounts, selUpdateAllowlist,
+		selUpdateBlocklist, selStageUpdateAdmin, selFinalizeUpdateAdmin, selRenounceAdmin,
+		selCreateComposite, selUpdateComposite:
+		if ctx.ReadOnly {
+			return nil, ErrWriteProtection
+		}
+		if err := ensureFeatureActivated(ctx, featurePolicyRegistry); err != nil {
+			return nil, err
+		}
+		ctx.ensureSentinel()
+	default:
+		return nil, ErrExecutionReverted // unknown selector
+	}
+
+	switch sel {
+	case selCreatePolicy:
+		return createPolicy(ctx, reg, args, false)
+	case selCreatePolicyWithAccounts:
+		return createPolicy(ctx, reg, args, true)
+	case selCreateComposite:
+		return createCompositePolicy(ctx, reg, args)
+	case selUpdateComposite:
+		return nil, updateComposite(ctx, reg, args)
+	case selUpdateAllowlist:
+		return nil, updateMembers(ctx, reg, args, cas20PolicyAllowlist)
+	case selUpdateBlocklist:
+		return nil, updateMembers(ctx, reg, args, cas20PolicyBlocklist)
+	case selStageUpdateAdmin:
+		return nil, stageUpdateAdmin(ctx, reg, args)
+	case selFinalizeUpdateAdmin:
+		return nil, finalizeUpdateAdmin(ctx, reg, args)
+	case selRenounceAdmin:
+		return nil, renounceAdmin(ctx, reg, args)
+	}
+	return nil, ErrExecutionReverted // unreachable: the gate above is exhaustive
+}
+
+// validateChildren checks a proposed child set: the count, then that every entry
+// exists, then that none is itself a composite. The no-nesting rule keeps
+// evaluation one level deep so isAuthorized cannot recurse without bound.
+func validateChildren(reg policyReg, kids []common.Hash) ([]uint64, error) {
+	if len(kids) < cas20CompositeMinChildren || len(kids) > cas20CompositeMaxChildren {
+		return nil, revCAS20("ChildPoliciesOutsideOfRange()", errSelChildrenOutOfRange)
+	}
+	out := make([]uint64, 0, len(kids))
+	for _, w := range kids {
+		// Strictly decoded, as Solidity's external decoder does: taking the low
+		// eight bytes of a 32-byte word would let a caller name one policy in the
+		// bytes that matter and anything at all in the rest, and we would act on
+		// the former where a revert is owed.
+		id, ok := u64FromWord(w)
+		if !ok {
+			return nil, ErrExecutionReverted
+		}
+		if !reg.policyExists(id) {
+			return nil, revCAS20("PolicyNotFound(uint64)", errSelPolicyNotFoundID, wU64(id))
+		}
+		if polIsComposite(id) {
+			return nil, revCAS20("InvalidChildPolicy(uint64)", errSelInvalidChildPolicy, wU64(id))
+		}
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+// emitCompositeUpdated logs the complete post-update child set, on creation and
+// on every replacement.
+func emitCompositeUpdated(ctx *PrecompileContext, id uint64, admin common.Address, kids []uint64) bool {
+	words := make([]common.Hash, len(kids))
+	for i, k := range kids {
+		words[i] = wU64(k)
+	}
+	return ctx.AddLog([]common.Hash{cas20TopicCompositeUpdated, idKey(id), addrKey(admin)},
+		encodeTuple(abiWordArray(words)))
+}
+
+// createCompositePolicy mints a UNION or INTERSECT over existing simple policies.
+// The type is checked first, before the zero-admin guard — the reverse of the
+// simple constructors, which check the admin first and then refuse composites.
+func createCompositePolicy(ctx *PrecompileContext, reg policyReg, args []byte) ([]byte, error) {
+	admin, err := readAddress(args, 0)
+	if err != nil {
+		return nil, err
+	}
+	ptypeWord, err := readWord(args, 1)
+	if err != nil {
+		return nil, err
+	}
+	if !isEnumWord(ptypeWord, cas20PolicyIntersect) {
+		return nil, revPanic(0x21)
+	}
+	ptype := ptypeWord[31]
+	if !polIsComposite(uint64(ptype) << 56) {
+		return nil, revCAS20("IncompatiblePolicyType()", errSelIncompatibleType)
+	}
+	if admin == (common.Address{}) {
+		return nil, revCAS20("ZeroAddress()", errSelZeroAddress)
+	}
+	rawKids, err := readWordArray(args, 2)
+	if err != nil {
+		return nil, err
+	}
+	kids, err := validateChildren(reg, rawKids)
+	if err != nil {
+		return nil, err
+	}
+
+	c := reg.ensureInitialized()
+	if c >= cas20PolicyCounterMax {
+		return nil, revPanic(0x11)
+	}
+	id := uint64(ptype)<<56 | c
+	reg.setCounter(c + 1)
+	reg.setPolicyAdmin(id, admin)
+	reg.setChildren(id, kids)
+	if !ctx.AddLog([]common.Hash{cas20TopicPolicyCreated, idKey(id), addrKey(ctx.Caller)}, wU8(ptype).Bytes()) {
+		return nil, ErrOutOfGas
+	}
+	if !emitPolicyAdminUpdated(ctx, id, common.Address{}, admin) {
+		return nil, ErrOutOfGas
+	}
+	if !emitCompositeUpdated(ctx, id, admin, kids) {
+		return nil, ErrOutOfGas
+	}
+	return wU64(id).Bytes(), nil
+}
+
+// updateComposite replaces a composite's child set in full. There is no partial
+// update and no way to empty the list, since the count bound forbids it.
+func updateComposite(ctx *PrecompileContext, reg policyReg, args []byte) error {
+	id, err := readU64(args, 0)
+	if err != nil {
+		return err
+	}
+	if !reg.policyExists(id) {
+		return revCAS20("PolicyNotFound(uint64)", errSelPolicyNotFoundID, wU64(id))
+	}
+	if !polIsComposite(id) {
+		return revCAS20("IncompatiblePolicyType()", errSelIncompatibleType)
+	}
+	if admin := reg.admin(id); admin == (common.Address{}) || admin != ctx.Caller {
+		return revCAS20("Unauthorized()", errSelUnauthorized)
+	}
+	rawKids, err := readWordArray(args, 1)
+	if err != nil {
+		return err
+	}
+	kids, err := validateChildren(reg, rawKids)
+	if err != nil {
+		return err
+	}
+	reg.setChildren(id, kids)
+	if !emitCompositeUpdated(ctx, id, ctx.Caller, kids) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func createPolicy(ctx *PrecompileContext, reg policyReg, args []byte, withAccounts bool) ([]byte, error) {
+	admin, err := readAddress(args, 0)
+	if err != nil {
+		return nil, err
+	}
+	ptypeWord, err := readWord(args, 1)
+	if err != nil {
+		return nil, err
+	}
+	ptype := ptypeWord[31]
+	// The enum widened to four values at Cobalt, so 2 and 3 now decode. They are
+	// refused by the logic instead, after the zero-admin check and before the batch
+	// bound — a composite is minted only through createCompositePolicy.
+	if !isEnumWord(ptypeWord, cas20PolicyIntersect) {
+		return nil, revPanic(0x21)
+	}
+	if admin == (common.Address{}) {
+		return nil, revCAS20("ZeroAddress()", errSelZeroAddress)
+	}
+	if polIsComposite(uint64(ptype) << 56) {
+		return nil, revCAS20("IncompatiblePolicyType()", errSelIncompatibleType)
+	}
+
+	// The batch is decoded and bounded before any state is written. An enclosing
+	// revert would discard premature writes anyway, but it would not give back the
+	// gas they were metered at.
+	var accounts []common.Hash
+	if withAccounts {
+		if accounts, err = readWordArray(args, 2); err != nil {
+			return nil, err
+		}
+		if len(accounts) > cas20PolicyBatchMax {
+			return nil, revCAS20("BatchSizeTooLarge(uint256)", errSelBatchTooLarge, wU64(cas20PolicyBatchMax))
+		}
+	}
+
+	c := reg.ensureInitialized()
+	// The counter shares its 56 bits across both types, so exhausting it must be
+	// refused rather than allowed to carry into the type byte.
+	if c >= cas20PolicyCounterMax {
+		return nil, revPanic(0x11)
+	}
+	id := uint64(ptype)<<56 | c
+	reg.setCounter(c + 1)
+	reg.setPolicyAdmin(id, admin)
+	if !ctx.AddLog([]common.Hash{cas20TopicPolicyCreated, idKey(id), addrKey(ctx.Caller)}, wU8(ptype).Bytes()) {
+		return nil, ErrOutOfGas
+	}
+	// The initial admin is reported as a transition from nobody, so it lands in
+	// the same event stream as every later handover.
+	if !emitPolicyAdminUpdated(ctx, id, common.Address{}, admin) {
+		return nil, ErrOutOfGas
+	}
+
+	if withAccounts {
+		for _, a := range accounts {
+			// Same strictness as a single address argument: readAddress refuses a
+			// dirty word, and an element of an array must not be laxer.
+			addr, ok := addressFromWord(a)
+			if !ok {
+				return nil, ErrExecutionReverted
+			}
+			reg.setMember(id, addr, true)
+		}
+		// Emitted even for an empty batch: the call form is part of the record.
+		if !emitMembersUpdated(ctx, ptype, id, ctx.Caller, true, accounts) {
+			return nil, ErrOutOfGas
+		}
+	}
+	return encU256(uint256.NewInt(id)), nil
+}
+
+func updateMembers(ctx *PrecompileContext, reg policyReg, args []byte, wantType byte) error {
+	pid, err := readU64(args, 0)
+	if err != nil {
+		return err
+	}
+	inWord, err := readWord(args, 1)
+	if err != nil {
+		return err
+	}
+	if !isEnumWord(inWord, 1) { // strict ABI bool
+		return revPanic(0x21)
+	}
+	accounts, err := readWordArray(args, 2)
+	if err != nil {
+		return err
+	}
+	// Order matters: it is observable through which error the caller receives —
+	// existence, then type, then admin, then batch.
+	if err := requirePolicyExists(reg, pid); err != nil {
+		return err
+	}
+	if polIDType(pid) != wantType {
+		return revCAS20("IncompatiblePolicyType()", errSelIncompatibleType)
+	}
+	if err := requirePolicyAdmin(reg, pid, ctx.Caller); err != nil {
+		return err
+	}
+	if len(accounts) > cas20PolicyBatchMax {
+		return revCAS20("BatchSizeTooLarge(uint256)", errSelBatchTooLarge, wU64(cas20PolicyBatchMax))
+	}
+	// Both strictly decoded, as Solidity's external decoder does. bool accepts
+	// only 0 or 1, and an address element must not drop its high padding — this
+	// path is the routine one, so a dirty word would add or remove a different
+	// account than the encoding names.
+	if !isEnumWord(inWord, 1) {
+		return ErrExecutionReverted
+	}
+	in := inWord[31] == 1
+	for _, a := range accounts {
+		addr, ok := addressFromWord(a)
+		if !ok {
+			return ErrExecutionReverted
+		}
+		reg.setMember(pid, addr, in)
+	}
+	if !emitMembersUpdated(ctx, wantType, pid, ctx.Caller, in, accounts) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func stageUpdateAdmin(ctx *PrecompileContext, reg policyReg, args []byte) error {
+	id, err := readU64(args, 0)
+	if err != nil {
+		return err
+	}
+	newAdmin, err := readAddress(args, 1)
+	if err != nil {
+		return err
+	}
+	if err := requirePolicyAdmin(reg, id, ctx.Caller); err != nil {
+		return err
+	}
+	reg.setPending(id, newAdmin)
+	// Emitted for a cancellation too, where newAdmin is zero: withdrawing a
+	// nomination is a governance action and should not be a silent one.
+	if !ctx.AddLog([]common.Hash{
+		cas20TopicPolicyAdminStaged, idKey(id), addrKey(ctx.Caller), addrKey(newAdmin),
+	}, nil) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func finalizeUpdateAdmin(ctx *PrecompileContext, reg policyReg, args []byte) error {
+	pid, err := readU64(args, 0)
+	if err != nil {
+		return err
+	}
+	if err := requirePolicyExists(reg, pid); err != nil {
+		return err
+	}
+	pending := reg.pending(pid)
+	if pending == (common.Address{}) {
+		return revCAS20("NoPendingAdmin()", errSelNoPendingAdmin)
+	}
+	if pending != ctx.Caller || ctx.Caller == (common.Address{}) {
+		return revCAS20("Unauthorized()", errSelUnauthorized)
+	}
+	previous := reg.admin(pid)
+	reg.setPolicyAdmin(pid, ctx.Caller)
+	reg.setPending(pid, common.Address{})
+	if !emitPolicyAdminUpdated(ctx, pid, previous, ctx.Caller) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+func renounceAdmin(ctx *PrecompileContext, reg policyReg, args []byte) error {
+	pid, err := readU64(args, 0)
+	if err != nil {
+		return err
+	}
+	if err := requirePolicyAdmin(reg, pid, ctx.Caller); err != nil {
+		return err
+	}
+	// Frozen, not deleted: the packed word keeps its exists bit, so the policy
+	// stays distinguishable from one never created and its membership keeps
+	// answering reads.
+	reg.setPolicyAdmin(pid, common.Address{})
+	reg.setPending(pid, common.Address{})
+	if !emitPolicyAdminUpdated(ctx, pid, ctx.Caller, common.Address{}) {
+		return ErrOutOfGas
+	}
+	return nil
+}
+
+// requirePolicyExists reverts PolicyNotFound unless the policy exists. It asks
+// policyExists rather than the raw bit, because the sentinels are seeded lazily
+// and always exist whether or not their word has been written; it is their zero
+// admin that keeps them un-administrable.
+func requirePolicyExists(reg policyReg, id uint64) error {
+	if !reg.policyExists(id) {
+		return revCAS20("PolicyNotFound()", errSelPolicyNotFound)
+	}
+	return nil
+}
+
+// requirePolicyAdmin reverts unless the policy exists and caller is its admin.
+func requirePolicyAdmin(reg policyReg, id uint64, caller common.Address) error {
+	if err := requirePolicyExists(reg, id); err != nil {
+		return err
+	}
+	if admin := reg.admin(id); admin == (common.Address{}) || admin != caller {
+		return revCAS20("Unauthorized()", errSelUnauthorized)
+	}
+	return nil
+}

--- a/core/vm/cas20_policy.go
+++ b/core/vm/cas20_policy.go
@@ -425,7 +425,6 @@ func runCAS20Policy(ctx *PrecompileContext, input []byte) ([]byte, error) {
 		if err := ensureFeatureActivated(ctx, featurePolicyRegistry); err != nil {
 			return nil, err
 		}
-		ctx.ensureSentinel()
 	default:
 		return nil, ErrExecutionReverted // unknown selector
 	}

--- a/core/vm/cas20_policy.go
+++ b/core/vm/cas20_policy.go
@@ -10,7 +10,6 @@ import (
 // id (high byte = type, low 56 bits = global counter). Reads never revert (they
 // sit on every transfer's hot path); writes are admin-gated.
 
-// CAS20PolicyRegistryAddress is the singleton registry precompile (BEP-702 §3.1).
 var CAS20PolicyRegistryAddress = common.HexToAddress("0x7020000000000000000000000000000000000002")
 
 const cas20PolicyNamespace = "bsc.policy_registry"
@@ -18,38 +17,30 @@ const cas20PolicyNamespace = "bsc.policy_registry"
 const (
 	cas20PolicyBlocklist = 0
 	cas20PolicyAllowlist = 1
-	cas20PolicyUnion     = 2 // authorized by ANY child (Cobalt)
-	cas20PolicyIntersect = 3 // authorized by EVERY child (Cobalt)
+	cas20PolicyUnion     = 2 // authorized by ANY child
+	cas20PolicyIntersect = 3 // authorized by EVERY child
 	cas20PolicyBatchMax  = 64
 
-	// A composite references between two and four simple policies, inclusive.
 	cas20CompositeMinChildren = 2
 	cas20CompositeMaxChildren = 4
 	cas20PolicyFirstID        = 2 // counters 0 and 1 belong to the two sentinels
 
-	// Sentinel policy ids, seeded at initialization and always valid to bind.
 	cas20PolicyAlwaysAllow = 0                 // blocklist type, empty -> allow all
 	cas20PolicyAlwaysBlock = uint64(1)<<56 | 1 // allowlist type, empty -> block all
 
-	// cas20PolicyCounterMax bounds the 56-bit counter space. Creation is refused at
-	// the boundary rather than allowed to carry into the type byte, where it
-	// would collide ids across types and could reach a sentinel.
 	cas20PolicyCounterMax = uint64(1)<<56 - 1
 )
 
-// Storage layout (BEP-702 3.17). Slots are append-only: never reorder them
-// across forks.
+// Storage layout. Slots are append-only across forks.
 const (
 	polSlotPolicies      = 0 // mapping(uint64 => packed word)
 	polSlotMembers       = 1 // mapping(uint64 => mapping(address => bool))
 	polSlotPendingAdmins = 2 // mapping(uint64 => address)
 	polSlotCounter       = 3 // uint64
-	polSlotChildren      = 4 // mapping(uint64 => uint64[]) (Cobalt)
+	polSlotChildren      = 4 // mapping(uint64 => uint64[])
 )
 
-// A policy's existence and admin share one word: bit 255 exists, bits 159:0 the
-// admin. That keeps a policy whose admin was renounced to zero distinct from an
-// unwritten slot.
+// Existence and admin share one word: bit 255 exists, bits 159:0 the admin.
 var polExistsBit = new(uint256.Int).Lsh(uint256.NewInt(1), 255)
 
 func packPolicy(admin common.Address) common.Hash {
@@ -62,7 +53,6 @@ func polWordAdmin(w common.Hash) common.Address { return common.BytesToAddress(w
 
 func polIDType(id uint64) byte { return byte(id >> 56) }
 
-// polIDWellFormed reports whether an id's type byte names a real policy type.
 func polIDWellFormed(id uint64) bool { return polIDType(id) <= cas20PolicyIntersect }
 
 func isSentinelPolicy(id uint64) bool {
@@ -97,16 +87,13 @@ var (
 	cas20TopicBlocklistUpdated   = eventTopic("BlocklistUpdated(uint64,address,bool,address[])")
 )
 
-// emitPolicyAdminUpdated reports creation, handover and renunciation through one
-// event, so a policy's whole admin history is a single filter.
+// One event for creation, handover and renunciation: an admin history is one filter.
 func emitPolicyAdminUpdated(ctx *PrecompileContext, id uint64, previous, next common.Address) bool {
 	return ctx.AddLog([]common.Hash{
 		cas20TopicPolicyAdminUpdated, idKey(id), addrKey(previous), addrKey(next),
 	}, nil)
 }
 
-// emitMembersUpdated reports under the event belonging to the policy's own type,
-// so a consumer can subscribe to just the list it cares about.
 func emitMembersUpdated(ctx *PrecompileContext, ptype byte, id uint64, updater common.Address, included bool, accounts []common.Hash) bool {
 	topic := cas20TopicBlocklistUpdated
 	if ptype == cas20PolicyAllowlist {
@@ -137,8 +124,6 @@ func polSlot(offset uint64) common.Hash { return offsetSlot(cas20PolicyRoot, off
 
 func idKey(id uint64) common.Hash { return uint256.NewInt(id).Bytes32() }
 
-// isEnumWord reports whether an ABI word strictly encodes an enum/bool value
-// in [0, max]: every byte above the last must be zero.
 func isEnumWord(w common.Hash, max byte) bool {
 	return wordFitsIn(w, 1) && w[31] <= max
 }
@@ -154,9 +139,6 @@ func (p policyReg) policyWord(id uint64) common.Hash {
 	return p.s.getWord(p.s.mapSlot(polSlot(polSlotPolicies), idKey(id)))
 }
 
-// setPolicyAdmin writes the packed word, which marks the policy as existing.
-// Renouncing goes through here too, with the zero address: the exists bit stays
-// set, so a renounced policy remains distinguishable from one never created.
 func (p policyReg) setPolicyAdmin(id uint64, a common.Address) {
 	p.s.setWord(p.s.mapSlot(polSlot(polSlotPolicies), idKey(id)), packPolicy(a))
 }
@@ -183,10 +165,7 @@ func (p policyReg) setMember(id uint64, account common.Address, in bool) {
 	p.s.setWord(p.s.mapSlot(inner, addrKey(account)), v)
 }
 
-// isAuthorized never reverts: it sits on every transfer's path. A malformed or
-// absent policy takes empty-set semantics — which authorizes everyone for a
-// BLOCKLIST or an INTERSECT and no one for an ALLOWLIST or a UNION — and the
-// sentinel ids answer before the registry is initialized.
+// isAuthorized never reverts: it sits on every transfer's path.
 func (p policyReg) isAuthorized(id uint64, account common.Address) bool {
 	if !polIDWellFormed(id) {
 		return false
@@ -197,9 +176,6 @@ func (p policyReg) isAuthorized(id uint64, account common.Address) bool {
 	case cas20PolicyAlwaysBlock:
 		return false
 	}
-	// A composite has no members of its own: it asks its children, every time, so
-	// mutating a child's membership changes the composite's verdict with no call on
-	// the composite itself.
 	switch polIDType(id) {
 	case cas20PolicyUnion:
 		for _, child := range p.children(id) {
@@ -209,10 +185,6 @@ func (p policyReg) isAuthorized(id uint64, account common.Address) bool {
 		}
 		return false
 	case cas20PolicyIntersect:
-		// An AND over no children is vacuously true, so a well-formed INTERSECT id
-		// that names no policy authorizes everyone — the same tolerance a
-		// never-created BLOCKLIST already gets, and for the same reason: binding
-		// checks existence, so no token can reference one (BEP-702 3.8).
 		for _, child := range p.children(id) {
 			if !p.isAuthorized(child, account) {
 				return false
@@ -233,10 +205,6 @@ func polIsComposite(id uint64) bool {
 	return t == cas20PolicyUnion || t == cas20PolicyIntersect
 }
 
-// children reads a composite's child set. Solidity stores a uint64[] as a length
-// word at the mapping slot with the elements packed four per word from
-// keccak256(slot), which is what the factory and a reference contract must agree
-// on byte for byte.
 func (p policyReg) childrenSlot(id uint64) common.Hash {
 	return p.s.mapSlot(polSlot(polSlotChildren), idKey(id))
 }
@@ -265,13 +233,9 @@ func (p policyReg) setChildren(id uint64, kids []uint64) {
 	slot := p.childrenSlot(id)
 	p.s.setWord(slot, uint256.NewInt(uint64(len(kids))).Bytes32())
 	base := p.s.stringDataRoot(slot)
-	// Each word is built from scratch and written whole, so lanes past the new
-	// length are zeroed rather than left behind. The loop then runs to the word
-	// count the *maximum* set would need, not the new one, which clears any tail a
-	// shrink orphaned — Solidity's array assignment does the same, and without it
-	// the state root would diverge from a reference contract even though every read
-	// agreed. Today the cap of four is exactly one word so the tail is empty; this
-	// is what keeps that from being load-bearing.
+	// Words are rebuilt whole and the loop runs to the count the *maximum* set needs,
+	// so a shrink's orphaned tail is cleared as Solidity's array assignment clears it;
+	// otherwise the state root would diverge though every read agreed.
 	maxWords := (cas20CompositeMaxChildren + 3) / 4
 	for w := 0; w < maxWords; w++ {
 		packed := new(uint256.Int)
@@ -280,8 +244,7 @@ func (p policyReg) setChildren(id uint64, kids []uint64) {
 		}
 		slotW := new(uint256.Int).AddUint64(base, uint64(w)).Bytes32()
 		if packed.IsZero() && w*4 >= len(kids) {
-			// Nothing to store here; only write if something is already there, so a
-			// fresh composite does not pay for clearing empty slots.
+			// Only clear a word that holds something: a fresh composite pays for no empty slots.
 			if p.s.getWord(slotW) == (common.Hash{}) {
 				continue
 			}
@@ -290,8 +253,6 @@ func (p policyReg) setChildren(id uint64, kids []uint64) {
 	}
 }
 
-// policyExists is the ABI view. A malformed id never exists; the sentinels
-// always do, before initialization included.
 func (p policyReg) policyExists(id uint64) bool {
 	if !polIDWellFormed(id) {
 		return false
@@ -302,8 +263,6 @@ func (p policyReg) policyExists(id uint64) bool {
 	return p.exists(id)
 }
 
-// policyAdminOf is the ABI view: zero for a malformed id and for any policy that
-// does not exist, so a caller cannot mistake an unwritten slot for an admin.
 func (p policyReg) policyAdminOf(id uint64) common.Address {
 	if !polIDWellFormed(id) {
 		return common.Address{}
@@ -315,8 +274,6 @@ func (p policyReg) policyAdminOf(id uint64) common.Address {
 	return polWordAdmin(w)
 }
 
-// pendingPolicyAdminOf is the ABI view. The sentinels can never have a pending
-// admin, so their slot is never even read.
 func (p policyReg) pendingPolicyAdminOf(id uint64) common.Address {
 	if !polIDWellFormed(id) || isSentinelPolicy(id) {
 		return common.Address{}
@@ -324,16 +281,13 @@ func (p policyReg) pendingPolicyAdminOf(id uint64) common.Address {
 	return p.pending(id)
 }
 
-// ensureInitialized seeds the two sentinel policies and leaves the counter on
-// the first id available to callers. It gates on the counter, not on the sentinel
-// words, so a harness that pre-warms the account's bytecode cannot cause the
-// seeding to be skipped.
+// ensureInitialized gates on the counter, not the sentinel words, so a harness
+// that pre-warms the account's bytecode cannot make the seeding skip.
 func (p policyReg) ensureInitialized() uint64 {
 	c := p.counter()
 	if c >= cas20PolicyFirstID {
 		return c
 	}
-	// Both sentinels are born renounced: they exist, and nobody administers them.
 	p.setPolicyAdmin(cas20PolicyAlwaysAllow, common.Address{})
 	p.setPolicyAdmin(cas20PolicyAlwaysBlock, common.Address{})
 	p.setCounter(cas20PolicyFirstID)
@@ -409,12 +363,7 @@ func runCAS20Policy(ctx *PrecompileContext, input []byte) ([]byte, error) {
 	}
 
 	// Writes: unknown selector, then static frame, then inactive feature, before
-	// decoding arguments. The order is consensus-visible (BEP-702 3.15).
-	//
-	// This is the only place a write path checks ReadOnly. The handlers below used
-	// to repeat it, which the reference implementation does not — it enforces the
-	// call-frame invariants in the frame machinery, not per method — and repeating
-	// it here bought nothing: none of them is reachable except through this switch.
+	// decoding arguments. The order is consensus-visible.
 	switch sel {
 	case selCreatePolicy, selCreatePolicyWithAccounts, selUpdateAllowlist,
 		selUpdateBlocklist, selStageUpdateAdmin, selFinalizeUpdateAdmin, selRenounceAdmin,
@@ -452,38 +401,25 @@ func runCAS20Policy(ctx *PrecompileContext, input []byte) ([]byte, error) {
 	return nil, ErrExecutionReverted // unreachable: the gate above is exhaustive
 }
 
-// validateChildren checks a proposed child set: the count, then that every entry
-// exists, then that every entry is eligible — neither a composite nor a sentinel.
-// The no-nesting rule keeps evaluation one level deep so isAuthorized cannot
-// recurse without bound; a sentinel is refused because it stores no membership
-// for a composite to consult.
+// validateChildren: the count, then existence over the whole set, then eligibility.
 func validateChildren(reg policyReg, kids []common.Hash) ([]uint64, error) {
 	if len(kids) < cas20CompositeMinChildren || len(kids) > cas20CompositeMaxChildren {
 		return nil, revCAS20("ChildPoliciesOutsideOfRange()", errSelChildrenOutOfRange)
 	}
 	out := make([]uint64, 0, len(kids))
 	for _, w := range kids {
-		// Strictly decoded, as Solidity's external decoder does: taking the low
-		// eight bytes of a 32-byte word would let a caller name one policy in the
-		// bytes that matter and anything at all in the rest, and we would act on
-		// the former where a revert is owed.
 		id, ok := u64FromWord(w)
 		if !ok {
 			return nil, ErrExecutionReverted
 		}
 		out = append(out, id)
 	}
-	// Two passes over the whole set, not one interleaved pass per child: a set
-	// holding both a missing child and an ineligible one owes PolicyNotFound,
-	// whichever comes first in the array. The order decides which error the
-	// caller receives, so it is consensus (BEP-702 3.9).
+	// Existence for every child before eligibility for any: the order is consensus.
 	for _, id := range out {
 		if !reg.policyExists(id) {
 			return nil, revCAS20("PolicyNotFound()", errSelPolicyNotFound)
 		}
 	}
-	// A sentinel is refused alongside a composite: only a simple policy the
-	// registry actually minted can be a child.
 	for _, id := range out {
 		if isSentinelPolicy(id) || polIsComposite(id) {
 			return nil, revCAS20("InvalidChildPolicy(uint64)", errSelInvalidChildPolicy, wU64(id))
@@ -492,8 +428,6 @@ func validateChildren(reg policyReg, kids []common.Hash) ([]uint64, error) {
 	return out, nil
 }
 
-// emitCompositeUpdated logs the complete post-update child set, on creation and
-// on every replacement.
 func emitCompositeUpdated(ctx *PrecompileContext, id uint64, admin common.Address, kids []uint64) bool {
 	words := make([]common.Hash, len(kids))
 	for i, k := range kids {
@@ -503,10 +437,6 @@ func emitCompositeUpdated(ctx *PrecompileContext, id uint64, admin common.Addres
 		encodeTuple(abiWordArray(words)))
 }
 
-// createCompositePolicy mints a UNION or INTERSECT over existing simple policies.
-// The zero-admin guard comes first, as it does in the simple constructors: all
-// three agree on the order, and it is observable through which error a caller
-// receives (BEP-702 3.9).
 func createCompositePolicy(ctx *PrecompileContext, reg policyReg, args []byte) ([]byte, error) {
 	admin, err := readAddress(args, 0)
 	if err != nil {
@@ -555,8 +485,6 @@ func createCompositePolicy(ctx *PrecompileContext, reg policyReg, args []byte) (
 	return wU64(id).Bytes(), nil
 }
 
-// updateComposite replaces a composite's child set in full. There is no partial
-// update and no way to empty the list, since the count bound forbids it.
 func updateComposite(ctx *PrecompileContext, reg policyReg, args []byte) error {
 	id, err := readU64(args, 0)
 	if err != nil {
@@ -596,9 +524,7 @@ func createPolicy(ctx *PrecompileContext, reg policyReg, args []byte, withAccoun
 		return nil, err
 	}
 	ptype := ptypeWord[31]
-	// The enum widened to four values at Cobalt, so 2 and 3 now decode. They are
-	// refused by the logic instead, after the zero-admin check and before the batch
-	// bound — a composite is minted only through createCompositePolicy.
+	// The enum widened, so 2 and 3 decode; refused here after the zero-admin check.
 	if !isEnumWord(ptypeWord, cas20PolicyIntersect) {
 		return nil, ErrExecutionReverted
 	}
@@ -609,9 +535,7 @@ func createPolicy(ctx *PrecompileContext, reg policyReg, args []byte, withAccoun
 		return nil, revCAS20("IncompatiblePolicyType()", errSelIncompatibleType)
 	}
 
-	// The batch is decoded and bounded before any state is written. An enclosing
-	// revert would discard premature writes anyway, but it would not give back the
-	// gas they were metered at.
+	// Decoded and bounded before any write: a revert would not refund gas metered on premature writes.
 	var accounts []common.Hash
 	if withAccounts {
 		if accounts, err = readWordArray(args, 2); err != nil {
@@ -623,8 +547,6 @@ func createPolicy(ctx *PrecompileContext, reg policyReg, args []byte, withAccoun
 	}
 
 	c := reg.ensureInitialized()
-	// The counter shares its 56 bits across both types, so exhausting it must be
-	// refused rather than allowed to carry into the type byte.
 	if c >= cas20PolicyCounterMax {
 		return nil, revPanic(0x11)
 	}
@@ -634,23 +556,18 @@ func createPolicy(ctx *PrecompileContext, reg policyReg, args []byte, withAccoun
 	if !ctx.AddLog([]common.Hash{cas20TopicPolicyCreated, idKey(id), addrKey(ctx.Caller)}, wU8(ptype).Bytes()) {
 		return nil, ErrOutOfGas
 	}
-	// The initial admin is reported as a transition from nobody, so it lands in
-	// the same event stream as every later handover.
 	if !emitPolicyAdminUpdated(ctx, id, common.Address{}, admin) {
 		return nil, ErrOutOfGas
 	}
 
 	if withAccounts {
 		for _, a := range accounts {
-			// Same strictness as a single address argument: readAddress refuses a
-			// dirty word, and an element of an array must not be laxer.
 			addr, ok := addressFromWord(a)
 			if !ok {
 				return nil, ErrExecutionReverted
 			}
 			reg.setMember(id, addr, true)
 		}
-		// Emitted even for an empty batch: the call form is part of the record.
 		if !emitMembersUpdated(ctx, ptype, id, ctx.Caller, true, accounts) {
 			return nil, ErrOutOfGas
 		}
@@ -667,15 +584,14 @@ func updateMembers(ctx *PrecompileContext, reg policyReg, args []byte, wantType 
 	if err != nil {
 		return err
 	}
-	if !isEnumWord(inWord, 1) { // strict ABI bool
+	// Decoded before the policy checks, as Solidity's external decoder would have.
+	if !isEnumWord(inWord, 1) {
 		return ErrExecutionReverted
 	}
 	accounts, err := readWordArray(args, 2)
 	if err != nil {
 		return err
 	}
-	// Order matters: it is observable through which error the caller receives —
-	// existence, then type, then admin, then batch.
 	if err := requirePolicyExists(reg, pid); err != nil {
 		return err
 	}
@@ -687,13 +603,6 @@ func updateMembers(ctx *PrecompileContext, reg policyReg, args []byte, wantType 
 	}
 	if len(accounts) > cas20PolicyBatchMax {
 		return revCAS20("BatchSizeTooLarge(uint256)", errSelBatchTooLarge, wU64(cas20PolicyBatchMax))
-	}
-	// Both strictly decoded, as Solidity's external decoder does. bool accepts
-	// only 0 or 1, and an address element must not drop its high padding — this
-	// path is the routine one, so a dirty word would add or remove a different
-	// account than the encoding names.
-	if !isEnumWord(inWord, 1) {
-		return ErrExecutionReverted
 	}
 	in := inWord[31] == 1
 	for _, a := range accounts {
@@ -722,8 +631,6 @@ func stageUpdateAdmin(ctx *PrecompileContext, reg policyReg, args []byte) error 
 		return err
 	}
 	reg.setPending(id, newAdmin)
-	// Emitted for a cancellation too, where newAdmin is zero: withdrawing a
-	// nomination is a governance action and should not be a silent one.
 	if !ctx.AddLog([]common.Hash{
 		cas20TopicPolicyAdminStaged, idKey(id), addrKey(ctx.Caller), addrKey(newAdmin),
 	}, nil) {
@@ -744,7 +651,7 @@ func finalizeUpdateAdmin(ctx *PrecompileContext, reg policyReg, args []byte) err
 	if pending == (common.Address{}) {
 		return revCAS20("NoPendingAdmin()", errSelNoPendingAdmin)
 	}
-	if pending != ctx.Caller || ctx.Caller == (common.Address{}) {
+	if pending != ctx.Caller {
 		return revCAS20("Unauthorized()", errSelUnauthorized)
 	}
 	previous := reg.admin(pid)
@@ -764,9 +671,7 @@ func renounceAdmin(ctx *PrecompileContext, reg policyReg, args []byte) error {
 	if err := requirePolicyAdmin(reg, pid, ctx.Caller); err != nil {
 		return err
 	}
-	// Frozen, not deleted: the packed word keeps its exists bit, so the policy
-	// stays distinguishable from one never created and its membership keeps
-	// answering reads.
+	// Frozen, not deleted: the exists bit stays, so a renounced policy is not one never created.
 	reg.setPolicyAdmin(pid, common.Address{})
 	reg.setPending(pid, common.Address{})
 	if !emitPolicyAdminUpdated(ctx, pid, ctx.Caller, common.Address{}) {
@@ -775,10 +680,6 @@ func renounceAdmin(ctx *PrecompileContext, reg policyReg, args []byte) error {
 	return nil
 }
 
-// requirePolicyExists reverts PolicyNotFound unless the policy exists. It asks
-// policyExists rather than the raw bit, because the sentinels are seeded lazily
-// and always exist whether or not their word has been written; it is their zero
-// admin that keeps them un-administrable.
 func requirePolicyExists(reg policyReg, id uint64) error {
 	if !reg.policyExists(id) {
 		return revCAS20("PolicyNotFound()", errSelPolicyNotFound)
@@ -786,7 +687,6 @@ func requirePolicyExists(reg policyReg, id uint64) error {
 	return nil
 }
 
-// requirePolicyAdmin reverts unless the policy exists and caller is its admin.
 func requirePolicyAdmin(reg policyReg, id uint64, caller common.Address) error {
 	if err := requirePolicyExists(reg, id); err != nil {
 		return err

--- a/core/vm/cas20_policy_test.go
+++ b/core/vm/cas20_policy_test.go
@@ -1,0 +1,819 @@
+package vm
+
+import (
+	"bytes"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+func encodeUpdateList(sel [4]byte, id uint64, flag bool, addrs []common.Address) []byte {
+	out := append([]byte{}, sel[:]...)
+	out = append(out, u256hash(id).Bytes()...)   // id
+	out = append(out, encBool(flag)...)          // add/remove
+	out = append(out, u256hash(0x60).Bytes()...) // offset to array (3-word head)
+	out = append(out, u256hash(uint64(len(addrs))).Bytes()...)
+	for _, a := range addrs {
+		out = append(out, addrKey(a).Bytes()...)
+	}
+	return out
+}
+
+// cas20BlockContext is the block context every CAS20 test runs under: post-merge, so
+// the fork rules resolve, with transfers stubbed out.
+func cas20BlockContext(time uint64) BlockContext {
+	return BlockContext{
+		Random:      &common.Hash{},
+		CanTransfer: func(StateDB, common.Address, *uint256.Int) bool { return true },
+		Transfer:    func(StateDB, common.Address, common.Address, *uint256.Int, *params.Rules) {},
+		BlockNumber: big.NewInt(1),
+		Time:        time,
+	}
+}
+
+func newCAS20EVM(t *testing.T) (*state.StateDB, *EVM) {
+	t.Helper()
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := *cas20TestChainConfig()
+	bc := cas20BlockContext(1)
+	seedActivation(statedb, cas20TestCaller)
+	return statedb, NewEVM(bc, statedb, &cfg, Config{})
+}
+
+// cas20TestCaller is the activation admin the test harness seeds.
+var cas20TestCaller = common.HexToAddress("0x60feed")
+
+// seedActivation puts the harness in the state a live network reaches once the
+// fork has run and governance has opened everything. The fork part delegates to
+// SeedCAS20Activation so the harness cannot drift from it; opening the features
+// stays local, since the fork deliberately opens nothing (BEP-702 3.15).
+// seedActivation puts the harness in the state a network reaches after
+// governance has appointed an admin and the admin has opened every feature.
+func seedActivation(statedb *state.StateDB, admin common.Address) {
+	SeedCAS20Activation(statedb)
+	reg := cas20Storage{state: statedb, token: CAS20ActivationRegistryAddress}
+	reg.setWord(actSlot(actSlotAdmin), addrKey(admin))
+	for _, f := range []common.Hash{featureCAS20Asset, featureCAS20Stablecoin, featurePolicyRegistry} {
+		reg.setWord(mappingSlot(actSlot(actSlotFeatures), f), common.Hash{31: 1})
+	}
+}
+
+func TestCAS20PolicyRegistry(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	admin := common.HexToAddress("0xad4149")
+	reg := CAS20PolicyRegistryAddress
+
+	call := func(caller common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, reg, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	authorized := func(id uint64, a common.Address) bool {
+		ret, err := call(admin, cas20Call(selIsAuthorized, u256hash(id), addrKey(a)))
+		if err != nil {
+			t.Fatalf("isAuthorized: %v", err)
+		}
+		return bytes.Equal(ret, encBool(true))
+	}
+
+	// create a blocklist policy.
+	ret, err := call(admin, cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyBlocklist)))
+	if err != nil {
+		t.Fatalf("createPolicy: %v", err)
+	}
+	block := new(uint256.Int).SetBytes(ret).Uint64()
+	if byte(block>>56) != cas20PolicyBlocklist {
+		t.Fatalf("blocklist id %#x has wrong type byte", block)
+	}
+	if r, _ := call(admin, cas20Call(selPolicyExists, u256hash(block))); !bytes.Equal(r, encBool(true)) {
+		t.Fatal("policy should exist")
+	}
+	if r, _ := call(admin, cas20Call(selPolicyAdmin, u256hash(block))); common.BytesToAddress(r) != admin {
+		t.Fatal("policyAdmin mismatch")
+	}
+
+	// empty blocklist allows everyone; adding bob blocks him.
+	if !authorized(block, cas20Bob) {
+		t.Fatal("empty blocklist should allow")
+	}
+	if _, err := call(admin, encodeUpdateList(selUpdateBlocklist, block, true, []common.Address{cas20Bob})); err != nil {
+		t.Fatalf("updateBlocklist: %v", err)
+	}
+	if authorized(block, cas20Bob) {
+		t.Fatal("bob should be blocked")
+	}
+	if !authorized(block, cas20Carol) {
+		t.Fatal("carol should still be allowed")
+	}
+
+	// create an allowlist policy: empty blocks everyone; adding carol allows her.
+	ret, _ = call(admin, cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyAllowlist)))
+	allow := new(uint256.Int).SetBytes(ret).Uint64()
+	if byte(allow>>56) != cas20PolicyAllowlist {
+		t.Fatalf("allowlist id %#x wrong type", allow)
+	}
+	if authorized(allow, cas20Carol) {
+		t.Fatal("empty allowlist should block")
+	}
+	if _, err := call(admin, encodeUpdateList(selUpdateAllowlist, allow, true, []common.Address{cas20Carol})); err != nil {
+		t.Fatalf("updateAllowlist: %v", err)
+	}
+	if !authorized(allow, cas20Carol) {
+		t.Fatal("carol should be allowed")
+	}
+
+	// type mismatch and authorization guards.
+	if _, err := call(admin, encodeUpdateList(selUpdateAllowlist, block, true, []common.Address{cas20Alice})); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatal("updateAllowlist on blocklist should revert")
+	}
+	if _, err := call(cas20Bob, encodeUpdateList(selUpdateBlocklist, block, true, []common.Address{cas20Alice})); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatal("non-admin update should revert")
+	}
+
+	// two-step admin transfer.
+	newAdmin := common.HexToAddress("0x9ead")
+	if _, err := call(admin, cas20Call(selStageUpdateAdmin, u256hash(block), addrKey(newAdmin))); err != nil {
+		t.Fatalf("stageUpdateAdmin: %v", err)
+	}
+	if _, err := call(cas20Alice, cas20Call(selFinalizeUpdateAdmin, u256hash(block))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatal("finalize by non-nominee should revert")
+	}
+	if _, err := call(newAdmin, cas20Call(selFinalizeUpdateAdmin, u256hash(block))); err != nil {
+		t.Fatalf("finalizeUpdateAdmin: %v", err)
+	}
+	if _, err := call(admin, encodeUpdateList(selUpdateBlocklist, block, true, []common.Address{cas20Alice})); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatal("old admin should no longer update")
+	}
+
+	// renounce freezes the policy; reads still work.
+	if _, err := call(newAdmin, cas20Call(selRenounceAdmin, u256hash(block))); err != nil {
+		t.Fatalf("renounceAdmin: %v", err)
+	}
+	if _, err := call(newAdmin, encodeUpdateList(selUpdateBlocklist, block, false, []common.Address{cas20Bob})); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatal("frozen policy should reject updates")
+	}
+	if authorized(block, cas20Bob) {
+		t.Fatal("frozen policy still evaluates: bob stays blocked")
+	}
+}
+
+// TestCAS20PolicyIntegration binds policies to a token's compliance scopes and
+// checks they gate transfers and mints.
+func TestCAS20PolicyIntegration(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc4ea70")
+	custody := common.HexToAddress("0xc45d1")
+	salt := common.HexToHash("0x0c")
+
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	// token with creator as admin + minter, 1000 to alice.
+	initCalls := [][]byte{
+		cas20Call(selGrantRole, roleMint, addrKey(creator)),
+		cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
+	}
+	ret, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, salt, creator, initCalls))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	// blocklist bob, bind to TRANSFER_RECEIVER.
+	ret, _ = call(creator, CAS20PolicyRegistryAddress, cas20Call(selCreatePolicy, addrKey(creator), u256hash(cas20PolicyBlocklist)))
+	blk := new(uint256.Int).SetBytes(ret).Uint64()
+	if _, err := call(creator, CAS20PolicyRegistryAddress, encodeUpdateList(selUpdateBlocklist, blk, true, []common.Address{cas20Bob})); err != nil {
+		t.Fatalf("updateBlocklist: %v", err)
+	}
+	if _, err := call(creator, token, cas20Call(selUpdatePolicy, scopeTransferReceiver, u256hash(blk))); err != nil {
+		t.Fatalf("updatePolicy(receiver): %v", err)
+	}
+
+	// transfer to bob (blocked receiver) reverts; to carol succeeds.
+	if _, err := call(cas20Alice, token, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(10))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("transfer to blocked receiver err = %v, want revert", err)
+	}
+	if _, err := call(cas20Alice, token, cas20Call(selTransfer, addrKey(cas20Carol), u256hash(10))); err != nil {
+		t.Fatalf("transfer to allowed receiver: %v", err)
+	}
+
+	// allowlist for MINT_RECEIVER: only custody may receive newly minted supply.
+	ret, _ = call(creator, CAS20PolicyRegistryAddress, cas20Call(selCreatePolicy, addrKey(creator), u256hash(cas20PolicyAllowlist)))
+	al := new(uint256.Int).SetBytes(ret).Uint64()
+	if _, err := call(creator, CAS20PolicyRegistryAddress, encodeUpdateList(selUpdateAllowlist, al, true, []common.Address{custody})); err != nil {
+		t.Fatalf("updateAllowlist: %v", err)
+	}
+	if _, err := call(creator, token, cas20Call(selUpdatePolicy, scopeMintReceiver, u256hash(al))); err != nil {
+		t.Fatalf("updatePolicy(mint receiver): %v", err)
+	}
+	if _, err := call(creator, token, cas20Call(selMint, addrKey(cas20Alice), u256hash(1))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("mint to non-listed err = %v, want revert", err)
+	}
+	if _, err := call(creator, token, cas20Call(selMint, addrKey(custody), u256hash(500))); err != nil {
+		t.Fatalf("mint to custody: %v", err)
+	}
+	view := newUnmeteredCAS20Storage(statedb, token)
+	if view.balanceOf(custody).Uint64() != 500 {
+		t.Fatalf("custody balance = %d, want 500", view.balanceOf(custody).Uint64())
+	}
+	// binding a never-created policy id is rejected.
+	if _, err := call(creator, token, cas20Call(selUpdatePolicy, scopeTransferSender, u256hash(0x99999))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatal("binding nonexistent policy should revert")
+	}
+}
+
+func TestCAS20SeizeWithMemo(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xc4ea70")
+	salt := common.HexToHash("0x0d")
+
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	// token: creator is admin, MINT and SEIZE holder; 1000 minted to bob.
+	initCalls := [][]byte{
+		cas20Call(selGrantRole, roleMint, addrKey(creator)),
+		cas20Call(selGrantRole, roleSeize, addrKey(creator)),
+		cas20Call(selMint, addrKey(cas20Bob), u256hash(1000)),
+	}
+	ret, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, salt, creator, initCalls))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+	view := newUnmeteredCAS20Storage(statedb, token)
+
+	memo := common.HexToHash("0x5e12e")
+
+	// seizing an un-frozen account fails (must freeze first).
+	if _, err := call(creator, token, cas20Call(selSeizeWithMemo, addrKey(cas20Bob), addrKey(cas20Alice), u256hash(100), memo)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("seize before freeze err = %v, want revert (AccountNotSeizable)", err)
+	}
+
+	// step 1: blacklist bob on the SEIZE_HOLDER scope.
+	ret, _ = call(creator, CAS20PolicyRegistryAddress, cas20Call(selCreatePolicy, addrKey(creator), u256hash(cas20PolicyBlocklist)))
+	blk := new(uint256.Int).SetBytes(ret).Uint64()
+	if _, err := call(creator, CAS20PolicyRegistryAddress, encodeUpdateList(selUpdateBlocklist, blk, true, []common.Address{cas20Bob})); err != nil {
+		t.Fatalf("updateBlocklist: %v", err)
+	}
+	if _, err := call(creator, token, cas20Call(selUpdatePolicy, scopeSeizeHolder, u256hash(blk))); err != nil {
+		t.Fatalf("updatePolicy(seizeHolder): %v", err)
+	}
+
+	// non-role caller cannot seize.
+	if _, err := call(cas20Alice, token, cas20Call(selSeizeWithMemo, addrKey(cas20Bob), addrKey(cas20Alice), u256hash(100), memo)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("unauthorized seize err = %v, want revert", err)
+	}
+
+	// the zero address is never a valid destination.
+	if _, err := call(creator, token, cas20Call(selSeizeWithMemo, addrKey(cas20Bob), common.Hash{}, u256hash(100), memo)); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("seize to zero err = %v, want revert (InvalidReceiver)", err)
+	}
+
+	// step 2: seize part of the frozen balance. Value moves; supply does not.
+	if _, err := call(creator, token, cas20Call(selSeizeWithMemo, addrKey(cas20Bob), addrKey(cas20Alice), u256hash(400), memo)); err != nil {
+		t.Fatalf("seizeWithMemo: %v", err)
+	}
+	if got := view.balanceOf(cas20Bob).Uint64(); got != 600 {
+		t.Fatalf("seized account balance = %d, want 600", got)
+	}
+	if got := view.balanceOf(cas20Alice).Uint64(); got != 400 {
+		t.Fatalf("destination balance = %d, want 400", got)
+	}
+	if got := view.totalSupply().Uint64(); got != 1000 {
+		t.Fatalf("totalSupply = %d, want 1000 (seizure moves value, it does not burn)", got)
+	}
+}
+
+// TestCAS20PolicyStorageLayout pins the registry's storage (BEP-702 3.17): the
+// namespaced root, the slot order, and the packed existence-and-admin word.
+// These are consensus-visible, so the assertions are on raw slots rather than on
+// what the ABI reports.
+func TestCAS20PolicyStorageLayout(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	admin := common.HexToAddress("0xad4149")
+
+	// Slot order: policies, members, pendingAdmins, counter, then a reserved slot
+	// for composite children.
+	root := new(uint256.Int).SetBytes(erc7201Root("bsc.policy_registry").Bytes())
+	for offset, want := range map[uint64]uint64{
+		polSlotPolicies: 0, polSlotMembers: 1, polSlotPendingAdmins: 2, polSlotCounter: 3,
+	} {
+		if offset != want {
+			t.Errorf("slot constant = %d, want %d", offset, want)
+		}
+		got := new(uint256.Int).SetBytes(polSlot(offset).Bytes())
+		if exp := new(uint256.Int).AddUint64(root, offset); !got.Eq(exp) {
+			t.Errorf("slot %d = %x, want root+%d = %x", offset, got, offset, exp)
+		}
+	}
+
+	ret, _, err := evm.Call(admin, CAS20PolicyRegistryAddress,
+		cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyAllowlist)),
+		NewGasBudget(5_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createPolicy: %v", err)
+	}
+	id := new(uint256.Int).SetBytes(ret).Uint64()
+
+	view := newUnmeteredCAS20Storage(statedb, CAS20PolicyRegistryAddress)
+	word := view.getWord(mappingSlot(polSlot(polSlotPolicies), idKey(id)))
+	if word[0]&0x80 == 0 {
+		t.Errorf("policy word %x has no exists bit", word)
+	}
+	if got := common.BytesToAddress(word[12:]); got != admin {
+		t.Errorf("packed admin = %s, want %s", got.Hex(), admin.Hex())
+	}
+	for _, b := range word[1:12] { // bits 254:160 are reserved and must stay zero
+		if b != 0 {
+			t.Errorf("policy word %x has dirty reserved bits", word)
+			break
+		}
+	}
+	// Two sentinels are seeded first, so the first caller id draws counter 2 and
+	// the counter lands on 3.
+	if got := new(uint256.Int).SetBytes(view.getWord(polSlot(polSlotCounter)).Bytes()).Uint64(); got != 3 {
+		t.Errorf("counter = %d, want 3", got)
+	}
+	if id != uint64(cas20PolicyAllowlist)<<56|2 {
+		t.Errorf("first allowlist id = %#x, want type 1 counter 2", id)
+	}
+}
+
+// TestCAS20PolicySentinels pins the sentinel semantics: they exist and answer
+// authorization from their id alone, so they are correct before any policy has
+// been created and no membership write can redefine them.
+func TestCAS20PolicySentinels(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	caller := common.HexToAddress("0xad4149")
+	ask := func(sel [4]byte, args ...common.Hash) []byte {
+		ret, _, err := evm.Call(caller, CAS20PolicyRegistryAddress, cas20Call(sel, args...),
+			NewGasBudget(5_000_000), uint256.NewInt(0))
+		if err != nil {
+			t.Fatalf("call: %v", err)
+		}
+		return ret
+	}
+
+	// Before anything is created: both sentinels report as existing, and their
+	// authorization is fixed. ALWAYS_ALLOW is the value every unset policy field
+	// holds, so it has to be right at this point in particular.
+	for _, id := range []uint64{cas20PolicyAlwaysAllow, cas20PolicyAlwaysBlock} {
+		if !bytes.Equal(ask(selPolicyExists, u256hash(id)), encBool(true)) {
+			t.Errorf("policyExists(%#x) = false, want true", id)
+		}
+		if got := common.BytesToAddress(ask(selPolicyAdmin, u256hash(id))); got != (common.Address{}) {
+			t.Errorf("policyAdmin(%#x) = %s, want zero", id, got.Hex())
+		}
+		if got := common.BytesToAddress(ask(selPendingPolicyAdmin, u256hash(id))); got != (common.Address{}) {
+			t.Errorf("pendingPolicyAdmin(%#x) = %s, want zero", id, got.Hex())
+		}
+	}
+	if !bytes.Equal(ask(selIsAuthorized, u256hash(cas20PolicyAlwaysAllow), addrKey(cas20Bob)), encBool(true)) {
+		t.Error("ALWAYS_ALLOW must authorize")
+	}
+	if !bytes.Equal(ask(selIsAuthorized, u256hash(cas20PolicyAlwaysBlock), addrKey(cas20Bob)), encBool(false)) {
+		t.Error("ALWAYS_BLOCK must refuse")
+	}
+
+	// A malformed type byte is not a policy: it never exists, never authorizes,
+	// and has no admin.
+	bad := uint64(5) << 56
+	if !bytes.Equal(ask(selPolicyExists, u256hash(bad)), encBool(false)) {
+		t.Error("a malformed type byte must not exist")
+	}
+	if !bytes.Equal(ask(selIsAuthorized, u256hash(bad), addrKey(cas20Bob)), encBool(false)) {
+		t.Error("a malformed type byte must not authorize")
+	}
+	if got := common.BytesToAddress(ask(selPolicyAdmin, u256hash(bad))); got != (common.Address{}) {
+		t.Errorf("policyAdmin(malformed) = %s, want zero", got.Hex())
+	}
+
+	// Neither sentinel can be administered: both are seeded with a zero admin.
+	for _, id := range []uint64{cas20PolicyAlwaysAllow, cas20PolicyAlwaysBlock} {
+		_, _, err := evm.Call(caller, CAS20PolicyRegistryAddress,
+			cas20Call(selStageUpdateAdmin, u256hash(id), addrKey(caller)),
+			NewGasBudget(5_000_000), uint256.NewInt(0))
+		if !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("stageUpdateAdmin(%#x) err = %v, want revert", id, err)
+		}
+	}
+}
+
+// TestCAS20PolicyCheckOrder pins the order a membership update applies its checks.
+// The order is observable through which error a caller receives, so the
+// existence -> type -> admin -> batch sequence is part of the surface.
+func TestCAS20PolicyCheckOrder(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	admin := common.HexToAddress("0xad4149")
+	stranger := common.HexToAddress("0x57ra9e")
+	call := func(caller common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, CAS20PolicyRegistryAddress, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	revertsWith := func(what string, caller common.Address, input []byte, sel [4]byte) {
+		t.Helper()
+		ret, err := call(caller, input)
+		if !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("%s: err = %v, want revert", what, err)
+			return
+		}
+		if len(ret) < 4 || !bytes.Equal(ret[:4], sel[:]) {
+			t.Errorf("%s: revert data %x, want selector %x", what, ret, sel)
+		}
+	}
+
+	// An id no createPolicy produced: existence is checked first, so this is
+	// PolicyNotFound and not Unauthorized.
+	ghost := uint64(cas20PolicyAllowlist)<<56 | 999
+	revertsWith("nonexistent policy", stranger,
+		encodeUpdateList(selUpdateAllowlist, ghost, true, []common.Address{cas20Bob}), errSelPolicyNotFound)
+
+	ret, err := call(admin, cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyBlocklist)))
+	if err != nil {
+		t.Fatalf("createPolicy: %v", err)
+	}
+	block := new(uint256.Int).SetBytes(ret).Uint64()
+
+	// Type is checked before admin, so a stranger calling the wrong method on a
+	// real policy sees IncompatiblePolicyType rather than Unauthorized.
+	revertsWith("wrong type, wrong caller", stranger,
+		encodeUpdateList(selUpdateAllowlist, block, true, []common.Address{cas20Bob}), errSelIncompatibleType)
+	// Right method, wrong caller: now admin is what fails.
+	revertsWith("right type, wrong caller", stranger,
+		encodeUpdateList(selUpdateBlocklist, block, true, []common.Address{cas20Bob}), errSelUnauthorized)
+	// Admin passes, so an oversized batch is what fails, last.
+	oversized := make([]common.Address, cas20PolicyBatchMax+1)
+	for i := range oversized {
+		oversized[i] = common.BigToAddress(new(big.Int).SetUint64(uint64(i + 1)))
+	}
+	revertsWith("oversized batch", admin,
+		encodeUpdateList(selUpdateBlocklist, block, true, oversized), errSelBatchTooLarge)
+
+	// The same ordering applies to the admin-handover paths.
+	revertsWith("stage on nonexistent", stranger,
+		cas20Call(selStageUpdateAdmin, u256hash(ghost), addrKey(stranger)), errSelPolicyNotFound)
+	revertsWith("finalize on nonexistent", stranger,
+		cas20Call(selFinalizeUpdateAdmin, u256hash(ghost)), errSelPolicyNotFound)
+	revertsWith("renounce on nonexistent", stranger,
+		cas20Call(selRenounceAdmin, u256hash(ghost)), errSelPolicyNotFound)
+}
+
+// TestCAS20PolicySentinelsIgnoreMembership pins why the sentinel fast-paths exist.
+// Their emptiness alone would give the same answers, so a membership-derived
+// implementation looks correct — until something writes membership under a
+// sentinel id, which a counter that carried into the type byte could do.
+// Answering from the id makes them constant by construction.
+func TestCAS20PolicySentinelsIgnoreMembership(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+
+	// Plant membership under both sentinels, bypassing the ABI entirely.
+	view := policyReg{s: newUnmeteredCAS20Storage(statedb, CAS20PolicyRegistryAddress)}
+	view.setMember(cas20PolicyAlwaysAllow, cas20Bob, true) // "block bob" on ALWAYS_ALLOW
+	view.setMember(cas20PolicyAlwaysBlock, cas20Bob, true) // "allow bob" on ALWAYS_BLOCK
+
+	ask := func(id uint64) []byte {
+		ret, _, err := evm.Call(cas20Alice, CAS20PolicyRegistryAddress,
+			cas20Call(selIsAuthorized, u256hash(id), addrKey(cas20Bob)),
+			NewGasBudget(5_000_000), uint256.NewInt(0))
+		if err != nil {
+			t.Fatalf("isAuthorized: %v", err)
+		}
+		return ret
+	}
+	if !bytes.Equal(ask(cas20PolicyAlwaysAllow), encBool(true)) {
+		t.Error("ALWAYS_ALLOW stopped authorizing after a membership write — it is not constant")
+	}
+	if !bytes.Equal(ask(cas20PolicyAlwaysBlock), encBool(false)) {
+		t.Error("ALWAYS_BLOCK started authorizing after a membership write — it is not constant")
+	}
+}
+
+// TestCAS20PolicyCounterExhaustion pins the 56-bit counter bound. Reaching it
+// takes more createPolicy calls than any chain will see, so the counter is
+// driven there directly; what matters is that the boundary is refused rather
+// than allowed to carry into the type byte, where an id would change type,
+// collide with another type's policy, or land on a sentinel.
+func TestCAS20PolicyCounterExhaustion(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	admin := common.HexToAddress("0xad4149")
+	view := policyReg{s: newUnmeteredCAS20Storage(statedb, CAS20PolicyRegistryAddress)}
+
+	create := func() ([]byte, error) {
+		ret, _, err := evm.Call(admin, CAS20PolicyRegistryAddress,
+			cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyBlocklist)),
+			NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	// One short of the bound still works, and stays inside its own type space.
+	view.setCounter(cas20PolicyCounterMax - 1)
+	ret, err := create()
+	if err != nil {
+		t.Fatalf("createPolicy at counter max-1: %v", err)
+	}
+	if id := new(uint256.Int).SetBytes(ret).Uint64(); polIDType(id) != cas20PolicyBlocklist {
+		t.Errorf("id %#x escaped its type byte", id)
+	}
+
+	// At the bound, creation is refused: Panic(0x11), the arithmetic-overflow code.
+	view.setCounter(cas20PolicyCounterMax)
+	ret, err = create()
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("createPolicy at counter max err = %v, want revert", err)
+	}
+	want := append(append([]byte{}, errSelPanic[:]...), wU8(0x11).Bytes()...)
+	if !bytes.Equal(ret, want) {
+		t.Errorf("revert data = %x, want Panic(0x11) = %x", ret, want)
+	}
+}
+
+// TestCAS20PolicyEvents pins the registry's log surface: which events each write
+// emits, in what order, and with what payload. The membership events mix a
+// static bool with a dynamic address[], so their data is also checked against
+// go-ethereum's own ABI packer — a head/tail mistake in that shape would
+// otherwise be invisible to an expectation built with the same encoder.
+func TestCAS20PolicyEvents(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	admin := common.HexToAddress("0xad4149")
+	heir := common.HexToAddress("0x8e14")
+
+	txSeq := 0
+	logsOf := func(caller common.Address, input []byte) []*types.Log {
+		t.Helper()
+		txSeq++
+		hash := common.BigToHash(new(big.Int).SetUint64(uint64(txSeq)))
+		statedb.SetTxContext(hash, txSeq)
+		if _, _, err := evm.Call(caller, CAS20PolicyRegistryAddress, input,
+			NewGasBudget(5_000_000), uint256.NewInt(0)); err != nil {
+			t.Fatalf("call: %v", err)
+		}
+		return statedb.GetLogs(hash, 1, common.Hash{}, 1)
+	}
+	wantTopics := func(what string, got *types.Log, expect ...common.Hash) {
+		t.Helper()
+		if len(got.Topics) != len(expect) {
+			t.Errorf("%s: %d topics, want %d", what, len(got.Topics), len(expect))
+			return
+		}
+		for i := range expect {
+			if got.Topics[i] != expect[i] {
+				t.Errorf("%s: topic %d = %s, want %s", what, i, got.Topics[i].Hex(), expect[i].Hex())
+			}
+		}
+	}
+
+	// createPolicy: PolicyCreated then the initial admin as a transition from
+	// nobody, so creation lands in the same stream as every later handover.
+	logs := logsOf(admin, cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyBlocklist)))
+	if len(logs) != 2 {
+		t.Fatalf("createPolicy emitted %d logs, want 2", len(logs))
+	}
+	block := uint64(cas20PolicyBlocklist)<<56 | 2
+	wantTopics("PolicyCreated", logs[0], cas20TopicPolicyCreated, idKey(block), addrKey(admin))
+	if !bytes.Equal(logs[0].Data, wU8(cas20PolicyBlocklist).Bytes()) {
+		t.Errorf("PolicyCreated data = %x, want the type byte", logs[0].Data)
+	}
+	wantTopics("PolicyAdminUpdated", logs[1],
+		cas20TopicPolicyAdminUpdated, idKey(block), addrKey(common.Address{}), addrKey(admin))
+	if len(logs[1].Data) != 0 {
+		t.Errorf("PolicyAdminUpdated data = %x, want empty", logs[1].Data)
+	}
+
+	// creator is the caller, not the nominated admin: a policy created on someone
+	// else's behalf must name whoever sent the transaction.
+	logs = logsOf(cas20Alice, cas20Call(selCreatePolicy, addrKey(heir), u256hash(cas20PolicyBlocklist)))
+	if len(logs) != 2 {
+		t.Fatalf("createPolicy (third party) emitted %d logs, want 2", len(logs))
+	}
+	third := uint64(cas20PolicyBlocklist)<<56 | 3
+	wantTopics("PolicyCreated (third party)", logs[0],
+		cas20TopicPolicyCreated, idKey(third), addrKey(cas20Alice))
+	wantTopics("PolicyAdminUpdated (third party)", logs[1],
+		cas20TopicPolicyAdminUpdated, idKey(third), addrKey(common.Address{}), addrKey(heir))
+
+	// updateBlocklist: one log under the blocklist event, carrying the flag and
+	// the accounts.
+	accounts := []common.Address{cas20Bob, cas20Carol}
+	logs = logsOf(admin, encodeUpdateList(selUpdateBlocklist, block, true, accounts))
+	if len(logs) != 1 {
+		t.Fatalf("updateBlocklist emitted %d logs, want 1", len(logs))
+	}
+	wantTopics("BlocklistUpdated", logs[0], cas20TopicBlocklistUpdated, idKey(block), addrKey(admin))
+
+	boolType, err := abi.NewType("bool", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addrsType, err := abi.NewType("address[]", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oracle, err := abi.Arguments{{Type: boolType}, {Type: addrsType}}.Pack(true, accounts)
+	if err != nil {
+		t.Fatalf("pack membership payload: %v", err)
+	}
+	if !bytes.Equal(logs[0].Data, oracle) {
+		t.Errorf("BlocklistUpdated data\n got = %x\nwant = %x", logs[0].Data, oracle)
+	}
+
+	// An allowlist reports under its own event, not the blocklist one.
+	ret, _, err := evm.Call(admin, CAS20PolicyRegistryAddress,
+		cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyAllowlist)),
+		NewGasBudget(5_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createPolicy allowlist: %v", err)
+	}
+	allow := new(uint256.Int).SetBytes(ret).Uint64()
+	logs = logsOf(admin, encodeUpdateList(selUpdateAllowlist, allow, false, accounts))
+	if len(logs) != 1 || logs[0].Topics[0] != cas20TopicAllowlistUpdated {
+		t.Fatalf("updateAllowlist logs = %v", logs)
+	}
+	oracle, _ = abi.Arguments{{Type: boolType}, {Type: addrsType}}.Pack(false, accounts)
+	if !bytes.Equal(logs[0].Data, oracle) {
+		t.Errorf("AllowlistUpdated data\n got = %x\nwant = %x", logs[0].Data, oracle)
+	}
+
+	// createPolicyWithAccounts emits the seed membership event too — including
+	// for an empty batch, since the call form is part of the record.
+	logs = logsOf(admin, encodeCreatePolicyWithAccounts(admin, cas20PolicyAllowlist, nil))
+	if len(logs) != 3 {
+		t.Fatalf("createPolicyWithAccounts emitted %d logs, want 3", len(logs))
+	}
+	if logs[2].Topics[0] != cas20TopicAllowlistUpdated {
+		t.Errorf("third log = %s, want AllowlistUpdated", logs[2].Topics[0].Hex())
+	}
+	oracle, _ = abi.Arguments{{Type: boolType}, {Type: addrsType}}.Pack(true, []common.Address{})
+	if !bytes.Equal(logs[2].Data, oracle) {
+		t.Errorf("seed AllowlistUpdated data\n got = %x\nwant = %x", logs[2].Data, oracle)
+	}
+
+	// The handover pair, then renunciation. Staging names the incumbent as well
+	// as the nominee, so a stage log is self-contained.
+	logs = logsOf(admin, cas20Call(selStageUpdateAdmin, u256hash(block), addrKey(heir)))
+	if len(logs) != 1 {
+		t.Fatalf("stageUpdateAdmin emitted %d logs, want 1", len(logs))
+	}
+	wantTopics("PolicyAdminStaged", logs[0],
+		cas20TopicPolicyAdminStaged, idKey(block), addrKey(admin), addrKey(heir))
+
+	// Withdrawing a nomination is a governance action, not a silent one.
+	logs = logsOf(admin, cas20Call(selStageUpdateAdmin, u256hash(block), addrKey(common.Address{})))
+	wantTopics("PolicyAdminStaged (cancel)", logs[0],
+		cas20TopicPolicyAdminStaged, idKey(block), addrKey(admin), addrKey(common.Address{}))
+
+	// Re-nominate, then the nominee takes over.
+	logsOf(admin, cas20Call(selStageUpdateAdmin, u256hash(block), addrKey(heir)))
+	logs = logsOf(heir, cas20Call(selFinalizeUpdateAdmin, u256hash(block)))
+	if len(logs) != 1 {
+		t.Fatalf("finalizeUpdateAdmin emitted %d logs, want 1", len(logs))
+	}
+	wantTopics("PolicyAdminUpdated (finalize)", logs[0],
+		cas20TopicPolicyAdminUpdated, idKey(block), addrKey(admin), addrKey(heir))
+
+	logs = logsOf(heir, cas20Call(selRenounceAdmin, u256hash(block)))
+	if len(logs) != 1 {
+		t.Fatalf("renounceAdmin emitted %d logs, want 1", len(logs))
+	}
+	wantTopics("PolicyAdminUpdated (renounce)", logs[0],
+		cas20TopicPolicyAdminUpdated, idKey(block), addrKey(heir), addrKey(common.Address{}))
+}
+
+func encodeCreatePolicyWithAccounts(admin common.Address, ptype byte, accounts []common.Address) []byte {
+	out := append([]byte{}, selCreatePolicyWithAccounts[:]...)
+	out = append(out, addrKey(admin).Bytes()...)
+	out = append(out, u256hash(uint64(ptype)).Bytes()...)
+	out = append(out, u256hash(0x60).Bytes()...) // offset past the 3-word head
+	out = append(out, u256hash(uint64(len(accounts))).Bytes()...)
+	for _, a := range accounts {
+		out = append(out, addrKey(a).Bytes()...)
+	}
+	return out
+}
+
+// TestCAS20MembershipArgsDecodeStrictly covers the two membership paths' narrow
+// arguments: an address element must not drop its high padding and a bool must be
+// 0 or 1, as Solidity's external decoder requires.
+func TestCAS20MembershipArgsDecodeStrictly(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	admin := cas20TestCaller
+	call := func(input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(admin, CAS20PolicyRegistryAddress, input,
+			NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	ret, err := call(cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyAllowlist)))
+	if err != nil {
+		t.Fatalf("createPolicy: %v", err)
+	}
+	id := new(uint256.Int).SetBytes(ret).Uint64()
+
+	dirty := addrKey(cas20Alice)
+	dirty[0] = 0x01 // a byte above the low twenty
+
+	// updateAllowlist: the routine path, where a dirty element would add an
+	// account other than the one the encoding names.
+	if _, err := call(encodeUpdateListRaw(selUpdateAllowlist, id, u256hash(1), []common.Hash{dirty})); !errors.Is(err, ErrExecutionReverted) {
+		t.Errorf("updateAllowlist with a dirty address element: err = %v, want a revert", err)
+	}
+	// The bool argument, likewise: 2 is neither true nor false.
+	if _, err := call(encodeUpdateListRaw(selUpdateAllowlist, id, u256hash(2), []common.Hash{addrKey(cas20Alice)})); !errors.Is(err, ErrExecutionReverted) {
+		t.Errorf("updateAllowlist with allowed = 2: err = %v, want a revert", err)
+	}
+	// And the clean form still works, so the guards are not refusing everything.
+	if _, err := call(encodeUpdateListRaw(selUpdateAllowlist, id, u256hash(1), []common.Hash{addrKey(cas20Alice)})); err != nil {
+		t.Fatalf("updateAllowlist with clean args: %v", err)
+	}
+	if got, err := call(cas20Call(selIsAuthorized, wU64(id), addrKey(cas20Alice))); err != nil {
+		t.Fatalf("isAuthorized: %v", err)
+	} else if !bytes.Equal(got, encBool(true)) {
+		t.Error("alice was not added by the clean call")
+	}
+
+	// createPolicyWithAccounts, the other path onto the same setter.
+	if _, err := call(encodeCreatePolicyWithAccountsRaw(addrKey(admin),
+		u256hash(cas20PolicyAllowlist), []common.Hash{dirty})); !errors.Is(err, ErrExecutionReverted) {
+		t.Errorf("createPolicyWithAccounts with a dirty element: err = %v, want a revert", err)
+	}
+}
+
+// encodeUpdateListRaw is encodeUpdateList with the words passed through
+// unchanged, so a test can hand it an encoding Solidity would not produce.
+func encodeUpdateListRaw(sel [4]byte, id uint64, flag common.Hash, accounts []common.Hash) []byte {
+	out := append([]byte{}, sel[:]...)
+	out = append(out, wU64(id).Bytes()...)
+	out = append(out, flag.Bytes()...)
+	out = append(out, u256hash(0x60).Bytes()...)
+	out = append(out, u256hash(uint64(len(accounts))).Bytes()...)
+	for _, a := range accounts {
+		out = append(out, a.Bytes()...)
+	}
+	return out
+}
+
+func encodeCreatePolicyWithAccountsRaw(admin, ptype common.Hash, accounts []common.Hash) []byte {
+	out := append([]byte{}, selCreatePolicyWithAccounts[:]...)
+	out = append(out, admin.Bytes()...)
+	out = append(out, ptype.Bytes()...)
+	out = append(out, u256hash(0x60).Bytes()...)
+	out = append(out, u256hash(uint64(len(accounts))).Bytes()...)
+	for _, a := range accounts {
+		out = append(out, a.Bytes()...)
+	}
+	return out
+}
+
+// TestCAS20SentinelErrorDoesNotDependOnInitialization covers the sentinels before
+// any policy exists, when ensureInitialized has never run.
+func TestCAS20SentinelErrorDoesNotDependOnInitialization(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	caller := common.HexToAddress("0xca11e4")
+	call := func(input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, CAS20PolicyRegistryAddress, input,
+			NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	// The registry is untouched: nothing has been created, so the sentinels' words
+	// are unwritten. Administering one must still fail as unauthorized, not as
+	// missing — reading the raw exists bit gave PolicyNotFound here and
+	// Unauthorized after the first unrelated creation.
+	want := func(input []byte, sel [4]byte, what string) {
+		t.Helper()
+		ret, err := call(input)
+		if !errors.Is(err, ErrExecutionReverted) {
+			t.Fatalf("%s: err = %v, want a revert", what, err)
+		}
+		if len(ret) < 4 || [4]byte(ret[:4]) != sel {
+			t.Errorf("%s: revert = %x, want %x", what, ret[:min(4, len(ret))], sel)
+		}
+	}
+	for _, id := range []uint64{cas20PolicyAlwaysAllow, cas20PolicyAlwaysBlock} {
+		want(cas20Call(selStageUpdateAdmin, wU64(id), addrKey(caller)),
+			errSelUnauthorized, "stageUpdateAdmin on a sentinel before initialization")
+	}
+
+	// Create something unrelated, which is what runs ensureInitialized, and the
+	// answer must not change.
+	if _, err := call(cas20Call(selCreatePolicy, addrKey(caller), u256hash(cas20PolicyAllowlist))); err != nil {
+		t.Fatalf("createPolicy: %v", err)
+	}
+	for _, id := range []uint64{cas20PolicyAlwaysAllow, cas20PolicyAlwaysBlock} {
+		want(cas20Call(selStageUpdateAdmin, wU64(id), addrKey(caller)),
+			errSelUnauthorized, "stageUpdateAdmin on a sentinel after initialization")
+	}
+}

--- a/core/vm/cas20_policy_test.go
+++ b/core/vm/cas20_policy_test.go
@@ -817,3 +817,182 @@ func TestCAS20SentinelErrorDoesNotDependOnInitialization(t *testing.T) {
 			errSelUnauthorized, "stageUpdateAdmin on a sentinel after initialization")
 	}
 }
+
+// encodeComposite builds calldata for createCompositePolicy / updateComposite:
+// a fixed head, then the offset to the uint64[] and the array itself.
+func encodeComposite(sel [4]byte, head []common.Hash, kids []uint64) []byte {
+	out := append([]byte{}, sel[:]...)
+	for _, w := range head {
+		out = append(out, w.Bytes()...)
+	}
+	out = append(out, u256hash(uint64((len(head)+1)*32)).Bytes()...)
+	out = append(out, u256hash(uint64(len(kids))).Bytes()...)
+	for _, k := range kids {
+		out = append(out, wU64(k).Bytes()...)
+	}
+	return out
+}
+
+// TestCAS20CompositeChildValidation pins the child-set rules, all four of which
+// are observable through which error a caller receives and none of which any
+// other test covers.
+//
+// The two-pass shape is the substantive one: a set holding both a missing child
+// and an ineligible one owes PolicyNotFound whatever their order in the array. An
+// implementation that validated each child fully before moving to the next would
+// answer InvalidChildPolicy for a set whose first element is a live composite,
+// and would pass every other assertion here.
+func TestCAS20CompositeChildValidation(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	admin := common.HexToAddress("0xad4149")
+	call := func(input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(admin, CAS20PolicyRegistryAddress, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	create := func(ptype uint64) uint64 {
+		t.Helper()
+		ret, err := call(cas20Call(selCreatePolicy, addrKey(admin), u256hash(ptype)))
+		if err != nil {
+			t.Fatalf("createPolicy(%d): %v", ptype, err)
+		}
+		return new(uint256.Int).SetBytes(ret).Uint64()
+	}
+	revertsWith := func(what string, input []byte, sel [4]byte, args ...common.Hash) {
+		t.Helper()
+		ret, err := call(input)
+		if !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("%s: err = %v, want revert", what, err)
+			return
+		}
+		want := append([]byte{}, sel[:]...)
+		for _, a := range args {
+			want = append(want, a.Bytes()...)
+		}
+		if !bytes.Equal(ret, want) {
+			t.Errorf("%s: revert data %x, want %x", what, ret, want)
+		}
+	}
+
+	block, allow := create(cas20PolicyBlocklist), create(cas20PolicyAllowlist)
+	unionHead := []common.Hash{addrKey(admin), u256hash(cas20PolicyUnion)}
+
+	ret, err := call(encodeComposite(selCreateComposite, unionHead, []uint64{block, allow}))
+	if err != nil {
+		t.Fatalf("createCompositePolicy: %v", err)
+	}
+	composite := new(uint256.Int).SetBytes(ret).Uint64()
+
+	ghost := uint64(cas20PolicyAllowlist)<<56 | 999
+
+	// Two passes: existence over the whole set precedes eligibility over the whole
+	// set, so a live composite ahead of a missing id still answers PolicyNotFound.
+	revertsWith("composite child before missing child",
+		encodeComposite(selCreateComposite, unionHead, []uint64{composite, ghost}), errSelPolicyNotFound)
+	// Both entry points, not just creation: they share one validator today, so a
+	// single case would keep passing if a refactor specialized either path.
+	revertsWith("composite child before missing child, on update",
+		encodeComposite(selUpdateComposite, []common.Hash{u256hash(composite)},
+			[]uint64{composite, ghost}), errSelPolicyNotFound)
+	// The registry's form carries no id: the caller supplied the set.
+	revertsWith("missing child alone",
+		encodeComposite(selCreateComposite, unionHead, []uint64{ghost, block}), errSelPolicyNotFound)
+
+	// Eligibility names the offending child, and a sentinel is as ineligible as a
+	// composite: only a simple policy the registry minted can be a child.
+	revertsWith("composite as child",
+		encodeComposite(selCreateComposite, unionHead, []uint64{composite, block}),
+		errSelInvalidChildPolicy, wU64(composite))
+	revertsWith("always-allow sentinel as child",
+		encodeComposite(selCreateComposite, unionHead, []uint64{cas20PolicyAlwaysAllow, block}),
+		errSelInvalidChildPolicy, wU64(cas20PolicyAlwaysAllow))
+	revertsWith("always-block sentinel as child",
+		encodeComposite(selCreateComposite, unionHead, []uint64{block, cas20PolicyAlwaysBlock}),
+		errSelInvalidChildPolicy, wU64(cas20PolicyAlwaysBlock))
+
+	// The count bound precedes both passes, so a lone missing child reports the
+	// count rather than the absence.
+	revertsWith("count bound precedes child checks",
+		encodeComposite(selCreateComposite, unionHead, []uint64{ghost}), errSelChildrenOutOfRange)
+
+	// The zero-admin guard precedes the type check, as it does in the simple
+	// constructors: all three agree on the order.
+	revertsWith("zero admin outranks incompatible type",
+		encodeComposite(selCreateComposite,
+			[]common.Hash{{}, u256hash(cas20PolicyBlocklist)}, []uint64{block, allow}),
+		errSelZeroAddress)
+
+	// updateComposite is the registry's own method, so its absence error carries
+	// no id either.
+	revertsWith("updateComposite on a missing composite",
+		encodeComposite(selUpdateComposite, []common.Hash{u256hash(ghost)}, []uint64{block, allow}),
+		errSelPolicyNotFound)
+	// A simple policy is not a composite, checked after existence.
+	revertsWith("updateComposite on a simple policy",
+		encodeComposite(selUpdateComposite, []common.Hash{u256hash(block)}, []uint64{block, allow}),
+		errSelIncompatibleType)
+
+	// And a well-formed replacement still lands, so the guards above are not
+	// simply refusing everything.
+	if _, err := call(encodeComposite(selUpdateComposite,
+		[]common.Hash{u256hash(composite)}, []uint64{allow, block})); err != nil {
+		t.Fatalf("updateComposite with a valid child set: %v", err)
+	}
+}
+
+// TestCAS20EmptyCompositeEvaluation pins how a composite with no children
+// answers, which is reachable only through a well-formed id the registry never
+// minted: a created composite carries two to four children and `updateComposite`
+// cannot empty it.
+//
+// The two types fall opposite ways, and neither is a special case: `isAuthorized`
+// runs the same loop for both, so an OR over nothing is false and an AND over
+// nothing is true. That makes a never-created INTERSECT behave as ALWAYS_ALLOW,
+// the same tolerance a never-created BLOCKLIST already has. It is safe for the
+// same reason: binding checks existence, so no token can reference either.
+func TestCAS20EmptyCompositeEvaluation(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	caller := cas20TestCaller
+	ask := func(id uint64) bool {
+		t.Helper()
+		ret, _, err := evm.Call(caller, CAS20PolicyRegistryAddress,
+			cas20Call(selIsAuthorized, wU64(id), addrKey(cas20Alice)),
+			NewGasBudget(5_000_000), uint256.NewInt(0))
+		if err != nil {
+			t.Fatalf("isAuthorized(%#x): %v", id, err)
+		}
+		return bytes.Equal(ret, encBool(true))
+	}
+
+	ghostUnion := uint64(cas20PolicyUnion)<<56 | 7
+	ghostIntersect := uint64(cas20PolicyIntersect)<<56 | 7
+	ghostBlocklist := uint64(cas20PolicyBlocklist)<<56 | 7
+	ghostAllowlist := uint64(cas20PolicyAllowlist)<<56 | 7
+
+	if ask(ghostUnion) {
+		t.Error("a never-created UNION authorized an account: an OR over no children is false")
+	}
+	if !ask(ghostIntersect) {
+		t.Error("a never-created INTERSECT refused an account: an AND over no children is " +
+			"vacuously true, so it authorizes everyone")
+	}
+	// The two simple types for contrast, so the composite answers above are read
+	// against the same emptiness rule rather than in isolation.
+	if !ask(ghostBlocklist) {
+		t.Error("a never-created BLOCKLIST refused an account: an empty blocklist blocks no one")
+	}
+	if ask(ghostAllowlist) {
+		t.Error("a never-created ALLOWLIST authorized an account: an empty allowlist admits no one")
+	}
+	// And none of them exists, which is what keeps the tolerance unreachable from
+	// a token: updatePolicy refuses to bind any of these ids.
+	for _, id := range []uint64{ghostUnion, ghostIntersect, ghostBlocklist, ghostAllowlist} {
+		ret, _, err := evm.Call(caller, CAS20PolicyRegistryAddress,
+			cas20Call(selPolicyExists, wU64(id)), NewGasBudget(5_000_000), uint256.NewInt(0))
+		if err != nil {
+			t.Fatalf("policyExists(%#x): %v", id, err)
+		}
+		if !bytes.Equal(ret, encBool(false)) {
+			t.Errorf("policyExists(%#x) = true, want false", id)
+		}
+	}
+}

--- a/core/vm/cas20_policy_test.go
+++ b/core/vm/cas20_policy_test.go
@@ -26,8 +26,6 @@ func encodeUpdateList(sel [4]byte, id uint64, flag bool, addrs []common.Address)
 	return out
 }
 
-// cas20BlockContext is the block context every CAS20 test runs under: post-merge, so
-// the fork rules resolve, with transfers stubbed out.
 func cas20BlockContext(time uint64) BlockContext {
 	return BlockContext{
 		Random:      &common.Hash{},
@@ -50,15 +48,10 @@ func newCAS20EVM(t *testing.T) (*state.StateDB, *EVM) {
 	return statedb, NewEVM(bc, statedb, &cfg, Config{})
 }
 
-// cas20TestCaller is the activation admin the test harness seeds.
 var cas20TestCaller = common.HexToAddress("0x60feed")
 
-// seedActivation puts the harness in the state a live network reaches once the
-// fork has run and governance has opened everything. The fork part delegates to
-// SeedCAS20Activation so the harness cannot drift from it; opening the features
-// stays local, since the fork deliberately opens nothing (BEP-702 3.15).
-// seedActivation puts the harness in the state a network reaches after
-// governance has appointed an admin and the admin has opened every feature.
+// The fork part delegates to SeedCAS20Activation so the harness cannot drift from
+// it; opening the features stays local, since the fork opens nothing (BEP-702 3.15).
 func seedActivation(statedb *state.StateDB, admin common.Address) {
 	SeedCAS20Activation(statedb)
 	reg := cas20Storage{state: statedb, token: CAS20ActivationRegistryAddress}
@@ -85,7 +78,6 @@ func TestCAS20PolicyRegistry(t *testing.T) {
 		return bytes.Equal(ret, encBool(true))
 	}
 
-	// create a blocklist policy.
 	ret, err := call(admin, cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyBlocklist)))
 	if err != nil {
 		t.Fatalf("createPolicy: %v", err)
@@ -101,7 +93,6 @@ func TestCAS20PolicyRegistry(t *testing.T) {
 		t.Fatal("policyAdmin mismatch")
 	}
 
-	// empty blocklist allows everyone; adding bob blocks him.
 	if !authorized(block, cas20Bob) {
 		t.Fatal("empty blocklist should allow")
 	}
@@ -115,7 +106,6 @@ func TestCAS20PolicyRegistry(t *testing.T) {
 		t.Fatal("carol should still be allowed")
 	}
 
-	// create an allowlist policy: empty blocks everyone; adding carol allows her.
 	ret, _ = call(admin, cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyAllowlist)))
 	allow := new(uint256.Int).SetBytes(ret).Uint64()
 	if byte(allow>>56) != cas20PolicyAllowlist {
@@ -131,7 +121,6 @@ func TestCAS20PolicyRegistry(t *testing.T) {
 		t.Fatal("carol should be allowed")
 	}
 
-	// type mismatch and authorization guards.
 	if _, err := call(admin, encodeUpdateList(selUpdateAllowlist, block, true, []common.Address{cas20Alice})); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatal("updateAllowlist on blocklist should revert")
 	}
@@ -139,7 +128,6 @@ func TestCAS20PolicyRegistry(t *testing.T) {
 		t.Fatal("non-admin update should revert")
 	}
 
-	// two-step admin transfer.
 	newAdmin := common.HexToAddress("0x9ead")
 	if _, err := call(admin, cas20Call(selStageUpdateAdmin, u256hash(block), addrKey(newAdmin))); err != nil {
 		t.Fatalf("stageUpdateAdmin: %v", err)
@@ -154,7 +142,6 @@ func TestCAS20PolicyRegistry(t *testing.T) {
 		t.Fatal("old admin should no longer update")
 	}
 
-	// renounce freezes the policy; reads still work.
 	if _, err := call(newAdmin, cas20Call(selRenounceAdmin, u256hash(block))); err != nil {
 		t.Fatalf("renounceAdmin: %v", err)
 	}
@@ -166,8 +153,6 @@ func TestCAS20PolicyRegistry(t *testing.T) {
 	}
 }
 
-// TestCAS20PolicyIntegration binds policies to a token's compliance scopes and
-// checks they gate transfers and mints.
 func TestCAS20PolicyIntegration(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xc4ea70")
@@ -179,7 +164,6 @@ func TestCAS20PolicyIntegration(t *testing.T) {
 		return ret, err
 	}
 
-	// token with creator as admin + minter, 1000 to alice.
 	initCalls := [][]byte{
 		cas20Call(selGrantRole, roleMint, addrKey(creator)),
 		cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
@@ -190,7 +174,6 @@ func TestCAS20PolicyIntegration(t *testing.T) {
 	}
 	token := common.BytesToAddress(ret)
 
-	// blocklist bob, bind to TRANSFER_RECEIVER.
 	ret, _ = call(creator, CAS20PolicyRegistryAddress, cas20Call(selCreatePolicy, addrKey(creator), u256hash(cas20PolicyBlocklist)))
 	blk := new(uint256.Int).SetBytes(ret).Uint64()
 	if _, err := call(creator, CAS20PolicyRegistryAddress, encodeUpdateList(selUpdateBlocklist, blk, true, []common.Address{cas20Bob})); err != nil {
@@ -200,7 +183,6 @@ func TestCAS20PolicyIntegration(t *testing.T) {
 		t.Fatalf("updatePolicy(receiver): %v", err)
 	}
 
-	// transfer to bob (blocked receiver) reverts; to carol succeeds.
 	if _, err := call(cas20Alice, token, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(10))); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("transfer to blocked receiver err = %v, want revert", err)
 	}
@@ -208,7 +190,6 @@ func TestCAS20PolicyIntegration(t *testing.T) {
 		t.Fatalf("transfer to allowed receiver: %v", err)
 	}
 
-	// allowlist for MINT_RECEIVER: only custody may receive newly minted supply.
 	ret, _ = call(creator, CAS20PolicyRegistryAddress, cas20Call(selCreatePolicy, addrKey(creator), u256hash(cas20PolicyAllowlist)))
 	al := new(uint256.Int).SetBytes(ret).Uint64()
 	if _, err := call(creator, CAS20PolicyRegistryAddress, encodeUpdateList(selUpdateAllowlist, al, true, []common.Address{custody})); err != nil {
@@ -227,7 +208,6 @@ func TestCAS20PolicyIntegration(t *testing.T) {
 	if view.balanceOf(custody).Uint64() != 500 {
 		t.Fatalf("custody balance = %d, want 500", view.balanceOf(custody).Uint64())
 	}
-	// binding a never-created policy id is rejected.
 	if _, err := call(creator, token, cas20Call(selUpdatePolicy, scopeTransferSender, u256hash(0x99999))); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatal("binding nonexistent policy should revert")
 	}
@@ -243,7 +223,6 @@ func TestCAS20SeizeWithMemo(t *testing.T) {
 		return ret, err
 	}
 
-	// token: creator is admin, MINT and SEIZE holder; 1000 minted to bob.
 	initCalls := [][]byte{
 		cas20Call(selGrantRole, roleMint, addrKey(creator)),
 		cas20Call(selGrantRole, roleSeize, addrKey(creator)),
@@ -258,12 +237,10 @@ func TestCAS20SeizeWithMemo(t *testing.T) {
 
 	memo := common.HexToHash("0x5e12e")
 
-	// seizing an un-frozen account fails (must freeze first).
 	if _, err := call(creator, token, cas20Call(selSeizeWithMemo, addrKey(cas20Bob), addrKey(cas20Alice), u256hash(100), memo)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("seize before freeze err = %v, want revert (AccountNotSeizable)", err)
 	}
 
-	// step 1: blacklist bob on the SEIZE_HOLDER scope.
 	ret, _ = call(creator, CAS20PolicyRegistryAddress, cas20Call(selCreatePolicy, addrKey(creator), u256hash(cas20PolicyBlocklist)))
 	blk := new(uint256.Int).SetBytes(ret).Uint64()
 	if _, err := call(creator, CAS20PolicyRegistryAddress, encodeUpdateList(selUpdateBlocklist, blk, true, []common.Address{cas20Bob})); err != nil {
@@ -273,17 +250,14 @@ func TestCAS20SeizeWithMemo(t *testing.T) {
 		t.Fatalf("updatePolicy(seizeHolder): %v", err)
 	}
 
-	// non-role caller cannot seize.
 	if _, err := call(cas20Alice, token, cas20Call(selSeizeWithMemo, addrKey(cas20Bob), addrKey(cas20Alice), u256hash(100), memo)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("unauthorized seize err = %v, want revert", err)
 	}
 
-	// the zero address is never a valid destination.
 	if _, err := call(creator, token, cas20Call(selSeizeWithMemo, addrKey(cas20Bob), common.Hash{}, u256hash(100), memo)); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("seize to zero err = %v, want revert (InvalidReceiver)", err)
 	}
 
-	// step 2: seize part of the frozen balance. Value moves; supply does not.
 	if _, err := call(creator, token, cas20Call(selSeizeWithMemo, addrKey(cas20Bob), addrKey(cas20Alice), u256hash(400), memo)); err != nil {
 		t.Fatalf("seizeWithMemo: %v", err)
 	}
@@ -298,16 +272,11 @@ func TestCAS20SeizeWithMemo(t *testing.T) {
 	}
 }
 
-// TestCAS20PolicyStorageLayout pins the registry's storage (BEP-702 3.17): the
-// namespaced root, the slot order, and the packed existence-and-admin word.
-// These are consensus-visible, so the assertions are on raw slots rather than on
-// what the ABI reports.
+// BEP-702 3.17, asserted on raw slots rather than on what the ABI reports.
 func TestCAS20PolicyStorageLayout(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	admin := common.HexToAddress("0xad4149")
 
-	// Slot order: policies, members, pendingAdmins, counter, then a reserved slot
-	// for composite children.
 	root := new(uint256.Int).SetBytes(erc7201Root("bsc.policy_registry").Bytes())
 	for offset, want := range map[uint64]uint64{
 		polSlotPolicies: 0, polSlotMembers: 1, polSlotPendingAdmins: 2, polSlotCounter: 3,
@@ -343,8 +312,7 @@ func TestCAS20PolicyStorageLayout(t *testing.T) {
 			break
 		}
 	}
-	// Two sentinels are seeded first, so the first caller id draws counter 2 and
-	// the counter lands on 3.
+	// Two sentinels are seeded first, so the first caller id draws counter 2.
 	if got := new(uint256.Int).SetBytes(view.getWord(polSlot(polSlotCounter)).Bytes()).Uint64(); got != 3 {
 		t.Errorf("counter = %d, want 3", got)
 	}
@@ -353,9 +321,6 @@ func TestCAS20PolicyStorageLayout(t *testing.T) {
 	}
 }
 
-// TestCAS20PolicySentinels pins the sentinel semantics: they exist and answer
-// authorization from their id alone, so they are correct before any policy has
-// been created and no membership write can redefine them.
 func TestCAS20PolicySentinels(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	caller := common.HexToAddress("0xad4149")
@@ -368,9 +333,7 @@ func TestCAS20PolicySentinels(t *testing.T) {
 		return ret
 	}
 
-	// Before anything is created: both sentinels report as existing, and their
-	// authorization is fixed. ALWAYS_ALLOW is the value every unset policy field
-	// holds, so it has to be right at this point in particular.
+	// Before anything is created; ALWAYS_ALLOW is what every unset policy field holds.
 	for _, id := range []uint64{cas20PolicyAlwaysAllow, cas20PolicyAlwaysBlock} {
 		if !bytes.Equal(ask(selPolicyExists, u256hash(id)), encBool(true)) {
 			t.Errorf("policyExists(%#x) = false, want true", id)
@@ -389,8 +352,6 @@ func TestCAS20PolicySentinels(t *testing.T) {
 		t.Error("ALWAYS_BLOCK must refuse")
 	}
 
-	// A malformed type byte is not a policy: it never exists, never authorizes,
-	// and has no admin.
 	bad := uint64(5) << 56
 	if !bytes.Equal(ask(selPolicyExists, u256hash(bad)), encBool(false)) {
 		t.Error("a malformed type byte must not exist")
@@ -402,7 +363,6 @@ func TestCAS20PolicySentinels(t *testing.T) {
 		t.Errorf("policyAdmin(malformed) = %s, want zero", got.Hex())
 	}
 
-	// Neither sentinel can be administered: both are seeded with a zero admin.
 	for _, id := range []uint64{cas20PolicyAlwaysAllow, cas20PolicyAlwaysBlock} {
 		_, _, err := evm.Call(caller, CAS20PolicyRegistryAddress,
 			cas20Call(selStageUpdateAdmin, u256hash(id), addrKey(caller)),
@@ -413,9 +373,7 @@ func TestCAS20PolicySentinels(t *testing.T) {
 	}
 }
 
-// TestCAS20PolicyCheckOrder pins the order a membership update applies its checks.
-// The order is observable through which error a caller receives, so the
-// existence -> type -> admin -> batch sequence is part of the surface.
+// existence -> type -> admin -> batch, observable through which error the caller receives.
 func TestCAS20PolicyCheckOrder(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	admin := common.HexToAddress("0xad4149")
@@ -436,8 +394,6 @@ func TestCAS20PolicyCheckOrder(t *testing.T) {
 		}
 	}
 
-	// An id no createPolicy produced: existence is checked first, so this is
-	// PolicyNotFound and not Unauthorized.
 	ghost := uint64(cas20PolicyAllowlist)<<56 | 999
 	revertsWith("nonexistent policy", stranger,
 		encodeUpdateList(selUpdateAllowlist, ghost, true, []common.Address{cas20Bob}), errSelPolicyNotFound)
@@ -448,14 +404,10 @@ func TestCAS20PolicyCheckOrder(t *testing.T) {
 	}
 	block := new(uint256.Int).SetBytes(ret).Uint64()
 
-	// Type is checked before admin, so a stranger calling the wrong method on a
-	// real policy sees IncompatiblePolicyType rather than Unauthorized.
 	revertsWith("wrong type, wrong caller", stranger,
 		encodeUpdateList(selUpdateAllowlist, block, true, []common.Address{cas20Bob}), errSelIncompatibleType)
-	// Right method, wrong caller: now admin is what fails.
 	revertsWith("right type, wrong caller", stranger,
 		encodeUpdateList(selUpdateBlocklist, block, true, []common.Address{cas20Bob}), errSelUnauthorized)
-	// Admin passes, so an oversized batch is what fails, last.
 	oversized := make([]common.Address, cas20PolicyBatchMax+1)
 	for i := range oversized {
 		oversized[i] = common.BigToAddress(new(big.Int).SetUint64(uint64(i + 1)))
@@ -463,7 +415,6 @@ func TestCAS20PolicyCheckOrder(t *testing.T) {
 	revertsWith("oversized batch", admin,
 		encodeUpdateList(selUpdateBlocklist, block, true, oversized), errSelBatchTooLarge)
 
-	// The same ordering applies to the admin-handover paths.
 	revertsWith("stage on nonexistent", stranger,
 		cas20Call(selStageUpdateAdmin, u256hash(ghost), addrKey(stranger)), errSelPolicyNotFound)
 	revertsWith("finalize on nonexistent", stranger,
@@ -472,15 +423,11 @@ func TestCAS20PolicyCheckOrder(t *testing.T) {
 		cas20Call(selRenounceAdmin, u256hash(ghost)), errSelPolicyNotFound)
 }
 
-// TestCAS20PolicySentinelsIgnoreMembership pins why the sentinel fast-paths exist.
-// Their emptiness alone would give the same answers, so a membership-derived
-// implementation looks correct — until something writes membership under a
-// sentinel id, which a counter that carried into the type byte could do.
-// Answering from the id makes them constant by construction.
+// Emptiness alone would give the same answers, so a membership-derived sentinel
+// looks correct until something writes membership under its id.
 func TestCAS20PolicySentinelsIgnoreMembership(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 
-	// Plant membership under both sentinels, bypassing the ABI entirely.
 	view := policyReg{s: newUnmeteredCAS20Storage(statedb, CAS20PolicyRegistryAddress)}
 	view.setMember(cas20PolicyAlwaysAllow, cas20Bob, true) // "block bob" on ALWAYS_ALLOW
 	view.setMember(cas20PolicyAlwaysBlock, cas20Bob, true) // "allow bob" on ALWAYS_BLOCK
@@ -502,11 +449,8 @@ func TestCAS20PolicySentinelsIgnoreMembership(t *testing.T) {
 	}
 }
 
-// TestCAS20PolicyCounterExhaustion pins the 56-bit counter bound. Reaching it
-// takes more createPolicy calls than any chain will see, so the counter is
-// driven there directly; what matters is that the boundary is refused rather
-// than allowed to carry into the type byte, where an id would change type,
-// collide with another type's policy, or land on a sentinel.
+// The counter is driven to the bound directly; a carry into the type byte would
+// change an id's type or land on a sentinel.
 func TestCAS20PolicyCounterExhaustion(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	admin := common.HexToAddress("0xad4149")
@@ -519,7 +463,6 @@ func TestCAS20PolicyCounterExhaustion(t *testing.T) {
 		return ret, err
 	}
 
-	// One short of the bound still works, and stays inside its own type space.
 	view.setCounter(cas20PolicyCounterMax - 1)
 	ret, err := create()
 	if err != nil {
@@ -529,7 +472,6 @@ func TestCAS20PolicyCounterExhaustion(t *testing.T) {
 		t.Errorf("id %#x escaped its type byte", id)
 	}
 
-	// At the bound, creation is refused: Panic(0x11), the arithmetic-overflow code.
 	view.setCounter(cas20PolicyCounterMax)
 	ret, err = create()
 	if !errors.Is(err, ErrExecutionReverted) {
@@ -541,11 +483,8 @@ func TestCAS20PolicyCounterExhaustion(t *testing.T) {
 	}
 }
 
-// TestCAS20PolicyEvents pins the registry's log surface: which events each write
-// emits, in what order, and with what payload. The membership events mix a
-// static bool with a dynamic address[], so their data is also checked against
-// go-ethereum's own ABI packer — a head/tail mistake in that shape would
-// otherwise be invisible to an expectation built with the same encoder.
+// The membership events mix a static bool with a dynamic address[], so their data
+// is also checked against go-ethereum's packer.
 func TestCAS20PolicyEvents(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	admin := common.HexToAddress("0xad4149")
@@ -576,8 +515,8 @@ func TestCAS20PolicyEvents(t *testing.T) {
 		}
 	}
 
-	// createPolicy: PolicyCreated then the initial admin as a transition from
-	// nobody, so creation lands in the same stream as every later handover.
+	// The initial admin is a transition from nobody, so creation lands in the same
+	// stream as every later handover.
 	logs := logsOf(admin, cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyBlocklist)))
 	if len(logs) != 2 {
 		t.Fatalf("createPolicy emitted %d logs, want 2", len(logs))
@@ -593,8 +532,7 @@ func TestCAS20PolicyEvents(t *testing.T) {
 		t.Errorf("PolicyAdminUpdated data = %x, want empty", logs[1].Data)
 	}
 
-	// creator is the caller, not the nominated admin: a policy created on someone
-	// else's behalf must name whoever sent the transaction.
+	// creator is the caller, not the nominated admin.
 	logs = logsOf(cas20Alice, cas20Call(selCreatePolicy, addrKey(heir), u256hash(cas20PolicyBlocklist)))
 	if len(logs) != 2 {
 		t.Fatalf("createPolicy (third party) emitted %d logs, want 2", len(logs))
@@ -605,8 +543,6 @@ func TestCAS20PolicyEvents(t *testing.T) {
 	wantTopics("PolicyAdminUpdated (third party)", logs[1],
 		cas20TopicPolicyAdminUpdated, idKey(third), addrKey(common.Address{}), addrKey(heir))
 
-	// updateBlocklist: one log under the blocklist event, carrying the flag and
-	// the accounts.
 	accounts := []common.Address{cas20Bob, cas20Carol}
 	logs = logsOf(admin, encodeUpdateList(selUpdateBlocklist, block, true, accounts))
 	if len(logs) != 1 {
@@ -630,7 +566,6 @@ func TestCAS20PolicyEvents(t *testing.T) {
 		t.Errorf("BlocklistUpdated data\n got = %x\nwant = %x", logs[0].Data, oracle)
 	}
 
-	// An allowlist reports under its own event, not the blocklist one.
 	ret, _, err := evm.Call(admin, CAS20PolicyRegistryAddress,
 		cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyAllowlist)),
 		NewGasBudget(5_000_000), uint256.NewInt(0))
@@ -647,8 +582,7 @@ func TestCAS20PolicyEvents(t *testing.T) {
 		t.Errorf("AllowlistUpdated data\n got = %x\nwant = %x", logs[0].Data, oracle)
 	}
 
-	// createPolicyWithAccounts emits the seed membership event too — including
-	// for an empty batch, since the call form is part of the record.
+	// Emitted for an empty batch too: the call form is part of the record.
 	logs = logsOf(admin, encodeCreatePolicyWithAccounts(admin, cas20PolicyAllowlist, nil))
 	if len(logs) != 3 {
 		t.Fatalf("createPolicyWithAccounts emitted %d logs, want 3", len(logs))
@@ -661,8 +595,6 @@ func TestCAS20PolicyEvents(t *testing.T) {
 		t.Errorf("seed AllowlistUpdated data\n got = %x\nwant = %x", logs[2].Data, oracle)
 	}
 
-	// The handover pair, then renunciation. Staging names the incumbent as well
-	// as the nominee, so a stage log is self-contained.
 	logs = logsOf(admin, cas20Call(selStageUpdateAdmin, u256hash(block), addrKey(heir)))
 	if len(logs) != 1 {
 		t.Fatalf("stageUpdateAdmin emitted %d logs, want 1", len(logs))
@@ -670,12 +602,10 @@ func TestCAS20PolicyEvents(t *testing.T) {
 	wantTopics("PolicyAdminStaged", logs[0],
 		cas20TopicPolicyAdminStaged, idKey(block), addrKey(admin), addrKey(heir))
 
-	// Withdrawing a nomination is a governance action, not a silent one.
 	logs = logsOf(admin, cas20Call(selStageUpdateAdmin, u256hash(block), addrKey(common.Address{})))
 	wantTopics("PolicyAdminStaged (cancel)", logs[0],
 		cas20TopicPolicyAdminStaged, idKey(block), addrKey(admin), addrKey(common.Address{}))
 
-	// Re-nominate, then the nominee takes over.
 	logsOf(admin, cas20Call(selStageUpdateAdmin, u256hash(block), addrKey(heir)))
 	logs = logsOf(heir, cas20Call(selFinalizeUpdateAdmin, u256hash(block)))
 	if len(logs) != 1 {
@@ -704,9 +634,6 @@ func encodeCreatePolicyWithAccounts(admin common.Address, ptype byte, accounts [
 	return out
 }
 
-// TestCAS20MembershipArgsDecodeStrictly covers the two membership paths' narrow
-// arguments: an address element must not drop its high padding and a bool must be
-// 0 or 1, as Solidity's external decoder requires.
 func TestCAS20MembershipArgsDecodeStrictly(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	admin := cas20TestCaller
@@ -725,16 +652,13 @@ func TestCAS20MembershipArgsDecodeStrictly(t *testing.T) {
 	dirty := addrKey(cas20Alice)
 	dirty[0] = 0x01 // a byte above the low twenty
 
-	// updateAllowlist: the routine path, where a dirty element would add an
-	// account other than the one the encoding names.
+	// A dirty element would add an account other than the one the encoding names.
 	if _, err := call(encodeUpdateListRaw(selUpdateAllowlist, id, u256hash(1), []common.Hash{dirty})); !errors.Is(err, ErrExecutionReverted) {
 		t.Errorf("updateAllowlist with a dirty address element: err = %v, want a revert", err)
 	}
-	// The bool argument, likewise: 2 is neither true nor false.
 	if _, err := call(encodeUpdateListRaw(selUpdateAllowlist, id, u256hash(2), []common.Hash{addrKey(cas20Alice)})); !errors.Is(err, ErrExecutionReverted) {
 		t.Errorf("updateAllowlist with allowed = 2: err = %v, want a revert", err)
 	}
-	// And the clean form still works, so the guards are not refusing everything.
 	if _, err := call(encodeUpdateListRaw(selUpdateAllowlist, id, u256hash(1), []common.Hash{addrKey(cas20Alice)})); err != nil {
 		t.Fatalf("updateAllowlist with clean args: %v", err)
 	}
@@ -744,15 +668,12 @@ func TestCAS20MembershipArgsDecodeStrictly(t *testing.T) {
 		t.Error("alice was not added by the clean call")
 	}
 
-	// createPolicyWithAccounts, the other path onto the same setter.
 	if _, err := call(encodeCreatePolicyWithAccountsRaw(addrKey(admin),
 		u256hash(cas20PolicyAllowlist), []common.Hash{dirty})); !errors.Is(err, ErrExecutionReverted) {
 		t.Errorf("createPolicyWithAccounts with a dirty element: err = %v, want a revert", err)
 	}
 }
 
-// encodeUpdateListRaw is encodeUpdateList with the words passed through
-// unchanged, so a test can hand it an encoding Solidity would not produce.
 func encodeUpdateListRaw(sel [4]byte, id uint64, flag common.Hash, accounts []common.Hash) []byte {
 	out := append([]byte{}, sel[:]...)
 	out = append(out, wU64(id).Bytes()...)
@@ -777,8 +698,6 @@ func encodeCreatePolicyWithAccountsRaw(admin, ptype common.Hash, accounts []comm
 	return out
 }
 
-// TestCAS20SentinelErrorDoesNotDependOnInitialization covers the sentinels before
-// any policy exists, when ensureInitialized has never run.
 func TestCAS20SentinelErrorDoesNotDependOnInitialization(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	caller := common.HexToAddress("0xca11e4")
@@ -788,10 +707,8 @@ func TestCAS20SentinelErrorDoesNotDependOnInitialization(t *testing.T) {
 		return ret, err
 	}
 
-	// The registry is untouched: nothing has been created, so the sentinels' words
-	// are unwritten. Administering one must still fail as unauthorized, not as
-	// missing — reading the raw exists bit gave PolicyNotFound here and
-	// Unauthorized after the first unrelated creation.
+	// The sentinels' words are unwritten; administering one must still fail as
+	// unauthorized, not as missing.
 	want := func(input []byte, sel [4]byte, what string) {
 		t.Helper()
 		ret, err := call(input)
@@ -807,8 +724,7 @@ func TestCAS20SentinelErrorDoesNotDependOnInitialization(t *testing.T) {
 			errSelUnauthorized, "stageUpdateAdmin on a sentinel before initialization")
 	}
 
-	// Create something unrelated, which is what runs ensureInitialized, and the
-	// answer must not change.
+	// Creating anything runs ensureInitialized; the answer must not change.
 	if _, err := call(cas20Call(selCreatePolicy, addrKey(caller), u256hash(cas20PolicyAllowlist))); err != nil {
 		t.Fatalf("createPolicy: %v", err)
 	}
@@ -818,8 +734,6 @@ func TestCAS20SentinelErrorDoesNotDependOnInitialization(t *testing.T) {
 	}
 }
 
-// encodeComposite builds calldata for createCompositePolicy / updateComposite:
-// a fixed head, then the offset to the uint64[] and the array itself.
 func encodeComposite(sel [4]byte, head []common.Hash, kids []uint64) []byte {
 	out := append([]byte{}, sel[:]...)
 	for _, w := range head {
@@ -833,15 +747,8 @@ func encodeComposite(sel [4]byte, head []common.Hash, kids []uint64) []byte {
 	return out
 }
 
-// TestCAS20CompositeChildValidation pins the child-set rules, all four of which
-// are observable through which error a caller receives and none of which any
-// other test covers.
-//
-// The two-pass shape is the substantive one: a set holding both a missing child
-// and an ineligible one owes PolicyNotFound whatever their order in the array. An
-// implementation that validated each child fully before moving to the next would
-// answer InvalidChildPolicy for a set whose first element is a live composite,
-// and would pass every other assertion here.
+// A set holding both a missing child and an ineligible one owes PolicyNotFound
+// whatever their order; a per-child validator would pass every other assertion here.
 func TestCAS20CompositeChildValidation(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	admin := common.HexToAddress("0xad4149")
@@ -884,21 +791,16 @@ func TestCAS20CompositeChildValidation(t *testing.T) {
 
 	ghost := uint64(cas20PolicyAllowlist)<<56 | 999
 
-	// Two passes: existence over the whole set precedes eligibility over the whole
-	// set, so a live composite ahead of a missing id still answers PolicyNotFound.
 	revertsWith("composite child before missing child",
 		encodeComposite(selCreateComposite, unionHead, []uint64{composite, ghost}), errSelPolicyNotFound)
-	// Both entry points, not just creation: they share one validator today, so a
-	// single case would keep passing if a refactor specialized either path.
+	// Both entry points, in case a refactor specializes either path.
 	revertsWith("composite child before missing child, on update",
 		encodeComposite(selUpdateComposite, []common.Hash{u256hash(composite)},
 			[]uint64{composite, ghost}), errSelPolicyNotFound)
-	// The registry's form carries no id: the caller supplied the set.
 	revertsWith("missing child alone",
 		encodeComposite(selCreateComposite, unionHead, []uint64{ghost, block}), errSelPolicyNotFound)
 
-	// Eligibility names the offending child, and a sentinel is as ineligible as a
-	// composite: only a simple policy the registry minted can be a child.
+	// Only a simple policy the registry minted can be a child.
 	revertsWith("composite as child",
 		encodeComposite(selCreateComposite, unionHead, []uint64{composite, block}),
 		errSelInvalidChildPolicy, wU64(composite))
@@ -909,46 +811,33 @@ func TestCAS20CompositeChildValidation(t *testing.T) {
 		encodeComposite(selCreateComposite, unionHead, []uint64{block, cas20PolicyAlwaysBlock}),
 		errSelInvalidChildPolicy, wU64(cas20PolicyAlwaysBlock))
 
-	// The count bound precedes both passes, so a lone missing child reports the
-	// count rather than the absence.
+	// The count bound precedes both passes.
 	revertsWith("count bound precedes child checks",
 		encodeComposite(selCreateComposite, unionHead, []uint64{ghost}), errSelChildrenOutOfRange)
 
-	// The zero-admin guard precedes the type check, as it does in the simple
-	// constructors: all three agree on the order.
+	// Zero admin before type, as in the simple constructors.
 	revertsWith("zero admin outranks incompatible type",
 		encodeComposite(selCreateComposite,
 			[]common.Hash{{}, u256hash(cas20PolicyBlocklist)}, []uint64{block, allow}),
 		errSelZeroAddress)
 
-	// updateComposite is the registry's own method, so its absence error carries
-	// no id either.
 	revertsWith("updateComposite on a missing composite",
 		encodeComposite(selUpdateComposite, []common.Hash{u256hash(ghost)}, []uint64{block, allow}),
 		errSelPolicyNotFound)
-	// A simple policy is not a composite, checked after existence.
 	revertsWith("updateComposite on a simple policy",
 		encodeComposite(selUpdateComposite, []common.Hash{u256hash(block)}, []uint64{block, allow}),
 		errSelIncompatibleType)
 
-	// And a well-formed replacement still lands, so the guards above are not
-	// simply refusing everything.
 	if _, err := call(encodeComposite(selUpdateComposite,
 		[]common.Hash{u256hash(composite)}, []uint64{allow, block})); err != nil {
 		t.Fatalf("updateComposite with a valid child set: %v", err)
 	}
 }
 
-// TestCAS20EmptyCompositeEvaluation pins how a composite with no children
-// answers, which is reachable only through a well-formed id the registry never
-// minted: a created composite carries two to four children and `updateComposite`
-// cannot empty it.
-//
-// The two types fall opposite ways, and neither is a special case: `isAuthorized`
-// runs the same loop for both, so an OR over nothing is false and an AND over
-// nothing is true. That makes a never-created INTERSECT behave as ALWAYS_ALLOW,
-// the same tolerance a never-created BLOCKLIST already has. It is safe for the
-// same reason: binding checks existence, so no token can reference either.
+// An empty composite is reachable only through an id the registry never minted.
+// OR over nothing is false and AND over nothing is true, so a never-created
+// INTERSECT behaves as ALWAYS_ALLOW; binding checks existence, so no token can
+// reference either.
 func TestCAS20EmptyCompositeEvaluation(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	caller := cas20TestCaller
@@ -975,16 +864,14 @@ func TestCAS20EmptyCompositeEvaluation(t *testing.T) {
 		t.Error("a never-created INTERSECT refused an account: an AND over no children is " +
 			"vacuously true, so it authorizes everyone")
 	}
-	// The two simple types for contrast, so the composite answers above are read
-	// against the same emptiness rule rather than in isolation.
+	// The simple types for contrast, under the same emptiness rule.
 	if !ask(ghostBlocklist) {
 		t.Error("a never-created BLOCKLIST refused an account: an empty blocklist blocks no one")
 	}
 	if ask(ghostAllowlist) {
 		t.Error("a never-created ALLOWLIST authorized an account: an empty allowlist admits no one")
 	}
-	// And none of them exists, which is what keeps the tolerance unreachable from
-	// a token: updatePolicy refuses to bind any of these ids.
+	// None of them exists, which is what keeps the tolerance unreachable from a token.
 	for _, id := range []uint64{ghostUnion, ghostIntersect, ghostBlocklist, ghostAllowlist} {
 		ret, _, err := evm.Call(caller, CAS20PolicyRegistryAddress,
 			cas20Call(selPolicyExists, wU64(id)), NewGasBudget(5_000_000), uint256.NewInt(0))

--- a/core/vm/cas20_policy_test.go
+++ b/core/vm/cas20_policy_test.go
@@ -56,7 +56,7 @@ func seedActivation(statedb *state.StateDB, admin common.Address) {
 	SeedCAS20Activation(statedb)
 	reg := cas20Storage{state: statedb, token: CAS20ActivationRegistryAddress}
 	reg.setWord(actSlot(actSlotAdmin), addrKey(admin))
-	for _, f := range []common.Hash{featureCAS20Asset, featureCAS20Stablecoin, featurePolicyRegistry} {
+	for _, f := range []common.Hash{featureCAS20Asset, featureCAS20Stablecoin, featurePolicyRegistry, featureMemoRegistry} {
 		reg.setWord(mappingSlot(actSlot(actSlotFeatures), f), common.Hash{31: 1})
 	}
 }

--- a/core/vm/cas20_singletons_test.go
+++ b/core/vm/cas20_singletons_test.go
@@ -1,0 +1,37 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TestCAS20SingletonAddresses pins the three fixed addresses as literals. Every
+// other test reaches them through these variables, so a change stays green
+// everywhere. They are consensus constants published in BEP-702 3.1.
+func TestCAS20SingletonAddresses(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  common.Address
+		want string
+	}{
+		{"CAS20Factory", CAS20FactoryAddress, "0xCA5F000000000000000000000000000000000000"},
+		{"ActivationRegistry", CAS20ActivationRegistryAddress, "0x7020000000000000000000000000000000000001"},
+		{"PolicyRegistry", CAS20PolicyRegistryAddress, "0x7020000000000000000000000000000000000002"},
+	} {
+		if want := common.HexToAddress(tc.want); tc.got != want {
+			t.Errorf("%s = %s, want %s", tc.name, tc.got.Hex(), want.Hex())
+		}
+	}
+
+	// The factory must not be matched by the token-space check, or creating a
+	// token could collide with the factory itself.
+	if IsCAS20Address(CAS20FactoryAddress) {
+		t.Error("the factory must fall outside the reserved token space")
+	}
+	for _, reg := range []common.Address{CAS20ActivationRegistryAddress, CAS20PolicyRegistryAddress} {
+		if IsCAS20Address(reg) {
+			t.Errorf("%s must fall outside the reserved token space", reg.Hex())
+		}
+	}
+}

--- a/core/vm/cas20_singletons_test.go
+++ b/core/vm/cas20_singletons_test.go
@@ -6,9 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// TestCAS20SingletonAddresses pins the three fixed addresses as literals. Every
-// other test reaches them through these variables, so a change stays green
-// everywhere. They are consensus constants published in BEP-702 3.1.
+// Consensus constants (BEP-702 3.1); every other test reaches them through the variables.
 func TestCAS20SingletonAddresses(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -24,8 +22,7 @@ func TestCAS20SingletonAddresses(t *testing.T) {
 		}
 	}
 
-	// The factory must not be matched by the token-space check, or creating a
-	// token could collide with the factory itself.
+	// Or creating a token could collide with the factory itself.
 	if IsCAS20Address(CAS20FactoryAddress) {
 		t.Error("the factory must fall outside the reserved token space")
 	}

--- a/core/vm/cas20_singletons_test.go
+++ b/core/vm/cas20_singletons_test.go
@@ -16,6 +16,7 @@ func TestCAS20SingletonAddresses(t *testing.T) {
 		{"CAS20Factory", CAS20FactoryAddress, "0xCA5F000000000000000000000000000000000000"},
 		{"ActivationRegistry", CAS20ActivationRegistryAddress, "0x7020000000000000000000000000000000000001"},
 		{"PolicyRegistry", CAS20PolicyRegistryAddress, "0x7020000000000000000000000000000000000002"},
+		{"MemoFormatRegistry", CAS20MemoFormatRegistryAddress, "0x7020000000000000000000000000000000000003"},
 	} {
 		if want := common.HexToAddress(tc.want); tc.got != want {
 			t.Errorf("%s = %s, want %s", tc.name, tc.got.Hex(), want.Hex())

--- a/core/vm/cas20_stablecoin.go
+++ b/core/vm/cas20_stablecoin.go
@@ -1,0 +1,52 @@
+package vm
+
+import "github.com/ethereum/go-ethereum/common"
+
+// CAS20 Stablecoin variant: adds an immutable currency() and fixes decimals at 6
+// (BEP-702 3.13).
+
+const cas20StablecoinNamespace = "bsc.cas20.stablecoin"
+
+const cas20StablecoinSlotCurrency = 0 // string
+
+var (
+	cas20StablecoinRoot = erc7201Root(cas20StablecoinNamespace)
+
+	selCurrency = selector("currency()")
+)
+
+// stablecoinExt is a gas-metered view over the Stablecoin extension storage.
+type stablecoinExt struct{ s cas20Storage }
+
+func newStablecoinExt(ctx *PrecompileContext) stablecoinExt {
+	return stablecoinExt{s: newMeteredCAS20Storage(ctx)}
+}
+
+func stablecoinSlot(offset uint64) common.Hash {
+	return offsetSlot(cas20StablecoinRoot, offset)
+}
+
+func (e stablecoinExt) currency() (string, bool) {
+	return e.s.getStringAt(stablecoinSlot(cas20StablecoinSlotCurrency))
+}
+
+func (e stablecoinExt) setCurrency(v string) bool {
+	return e.s.setStringAt(stablecoinSlot(cas20StablecoinSlotCurrency), v)
+}
+
+// stablecoinDispatch routes a Stablecoin call: the one extension selector
+// first, then the shared IB20 surface.
+func stablecoinDispatch(tok cas20Token, ext stablecoinExt, input []byte) ([]byte, error) {
+	if len(input) >= 4 {
+		var sel [4]byte
+		copy(sel[:], input[:4])
+		if sel == selCurrency {
+			v, ok := ext.currency()
+			if !ok {
+				return nil, ErrOutOfGas
+			}
+			return encString(v), nil
+		}
+	}
+	return tok.dispatch(input)
+}

--- a/core/vm/cas20_stablecoin.go
+++ b/core/vm/cas20_stablecoin.go
@@ -2,12 +2,11 @@ package vm
 
 import "github.com/ethereum/go-ethereum/common"
 
-// CAS20 Stablecoin variant: adds an immutable currency() and fixes decimals at 6
-// (BEP-702 3.13).
+// BEP-702 3.13: an immutable currency() and decimals fixed at 6.
 
 const cas20StablecoinNamespace = "bsc.cas20.stablecoin"
 
-const cas20StablecoinSlotCurrency = 0 // string
+const cas20StablecoinSlotCurrency = 0
 
 var (
 	cas20StablecoinRoot = erc7201Root(cas20StablecoinNamespace)
@@ -15,7 +14,6 @@ var (
 	selCurrency = selector("currency()")
 )
 
-// stablecoinExt is a gas-metered view over the Stablecoin extension storage.
 type stablecoinExt struct{ s cas20Storage }
 
 func newStablecoinExt(ctx *PrecompileContext) stablecoinExt {
@@ -34,8 +32,6 @@ func (e stablecoinExt) setCurrency(v string) bool {
 	return e.s.setStringAt(stablecoinSlot(cas20StablecoinSlotCurrency), v)
 }
 
-// stablecoinDispatch routes a Stablecoin call: the one extension selector
-// first, then the shared IB20 surface.
 func stablecoinDispatch(tok cas20Token, ext stablecoinExt, input []byte) ([]byte, error) {
 	if len(input) >= 4 {
 		var sel [4]byte

--- a/core/vm/cas20_storage.go
+++ b/core/vm/cas20_storage.go
@@ -1,0 +1,493 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// CAS20 core storage layout.
+const cas20Namespace = "bsc.cas20"
+
+const (
+	cas20SlotName             = 0
+	cas20SlotSymbol           = 1
+	cas20SlotContractURI      = 2
+	cas20SlotTotalSupply      = 3
+	cas20SlotBalances         = 4
+	cas20SlotAllowances       = 5
+	cas20SlotRoles            = 6
+	cas20SlotRoleAdmins       = 7
+	cas20SlotAdminCount       = 8
+	cas20SlotTransferPolicies = 9
+	cas20SlotMintPolicy       = 10
+	cas20SlotPaused           = 11
+	cas20SlotSupplyCap        = 12
+	cas20SlotNonces           = 13
+	cas20SlotSeizePolicies    = 14
+)
+
+// Packed u64 byte offsets within the policy slots. The lanes a group leaves
+// free are reserved for that group: the mint slot holds one id today and the
+// rest of it belongs to future mint-side policy types, which is why the seize
+// ids sit in a slot of their own rather than filling it. Seize is a cold path,
+// so the extra load costs nothing that matters.
+const (
+	cas20OffTransferSender   = 0
+	cas20OffTransferReceiver = 8
+	cas20OffTransferExecutor = 16
+	cas20OffMintReceiver     = 0
+	cas20OffSeizeHolder      = 0
+	cas20OffSeizeReceiver    = 8
+)
+
+// cas20CoreRoot is the ERC-7201 root of the core storage namespace, computed once.
+var cas20CoreRoot = erc7201Root(cas20Namespace)
+
+// erc7201Root computes the ERC-7201 storage root of a namespace:
+func erc7201Root(namespace string) common.Hash {
+	inner := new(uint256.Int).SetBytes(crypto.Keccak256([]byte(namespace)))
+	inner.SubUint64(inner, 1)
+	buf := inner.Bytes32()
+	root := crypto.Keccak256Hash(buf[:])
+	root[31] = 0 // clear the low byte
+	return root
+}
+
+// slotAt returns the absolute storage slot of a fixed field at the given
+// offset from the core root.
+func slotAt(offset uint64) common.Hash {
+	s := new(uint256.Int).SetBytes(cas20CoreRoot.Bytes())
+	s.AddUint64(s, offset)
+	return s.Bytes32()
+}
+
+// offsetSlot returns the slot at root+offset, the fixed-field addressing every
+// CAS20 namespace uses.
+func offsetSlot(root common.Hash, offset uint64) common.Hash {
+	x := new(uint256.Int).SetBytes(root.Bytes())
+	x.AddUint64(x, offset)
+	return x.Bytes32()
+}
+
+// mappingSlot returns the Solidity storage slot of mapping[key] where the
+// mapping is declared at base: keccak256(pad32(key) ++ base).
+func mappingSlot(base, key common.Hash) common.Hash {
+	return crypto.Keccak256Hash(key.Bytes(), base.Bytes())
+}
+
+// addrKey left-pads an address to a 32-byte mapping key.
+func addrKey(a common.Address) common.Hash { return common.BytesToHash(a.Bytes()) }
+
+type cas20Storage struct {
+	state StateDB
+	token common.Address
+	ctx   *PrecompileContext
+}
+
+// mapSlot derives mapping[key] and meters the keccak, which hashes the 64-byte
+// (key ++ base) preimage. Use it on any metered path; the bare mappingSlot helper
+// stays available for tests and unmetered views.
+//
+// The three derivations below return the zero slot when their charge is refused.
+// That slot is meaningless, not dangerous: the frame is out of gas by then, so
+// every read or write through it is refused too. Skipping the hash matters most
+// for strMapSlot, whose preimage is caller-sized.
+func (s cas20Storage) mapSlot(base, key common.Hash) common.Hash {
+	if s.ctx != nil && !s.ctx.chargeKeccak(64) {
+		return common.Hash{}
+	}
+	return mappingSlot(base, key)
+}
+
+// strMapSlot derives mapping[key] for a string-keyed mapping. Solidity hashes
+// the key's raw bytes concatenated with the base slot rather than padding the
+// key to a word, so the preimage is variable-length — and so is the charge,
+// which is what keeps a long caller-supplied key from hashing for free.
+func (s cas20Storage) strMapSlot(base common.Hash, key string) common.Hash {
+	if s.ctx != nil && !s.ctx.chargeKeccak(len(key)+32) {
+		return common.Hash{}
+	}
+	return crypto.Keccak256Hash([]byte(key), base.Bytes())
+}
+
+// newUnmeteredCAS20Storage returns a view that charges no gas. Only for callers
+// that have no frame to charge — the fork seeding hook and the state queries
+// behind it — and for tests. Everything reached from a precompile call must use
+// newMeteredCAS20Storage, or its state access is free.
+func newUnmeteredCAS20Storage(state StateDB, token common.Address) cas20Storage {
+	return cas20Storage{state: state, token: token}
+}
+
+// newMeteredCAS20Storage returns a view bound to ctx.Self that charges gas for
+// each slot access.
+func newMeteredCAS20Storage(ctx *PrecompileContext) cas20Storage {
+	return cas20Storage{state: ctx.StateDB, token: ctx.Self, ctx: ctx}
+}
+
+// newMeteredCAS20StorageAt is newMeteredCAS20Storage for a fixed address instead of
+// ctx.Self, which a token needs when it consults a registry for its own gating.
+// Charged as storage with no account-access surcharge, as if the slot were its
+// own (BEP-702 3.14).
+func newMeteredCAS20StorageAt(ctx *PrecompileContext, token common.Address) cas20Storage {
+	return cas20Storage{state: ctx.StateDB, token: token, ctx: ctx}
+}
+
+// chargeRead meters an SLOAD-equivalent at EIP-2929 prices: warm always, plus
+// the cold surcharge on the first touch of the slot in this transaction.
+func (s cas20Storage) chargeRead(slot common.Hash) bool {
+	if s.ctx == nil {
+		return true
+	}
+	if _, warm := s.state.SlotInAccessList(s.token, slot); warm {
+		return s.ctx.chargeGas(params.WarmStorageReadCostEIP2929)
+	}
+	s.state.AddSlotToAccessList(s.token, slot)
+	return s.ctx.chargeGas(params.ColdSloadCostEIP2929)
+}
+
+// getWord reads a slot after charging for it. The second result is false when the
+// charge could not be covered, in which case nothing was read and the caller must
+// stop — the value is meaningless, and acting on a zero is how a frame out of gas
+// took a fail-open branch.
+// getWordChecked is getWord with the charge result, for reads whose value decides
+// a branch. getWord's zero is safe only where the next charge stops the caller
+// anyway; where a zero means "absent" and absent means "proceed", the caller has
+// to know the read never happened.
+func (s cas20Storage) getWordChecked(slot common.Hash) (common.Hash, bool) {
+	if !s.chargeRead(slot) {
+		return common.Hash{}, false
+	}
+	return s.state.GetState(s.token, slot), true
+}
+
+func (s cas20Storage) getWord(slot common.Hash) common.Hash {
+	if !s.chargeRead(slot) {
+		return common.Hash{}
+	}
+	return s.state.GetState(s.token, slot)
+}
+
+// setWord writes a slot after metering it (see chargeStorageWrite) and reports
+// whether the write happened. False covers an unaffordable charge, the reentrancy
+// sentry, and a read-only frame.
+//
+// Honour the result before doing work proportional to what the caller sent. The
+// fixed-size wrappers below drop it deliberately: the out-of-gas flag is sticky
+// and the exit reports it either way, so what dropping it costs is the bound on
+// work, not correctness.
+func (s cas20Storage) setWord(slot, val common.Hash) bool {
+	if !s.chargeStorageWrite(slot, val) {
+		return false
+	}
+	s.state.SetState(s.token, slot, val)
+	return true
+}
+
+// --- fixed uint256 fields ---------------------------------------------------
+
+func (s cas20Storage) getU256(offset uint64) *uint256.Int {
+	return new(uint256.Int).SetBytes(s.getWord(slotAt(offset)).Bytes())
+}
+
+func (s cas20Storage) setU256(offset uint64, v *uint256.Int) {
+	s.setWord(slotAt(offset), v.Bytes32())
+}
+
+func (s cas20Storage) totalSupply() *uint256.Int     { return s.getU256(cas20SlotTotalSupply) }
+func (s cas20Storage) setTotalSupply(v *uint256.Int) { s.setU256(cas20SlotTotalSupply, v) }
+func (s cas20Storage) supplyCap() *uint256.Int       { return s.getU256(cas20SlotSupplyCap) }
+func (s cas20Storage) setSupplyCap(v *uint256.Int)   { s.setU256(cas20SlotSupplyCap, v) }
+func (s cas20Storage) adminCount() *uint256.Int      { return s.getU256(cas20SlotAdminCount) }
+func (s cas20Storage) setAdminCount(v *uint256.Int)  { s.setU256(cas20SlotAdminCount, v) }
+
+// pausedChecked is paused with the charge result, for the write path, whose work
+// after the read is proportional to the caller's feature array.
+func (s cas20Storage) pausedChecked() (*uint256.Int, bool) {
+	w, ok := s.getWordChecked(slotAt(cas20SlotPaused))
+	if !ok {
+		return new(uint256.Int), false
+	}
+	return new(uint256.Int).SetBytes(w.Bytes()), true
+}
+
+func (s cas20Storage) paused() *uint256.Int     { return s.getU256(cas20SlotPaused) }
+func (s cas20Storage) setPaused(v *uint256.Int) { s.setU256(cas20SlotPaused, v) }
+
+// --- balances / allowances / nonces ----------------------------------------
+
+// Deriving a mapping slot is a metered keccak, so a read-modify-write that goes
+// through balanceOf then setBalance pays for the hash twice where a Solidity
+// implementation computes it once. The slot-taking forms below let a caller
+// derive once and reuse; the address-taking forms remain for single accesses,
+// views and tests.
+
+func (s cas20Storage) balanceSlot(a common.Address) common.Hash {
+	return s.mapSlot(slotAt(cas20SlotBalances), addrKey(a))
+}
+
+func (s cas20Storage) allowanceSlot(owner, spender common.Address) common.Hash {
+	return s.mapSlot(s.mapSlot(slotAt(cas20SlotAllowances), addrKey(owner)), addrKey(spender))
+}
+
+func (s cas20Storage) getU256At(slot common.Hash) *uint256.Int {
+	return new(uint256.Int).SetBytes(s.getWord(slot).Bytes())
+}
+
+func (s cas20Storage) setU256At(slot common.Hash, v *uint256.Int) {
+	s.setWord(slot, v.Bytes32())
+}
+
+func (s cas20Storage) balanceOf(a common.Address) *uint256.Int {
+	return s.getU256At(s.balanceSlot(a))
+}
+
+func (s cas20Storage) setBalance(a common.Address, v *uint256.Int) {
+	s.setU256At(s.balanceSlot(a), v)
+}
+
+func (s cas20Storage) allowance(owner, spender common.Address) *uint256.Int {
+	return s.getU256At(s.allowanceSlot(owner, spender))
+}
+
+func (s cas20Storage) setAllowance(owner, spender common.Address, v *uint256.Int) {
+	s.setU256At(s.allowanceSlot(owner, spender), v)
+}
+
+func (s cas20Storage) nonce(owner common.Address) *uint256.Int {
+	slot := s.mapSlot(slotAt(cas20SlotNonces), addrKey(owner))
+	return new(uint256.Int).SetBytes(s.getWord(slot).Bytes())
+}
+
+func (s cas20Storage) setNonce(owner common.Address, v *uint256.Int) {
+	slot := s.mapSlot(slotAt(cas20SlotNonces), addrKey(owner))
+	s.setWord(slot, v.Bytes32())
+}
+
+// --- roles ------------------------------------------------------------------
+
+func (s cas20Storage) hasRole(role common.Hash, a common.Address) bool {
+	inner := s.mapSlot(slotAt(cas20SlotRoles), role)
+	slot := s.mapSlot(inner, addrKey(a))
+	return s.getWord(slot) != (common.Hash{})
+}
+
+func (s cas20Storage) setRole(role common.Hash, a common.Address, enabled bool) {
+	inner := s.mapSlot(slotAt(cas20SlotRoles), role)
+	slot := s.mapSlot(inner, addrKey(a))
+	var v common.Hash
+	if enabled {
+		v[31] = 1
+	}
+	s.setWord(slot, v)
+}
+
+func (s cas20Storage) roleAdmin(role common.Hash) common.Hash {
+	return s.getWord(s.mapSlot(slotAt(cas20SlotRoleAdmins), role))
+}
+
+func (s cas20Storage) setRoleAdmin(role, admin common.Hash) {
+	s.setWord(s.mapSlot(slotAt(cas20SlotRoleAdmins), role), admin)
+}
+
+// --- packed policy ids ------------------------------------------------------
+
+func (s cas20Storage) getPackedU64(offset uint64, byteOff uint) uint64 {
+	word := new(uint256.Int).SetBytes(s.getWord(slotAt(offset)).Bytes())
+	return word.Rsh(word, byteOff*8).Uint64()
+}
+
+// setPackedU64 writes v into the u64 lane at byteOff, preserving the other lanes.
+func (s cas20Storage) setPackedU64(offset uint64, byteOff uint, v uint64) {
+	slot := slotAt(offset)
+	word := new(uint256.Int).SetBytes(s.getWord(slot).Bytes())
+	lane := new(uint256.Int).Lsh(uint256.NewInt(0xffffffffffffffff), byteOff*8)
+	word.And(word, lane.Not(lane))
+	word.Or(word, new(uint256.Int).Lsh(uint256.NewInt(v), byteOff*8))
+	s.setWord(slot, word.Bytes32())
+}
+
+// transferPolicies reads all three transfer-side ids with one storage access:
+// they share a slot, so reading them separately pays for the same slot three
+// times. seizePolicies does the same for its pair.
+func (s cas20Storage) transferPolicies() (sender, receiver, executor uint64) {
+	w := s.getU256At(slotAt(cas20SlotTransferPolicies))
+	return packedLane(w, cas20OffTransferSender), packedLane(w, cas20OffTransferReceiver),
+		packedLane(w, cas20OffTransferExecutor)
+}
+
+func (s cas20Storage) seizePolicies() (holder, receiver uint64) {
+	w := s.getU256At(slotAt(cas20SlotSeizePolicies))
+	return packedLane(w, cas20OffSeizeHolder), packedLane(w, cas20OffSeizeReceiver)
+}
+
+// packedLane extracts the u64 lane at byteOff from an already-read slot value.
+func packedLane(word *uint256.Int, byteOff uint) uint64 {
+	return new(uint256.Int).Rsh(word, byteOff*8).Uint64()
+}
+
+func (s cas20Storage) transferSenderPolicy() uint64 {
+	return s.getPackedU64(cas20SlotTransferPolicies, cas20OffTransferSender)
+}
+func (s cas20Storage) transferReceiverPolicy() uint64 {
+	return s.getPackedU64(cas20SlotTransferPolicies, cas20OffTransferReceiver)
+}
+func (s cas20Storage) transferExecutorPolicy() uint64 {
+	return s.getPackedU64(cas20SlotTransferPolicies, cas20OffTransferExecutor)
+}
+func (s cas20Storage) mintReceiverPolicy() uint64 {
+	return s.getPackedU64(cas20SlotMintPolicy, cas20OffMintReceiver)
+}
+func (s cas20Storage) setTransferSenderPolicy(id uint64) {
+	s.setPackedU64(cas20SlotTransferPolicies, cas20OffTransferSender, id)
+}
+func (s cas20Storage) setTransferReceiverPolicy(id uint64) {
+	s.setPackedU64(cas20SlotTransferPolicies, cas20OffTransferReceiver, id)
+}
+func (s cas20Storage) setTransferExecutorPolicy(id uint64) {
+	s.setPackedU64(cas20SlotTransferPolicies, cas20OffTransferExecutor, id)
+}
+func (s cas20Storage) setMintReceiverPolicy(id uint64) {
+	s.setPackedU64(cas20SlotMintPolicy, cas20OffMintReceiver, id)
+}
+func (s cas20Storage) setSeizeHolderPolicy(id uint64) {
+	s.setPackedU64(cas20SlotSeizePolicies, cas20OffSeizeHolder, id)
+}
+func (s cas20Storage) setSeizeReceiverPolicy(id uint64) {
+	s.setPackedU64(cas20SlotSeizePolicies, cas20OffSeizeReceiver, id)
+}
+
+// --- strings (Solidity storage encoding) ------------------------------------
+
+func (s cas20Storage) getString(offset uint64) (string, bool) { return s.getStringAt(slotAt(offset)) }
+func (s cas20Storage) setString(offset uint64, str string) bool {
+	return s.setStringAt(slotAt(offset), str)
+}
+
+// stringDataRoot derives the slot a long string's data begins at, keccak256 of
+// the length slot, and meters the hash of that 32-byte preimage. Deriving a
+// mapping slot is metered the same way (see mapSlot); a long string's data root
+// is no less a runtime keccak just because the preimage is one word.
+func (s cas20Storage) stringDataRoot(slot common.Hash) *uint256.Int {
+	if s.ctx != nil && !s.ctx.chargeKeccak(32) {
+		return new(uint256.Int)
+	}
+	return new(uint256.Int).SetBytes(crypto.Keccak256(slot.Bytes()))
+}
+
+// cas20MaxStringLen bounds a string read against a malformed length word.
+const cas20MaxStringLen = 1 << 24
+
+// getStringAt / setStringAt read and write a Solidity string at an arbitrary
+// slot (used for fixed fields and for string-keyed mapping values).
+func (s cas20Storage) getStringAt(slot common.Hash) (string, bool) {
+	word, ok := s.getWordChecked(slot)
+	if !ok {
+		return "", false
+	}
+	if word[31]&1 == 0 {
+		// short string: content in the high bytes, low byte holds 2*len.
+		n := int(word[31]) / 2
+		if n > 31 {
+			return "", true
+		}
+		return string(word[:n]), true
+	}
+	// long string: slot holds 2*len+1; content starts at keccak256(slot).
+	encoded := new(uint256.Int).SetBytes(word.Bytes())
+	if encoded.Gt(uint256.NewInt(2*cas20MaxStringLen + 1)) {
+		return "", true
+	}
+	length := (encoded.Uint64() - 1) / 2
+	base := s.stringDataRoot(slot)
+	// Before the allocation, not after: the loop below checks each iteration, but
+	// make() runs once with the stored length whatever the budget says.
+	if s.ctx != nil && s.ctx.OutOfGas() {
+		return "", false
+	}
+	out := make([]byte, 0, length)
+	for i := uint64(0); i < length; i += 32 {
+		chunkSlot := new(uint256.Int).AddUint64(base, i/32).Bytes32()
+		chunk, ok := s.getWordChecked(chunkSlot)
+		if !ok {
+			return "", false
+		}
+		out = append(out, chunk[:]...)
+	}
+	return string(out[:length]), true
+}
+
+// setStringAt writes a string, releasing whatever the previous value held.
+func (s cas20Storage) setStringAt(slot common.Hash, str string) bool {
+	b := []byte(str)
+	oldChunks := s.stringChunks(slot)
+	newChunks := uint64(0)
+	if len(b) >= 32 {
+		newChunks = uint64((len(b) + 31) / 32)
+	}
+
+	if len(b) < 32 {
+		var word common.Hash
+		copy(word[:], b)
+		word[31] = byte(len(b) * 2)
+		if !s.setWord(slot, word) {
+			return false
+		}
+	} else if !s.setWord(slot, uint256.NewInt(uint64(len(b)*2+1)).Bytes32()) {
+		return false
+	}
+	if newChunks == 0 && oldChunks == 0 {
+		return true // wholly inline, before and after: no data region exists
+	}
+	// One keccak covers writing the new chunks and releasing the old ones, as
+	// it would in Solidity — deriving the root twice would overcharge.
+	base := s.stringDataRoot(slot)
+	for i := uint64(0); i < newChunks; i++ {
+		if s.ctx != nil && s.ctx.OutOfGas() {
+			return false
+		}
+		var chunk common.Hash
+		copy(chunk[:], b[i*32:])
+		s.setWord(new(uint256.Int).AddUint64(base, i).Bytes32(), chunk)
+	}
+	// The release loop needs its own guard, and for a different reason than the
+	// write loop above: oldChunks comes from state, not from this call's calldata.
+	// Replacing a long stored string with a short one does work proportional to the
+	// *old* length, which the current caller never paid for — and since an
+	// exhausted frame reverts, the long string survives for the next attempt. A
+	// 60,000-byte name costs 41.9M gas to store once, after which updateName("x")
+	// on 30,000 gas cleared 1875 slots in 126us and could do so again forever.
+	for i := newChunks; i < oldChunks; i++ {
+		if s.ctx != nil && s.ctx.OutOfGas() {
+			return false
+		}
+		s.setWord(new(uint256.Int).AddUint64(base, i).Bytes32(), common.Hash{})
+	}
+	return true
+}
+
+// stringChunks reports how many tail slots the string currently at slot
+// occupies. A short string is held inline and occupies none.
+func (s cas20Storage) stringChunks(slot common.Hash) uint64 {
+	word := s.getWord(slot)
+	if word[31]&1 == 0 {
+		return 0
+	}
+	// Same untrusted word as getStringAt, so the same bound: without it the
+	// release loop in setStringAt would be handed a chunk count of any size, and
+	// an unmetered view has no out-of-gas guard to stop it.
+	encoded := new(uint256.Int).SetBytes(word.Bytes())
+	if encoded.Gt(uint256.NewInt(2*cas20MaxStringLen + 1)) {
+		return 0
+	}
+	length := (encoded.Uint64() - 1) / 2
+	return (length + 31) / 32
+}
+
+func (s cas20Storage) name() (string, bool)         { return s.getString(cas20SlotName) }
+func (s cas20Storage) setName(v string) bool        { return s.setString(cas20SlotName, v) }
+func (s cas20Storage) symbol() (string, bool)       { return s.getString(cas20SlotSymbol) }
+func (s cas20Storage) setSymbol(v string) bool      { return s.setString(cas20SlotSymbol, v) }
+func (s cas20Storage) contractURI() (string, bool)  { return s.getString(cas20SlotContractURI) }
+func (s cas20Storage) setContractURI(v string) bool { return s.setString(cas20SlotContractURI, v) }

--- a/core/vm/cas20_storage.go
+++ b/core/vm/cas20_storage.go
@@ -400,6 +400,13 @@ func (s cas20Storage) getStringAt(slot common.Hash) (string, bool) {
 		return "", true
 	}
 	length := (encoded.Uint64() - 1) / 2
+	// The long form encodes 32 bytes or more; a shorter length belongs to the
+	// short form and no write produces it here. Reading it as empty keeps every
+	// non-canonical length word answering the same way, rather than leaving the
+	// short form's own bound (above) as the only one enforced.
+	if length < 32 {
+		return "", true
+	}
 	base := s.stringDataRoot(slot)
 	// Before the allocation, not after: the loop below checks each iteration, but
 	// make() runs once with the stored length whatever the budget says.
@@ -474,14 +481,19 @@ func (s cas20Storage) stringChunks(slot common.Hash) uint64 {
 	if word[31]&1 == 0 {
 		return 0
 	}
-	// Same untrusted word as getStringAt, so the same bound: without it the
-	// release loop in setStringAt would be handed a chunk count of any size, and
-	// an unmetered view has no out-of-gas guard to stop it.
+	// Same untrusted word as getStringAt, so the same bounds, both of them: the
+	// upper one because the release loop in setStringAt would otherwise be handed
+	// a chunk count of any size and an unmetered view has no out-of-gas guard to
+	// stop it, the lower one because a word getStringAt reads as empty must not
+	// leave chunks behind for the release loop to walk.
 	encoded := new(uint256.Int).SetBytes(word.Bytes())
 	if encoded.Gt(uint256.NewInt(2*cas20MaxStringLen + 1)) {
 		return 0
 	}
 	length := (encoded.Uint64() - 1) / 2
+	if length < 32 {
+		return 0
+	}
 	return (length + 31) / 32
 }
 

--- a/core/vm/cas20_storage.go
+++ b/core/vm/cas20_storage.go
@@ -42,7 +42,6 @@ const (
 	cas20OffSeizeReceiver    = 8
 )
 
-// cas20CoreRoot is the ERC-7201 root of the core storage namespace, computed once.
 var cas20CoreRoot = erc7201Root(cas20Namespace)
 
 // erc7201Root computes the ERC-7201 storage root of a namespace:

--- a/core/vm/cas20_storage.go
+++ b/core/vm/cas20_storage.go
@@ -10,21 +10,22 @@ import (
 const cas20Namespace = "bsc.cas20"
 
 const (
-	cas20SlotName             = 0
-	cas20SlotSymbol           = 1
-	cas20SlotContractURI      = 2
-	cas20SlotTotalSupply      = 3
-	cas20SlotBalances         = 4
-	cas20SlotAllowances       = 5
-	cas20SlotRoles            = 6
-	cas20SlotRoleAdmins       = 7
-	cas20SlotAdminCount       = 8
-	cas20SlotTransferPolicies = 9
-	cas20SlotMintPolicy       = 10
-	cas20SlotPaused           = 11
-	cas20SlotSupplyCap        = 12
-	cas20SlotNonces           = 13
-	cas20SlotSeizePolicies    = 14
+	cas20SlotName                = 0
+	cas20SlotSymbol              = 1
+	cas20SlotContractURI         = 2
+	cas20SlotTotalSupply         = 3
+	cas20SlotBalances            = 4
+	cas20SlotAllowances          = 5
+	cas20SlotRoles               = 6
+	cas20SlotRoleAdmins          = 7
+	cas20SlotAdminCount          = 8
+	cas20SlotTransferPolicies    = 9
+	cas20SlotMintPolicy          = 10
+	cas20SlotPaused              = 11
+	cas20SlotSupplyCap           = 12
+	cas20SlotNonces              = 13
+	cas20SlotSeizePolicies       = 14
+	cas20SlotExpectedMemoFormats = 15
 )
 
 // The free lanes of each policy slot are reserved for that group, which is why
@@ -306,6 +307,49 @@ func (s cas20Storage) setSeizeHolderPolicy(id uint64) {
 }
 func (s cas20Storage) setSeizeReceiverPolicy(id uint64) {
 	s.setPackedU64(cas20SlotSeizePolicies, cas20OffSeizeReceiver, id)
+}
+
+// --- uint64[] (Solidity storage encoding, four lanes per word) --------------
+
+// u64ArrayAt reads a uint64[] whose length word is at slot, refusing a length
+// above max as a word no write could have produced.
+func (s cas20Storage) u64ArrayAt(slot common.Hash, max uint64) []uint64 {
+	n := new(uint256.Int).SetBytes(s.getWord(slot).Bytes()).Uint64()
+	if n == 0 || n > max {
+		return nil
+	}
+	base := s.stringDataRoot(slot)
+	out := make([]uint64, 0, n)
+	for i := uint64(0); i < n; i++ {
+		if s.ctx != nil && s.ctx.OutOfGas() {
+			return nil
+		}
+		w := new(uint256.Int).SetBytes(s.getWord(new(uint256.Int).AddUint64(base, i/4).Bytes32()).Bytes())
+		out = append(out, new(uint256.Int).Rsh(w, uint(i%4)*64).Uint64())
+	}
+	return out
+}
+
+// setU64ArrayAt writes a uint64[] at slot, clearing the words a shorter value no
+// longer needs, as a Solidity assignment would.
+func (s cas20Storage) setU64ArrayAt(slot common.Hash, vals []uint64) {
+	oldWords := (new(uint256.Int).SetBytes(s.getWord(slot).Bytes()).Uint64() + 3) / 4
+	newWords := (uint64(len(vals)) + 3) / 4
+	s.setWord(slot, wU64(uint64(len(vals))))
+	if oldWords == 0 && newWords == 0 {
+		return
+	}
+	base := s.stringDataRoot(slot)
+	for w := uint64(0); w < newWords || w < oldWords; w++ {
+		if s.ctx != nil && s.ctx.OutOfGas() {
+			return
+		}
+		packed := new(uint256.Int)
+		for lane := uint64(0); lane < 4 && w*4+lane < uint64(len(vals)); lane++ {
+			packed.Or(packed, new(uint256.Int).Lsh(uint256.NewInt(vals[w*4+lane]), uint(lane)*64))
+		}
+		s.setWord(new(uint256.Int).AddUint64(base, w).Bytes32(), packed.Bytes32())
+	}
 }
 
 // --- strings (Solidity storage encoding) ------------------------------------

--- a/core/vm/cas20_storage.go
+++ b/core/vm/cas20_storage.go
@@ -7,7 +7,6 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// CAS20 core storage layout.
 const cas20Namespace = "bsc.cas20"
 
 const (
@@ -28,11 +27,8 @@ const (
 	cas20SlotSeizePolicies    = 14
 )
 
-// Packed u64 byte offsets within the policy slots. The lanes a group leaves
-// free are reserved for that group: the mint slot holds one id today and the
-// rest of it belongs to future mint-side policy types, which is why the seize
-// ids sit in a slot of their own rather than filling it. Seize is a cold path,
-// so the extra load costs nothing that matters.
+// The free lanes of each policy slot are reserved for that group, which is why
+// the seize ids have a slot of their own rather than filling the mint slot.
 const (
 	cas20OffTransferSender   = 0
 	cas20OffTransferReceiver = 8
@@ -44,39 +40,31 @@ const (
 
 var cas20CoreRoot = erc7201Root(cas20Namespace)
 
-// erc7201Root computes the ERC-7201 storage root of a namespace:
 func erc7201Root(namespace string) common.Hash {
 	inner := new(uint256.Int).SetBytes(crypto.Keccak256([]byte(namespace)))
 	inner.SubUint64(inner, 1)
 	buf := inner.Bytes32()
 	root := crypto.Keccak256Hash(buf[:])
-	root[31] = 0 // clear the low byte
+	root[31] = 0
 	return root
 }
 
-// slotAt returns the absolute storage slot of a fixed field at the given
-// offset from the core root.
 func slotAt(offset uint64) common.Hash {
 	s := new(uint256.Int).SetBytes(cas20CoreRoot.Bytes())
 	s.AddUint64(s, offset)
 	return s.Bytes32()
 }
 
-// offsetSlot returns the slot at root+offset, the fixed-field addressing every
-// CAS20 namespace uses.
 func offsetSlot(root common.Hash, offset uint64) common.Hash {
 	x := new(uint256.Int).SetBytes(root.Bytes())
 	x.AddUint64(x, offset)
 	return x.Bytes32()
 }
 
-// mappingSlot returns the Solidity storage slot of mapping[key] where the
-// mapping is declared at base: keccak256(pad32(key) ++ base).
 func mappingSlot(base, key common.Hash) common.Hash {
 	return crypto.Keccak256Hash(key.Bytes(), base.Bytes())
 }
 
-// addrKey left-pads an address to a 32-byte mapping key.
 func addrKey(a common.Address) common.Hash { return common.BytesToHash(a.Bytes()) }
 
 type cas20Storage struct {
@@ -85,14 +73,8 @@ type cas20Storage struct {
 	ctx   *PrecompileContext
 }
 
-// mapSlot derives mapping[key] and meters the keccak, which hashes the 64-byte
-// (key ++ base) preimage. Use it on any metered path; the bare mappingSlot helper
-// stays available for tests and unmetered views.
-//
-// The three derivations below return the zero slot when their charge is refused.
-// That slot is meaningless, not dangerous: the frame is out of gas by then, so
-// every read or write through it is refused too. Skipping the hash matters most
-// for strMapSlot, whose preimage is caller-sized.
+// A refused charge yields the zero slot, which is harmless: the frame is out of
+// gas by then, so every access through it is refused too.
 func (s cas20Storage) mapSlot(base, key common.Hash) common.Hash {
 	if s.ctx != nil && !s.ctx.chargeKeccak(64) {
 		return common.Hash{}
@@ -100,10 +82,8 @@ func (s cas20Storage) mapSlot(base, key common.Hash) common.Hash {
 	return mappingSlot(base, key)
 }
 
-// strMapSlot derives mapping[key] for a string-keyed mapping. Solidity hashes
-// the key's raw bytes concatenated with the base slot rather than padding the
-// key to a word, so the preimage is variable-length — and so is the charge,
-// which is what keeps a long caller-supplied key from hashing for free.
+// Solidity hashes a string key's raw bytes ++ base, so the preimage and the charge
+// are caller-sized.
 func (s cas20Storage) strMapSlot(base common.Hash, key string) common.Hash {
 	if s.ctx != nil && !s.ctx.chargeKeccak(len(key)+32) {
 		return common.Hash{}
@@ -111,30 +91,22 @@ func (s cas20Storage) strMapSlot(base common.Hash, key string) common.Hash {
 	return crypto.Keccak256Hash([]byte(key), base.Bytes())
 }
 
-// newUnmeteredCAS20Storage returns a view that charges no gas. Only for callers
-// that have no frame to charge — the fork seeding hook and the state queries
-// behind it — and for tests. Everything reached from a precompile call must use
-// newMeteredCAS20Storage, or its state access is free.
+// Only for callers with no frame to charge: the fork seeding hook, state queries
+// and tests. Everything reached from a precompile call must be metered.
 func newUnmeteredCAS20Storage(state StateDB, token common.Address) cas20Storage {
 	return cas20Storage{state: state, token: token}
 }
 
-// newMeteredCAS20Storage returns a view bound to ctx.Self that charges gas for
-// each slot access.
 func newMeteredCAS20Storage(ctx *PrecompileContext) cas20Storage {
 	return cas20Storage{state: ctx.StateDB, token: ctx.Self, ctx: ctx}
 }
 
-// newMeteredCAS20StorageAt is newMeteredCAS20Storage for a fixed address instead of
-// ctx.Self, which a token needs when it consults a registry for its own gating.
-// Charged as storage with no account-access surcharge, as if the slot were its
-// own (BEP-702 3.14).
+// A token consulting a registry pays as if the slot were its own: no
+// account-access surcharge (BEP-702 3.14).
 func newMeteredCAS20StorageAt(ctx *PrecompileContext, token common.Address) cas20Storage {
 	return cas20Storage{state: ctx.StateDB, token: token, ctx: ctx}
 }
 
-// chargeRead meters an SLOAD-equivalent at EIP-2929 prices: warm always, plus
-// the cold surcharge on the first touch of the slot in this transaction.
 func (s cas20Storage) chargeRead(slot common.Hash) bool {
 	if s.ctx == nil {
 		return true
@@ -146,14 +118,8 @@ func (s cas20Storage) chargeRead(slot common.Hash) bool {
 	return s.ctx.chargeGas(params.ColdSloadCostEIP2929)
 }
 
-// getWord reads a slot after charging for it. The second result is false when the
-// charge could not be covered, in which case nothing was read and the caller must
-// stop — the value is meaningless, and acting on a zero is how a frame out of gas
-// took a fail-open branch.
-// getWordChecked is getWord with the charge result, for reads whose value decides
-// a branch. getWord's zero is safe only where the next charge stops the caller
-// anyway; where a zero means "absent" and absent means "proceed", the caller has
-// to know the read never happened.
+// getWordChecked is for reads whose value decides a branch: getWord's zero is safe
+// only where the next charge stops the caller anyway, not where zero means "proceed".
 func (s cas20Storage) getWordChecked(slot common.Hash) (common.Hash, bool) {
 	if !s.chargeRead(slot) {
 		return common.Hash{}, false
@@ -168,14 +134,8 @@ func (s cas20Storage) getWord(slot common.Hash) common.Hash {
 	return s.state.GetState(s.token, slot)
 }
 
-// setWord writes a slot after metering it (see chargeStorageWrite) and reports
-// whether the write happened. False covers an unaffordable charge, the reentrancy
-// sentry, and a read-only frame.
-//
-// Honour the result before doing work proportional to what the caller sent. The
-// fixed-size wrappers below drop it deliberately: the out-of-gas flag is sticky
-// and the exit reports it either way, so what dropping it costs is the bound on
-// work, not correctness.
+// The fixed-size wrappers below drop the result deliberately: the out-of-gas flag
+// is sticky, so what dropping it costs is the bound on work, not correctness.
 func (s cas20Storage) setWord(slot, val common.Hash) bool {
 	if !s.chargeStorageWrite(slot, val) {
 		return false
@@ -201,8 +161,6 @@ func (s cas20Storage) setSupplyCap(v *uint256.Int)   { s.setU256(cas20SlotSupply
 func (s cas20Storage) adminCount() *uint256.Int      { return s.getU256(cas20SlotAdminCount) }
 func (s cas20Storage) setAdminCount(v *uint256.Int)  { s.setU256(cas20SlotAdminCount, v) }
 
-// pausedChecked is paused with the charge result, for the write path, whose work
-// after the read is proportional to the caller's feature array.
 func (s cas20Storage) pausedChecked() (*uint256.Int, bool) {
 	w, ok := s.getWordChecked(slotAt(cas20SlotPaused))
 	if !ok {
@@ -216,11 +174,8 @@ func (s cas20Storage) setPaused(v *uint256.Int) { s.setU256(cas20SlotPaused, v) 
 
 // --- balances / allowances / nonces ----------------------------------------
 
-// Deriving a mapping slot is a metered keccak, so a read-modify-write that goes
-// through balanceOf then setBalance pays for the hash twice where a Solidity
-// implementation computes it once. The slot-taking forms below let a caller
-// derive once and reuse; the address-taking forms remain for single accesses,
-// views and tests.
+// Deriving a mapping slot is a metered keccak, so a read-modify-write derives the
+// slot once and reuses it, as Solidity would.
 
 func (s cas20Storage) balanceSlot(a common.Address) common.Hash {
 	return s.mapSlot(slotAt(cas20SlotBalances), addrKey(a))
@@ -297,7 +252,6 @@ func (s cas20Storage) getPackedU64(offset uint64, byteOff uint) uint64 {
 	return word.Rsh(word, byteOff*8).Uint64()
 }
 
-// setPackedU64 writes v into the u64 lane at byteOff, preserving the other lanes.
 func (s cas20Storage) setPackedU64(offset uint64, byteOff uint, v uint64) {
 	slot := slotAt(offset)
 	word := new(uint256.Int).SetBytes(s.getWord(slot).Bytes())
@@ -307,9 +261,6 @@ func (s cas20Storage) setPackedU64(offset uint64, byteOff uint, v uint64) {
 	s.setWord(slot, word.Bytes32())
 }
 
-// transferPolicies reads all three transfer-side ids with one storage access:
-// they share a slot, so reading them separately pays for the same slot three
-// times. seizePolicies does the same for its pair.
 func (s cas20Storage) transferPolicies() (sender, receiver, executor uint64) {
 	w := s.getU256At(slotAt(cas20SlotTransferPolicies))
 	return packedLane(w, cas20OffTransferSender), packedLane(w, cas20OffTransferReceiver),
@@ -321,7 +272,6 @@ func (s cas20Storage) seizePolicies() (holder, receiver uint64) {
 	return packedLane(w, cas20OffSeizeHolder), packedLane(w, cas20OffSeizeReceiver)
 }
 
-// packedLane extracts the u64 lane at byteOff from an already-read slot value.
 func packedLane(word *uint256.Int, byteOff uint) uint64 {
 	return new(uint256.Int).Rsh(word, byteOff*8).Uint64()
 }
@@ -364,10 +314,6 @@ func (s cas20Storage) setString(offset uint64, str string) bool {
 	return s.setStringAt(slotAt(offset), str)
 }
 
-// stringDataRoot derives the slot a long string's data begins at, keccak256 of
-// the length slot, and meters the hash of that 32-byte preimage. Deriving a
-// mapping slot is metered the same way (see mapSlot); a long string's data root
-// is no less a runtime keccak just because the preimage is one word.
 func (s cas20Storage) stringDataRoot(slot common.Hash) *uint256.Int {
 	if s.ctx != nil && !s.ctx.chargeKeccak(32) {
 		return new(uint256.Int)
@@ -375,40 +321,30 @@ func (s cas20Storage) stringDataRoot(slot common.Hash) *uint256.Int {
 	return new(uint256.Int).SetBytes(crypto.Keccak256(slot.Bytes()))
 }
 
-// cas20MaxStringLen bounds a string read against a malformed length word.
 const cas20MaxStringLen = 1 << 24
 
-// getStringAt / setStringAt read and write a Solidity string at an arbitrary
-// slot (used for fixed fields and for string-keyed mapping values).
 func (s cas20Storage) getStringAt(slot common.Hash) (string, bool) {
 	word, ok := s.getWordChecked(slot)
 	if !ok {
 		return "", false
 	}
 	if word[31]&1 == 0 {
-		// short string: content in the high bytes, low byte holds 2*len.
 		n := int(word[31]) / 2
 		if n > 31 {
 			return "", true
 		}
 		return string(word[:n]), true
 	}
-	// long string: slot holds 2*len+1; content starts at keccak256(slot).
 	encoded := new(uint256.Int).SetBytes(word.Bytes())
 	if encoded.Gt(uint256.NewInt(2*cas20MaxStringLen + 1)) {
 		return "", true
 	}
 	length := (encoded.Uint64() - 1) / 2
-	// The long form encodes 32 bytes or more; a shorter length belongs to the
-	// short form and no write produces it here. Reading it as empty keeps every
-	// non-canonical length word answering the same way, rather than leaving the
-	// short form's own bound (above) as the only one enforced.
 	if length < 32 {
 		return "", true
 	}
 	base := s.stringDataRoot(slot)
-	// Before the allocation, not after: the loop below checks each iteration, but
-	// make() runs once with the stored length whatever the budget says.
+	// Before the allocation: make() runs with the stored length whatever the budget says.
 	if s.ctx != nil && s.ctx.OutOfGas() {
 		return "", false
 	}
@@ -424,7 +360,6 @@ func (s cas20Storage) getStringAt(slot common.Hash) (string, bool) {
 	return string(out[:length]), true
 }
 
-// setStringAt writes a string, releasing whatever the previous value held.
 func (s cas20Storage) setStringAt(slot common.Hash, str string) bool {
 	b := []byte(str)
 	oldChunks := s.stringChunks(slot)
@@ -444,10 +379,8 @@ func (s cas20Storage) setStringAt(slot common.Hash, str string) bool {
 		return false
 	}
 	if newChunks == 0 && oldChunks == 0 {
-		return true // wholly inline, before and after: no data region exists
+		return true
 	}
-	// One keccak covers writing the new chunks and releasing the old ones, as
-	// it would in Solidity — deriving the root twice would overcharge.
 	base := s.stringDataRoot(slot)
 	for i := uint64(0); i < newChunks; i++ {
 		if s.ctx != nil && s.ctx.OutOfGas() {
@@ -457,13 +390,8 @@ func (s cas20Storage) setStringAt(slot common.Hash, str string) bool {
 		copy(chunk[:], b[i*32:])
 		s.setWord(new(uint256.Int).AddUint64(base, i).Bytes32(), chunk)
 	}
-	// The release loop needs its own guard, and for a different reason than the
-	// write loop above: oldChunks comes from state, not from this call's calldata.
-	// Replacing a long stored string with a short one does work proportional to the
-	// *old* length, which the current caller never paid for — and since an
-	// exhausted frame reverts, the long string survives for the next attempt. A
-	// 60,000-byte name costs 41.9M gas to store once, after which updateName("x")
-	// on 30,000 gas cleared 1875 slots in 126us and could do so again forever.
+	// oldChunks comes from state, not calldata: without this guard a starved frame
+	// would do work proportional to the old length and never pay for it.
 	for i := newChunks; i < oldChunks; i++ {
 		if s.ctx != nil && s.ctx.OutOfGas() {
 			return false
@@ -473,18 +401,13 @@ func (s cas20Storage) setStringAt(slot common.Hash, str string) bool {
 	return true
 }
 
-// stringChunks reports how many tail slots the string currently at slot
-// occupies. A short string is held inline and occupies none.
 func (s cas20Storage) stringChunks(slot common.Hash) uint64 {
 	word := s.getWord(slot)
 	if word[31]&1 == 0 {
 		return 0
 	}
-	// Same untrusted word as getStringAt, so the same bounds, both of them: the
-	// upper one because the release loop in setStringAt would otherwise be handed
-	// a chunk count of any size and an unmetered view has no out-of-gas guard to
-	// stop it, the lower one because a word getStringAt reads as empty must not
-	// leave chunks behind for the release loop to walk.
+	// Same bounds as getStringAt: a word it reads as empty must not leave chunks
+	// for the release loop to walk.
 	encoded := new(uint256.Int).SetBytes(word.Bytes())
 	if encoded.Gt(uint256.NewInt(2*cas20MaxStringLen + 1)) {
 		return 0

--- a/core/vm/cas20_storage.go
+++ b/core/vm/cas20_storage.go
@@ -111,6 +111,7 @@ func (s cas20Storage) chargeRead(slot common.Hash) bool {
 	if s.ctx == nil {
 		return true
 	}
+	s.ctx.traceStorageRead(s.token, slot)
 	if _, warm := s.state.SlotInAccessList(s.token, slot); warm {
 		return s.ctx.chargeGas(params.WarmStorageReadCostEIP2929)
 	}

--- a/core/vm/cas20_storage.go
+++ b/core/vm/cas20_storage.go
@@ -344,11 +344,8 @@ func (s cas20Storage) getStringAt(slot common.Hash) (string, bool) {
 		return "", true
 	}
 	base := s.stringDataRoot(slot)
-	// Before the allocation: make() runs with the stored length whatever the budget says.
-	if s.ctx != nil && s.ctx.OutOfGas() {
-		return "", false
-	}
-	out := make([]byte, 0, length)
+	// Grown only behind paid reads, so the allocation is bounded by the gas spent.
+	var out []byte
 	for i := uint64(0); i < length; i += 32 {
 		chunkSlot := new(uint256.Int).AddUint64(base, i/32).Bytes32()
 		chunk, ok := s.getWordChecked(chunkSlot)

--- a/core/vm/cas20_storage_test.go
+++ b/core/vm/cas20_storage_test.go
@@ -1,0 +1,702 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// strOf drops the read-status half of a string getter. The unmetered views tests
+// build always report true, so a test that only wants the value says so here
+// rather than at twenty call sites.
+func strOf(v string, _ bool) string { return v }
+
+func newTestStorage(t *testing.T) cas20Storage {
+	t.Helper()
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return newUnmeteredCAS20Storage(statedb, cas20Addr(cas20VariantAsset, 1))
+}
+
+func TestCAS20StorageScalars(t *testing.T) {
+	s := newTestStorage(t)
+	v := uint256.NewInt(123456789)
+	s.setTotalSupply(v)
+	s.setSupplyCap(uint256.NewInt(1_000_000))
+	s.setAdminCount(uint256.NewInt(2))
+	s.setPaused(uint256.NewInt(0b101))
+
+	if got := s.totalSupply(); got.Cmp(v) != 0 {
+		t.Errorf("totalSupply = %v, want %v", got, v)
+	}
+	if got := s.supplyCap().Uint64(); got != 1_000_000 {
+		t.Errorf("supplyCap = %d", got)
+	}
+	if got := s.adminCount().Uint64(); got != 2 {
+		t.Errorf("adminCount = %d", got)
+	}
+	if got := s.paused().Uint64(); got != 0b101 {
+		t.Errorf("paused = %b", got)
+	}
+}
+
+func TestCAS20StorageMappings(t *testing.T) {
+	s := newTestStorage(t)
+	alice := common.HexToAddress("0xa11ce")
+	bob := common.HexToAddress("0xb0b")
+
+	s.setBalance(alice, uint256.NewInt(500))
+	s.setAllowance(alice, bob, uint256.NewInt(42))
+	s.setNonce(alice, uint256.NewInt(7))
+
+	if got := s.balanceOf(alice).Uint64(); got != 500 {
+		t.Errorf("balanceOf = %d", got)
+	}
+	if got := s.balanceOf(bob).Uint64(); got != 0 {
+		t.Errorf("unset balance = %d, want 0", got)
+	}
+	if got := s.allowance(alice, bob).Uint64(); got != 42 {
+		t.Errorf("allowance = %d", got)
+	}
+	if got := s.allowance(bob, alice).Uint64(); got != 0 {
+		t.Errorf("reversed allowance = %d, want 0", got)
+	}
+	if got := s.nonce(alice).Uint64(); got != 7 {
+		t.Errorf("nonce = %d", got)
+	}
+
+	// Raw-slot checks, spelling out Solidity's derivation independently of the
+	// helpers. Round-tripping through the accessors cannot catch a wrong layout:
+	// a nested mapping whose two keys are swapped is self-consistent, so reads
+	// and writes still agree with each other while diverging from every
+	// reference implementation. Only the slot the value actually lands in tells
+	// them apart.
+	pad := func(b []byte) []byte { return common.BytesToHash(b).Bytes() }
+	solMap := func(key, base []byte) []byte { return crypto.Keccak256(pad(key), pad(base)) }
+
+	balSlot := solMap(alice.Bytes(), slotAt(cas20SlotBalances).Bytes())
+	if got := s.getWord(common.BytesToHash(balSlot)); new(uint256.Int).SetBytes(got.Bytes()).Uint64() != 500 {
+		t.Errorf("balance is not at keccak256(alice ++ balancesBase)")
+	}
+
+	// allowances[owner][spender]: owner is the OUTER key, spender the inner one.
+	inner := solMap(alice.Bytes(), slotAt(cas20SlotAllowances).Bytes())
+	allowSlot := solMap(bob.Bytes(), inner)
+	if got := s.getWord(common.BytesToHash(allowSlot)); new(uint256.Int).SetBytes(got.Bytes()).Uint64() != 42 {
+		t.Error("allowance is not at keccak256(spender ++ keccak256(owner ++ base)) — nesting order is wrong")
+	}
+	// The swapped nesting must be empty, which is what distinguishes the two.
+	swappedInner := solMap(bob.Bytes(), slotAt(cas20SlotAllowances).Bytes())
+	if got := s.getWord(common.BytesToHash(solMap(alice.Bytes(), swappedInner))); got != (common.Hash{}) {
+		t.Error("allowance also landed under the swapped nesting order")
+	}
+
+	// roles[role][account] nests the same way: role outer, account inner.
+	s.setRole(roleMint, alice, true)
+	roleInner := solMap(roleMint.Bytes(), slotAt(cas20SlotRoles).Bytes())
+	if got := s.getWord(common.BytesToHash(solMap(alice.Bytes(), roleInner))); got == (common.Hash{}) {
+		t.Error("role is not at keccak256(account ++ keccak256(role ++ base))")
+	}
+}
+
+func TestCAS20StorageRoles(t *testing.T) {
+	s := newTestStorage(t)
+	mintRole := crypto.Keccak256Hash([]byte("MINT_ROLE"))
+	alice := common.HexToAddress("0xa11ce")
+
+	if s.hasRole(mintRole, alice) {
+		t.Fatal("role should be unset initially")
+	}
+	s.setRole(mintRole, alice, true)
+	if !s.hasRole(mintRole, alice) {
+		t.Error("role should be set")
+	}
+	s.setRole(mintRole, alice, false)
+	if s.hasRole(mintRole, alice) {
+		t.Error("role should be cleared")
+	}
+
+	s.setRoleAdmin(mintRole, common.Hash{}) // DEFAULT_ADMIN
+	if got := s.roleAdmin(mintRole); got != (common.Hash{}) {
+		t.Errorf("roleAdmin = %s", got.Hex())
+	}
+}
+
+// TestCAS20StoragePackedPolicies verifies the four policy ids share their packed
+// slots without clobbering each other.
+func TestCAS20StoragePackedPolicies(t *testing.T) {
+	s := newTestStorage(t)
+	s.setTransferSenderPolicy(0x1111111111111111)
+	s.setTransferReceiverPolicy(0x2222222222222222)
+	s.setTransferExecutorPolicy(0x3333333333333333)
+	s.setMintReceiverPolicy(0x4444444444444444)
+
+	if got := s.transferSenderPolicy(); got != 0x1111111111111111 {
+		t.Errorf("sender = %#x", got)
+	}
+	if got := s.transferReceiverPolicy(); got != 0x2222222222222222 {
+		t.Errorf("receiver = %#x", got)
+	}
+	if got := s.transferExecutorPolicy(); got != 0x3333333333333333 {
+		t.Errorf("executor = %#x", got)
+	}
+	if got := s.mintReceiverPolicy(); got != 0x4444444444444444 {
+		t.Errorf("mintReceiver = %#x", got)
+	}
+
+	// The three transfer lanes must live in a single slot (slot 9), packed at
+	// byte offsets 0/8/16.
+	word := s.getWord(slotAt(cas20SlotTransferPolicies))
+	// byte offsets 24(reserved,0) | 16(executor) | 8(receiver) | 0(sender)
+	wantWord := "0x" + "0000000000000000" + "3333333333333333" + "2222222222222222" + "1111111111111111"
+	if word.Hex() != wantWord {
+		t.Errorf("packed slot 9 = %s, want %s", word.Hex(), wantWord)
+	}
+
+	// Overwriting one lane must not disturb the others.
+	s.setTransferReceiverPolicy(0xdeadbeefdeadbeef)
+	if got := s.transferSenderPolicy(); got != 0x1111111111111111 {
+		t.Errorf("sender disturbed: %#x", got)
+	}
+	if got := s.transferExecutorPolicy(); got != 0x3333333333333333 {
+		t.Errorf("executor disturbed: %#x", got)
+	}
+	if got := s.transferReceiverPolicy(); got != 0xdeadbeefdeadbeef {
+		t.Errorf("receiver = %#x", got)
+	}
+}
+
+// TestCAS20StorageGas checks the v0 storage gas schedule: cold/warm reads and
+// SSTORE set/reset/no-op writes, plus out-of-gas propagation.
+func TestCAS20StorageGas(t *testing.T) {
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := cas20Addr(cas20VariantAsset, 1)
+	gas := NewGasBudget(1_000_000)
+	ctx := &PrecompileContext{StateDB: statedb, Self: token, gas: &gas}
+	s := newMeteredCAS20Storage(ctx)
+
+	alice := common.HexToAddress("0xa11ce")
+	charged := func(fn func()) uint64 {
+		before := gas.RegularGas
+		fn()
+		return before - gas.RegularGas
+	}
+
+	// A balance slot is mapping-derived, so every access also pays the keccak
+	// over the 64-byte (key ++ base) preimage.
+	const keccak64 = params.Keccak256Gas + 2*params.Keccak256WordGas
+	var (
+		cold  = params.ColdSloadCostEIP2929
+		warm  = params.WarmStorageReadCostEIP2929
+		set   = params.SstoreSetGasEIP2200
+		reset = params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929
+	)
+
+	// cold write, zero -> non-zero: cold surcharge + set.
+	if c := charged(func() { s.setBalance(alice, uint256.NewInt(500)) }); c != keccak64+cold+set {
+		t.Errorf("cold set write charged %d, want %d", c, keccak64+cold+set)
+	}
+	// warm read of the same slot.
+	if c := charged(func() { _ = s.balanceOf(alice) }); c != keccak64+warm {
+		t.Errorf("warm read charged %d, want %d", c, keccak64+warm)
+	}
+	// warm write, non-zero -> other. The slot was zero at the start of the
+	// transaction, so under EIP-2200 net metering this is a dirty update
+	// charged at the warm price, not a reset — the 20000 was already paid by
+	// the first write. `reset` is exercised by TestCAS20StorageRefunds, where the
+	// slot starts committed non-zero.
+	if c := charged(func() { s.setBalance(alice, uint256.NewInt(600)) }); c != keccak64+warm {
+		t.Errorf("dirty update charged %d, want %d", c, keccak64+warm)
+	}
+	// warm write, same value: no-op.
+	if c := charged(func() { s.setBalance(alice, uint256.NewInt(600)) }); c != keccak64+warm {
+		t.Errorf("warm no-op write charged %d, want %d", c, keccak64+warm)
+	}
+	_ = reset
+
+	if got, want := ctx.meteredGasUsed(), 4*keccak64+cold+set+warm+warm+warm; got != want {
+		t.Errorf("meteredGasUsed = %d, want %d", got, want)
+	}
+	if ctx.OutOfGas() {
+		t.Error("should not be out of gas")
+	}
+
+	// Unmetered view never charges.
+	free := newUnmeteredCAS20Storage(statedb, token)
+	if c := charged(func() { _ = free.balanceOf(alice) }); c != 0 {
+		t.Errorf("unmetered read charged %d, want 0", c)
+	}
+}
+
+func TestCAS20StorageGasOutOfGas(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	token := cas20Addr(cas20VariantAsset, 1)
+	gas := NewGasBudget(100) // less than one cold access
+	ctx := &PrecompileContext{StateDB: statedb, Self: token, gas: &gas}
+	s := newMeteredCAS20Storage(ctx)
+
+	_ = s.getWord(slotAt(cas20SlotTotalSupply)) // cold read needs 2100 > 100
+	if !ctx.OutOfGas() {
+		t.Fatal("expected out of gas")
+	}
+	if gas.RegularGas != 0 {
+		t.Errorf("budget should be exhausted, got %d", gas.RegularGas)
+	}
+}
+
+func TestCAS20StorageStrings(t *testing.T) {
+	s := newTestStorage(t)
+
+	// short string (< 32 bytes): stored in-slot, low byte = 2*len.
+	s.setName("USD Coin")
+	if got := strOf(s.name()); got != "USD Coin" {
+		t.Errorf("name = %q", got)
+	}
+	if w := s.getWord(slotAt(cas20SlotName)); w[31] != byte(len("USD Coin")*2) {
+		t.Errorf("short string length byte = %d, want %d", w[31], len("USD Coin")*2)
+	}
+
+	// exactly 31 bytes stays short; 32+ goes long.
+	short31 := strings.Repeat("a", 31)
+	s.setSymbol(short31)
+	if got := strOf(s.symbol()); got != short31 {
+		t.Errorf("31-byte string round-trip failed")
+	}
+
+	long := strings.Repeat("x", 100)
+	s.setContractURI(long)
+	if got := strOf(s.contractURI()); got != long {
+		t.Errorf("long string round-trip failed: len %d", len(got))
+	}
+	// long-string marker: low bit of the length slot is set.
+	if w := s.getWord(slotAt(cas20SlotContractURI)); w[31]&1 != 1 {
+		t.Error("long string should set the low bit of the length slot")
+	}
+}
+
+// TestCAS20StorageStringShrink pins that rewriting a string releases the tail
+// slots it no longer needs, as a Solidity assignment would. Reads are
+// length-bounded and would look correct either way, so the check is on the raw
+// slots: a leftover word diverges the state root from a Solidity reference.
+func TestCAS20StorageStringShrink(t *testing.T) {
+	s := newTestStorage(t)
+	tailSlot := func(i uint64) common.Hash {
+		base := new(uint256.Int).SetBytes(crypto.Keccak256(slotAt(cas20SlotName).Bytes()))
+		return common.Hash(base.AddUint64(base, i).Bytes32())
+	}
+
+	// 100 bytes spans four tail slots.
+	s.setName(strings.Repeat("x", 100))
+	for i := uint64(0); i < 4; i++ {
+		if s.getWord(tailSlot(i)) == (common.Hash{}) {
+			t.Fatalf("tail slot %d empty after writing a 100-byte name", i)
+		}
+	}
+
+	// Shrink to a long-but-shorter value: slots 2 and 3 must be released.
+	s.setName(strings.Repeat("y", 40))
+	if got := strOf(s.name()); got != strings.Repeat("y", 40) {
+		t.Errorf("name = %q, want 40 y's", got)
+	}
+	for i := uint64(2); i < 4; i++ {
+		if got := s.getWord(tailSlot(i)); got != (common.Hash{}) {
+			t.Errorf("tail slot %d = %x after shrink, want cleared", i, got)
+		}
+	}
+
+	// Shrink to an inline short string: every tail slot must be released.
+	s.setName("USD")
+	if got := strOf(s.name()); got != "USD" {
+		t.Errorf("name = %q, want USD", got)
+	}
+	for i := uint64(0); i < 4; i++ {
+		if got := s.getWord(tailSlot(i)); got != (common.Hash{}) {
+			t.Errorf("tail slot %d = %x after shrink to short, want cleared", i, got)
+		}
+	}
+}
+
+// TestCAS20StringBoundaryMatrix walks every directed transition between the
+// lengths where the storage encoding changes shape: empty, inline, the 31/32
+// inline-to-long boundary, and the 32-byte chunk boundaries. For each it checks
+// the value round-trips, the length slot carries the right short/long marker,
+// and the data region holds exactly the chunks the new value needs — no stale
+// slot left behind by the old one.
+func TestCAS20StringBoundaryMatrix(t *testing.T) {
+	lengths := []int{0, 1, 31, 32, 33, 64, 65}
+	// A generous scan bound: the largest case needs 3 chunks, so 8 proves that
+	// nothing lingers past the end as well.
+	const scan = 8
+
+	for _, from := range lengths {
+		for _, to := range lengths {
+			s := newTestStorage(t)
+			slot := slotAt(cas20SlotName)
+			dataSlot := func(i uint64) common.Hash {
+				base := new(uint256.Int).SetBytes(crypto.Keccak256(slot.Bytes()))
+				return common.Hash(base.AddUint64(base, i).Bytes32())
+			}
+			// Distinct fill bytes so a stale chunk cannot masquerade as fresh.
+			before, after := strings.Repeat("a", from), strings.Repeat("b", to)
+
+			s.setName(before)
+			s.setName(after)
+
+			if got := strOf(s.name()); got != after {
+				t.Errorf("%d->%d: name = %q (len %d), want len %d", from, to, got, len(got), to)
+			}
+			word := s.getWord(slot)
+			wantLong := to >= 32
+			if isLong := word[31]&1 == 1; isLong != wantLong {
+				t.Errorf("%d->%d: length slot long-marker = %v, want %v", from, to, isLong, wantLong)
+			}
+			if !wantLong && int(word[31]) != to*2 {
+				t.Errorf("%d->%d: inline length byte = %d, want %d", from, to, word[31], to*2)
+			}
+			wantChunks := 0
+			if wantLong {
+				wantChunks = (to + 31) / 32
+			}
+			for i := uint64(0); i < scan; i++ {
+				occupied := s.getWord(dataSlot(i)) != (common.Hash{})
+				if want := i < uint64(wantChunks); occupied != want {
+					t.Errorf("%d->%d: data slot %d occupied = %v, want %v (stale tail not released)",
+						from, to, i, occupied, want)
+				}
+			}
+		}
+	}
+}
+
+// TestCAS20LongStringGas pins the cost of a long string's keccak-derived data
+// region. Deriving that root is a runtime keccak exactly as a mapping slot is,
+// and leaving it unmetered would donate the computation on every long name,
+// symbol or contractURI access.
+func TestCAS20LongStringGas(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	token := cas20Addr(cas20VariantAsset, 1)
+	gas := NewGasBudget(10_000_000)
+	ctx := &PrecompileContext{StateDB: statedb, Self: token, gas: &gas}
+	s := newMeteredCAS20Storage(ctx)
+
+	charged := func(fn func()) uint64 {
+		before := gas.RegularGas
+		fn()
+		return before - gas.RegularGas
+	}
+	const (
+		keccak32 = params.Keccak256Gas + params.Keccak256WordGas // 32-byte preimage
+		cold     = params.ColdSloadCostEIP2929
+		warm     = params.WarmStorageReadCostEIP2929
+		set      = params.SstoreSetGasEIP2200
+	)
+
+	// A short string lives inline: one slot, no data region, no keccak.
+	if c := charged(func() { s.setName("USD Coin") }); c != cold+set {
+		t.Errorf("short-string write charged %d, want %d", c, cold+set)
+	}
+	if c := charged(func() { _ = strOf(s.name()) }); c != warm {
+		t.Errorf("short-string read charged %d, want %d", c, warm)
+	}
+
+	// 100 bytes spans four data slots. The write pays: reading the old length to
+	// see what has to be released, rewriting the length slot, one keccak for the
+	// data root, and four cold sets. Both length-slot touches are warm dirty
+	// updates — the slot was written above in the same transaction.
+	long := strings.Repeat("x", 100)
+	if c := charged(func() { s.setName(long) }); c != 2*warm+keccak32+4*(cold+set) {
+		t.Errorf("long-string write charged %d, want %d", c, 2*warm+keccak32+4*(cold+set))
+	}
+	// The read pays the length slot, the same single keccak, and four warm reads.
+	if c := charged(func() { _ = strOf(s.name()) }); c != warm+keccak32+4*warm {
+		t.Errorf("long-string read charged %d, want %d", c, warm+keccak32+4*warm)
+	}
+
+	// Shrinking back to inline releases the four data slots, and must derive the
+	// data root only once for the whole operation — a second derivation would
+	// show up here as an extra keccak32.
+	if c := charged(func() { s.setName("USD") }); c != 2*warm+keccak32+4*warm {
+		t.Errorf("shrink-to-short charged %d, want %d", c, 2*warm+keccak32+4*warm)
+	}
+	if got := strOf(s.name()); got != "USD" {
+		t.Errorf("name = %q, want USD", got)
+	}
+}
+
+// TestCAS20SpawnedContextPropagatesOutOfGas pins that exhausting a spawned
+// context's budget is visible to the context it was spawned from. The budget is
+// shared by pointer, so only the flag can go missing — and it is the spawner's
+// dispatcher, never the child's, that checks it before reporting success.
+func TestCAS20SpawnedContextPropagatesOutOfGas(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	gas := NewGasBudget(100)
+	parent := &PrecompileContext{
+		StateDB: statedb, Self: cas20Addr(cas20VariantAsset, 1),
+		Caller: cas20Alice, DirectCall: true, gas: &gas,
+	}
+	child := parent.spawnBootstrap(cas20Addr(cas20VariantAsset, 2), cas20Alice)
+
+	if parent.OutOfGas() || child.OutOfGas() {
+		t.Fatal("fresh contexts must not report out of gas")
+	}
+	child.chargeGas(1_000_000) // more than the shared budget holds
+
+	if !child.OutOfGas() {
+		t.Error("child does not report out of gas after an unaffordable charge")
+	}
+	if !parent.OutOfGas() {
+		t.Error("spawner does not see the child's exhaustion — it would report success over an empty budget")
+	}
+	if got := parent.gasLeft(); got != 0 {
+		t.Errorf("shared budget = %d, want 0", got)
+	}
+
+	// The flag is one shared cell, not a copy kept in step, so it travels the
+	// other way too: a context spawned after exhaustion starts exhausted.
+	if later := parent.spawnBootstrap(cas20Addr(cas20VariantAsset, 3), cas20Alice); !later.OutOfGas() {
+		t.Error("a context spawned from an exhausted frame does not start exhausted")
+	}
+	// And a charge failing in the parent is visible to a child spawned earlier.
+	gas2 := NewGasBudget(100)
+	p2 := &PrecompileContext{StateDB: statedb, Self: cas20Addr(cas20VariantAsset, 4), gas: &gas2}
+	c2 := p2.spawnBootstrap(cas20Addr(cas20VariantAsset, 5), cas20Alice)
+	p2.chargeGas(1_000_000)
+	if !c2.OutOfGas() {
+		t.Error("child spawned before the spawner's exhaustion does not observe it")
+	}
+}
+
+// TestCAS20SpawnedContextSharesStateGasTally pins that state gas charged inside a
+// bootstrap child counts toward the frame's total. A bootstrap is the same EVM
+// frame with a different Self — it shares the enforced budget — so a tally that
+// dropped its charges would under-report the frame once the StateGas reservoir
+// is enforced rather than merely recorded.
+func TestCAS20SpawnedContextSharesStateGasTally(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	gas := NewGasBudget(10_000_000)
+	parent := &PrecompileContext{
+		StateDB: statedb, Self: cas20Addr(cas20VariantAsset, 1),
+		Caller: cas20Alice, DirectCall: true, gas: &gas,
+	}
+	child := parent.spawnBootstrap(cas20Addr(cas20VariantAsset, 2), cas20Alice)
+
+	parent.chargeGas(700)
+	child.chargeGas(300)
+
+	if got := parent.meteredGasUsed(); got != 1000 {
+		t.Errorf("spawner StateGasUsed = %d, want 1000 — the child's charges are missing", got)
+	}
+	if got := child.meteredGasUsed(); got != 1000 {
+		t.Errorf("child StateGasUsed = %d, want 1000 — the tally is not frame-wide", got)
+	}
+}
+
+// TestCAS20SpawnedContextPropagatesSentryRefusal covers the other way a spawned
+// frame stops being able to write: the EIP-2200 reentrancy sentry refuses an
+// SSTORE while gas remains. Nothing drains the budget here, so unlike an
+// unaffordable charge this cannot be caught downstream by a later failing
+// charge — the spawner would hold gas in hand and report success over a write
+// that never landed.
+func TestCAS20SpawnedContextPropagatesSentryRefusal(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	// Above zero but at or below the 2300 stipend, so the sentry refuses.
+	gas := NewGasBudget(params.SstoreSentryGasEIP2200)
+	parent := &PrecompileContext{
+		StateDB: statedb, Self: cas20Addr(cas20VariantAsset, 1),
+		Caller: cas20Alice, DirectCall: true, gas: &gas,
+	}
+	token := cas20Addr(cas20VariantAsset, 2)
+	child := parent.spawnBootstrap(token, cas20Alice)
+
+	cas20Storage{state: statedb, token: token, ctx: child}.
+		setWord(common.Hash{31: 7}, common.Hash{31: 1})
+
+	if !child.OutOfGas() {
+		t.Error("child does not report out of gas after a sentry-refused write")
+	}
+	if !parent.OutOfGas() {
+		t.Error("spawner does not see the sentry refusal — it would report success over a skipped write")
+	}
+	if got := statedb.GetState(token, common.Hash{31: 7}); got != (common.Hash{}) {
+		t.Errorf("refused write landed anyway: slot = %x", got)
+	}
+	if parent.gasLeft() == 0 {
+		t.Error("sentry refusal should not itself drain the budget; the test would prove nothing")
+	}
+}
+
+// TestCAS20StorageRefunds pins the EIP-3529 refund arms of the net-metered
+// write path against the interpreter's own makeGasSStoreFunc.
+func TestCAS20StorageRefunds(t *testing.T) {
+	clearing := params.SstoreClearsScheduleRefundEIP3529
+
+	newCtx := func() (*state.StateDB, cas20Storage, *PrecompileContext) {
+		statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+		if err != nil {
+			t.Fatal(err)
+		}
+		token := cas20Addr(cas20VariantAsset, 1)
+		// Without the sentinel the token is an EIP-161 empty account and
+		// Finalise below would reap it, storage included (BEP-702 3.16).
+		statedb.SetCode(token, CAS20MarkerCode, tracing.CodeChangeContractCreation)
+		gas := NewGasBudget(10_000_000)
+		ctx := &PrecompileContext{StateDB: statedb, Self: token, gas: &gas}
+		return statedb, newMeteredCAS20Storage(ctx), ctx
+	}
+	slot := slotAt(cas20SlotTotalSupply)
+	one := common.Hash{31: 1}
+	two := common.Hash{31: 2}
+
+	// Clearing a slot that existed at the start of the transaction refunds.
+	statedb, s, _ := newCtx()
+	s.state.SetState(s.token, slot, one)
+	statedb.Finalise(true) // commit, so `original` is non-zero
+	s.setWord(slot, common.Hash{})
+	if got := statedb.GetRefund(); got != clearing {
+		t.Errorf("clear refund = %d, want %d", got, clearing)
+	}
+
+	// Re-creating it in the same transaction takes the refund back.
+	s.setWord(slot, two)
+	if got := statedb.GetRefund(); got != 0 {
+		t.Errorf("refund after recreate = %d, want 0", got)
+	}
+
+	// Restoring a dirty slot to its committed value refunds the difference
+	// between the reset price and a warm read.
+	statedb, s, _ = newCtx()
+	s.state.SetState(s.token, slot, one)
+	statedb.Finalise(true)
+	s.setWord(slot, two)
+	s.setWord(slot, one)
+	want := (params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929) - params.WarmStorageReadCostEIP2929
+	if got := statedb.GetRefund(); got != want {
+		t.Errorf("reset-to-original refund = %d, want %d", got, want)
+	}
+}
+
+// TestCAS20SstoreSentry verifies the EIP-2200 reentrancy guard: a write is
+// refused whenever remaining gas is at or below the 2300 call stipend, however
+// cheap the write itself would be, and no state change happens.
+func TestCAS20SstoreSentry(t *testing.T) {
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := cas20Addr(cas20VariantAsset, 1)
+	slot := slotAt(cas20SlotTotalSupply)
+
+	// Warm the slot and dirty it so the write itself would be cheap (~100 gas),
+	// then leave exactly the stipend in the budget.
+	gas := NewGasBudget(params.SstoreSentryGasEIP2200)
+	ctx := &PrecompileContext{StateDB: statedb, Self: token, gas: &gas}
+	s := newMeteredCAS20Storage(ctx)
+	statedb.AddSlotToAccessList(token, slot)
+
+	s.setWord(slot, common.Hash{31: 7})
+	if !ctx.OutOfGas() {
+		t.Fatal("write at the stipend boundary must trip the sentry")
+	}
+	if got := statedb.GetState(token, slot); got != (common.Hash{}) {
+		t.Fatalf("refused write still mutated state: %x", got)
+	}
+
+	// One gas above the stipend, the same write succeeds.
+	gas2 := NewGasBudget(params.SstoreSentryGasEIP2200 + 1 + params.SstoreSetGasEIP2200)
+	ctx2 := &PrecompileContext{StateDB: statedb, Self: token, gas: &gas2}
+	newMeteredCAS20Storage(ctx2).setWord(slot, common.Hash{31: 7})
+	if ctx2.OutOfGas() {
+		t.Fatal("write above the stipend must be allowed")
+	}
+	if got := statedb.GetState(token, slot); got != (common.Hash{31: 7}) {
+		t.Fatalf("state = %x, want 7", got)
+	}
+}
+
+// TestCAS20GasNeverCheaperThanBytecode pins BEP-702 3.14's central rule: a CAS20
+// operation must never cost less than the same state accesses performed
+// through bytecode. It compares a transfer's charge against the floor an
+// equivalent BEP-20 implementation pays for the same accesses — two cold slot
+// reads and two cold writes for a first-time recipient — and additionally
+// requires the derivation and dispatch work CAS20 does on top to be accounted.
+func TestCAS20GasNeverCheaperThanBytecode(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xfee")
+	call := func(caller, to common.Address, input []byte) ([]byte, error) {
+		ret, _, err := evm.Call(caller, to, input, NewGasBudget(5_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+	initCalls := [][]byte{
+		cas20Call(selGrantRole, roleMint, addrKey(creator)),
+		cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
+	}
+	ret, err := call(creator, CAS20FactoryAddress, encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0x9a"), creator, initCalls))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+
+	const budget = 1_000_000
+	measure := func(to common.Address, amount uint64) uint64 {
+		t.Helper()
+		in := cas20Call(selTransfer, addrKey(to), u256hash(amount))
+		// Warm the slots first, then measure the second call.
+		if _, _, err := evm.Call(cas20Alice, token, in, NewGasBudget(budget), uint256.NewInt(0)); err != nil {
+			t.Fatalf("warming transfer: %v", err)
+		}
+		_, left, err := evm.Call(cas20Alice, token, in, NewGasBudget(budget), uint256.NewInt(0))
+		if err != nil {
+			t.Fatalf("measured transfer: %v", err)
+		}
+		return uint64(budget) - left.RegularGas
+	}
+
+	// Warm-path floor: both balance slots are warm and dirty by now, so bytecode
+	// would pay 2 * SLOAD_warm + 2 * SSTORE_dirty, plus a 64-byte keccak per
+	// balance slot to derive it.
+	keccak64 := params.Keccak256Gas + 2*params.Keccak256WordGas
+	floor := 4*params.WarmStorageReadCostEIP2929 + 2*keccak64
+
+	ordinary := measure(cas20Bob, 10)
+	if ordinary < floor {
+		t.Fatalf("warm transfer charged %d, below the bytecode floor %d", ordinary, floor)
+	}
+
+	// The degenerate shapes must cost exactly what an ordinary transfer costs.
+	// A self-transfer and a zero-value transfer look like free wins — no balance
+	// ends up different — but bytecode performs both assignments regardless, so
+	// skipping them would make a native token cheaper than the contract it
+	// replaces, which BEP-702 3.14 forbids outright.
+	//
+	// The floor above is far too loose to catch that on its own: the balance
+	// accesses are a few hundred gas out of a few thousand, so dropping two
+	// writes still clears it. Equality with the ordinary shape is what actually
+	// pins it, and this is precisely the "optimisation" a later reader would
+	// reach for.
+	for _, tc := range []struct {
+		what   string
+		to     common.Address
+		amount uint64
+	}{
+		{"self-transfer", cas20Alice, 10},
+		{"zero-value transfer", cas20Bob, 0},
+		{"zero-value self-transfer", cas20Alice, 0},
+	} {
+		if charged := measure(tc.to, tc.amount); charged != ordinary {
+			t.Errorf("%s charged %d, want %d — the same accesses bytecode would perform",
+				tc.what, charged, ordinary)
+		}
+	}
+}

--- a/core/vm/cas20_storage_test.go
+++ b/core/vm/cas20_storage_test.go
@@ -13,9 +13,6 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// strOf drops the read-status half of a string getter. The unmetered views tests
-// build always report true, so a test that only wants the value says so here
-// rather than at twenty call sites.
 func strOf(v string, _ bool) string { return v }
 
 func newTestStorage(t *testing.T) cas20Storage {
@@ -74,12 +71,8 @@ func TestCAS20StorageMappings(t *testing.T) {
 		t.Errorf("nonce = %d", got)
 	}
 
-	// Raw-slot checks, spelling out Solidity's derivation independently of the
-	// helpers. Round-tripping through the accessors cannot catch a wrong layout:
-	// a nested mapping whose two keys are swapped is self-consistent, so reads
-	// and writes still agree with each other while diverging from every
-	// reference implementation. Only the slot the value actually lands in tells
-	// them apart.
+	// Raw slots, spelled out from Solidity's rules: a nested mapping with swapped
+	// keys is self-consistent, so only the slot the value lands in tells them apart.
 	pad := func(b []byte) []byte { return common.BytesToHash(b).Bytes() }
 	solMap := func(key, base []byte) []byte { return crypto.Keccak256(pad(key), pad(base)) }
 
@@ -88,19 +81,16 @@ func TestCAS20StorageMappings(t *testing.T) {
 		t.Errorf("balance is not at keccak256(alice ++ balancesBase)")
 	}
 
-	// allowances[owner][spender]: owner is the OUTER key, spender the inner one.
 	inner := solMap(alice.Bytes(), slotAt(cas20SlotAllowances).Bytes())
 	allowSlot := solMap(bob.Bytes(), inner)
 	if got := s.getWord(common.BytesToHash(allowSlot)); new(uint256.Int).SetBytes(got.Bytes()).Uint64() != 42 {
 		t.Error("allowance is not at keccak256(spender ++ keccak256(owner ++ base)) — nesting order is wrong")
 	}
-	// The swapped nesting must be empty, which is what distinguishes the two.
 	swappedInner := solMap(bob.Bytes(), slotAt(cas20SlotAllowances).Bytes())
 	if got := s.getWord(common.BytesToHash(solMap(alice.Bytes(), swappedInner))); got != (common.Hash{}) {
 		t.Error("allowance also landed under the swapped nesting order")
 	}
 
-	// roles[role][account] nests the same way: role outer, account inner.
 	s.setRole(roleMint, alice, true)
 	roleInner := solMap(roleMint.Bytes(), slotAt(cas20SlotRoles).Bytes())
 	if got := s.getWord(common.BytesToHash(solMap(alice.Bytes(), roleInner))); got == (common.Hash{}) {
@@ -131,8 +121,6 @@ func TestCAS20StorageRoles(t *testing.T) {
 	}
 }
 
-// TestCAS20StoragePackedPolicies verifies the four policy ids share their packed
-// slots without clobbering each other.
 func TestCAS20StoragePackedPolicies(t *testing.T) {
 	s := newTestStorage(t)
 	s.setTransferSenderPolicy(0x1111111111111111)
@@ -153,16 +141,12 @@ func TestCAS20StoragePackedPolicies(t *testing.T) {
 		t.Errorf("mintReceiver = %#x", got)
 	}
 
-	// The three transfer lanes must live in a single slot (slot 9), packed at
-	// byte offsets 0/8/16.
 	word := s.getWord(slotAt(cas20SlotTransferPolicies))
-	// byte offsets 24(reserved,0) | 16(executor) | 8(receiver) | 0(sender)
 	wantWord := "0x" + "0000000000000000" + "3333333333333333" + "2222222222222222" + "1111111111111111"
 	if word.Hex() != wantWord {
 		t.Errorf("packed slot 9 = %s, want %s", word.Hex(), wantWord)
 	}
 
-	// Overwriting one lane must not disturb the others.
 	s.setTransferReceiverPolicy(0xdeadbeefdeadbeef)
 	if got := s.transferSenderPolicy(); got != 0x1111111111111111 {
 		t.Errorf("sender disturbed: %#x", got)
@@ -175,8 +159,6 @@ func TestCAS20StoragePackedPolicies(t *testing.T) {
 	}
 }
 
-// TestCAS20StorageGas checks the v0 storage gas schedule: cold/warm reads and
-// SSTORE set/reset/no-op writes, plus out-of-gas propagation.
 func TestCAS20StorageGas(t *testing.T) {
 	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	if err != nil {
@@ -194,8 +176,7 @@ func TestCAS20StorageGas(t *testing.T) {
 		return before - gas.RegularGas
 	}
 
-	// A balance slot is mapping-derived, so every access also pays the keccak
-	// over the 64-byte (key ++ base) preimage.
+	// Every access also pays the 64-byte keccak that derives the slot.
 	const keccak64 = params.Keccak256Gas + 2*params.Keccak256WordGas
 	var (
 		cold  = params.ColdSloadCostEIP2929
@@ -204,23 +185,17 @@ func TestCAS20StorageGas(t *testing.T) {
 		reset = params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929
 	)
 
-	// cold write, zero -> non-zero: cold surcharge + set.
 	if c := charged(func() { s.setBalance(alice, uint256.NewInt(500)) }); c != keccak64+cold+set {
 		t.Errorf("cold set write charged %d, want %d", c, keccak64+cold+set)
 	}
-	// warm read of the same slot.
 	if c := charged(func() { _ = s.balanceOf(alice) }); c != keccak64+warm {
 		t.Errorf("warm read charged %d, want %d", c, keccak64+warm)
 	}
-	// warm write, non-zero -> other. The slot was zero at the start of the
-	// transaction, so under EIP-2200 net metering this is a dirty update
-	// charged at the warm price, not a reset — the 20000 was already paid by
-	// the first write. `reset` is exercised by TestCAS20StorageRefunds, where the
-	// slot starts committed non-zero.
+	// A dirty update at the warm price, not a reset: the slot was zero at the start
+	// of the transaction. TestCAS20StorageRefunds covers reset.
 	if c := charged(func() { s.setBalance(alice, uint256.NewInt(600)) }); c != keccak64+warm {
 		t.Errorf("dirty update charged %d, want %d", c, keccak64+warm)
 	}
-	// warm write, same value: no-op.
 	if c := charged(func() { s.setBalance(alice, uint256.NewInt(600)) }); c != keccak64+warm {
 		t.Errorf("warm no-op write charged %d, want %d", c, keccak64+warm)
 	}
@@ -233,7 +208,6 @@ func TestCAS20StorageGas(t *testing.T) {
 		t.Error("should not be out of gas")
 	}
 
-	// Unmetered view never charges.
 	free := newUnmeteredCAS20Storage(statedb, token)
 	if c := charged(func() { _ = free.balanceOf(alice) }); c != 0 {
 		t.Errorf("unmetered read charged %d, want 0", c)
@@ -259,7 +233,6 @@ func TestCAS20StorageGasOutOfGas(t *testing.T) {
 func TestCAS20StorageStrings(t *testing.T) {
 	s := newTestStorage(t)
 
-	// short string (< 32 bytes): stored in-slot, low byte = 2*len.
 	s.setName("USD Coin")
 	if got := strOf(s.name()); got != "USD Coin" {
 		t.Errorf("name = %q", got)
@@ -268,7 +241,6 @@ func TestCAS20StorageStrings(t *testing.T) {
 		t.Errorf("short string length byte = %d, want %d", w[31], len("USD Coin")*2)
 	}
 
-	// exactly 31 bytes stays short; 32+ goes long.
 	short31 := strings.Repeat("a", 31)
 	s.setSymbol(short31)
 	if got := strOf(s.symbol()); got != short31 {
@@ -280,16 +252,13 @@ func TestCAS20StorageStrings(t *testing.T) {
 	if got := strOf(s.contractURI()); got != long {
 		t.Errorf("long string round-trip failed: len %d", len(got))
 	}
-	// long-string marker: low bit of the length slot is set.
 	if w := s.getWord(slotAt(cas20SlotContractURI)); w[31]&1 != 1 {
 		t.Error("long string should set the low bit of the length slot")
 	}
 }
 
-// TestCAS20StorageStringShrink pins that rewriting a string releases the tail
-// slots it no longer needs, as a Solidity assignment would. Reads are
-// length-bounded and would look correct either way, so the check is on the raw
-// slots: a leftover word diverges the state root from a Solidity reference.
+// Reads are length-bounded and would look correct either way; a leftover tail word
+// diverges the state root from a Solidity reference.
 func TestCAS20StorageStringShrink(t *testing.T) {
 	s := newTestStorage(t)
 	tailSlot := func(i uint64) common.Hash {
@@ -297,7 +266,6 @@ func TestCAS20StorageStringShrink(t *testing.T) {
 		return common.Hash(base.AddUint64(base, i).Bytes32())
 	}
 
-	// 100 bytes spans four tail slots.
 	s.setName(strings.Repeat("x", 100))
 	for i := uint64(0); i < 4; i++ {
 		if s.getWord(tailSlot(i)) == (common.Hash{}) {
@@ -305,7 +273,6 @@ func TestCAS20StorageStringShrink(t *testing.T) {
 		}
 	}
 
-	// Shrink to a long-but-shorter value: slots 2 and 3 must be released.
 	s.setName(strings.Repeat("y", 40))
 	if got := strOf(s.name()); got != strings.Repeat("y", 40) {
 		t.Errorf("name = %q, want 40 y's", got)
@@ -316,7 +283,6 @@ func TestCAS20StorageStringShrink(t *testing.T) {
 		}
 	}
 
-	// Shrink to an inline short string: every tail slot must be released.
 	s.setName("USD")
 	if got := strOf(s.name()); got != "USD" {
 		t.Errorf("name = %q, want USD", got)
@@ -328,16 +294,10 @@ func TestCAS20StorageStringShrink(t *testing.T) {
 	}
 }
 
-// TestCAS20StringBoundaryMatrix walks every directed transition between the
-// lengths where the storage encoding changes shape: empty, inline, the 31/32
-// inline-to-long boundary, and the 32-byte chunk boundaries. For each it checks
-// the value round-trips, the length slot carries the right short/long marker,
-// and the data region holds exactly the chunks the new value needs — no stale
-// slot left behind by the old one.
+// Every directed transition between the lengths where the encoding changes shape.
 func TestCAS20StringBoundaryMatrix(t *testing.T) {
 	lengths := []int{0, 1, 31, 32, 33, 64, 65}
-	// A generous scan bound: the largest case needs 3 chunks, so 8 proves that
-	// nothing lingers past the end as well.
+	// The largest case needs 3 chunks; scanning 8 proves nothing lingers past the end.
 	const scan = 8
 
 	for _, from := range lengths {
@@ -348,7 +308,6 @@ func TestCAS20StringBoundaryMatrix(t *testing.T) {
 				base := new(uint256.Int).SetBytes(crypto.Keccak256(slot.Bytes()))
 				return common.Hash(base.AddUint64(base, i).Bytes32())
 			}
-			// Distinct fill bytes so a stale chunk cannot masquerade as fresh.
 			before, after := strings.Repeat("a", from), strings.Repeat("b", to)
 
 			s.setName(before)
@@ -380,10 +339,7 @@ func TestCAS20StringBoundaryMatrix(t *testing.T) {
 	}
 }
 
-// TestCAS20LongStringGas pins the cost of a long string's keccak-derived data
-// region. Deriving that root is a runtime keccak exactly as a mapping slot is,
-// and leaving it unmetered would donate the computation on every long name,
-// symbol or contractURI access.
+// A long string's data root is a runtime keccak exactly as a mapping slot is.
 func TestCAS20LongStringGas(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	token := cas20Addr(cas20VariantAsset, 1)
@@ -403,7 +359,6 @@ func TestCAS20LongStringGas(t *testing.T) {
 		set      = params.SstoreSetGasEIP2200
 	)
 
-	// A short string lives inline: one slot, no data region, no keccak.
 	if c := charged(func() { s.setName("USD Coin") }); c != cold+set {
 		t.Errorf("short-string write charged %d, want %d", c, cold+set)
 	}
@@ -411,22 +366,16 @@ func TestCAS20LongStringGas(t *testing.T) {
 		t.Errorf("short-string read charged %d, want %d", c, warm)
 	}
 
-	// 100 bytes spans four data slots. The write pays: reading the old length to
-	// see what has to be released, rewriting the length slot, one keccak for the
-	// data root, and four cold sets. Both length-slot touches are warm dirty
-	// updates — the slot was written above in the same transaction.
+	// Old length read, length slot rewritten, one data-root keccak, four cold sets.
 	long := strings.Repeat("x", 100)
 	if c := charged(func() { s.setName(long) }); c != 2*warm+keccak32+4*(cold+set) {
 		t.Errorf("long-string write charged %d, want %d", c, 2*warm+keccak32+4*(cold+set))
 	}
-	// The read pays the length slot, the same single keccak, and four warm reads.
 	if c := charged(func() { _ = strOf(s.name()) }); c != warm+keccak32+4*warm {
 		t.Errorf("long-string read charged %d, want %d", c, warm+keccak32+4*warm)
 	}
 
-	// Shrinking back to inline releases the four data slots, and must derive the
-	// data root only once for the whole operation — a second derivation would
-	// show up here as an extra keccak32.
+	// The data root must be derived once for the whole release.
 	if c := charged(func() { s.setName("USD") }); c != 2*warm+keccak32+4*warm {
 		t.Errorf("shrink-to-short charged %d, want %d", c, 2*warm+keccak32+4*warm)
 	}
@@ -435,10 +384,8 @@ func TestCAS20LongStringGas(t *testing.T) {
 	}
 }
 
-// TestCAS20SpawnedContextPropagatesOutOfGas pins that exhausting a spawned
-// context's budget is visible to the context it was spawned from. The budget is
-// shared by pointer, so only the flag can go missing — and it is the spawner's
-// dispatcher, never the child's, that checks it before reporting success.
+// The budget is shared by pointer, so only the flag can go missing, and it is the
+// spawner's dispatcher that checks it.
 func TestCAS20SpawnedContextPropagatesOutOfGas(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	gas := NewGasBudget(100)
@@ -463,12 +410,10 @@ func TestCAS20SpawnedContextPropagatesOutOfGas(t *testing.T) {
 		t.Errorf("shared budget = %d, want 0", got)
 	}
 
-	// The flag is one shared cell, not a copy kept in step, so it travels the
-	// other way too: a context spawned after exhaustion starts exhausted.
+	// One shared cell, not a copy: a context spawned after exhaustion starts exhausted.
 	if later := parent.spawnBootstrap(cas20Addr(cas20VariantAsset, 3), cas20Alice); !later.OutOfGas() {
 		t.Error("a context spawned from an exhausted frame does not start exhausted")
 	}
-	// And a charge failing in the parent is visible to a child spawned earlier.
 	gas2 := NewGasBudget(100)
 	p2 := &PrecompileContext{StateDB: statedb, Self: cas20Addr(cas20VariantAsset, 4), gas: &gas2}
 	c2 := p2.spawnBootstrap(cas20Addr(cas20VariantAsset, 5), cas20Alice)
@@ -478,11 +423,8 @@ func TestCAS20SpawnedContextPropagatesOutOfGas(t *testing.T) {
 	}
 }
 
-// TestCAS20SpawnedContextSharesStateGasTally pins that state gas charged inside a
-// bootstrap child counts toward the frame's total. A bootstrap is the same EVM
-// frame with a different Self — it shares the enforced budget — so a tally that
-// dropped its charges would under-report the frame once the StateGas reservoir
-// is enforced rather than merely recorded.
+// A bootstrap is the same EVM frame with a different Self, so its charges count
+// toward the frame's tally.
 func TestCAS20SpawnedContextSharesStateGasTally(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	gas := NewGasBudget(10_000_000)
@@ -503,15 +445,11 @@ func TestCAS20SpawnedContextSharesStateGasTally(t *testing.T) {
 	}
 }
 
-// TestCAS20SpawnedContextPropagatesSentryRefusal covers the other way a spawned
-// frame stops being able to write: the EIP-2200 reentrancy sentry refuses an
-// SSTORE while gas remains. Nothing drains the budget here, so unlike an
-// unaffordable charge this cannot be caught downstream by a later failing
-// charge — the spawner would hold gas in hand and report success over a write
-// that never landed.
+// The sentry refuses while gas remains, so unlike an unaffordable charge nothing
+// downstream would catch it: the spawner would report success over a write that
+// never landed.
 func TestCAS20SpawnedContextPropagatesSentryRefusal(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
-	// Above zero but at or below the 2300 stipend, so the sentry refuses.
 	gas := NewGasBudget(params.SstoreSentryGasEIP2200)
 	parent := &PrecompileContext{
 		StateDB: statedb, Self: cas20Addr(cas20VariantAsset, 1),
@@ -537,8 +475,6 @@ func TestCAS20SpawnedContextPropagatesSentryRefusal(t *testing.T) {
 	}
 }
 
-// TestCAS20StorageRefunds pins the EIP-3529 refund arms of the net-metered
-// write path against the interpreter's own makeGasSStoreFunc.
 func TestCAS20StorageRefunds(t *testing.T) {
 	clearing := params.SstoreClearsScheduleRefundEIP3529
 
@@ -548,8 +484,7 @@ func TestCAS20StorageRefunds(t *testing.T) {
 			t.Fatal(err)
 		}
 		token := cas20Addr(cas20VariantAsset, 1)
-		// Without the sentinel the token is an EIP-161 empty account and
-		// Finalise below would reap it, storage included (BEP-702 3.16).
+		// Without the sentinel Finalise below would reap the account, storage included.
 		statedb.SetCode(token, CAS20MarkerCode, tracing.CodeChangeContractCreation)
 		gas := NewGasBudget(10_000_000)
 		ctx := &PrecompileContext{StateDB: statedb, Self: token, gas: &gas}
@@ -559,7 +494,6 @@ func TestCAS20StorageRefunds(t *testing.T) {
 	one := common.Hash{31: 1}
 	two := common.Hash{31: 2}
 
-	// Clearing a slot that existed at the start of the transaction refunds.
 	statedb, s, _ := newCtx()
 	s.state.SetState(s.token, slot, one)
 	statedb.Finalise(true) // commit, so `original` is non-zero
@@ -568,14 +502,11 @@ func TestCAS20StorageRefunds(t *testing.T) {
 		t.Errorf("clear refund = %d, want %d", got, clearing)
 	}
 
-	// Re-creating it in the same transaction takes the refund back.
 	s.setWord(slot, two)
 	if got := statedb.GetRefund(); got != 0 {
 		t.Errorf("refund after recreate = %d, want 0", got)
 	}
 
-	// Restoring a dirty slot to its committed value refunds the difference
-	// between the reset price and a warm read.
 	statedb, s, _ = newCtx()
 	s.state.SetState(s.token, slot, one)
 	statedb.Finalise(true)
@@ -587,9 +518,6 @@ func TestCAS20StorageRefunds(t *testing.T) {
 	}
 }
 
-// TestCAS20SstoreSentry verifies the EIP-2200 reentrancy guard: a write is
-// refused whenever remaining gas is at or below the 2300 call stipend, however
-// cheap the write itself would be, and no state change happens.
 func TestCAS20SstoreSentry(t *testing.T) {
 	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	if err != nil {
@@ -598,8 +526,7 @@ func TestCAS20SstoreSentry(t *testing.T) {
 	token := cas20Addr(cas20VariantAsset, 1)
 	slot := slotAt(cas20SlotTotalSupply)
 
-	// Warm the slot and dirty it so the write itself would be cheap (~100 gas),
-	// then leave exactly the stipend in the budget.
+	// Warm and dirty, so the write itself would be cheap; exactly the stipend left.
 	gas := NewGasBudget(params.SstoreSentryGasEIP2200)
 	ctx := &PrecompileContext{StateDB: statedb, Self: token, gas: &gas}
 	s := newMeteredCAS20Storage(ctx)
@@ -613,7 +540,6 @@ func TestCAS20SstoreSentry(t *testing.T) {
 		t.Fatalf("refused write still mutated state: %x", got)
 	}
 
-	// One gas above the stipend, the same write succeeds.
 	gas2 := NewGasBudget(params.SstoreSentryGasEIP2200 + 1 + params.SstoreSetGasEIP2200)
 	ctx2 := &PrecompileContext{StateDB: statedb, Self: token, gas: &gas2}
 	newMeteredCAS20Storage(ctx2).setWord(slot, common.Hash{31: 7})
@@ -625,12 +551,8 @@ func TestCAS20SstoreSentry(t *testing.T) {
 	}
 }
 
-// TestCAS20GasNeverCheaperThanBytecode pins BEP-702 3.14's central rule: a CAS20
-// operation must never cost less than the same state accesses performed
-// through bytecode. It compares a transfer's charge against the floor an
-// equivalent BEP-20 implementation pays for the same accesses — two cold slot
-// reads and two cold writes for a first-time recipient — and additionally
-// requires the derivation and dispatch work CAS20 does on top to be accounted.
+// BEP-702 3.14: a transfer must cost at least what bytecode pays for the same
+// accesses, plus the derivation and dispatch work on top.
 func TestCAS20GasNeverCheaperThanBytecode(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xfee")
@@ -652,7 +574,6 @@ func TestCAS20GasNeverCheaperThanBytecode(t *testing.T) {
 	measure := func(to common.Address, amount uint64) uint64 {
 		t.Helper()
 		in := cas20Call(selTransfer, addrKey(to), u256hash(amount))
-		// Warm the slots first, then measure the second call.
 		if _, _, err := evm.Call(cas20Alice, token, in, NewGasBudget(budget), uint256.NewInt(0)); err != nil {
 			t.Fatalf("warming transfer: %v", err)
 		}
@@ -663,9 +584,6 @@ func TestCAS20GasNeverCheaperThanBytecode(t *testing.T) {
 		return uint64(budget) - left.RegularGas
 	}
 
-	// Warm-path floor: both balance slots are warm and dirty by now, so bytecode
-	// would pay 2 * SLOAD_warm + 2 * SSTORE_dirty, plus a 64-byte keccak per
-	// balance slot to derive it.
 	keccak64 := params.Keccak256Gas + 2*params.Keccak256WordGas
 	floor := 4*params.WarmStorageReadCostEIP2929 + 2*keccak64
 
@@ -674,17 +592,9 @@ func TestCAS20GasNeverCheaperThanBytecode(t *testing.T) {
 		t.Fatalf("warm transfer charged %d, below the bytecode floor %d", ordinary, floor)
 	}
 
-	// The degenerate shapes must cost exactly what an ordinary transfer costs.
-	// A self-transfer and a zero-value transfer look like free wins — no balance
-	// ends up different — but bytecode performs both assignments regardless, so
-	// skipping them would make a native token cheaper than the contract it
-	// replaces, which BEP-702 3.14 forbids outright.
-	//
-	// The floor above is far too loose to catch that on its own: the balance
-	// accesses are a few hundred gas out of a few thousand, so dropping two
-	// writes still clears it. Equality with the ordinary shape is what actually
-	// pins it, and this is precisely the "optimisation" a later reader would
-	// reach for.
+	// Self and zero-value transfers must cost exactly the ordinary shape: the floor
+	// above is too loose to notice two skipped writes, and skipping them is
+	// precisely the optimisation a later reader would reach for.
 	for _, tc := range []struct {
 		what   string
 		to     common.Address

--- a/core/vm/cas20_string_length_test.go
+++ b/core/vm/cas20_string_length_test.go
@@ -30,6 +30,13 @@ func TestCAS20StringLengthWordIsNotTrusted(t *testing.T) {
 		})},
 		{"long string one byte past the cap", common.Hash(
 			uint256.NewInt(2*(cas20MaxStringLen+1) + 1).Bytes32())},
+		// The long form encodes 32 bytes or more. A shorter length belongs to the
+		// short form, so these words are as non-canonical as the oversized ones
+		// above and must answer the same way — without them the short form's bound
+		// is the only one under test, and dropping the long form's would go
+		// unnoticed while the reader went off to the data root for content.
+		{"long string claiming one byte", common.Hash(uint256.NewInt(3).Bytes32())},
+		{"long string claiming 31 bytes", common.Hash(uint256.NewInt(2*31 + 1).Bytes32())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())

--- a/core/vm/cas20_string_length_test.go
+++ b/core/vm/cas20_string_length_test.go
@@ -1,0 +1,75 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+// TestCAS20StringLengthWordIsNotTrusted covers a length word no write could have
+// produced. Before the bound, both read paths crashed the node:
+func TestCAS20StringLengthWordIsNotTrusted(t *testing.T) {
+	word := func(build func(*common.Hash)) common.Hash {
+		var h common.Hash
+		build(&h)
+		return h
+	}
+	for _, tc := range []struct {
+		name string
+		word common.Hash
+	}{
+		{"short string claiming 100 bytes", word(func(h *common.Hash) { h[31] = 200 })},
+		{"short string claiming 127 bytes", word(func(h *common.Hash) { h[31] = 254 })},
+		{"long string of almost 2^255 bytes", word(func(h *common.Hash) {
+			for i := range h {
+				h[i] = 0xff
+			}
+		})},
+		{"long string one byte past the cap", common.Hash(
+			uint256.NewInt(2*(cas20MaxStringLen+1) + 1).Bytes32())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+			if err != nil {
+				t.Fatal(err)
+			}
+			s := newUnmeteredCAS20Storage(statedb, cas20Addr(cas20VariantAsset, 1))
+			statedb.SetState(s.token, slotAt(cas20SlotName), tc.word)
+
+			if got := strOf(s.name()); got != "" {
+				t.Errorf("name() = %q, want the empty string", got)
+			}
+			// Fatal, not Errorf: the repair below feeds this count to setStringAt's
+			// release loop, which on an unmetered view has no out-of-gas guard. An
+			// unbounded count there does not fail the test, it hangs it.
+			if got := s.stringChunks(slotAt(cas20SlotName)); got != 0 {
+				t.Fatalf("stringChunks = %d, want 0 — setStringAt would release that "+
+					"many slots, and nothing would stop it", got)
+			}
+			// A write over the corrupt word must still land, so a token whose state
+			// arrived that way is repairable rather than bricked.
+			s.setName("ok")
+			if got := strOf(s.name()); got != "ok" {
+				t.Errorf("name() after setName = %q, want %q", got, "ok")
+			}
+		})
+	}
+
+	// The bound must not touch a value the chain could actually hold. The longest
+	// string these tests can afford is far shorter than the cap, so check the
+	// boundary arithmetic directly instead.
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := newUnmeteredCAS20Storage(statedb, cas20Addr(cas20VariantAsset, 2))
+	atCap := common.Hash(uint256.NewInt(2*cas20MaxStringLen + 1).Bytes32())
+	statedb.SetState(s.token, slotAt(cas20SlotName), atCap)
+	if got := s.stringChunks(slotAt(cas20SlotName)); got != cas20MaxStringLen/32 {
+		t.Errorf("a string exactly at the cap reports %d chunks, want %d — the bound is "+
+			"off by one and rejects a length it should accept", got, cas20MaxStringLen/32)
+	}
+}

--- a/core/vm/cas20_string_length_test.go
+++ b/core/vm/cas20_string_length_test.go
@@ -9,8 +9,7 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// TestCAS20StringLengthWordIsNotTrusted covers a length word no write could have
-// produced. Before the bound, both read paths crashed the node:
+// A length word no write could have produced once crashed both read paths.
 func TestCAS20StringLengthWordIsNotTrusted(t *testing.T) {
 	word := func(build func(*common.Hash)) common.Hash {
 		var h common.Hash
@@ -30,11 +29,7 @@ func TestCAS20StringLengthWordIsNotTrusted(t *testing.T) {
 		})},
 		{"long string one byte past the cap", common.Hash(
 			uint256.NewInt(2*(cas20MaxStringLen+1) + 1).Bytes32())},
-		// The long form encodes 32 bytes or more. A shorter length belongs to the
-		// short form, so these words are as non-canonical as the oversized ones
-		// above and must answer the same way — without them the short form's bound
-		// is the only one under test, and dropping the long form's would go
-		// unnoticed while the reader went off to the data root for content.
+		// A long-form word claiming under 32 bytes is as non-canonical as an oversized one.
 		{"long string claiming one byte", common.Hash(uint256.NewInt(3).Bytes32())},
 		{"long string claiming 31 bytes", common.Hash(uint256.NewInt(2*31 + 1).Bytes32())},
 	} {
@@ -49,15 +44,12 @@ func TestCAS20StringLengthWordIsNotTrusted(t *testing.T) {
 			if got := strOf(s.name()); got != "" {
 				t.Errorf("name() = %q, want the empty string", got)
 			}
-			// Fatal, not Errorf: the repair below feeds this count to setStringAt's
-			// release loop, which on an unmetered view has no out-of-gas guard. An
-			// unbounded count there does not fail the test, it hangs it.
+			// Fatal, not Errorf: an unbounded count would hang the unmetered release loop below.
 			if got := s.stringChunks(slotAt(cas20SlotName)); got != 0 {
 				t.Fatalf("stringChunks = %d, want 0 — setStringAt would release that "+
 					"many slots, and nothing would stop it", got)
 			}
-			// A write over the corrupt word must still land, so a token whose state
-			// arrived that way is repairable rather than bricked.
+			// A token whose state arrived that way must be repairable, not bricked.
 			s.setName("ok")
 			if got := strOf(s.name()); got != "ok" {
 				t.Errorf("name() after setName = %q, want %q", got, "ok")
@@ -65,9 +57,7 @@ func TestCAS20StringLengthWordIsNotTrusted(t *testing.T) {
 		})
 	}
 
-	// The bound must not touch a value the chain could actually hold. The longest
-	// string these tests can afford is far shorter than the cap, so check the
-	// boundary arithmetic directly instead.
+	// The longest string a test can afford is far below the cap, so check the boundary arithmetic directly.
 	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	if err != nil {
 		t.Fatal(err)

--- a/core/vm/cas20_test.go
+++ b/core/vm/cas20_test.go
@@ -47,7 +47,7 @@ func TestIsCAS20Address(t *testing.T) {
 		{"unknown variant still in space", cas20Addr(0x7f, 1), true},
 		{"factory is outside token space", CAS20FactoryAddress, false},
 		{"wrong magic prefix", common.HexToAddress("0xb3000000000000000000ab0000000000000000ff"), false},
-		{"nonzero padding byte", common.HexToAddress("0xca500000000001000000000000000000000000ff"), false},
+		{"nonzero padding byte", common.HexToAddress("0xca520000000001000000000000000000000000ff"), false},
 		{"the reference implementation's prefix", common.HexToAddress("0xb2000000000000000000000000000000000000ff"), false},
 		{"zero address", common.Address{}, false},
 	}

--- a/core/vm/cas20_test.go
+++ b/core/vm/cas20_test.go
@@ -1,0 +1,355 @@
+package vm
+
+import (
+	"bytes"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// cas20TestChainConfig returns a chain config CAS20 is actually active under:
+// Pasteur scheduled, and Parlia set so IsInBSC holds. The BSC gate matters —
+// params.TestChainConfig alone has no Parlia, so a harness built on it would
+// exercise CAS20 on a chain where production never enables it.
+func cas20TestChainConfig() *params.ChainConfig {
+	cfg := *params.TestChainConfig
+	zero := uint64(0)
+	cfg.JennerTime = &zero
+	cfg.Parlia = &params.ParliaConfig{}
+	return &cfg
+}
+
+// cas20Addr builds a token address in the reserved space with the given variant
+// byte and a one-byte identity fingerprint.
+func cas20Addr(variant, id byte) common.Address {
+	var a common.Address
+	a[0], a[1] = cas20MarkerPrefix[0], cas20MarkerPrefix[1]
+	a[10] = variant
+	a[19] = id
+	return a
+}
+
+func TestIsCAS20Address(t *testing.T) {
+	cases := []struct {
+		name string
+		addr common.Address
+		want bool
+	}{
+		{"asset token", cas20Addr(cas20VariantAsset, 1), true},
+		{"stablecoin token", cas20Addr(cas20VariantStablecoin, 1), true},
+		{"unknown variant still in space", cas20Addr(0x7f, 1), true},
+		{"factory is outside token space", CAS20FactoryAddress, false},
+		{"wrong magic prefix", common.HexToAddress("0xb3000000000000000000ab0000000000000000ff"), false},
+		{"nonzero padding byte", common.HexToAddress("0xca500000000001000000000000000000000000ff"), false},
+		{"the reference implementation's prefix", common.HexToAddress("0xb2000000000000000000000000000000000000ff"), false},
+		{"zero address", common.Address{}, false},
+	}
+	for _, tc := range cases {
+		if got := IsCAS20Address(tc.addr); got != tc.want {
+			t.Errorf("%s: IsCAS20Address(%s) = %v, want %v", tc.name, tc.addr.Hex(), got, tc.want)
+		}
+	}
+}
+
+func TestResolveCAS20(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+
+	asset := cas20Addr(cas20VariantAsset, 1)
+	stable := cas20Addr(cas20VariantStablecoin, 1)
+	unknown := cas20Addr(0x02, 1)
+	uninit := cas20Addr(cas20VariantAsset, 2)
+
+	// Mark three tokens as initialized (factory writes a marker code).
+	for _, a := range []common.Address{asset, stable, unknown} {
+		statedb.SetCode(a, CAS20MarkerCode, tracing.CodeChangeContractCreation)
+	}
+
+	// Factory resolves regardless of state.
+	if p, ok := resolveCAS20(CAS20FactoryAddress); !ok {
+		t.Fatal("factory address should resolve")
+	} else if _, ok := p.(*cas20FactoryPrecompile); !ok {
+		t.Fatalf("factory resolved to %T, want *cas20FactoryPrecompile", p)
+	}
+
+	// Initialized Asset / Stablecoin route to the right variant.
+	if p, ok := resolveCAS20(asset); !ok {
+		t.Fatal("initialized asset token should resolve")
+	} else if _, ok := p.(*cas20AssetPrecompile); !ok {
+		t.Fatalf("asset resolved to %T, want *cas20AssetPrecompile", p)
+	}
+	if p, ok := resolveCAS20(stable); !ok {
+		t.Fatal("initialized stablecoin token should resolve")
+	} else if _, ok := p.(*cas20StablecoinPrecompile); !ok {
+		t.Fatalf("stablecoin resolved to %T, want *cas20StablecoinPrecompile", p)
+	}
+
+	// Unknown variant byte is not routed even when initialized.
+	if _, ok := resolveCAS20(unknown); ok {
+		t.Error("unknown variant should not resolve")
+	}
+	// An uninitialized address with a recognized variant is still routed:
+	// existence is checked inside the handler, not by dispatch, so a
+	// value-bearing call to it is refused rather than stranded (BEP-702 3.3).
+	if p, ok := resolveCAS20(uninit); !ok {
+		t.Error("uninitialized recognized-variant address should still route")
+	} else if _, ok := p.(*cas20AssetPrecompile); !ok {
+		t.Errorf("uninitialized asset address resolved to %T, want *cas20AssetPrecompile", p)
+	}
+	// A plain address outside the space is not a CAS20 precompile.
+	if _, ok := resolveCAS20(common.HexToAddress("0x1234")); ok {
+		t.Error("non-CAS20 address should not resolve")
+	}
+}
+
+// TestCAS20VariantOf covers the factory view. It validates the variant byte,
+// unlike isCAS20: the return is an enum, so an unrecognized variant must revert
+// rather than hand back a value the caller's own decoder would reject.
+func TestCAS20VariantOf(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	call := func(to common.Address) ([]byte, error) {
+		ret, _, err := evm.Call(cas20Alice, CAS20FactoryAddress,
+			cas20Call(selVariantOf, addrKey(to)), NewGasBudget(1_000_000), uint256.NewInt(0))
+		return ret, err
+	}
+
+	for _, tc := range []struct {
+		name string
+		addr common.Address
+		want byte
+	}{
+		{"asset", cas20Addr(cas20VariantAsset, 1), cas20VariantAsset},
+		{"stablecoin", cas20Addr(cas20VariantStablecoin, 1), cas20VariantStablecoin},
+	} {
+		ret, err := call(tc.addr)
+		if err != nil {
+			t.Fatalf("%s: variantOf err %v", tc.name, err)
+		}
+		if !bytes.Equal(ret, wU8(tc.want).Bytes()) {
+			t.Errorf("%s: variantOf = %x, want %x", tc.name, ret, wU8(tc.want).Bytes())
+		}
+	}
+
+	// Existence is irrelevant: the answer is derived from the address alone, so
+	// an address no createCAS20 has produced still reports its variant.
+	if _, err := call(cas20Addr(cas20VariantAsset, 0xfe)); err != nil {
+		t.Errorf("variantOf on an uncreated address err = %v, want success", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		addr common.Address
+	}{
+		{"unrecognized variant", cas20Addr(0x7f, 1)},
+		{"outside the token space", common.HexToAddress("0x1234")},
+		{"the factory itself", CAS20FactoryAddress},
+		{"zero address", common.Address{}},
+	} {
+		ret, err := call(tc.addr)
+		if !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("%s: variantOf err = %v, want revert", tc.name, err)
+		}
+		if !bytes.Equal(ret, errSelInvalidVariant[:]) {
+			t.Errorf("%s: revert data = %x, want InvalidVariant()", tc.name, ret)
+		}
+	}
+}
+
+// TestCAS20DelegateCallGuard checks that every variant rejects non-direct calls
+// before touching any state, and reverts rather than halting: BEP-702 3.2 says
+// DELEGATECALL and CALLCODE MUST revert, so the caller keeps its gas and can
+// decode the reason. Returning the bare sentinel drained the whole budget and
+// returned nothing.
+func TestCAS20DelegateCallGuard(t *testing.T) {
+	want := revCAS20("DelegateCallNotAllowed()", errSelDelegateCallDenied)
+	wantData, _ := finishCAS20(nil, want)
+	if len(wantData) != 4 {
+		t.Fatalf("the expected payload is %d bytes, want a bare selector", len(wantData))
+	}
+	precompiles := []StatefulPrecompiledContract{cas20Factory, cas20Asset, cas20Stablecoin, cas20Policy, cas20Activation}
+	for _, p := range precompiles {
+		ret, err := p.RunStateful(&PrecompileContext{DirectCall: false}, nil)
+		if !errors.Is(err, ErrExecutionReverted) {
+			t.Errorf("%T: err = %v, want a revert", p, err)
+		}
+		if !bytes.Equal(ret, wantData) {
+			t.Errorf("%T: returndata = %x, want DelegateCallNotAllowed() = %x", p, ret, wantData)
+		}
+	}
+}
+
+// TestCAS20StatelessDispatchGuard checks the defensive backstop on the plain Run
+// path (should never be reached in practice, but must not silently no-op).
+func TestCAS20StatelessDispatchGuard(t *testing.T) {
+	var p PrecompiledContract = &cas20AssetPrecompile{}
+	if _, err := p.Run(nil); !errors.Is(err, ErrCAS20StatelessDispatch) {
+		t.Errorf("Run err = %v, want ErrCAS20StatelessDispatch", err)
+	}
+}
+
+// TestCAS20UninitializedAddressBehavior pins BEP-702 3.3's dispatch table for a
+// reserved address that holds no token. It is routed to the handler, not left
+// to the ordinary account path, so a value-bearing call is refused instead of
+// being accepted and stranded at an address with no way to withdraw from.
+func TestCAS20UninitializedAddressBehavior(t *testing.T) {
+	_, evm := newCAS20EVM(t)
+	caller := common.HexToAddress("0xca11e5")
+	// A well-formed Asset address nobody has created.
+	empty := cas20Addr(cas20VariantAsset, 0x77)
+
+	// Zero-value call: reaches the handler, which reverts with empty
+	// returndata because no token exists there.
+	ret, _, err := evm.Call(caller, empty, cas20Call(selTotalSupply), NewGasBudget(100_000), uint256.NewInt(0))
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("call to uninitialized token err = %v, want ErrExecutionReverted", err)
+	}
+	if len(ret) != 0 {
+		t.Fatalf("revert data = %x, want empty", ret)
+	}
+
+	// Value-bearing call: refused with NonPayable before anything else, so the
+	// value never lands.
+	ret, _, err = evm.Call(caller, empty, cas20Call(selTotalSupply), NewGasBudget(100_000), uint256.NewInt(5))
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("value-bearing call err = %v, want ErrExecutionReverted", err)
+	}
+	if !bytes.Equal(ret, errSelNonPayable[:]) {
+		t.Fatalf("revert data = %x, want NonPayable() = %x", ret, errSelNonPayable)
+	}
+
+	// An unrecognized variant is the other case: not routed at all, so the
+	// ordinary account path applies and the call succeeds trivially.
+	future := cas20Addr(0x02, 0x77)
+	ret, _, err = evm.Call(caller, future, cas20Call(selTotalSupply), NewGasBudget(100_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("call to a future-variant address err = %v, want success", err)
+	}
+	if len(ret) != 0 {
+		t.Fatalf("future-variant call returned %x, want empty", ret)
+	}
+}
+
+// TestCAS20GateIsBSCOnly pins that the CAS20 address space is routed only on BSC.
+func TestCAS20GateIsBSCOnly(t *testing.T) {
+	newEVM := func(cfg *params.ChainConfig) *EVM {
+		statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+		if err != nil {
+			t.Fatal(err)
+		}
+		bc := BlockContext{
+			Random:      &common.Hash{}, // post-merge rules, matching a live BSC chain
+			CanTransfer: func(StateDB, common.Address, *uint256.Int) bool { return true },
+			Transfer:    func(StateDB, common.Address, common.Address, *uint256.Int, *params.Rules) {},
+			BlockNumber: big.NewInt(1),
+			Time:        1,
+		}
+		return NewEVM(bc, statedb, cfg, Config{})
+	}
+
+	bsc := newEVM(cas20TestChainConfig())
+	if !bsc.chainRules.IsJenner || !bsc.chainRules.IsInBSC {
+		t.Fatal("the BSC harness must have both the CAS20 fork flag and IsInBSC")
+	}
+	if !bsc.cas20Enabled() {
+		t.Error("CAS20 must be enabled on a BSC chain past the fork")
+	}
+
+	// Same fork time, no Parlia. IsJenner is where the BSC gate now lives, so the
+	// flag itself must be false — that is the property, not just the routing.
+	nonBSCCfg := *cas20TestChainConfig()
+	nonBSCCfg.Parlia = nil
+	nonBSC := newEVM(&nonBSCCfg)
+	if nonBSC.chainRules.IsInBSC {
+		t.Fatal("a config without Parlia must not report IsInBSC")
+	}
+	if nonBSC.chainRules.IsJenner {
+		t.Error("IsJenner must embed the IsInBSC gate, so a non-BSC config with jennerTime " +
+			"set does not reach the fork at all")
+	}
+	if nonBSC.cas20Enabled() {
+		t.Error("CAS20 must not be enabled off BSC, even past the fork")
+	}
+	// And the reserved space must resolve to nothing there.
+	for _, addr := range []common.Address{
+		CAS20FactoryAddress, CAS20PolicyRegistryAddress, CAS20ActivationRegistryAddress,
+		cas20Addr(cas20VariantAsset, 1),
+	} {
+		if _, ok := nonBSC.precompile(addr); ok {
+			t.Errorf("%s resolved to a precompile off BSC", addr.Hex())
+		}
+	}
+}
+
+// TestCAS20UninitializedExitReportsOutOfGas covers the exit taken when a routed
+// address holds no token. That exit reverts with empty returndata, but the
+// existence check it just performed charged an account access — so when that
+// charge is what exhausted the budget, the call is out of gas and not a revert.
+// The two differ in what the enclosing frame is told and what a tracer records.
+func TestCAS20UninitializedExitReportsOutOfGas(t *testing.T) {
+	call := func(budget uint64) (*PrecompileContext, error) {
+		statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+		gas := NewGasBudget(budget)
+		ctx := &PrecompileContext{
+			StateDB: statedb, Self: cas20Addr(cas20VariantAsset, 9),
+			Caller: cas20Alice, DirectCall: true, gas: &gas,
+		}
+		_, err := cas20Asset.RunStateful(ctx, cas20Call(selBalanceOf, addrKey(cas20Alice)))
+		return ctx, err
+	}
+
+	// Enough for the calldata charge but not the cold account access: the
+	// existence check cannot be paid for.
+	ctx, err := call(params.ColdAccountAccessCostEIP2929 - 1)
+	if !ctx.OutOfGas() {
+		t.Fatal("expected the account access to exhaust this budget")
+	}
+	if !errors.Is(err, ErrOutOfGas) {
+		t.Errorf("err = %v, want ErrOutOfGas — an unaffordable charge is not a revert", err)
+	}
+
+	// With room to pay for it, the same exit is an ordinary empty revert.
+	ctx, err = call(1_000_000)
+	if ctx.OutOfGas() {
+		t.Fatal("did not expect exhaustion with a generous budget")
+	}
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Errorf("err = %v, want ErrExecutionReverted for an uninitialized token", err)
+	}
+}
+
+// TestCAS20RoutingFollowsTheFork pins the whole gate: the reserved space is routed
+// exactly when Jenner is active, and behaves as it did before CAS20 existed
+// otherwise. The gate used to have a second half — a usable activation admin in
+// configuration — which governance-held authority removed.
+func TestCAS20RoutingFollowsTheFork(t *testing.T) {
+	token := cas20Addr(cas20VariantAsset, 1)
+	for _, tc := range []struct {
+		name   string
+		jenner *uint64
+		want   bool
+	}{
+		{"Jenner active", new(uint64), true},
+		{"Jenner unscheduled", nil, false},
+	} {
+		cfg := *cas20TestChainConfig()
+		cfg.JennerTime = tc.jenner
+		evm := NewEVM(cas20BlockContext(1), nil, &cfg, Config{})
+
+		if got := evm.cas20Enabled(); got != tc.want {
+			t.Errorf("%s: cas20Enabled = %v, want %v", tc.name, got, tc.want)
+		}
+		for _, addr := range []common.Address{token, CAS20FactoryAddress,
+			CAS20PolicyRegistryAddress, CAS20ActivationRegistryAddress} {
+			_, ok := evm.precompile(addr)
+			if ok != tc.want {
+				t.Errorf("%s: %s resolves to a precompile = %v, want %v", tc.name, addr.Hex(), ok, tc.want)
+			}
+		}
+	}
+}

--- a/core/vm/cas20_test.go
+++ b/core/vm/cas20_test.go
@@ -44,7 +44,7 @@ func TestIsCAS20Address(t *testing.T) {
 		{"factory is outside token space", CAS20FactoryAddress, false},
 		{"wrong magic prefix", common.HexToAddress("0xb3000000000000000000ab0000000000000000ff"), false},
 		{"nonzero padding byte", common.HexToAddress("0xca520000000001000000000000000000000000ff"), false},
-		{"the reference implementation's prefix", common.HexToAddress("0xb2000000000000000000000000000000000000ff"), false},
+		{"a neighbouring prefix", common.HexToAddress("0xb2000000000000000000000000000000000000ff"), false},
 		{"zero address", common.Address{}, false},
 	}
 	for _, tc := range cases {

--- a/core/vm/cas20_test.go
+++ b/core/vm/cas20_test.go
@@ -14,10 +14,8 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// cas20TestChainConfig returns a chain config CAS20 is actually active under:
-// Pasteur scheduled, and Parlia set so IsInBSC holds. The BSC gate matters —
-// params.TestChainConfig alone has no Parlia, so a harness built on it would
-// exercise CAS20 on a chain where production never enables it.
+// params.TestChainConfig has no Parlia, so a harness built on it would exercise
+// CAS20 on a chain where production never enables it.
 func cas20TestChainConfig() *params.ChainConfig {
 	cfg := *params.TestChainConfig
 	zero := uint64(0)
@@ -26,8 +24,6 @@ func cas20TestChainConfig() *params.ChainConfig {
 	return &cfg
 }
 
-// cas20Addr builds a token address in the reserved space with the given variant
-// byte and a one-byte identity fingerprint.
 func cas20Addr(variant, id byte) common.Address {
 	var a common.Address
 	a[0], a[1] = cas20MarkerPrefix[0], cas20MarkerPrefix[1]
@@ -66,19 +62,16 @@ func TestResolveCAS20(t *testing.T) {
 	unknown := cas20Addr(0x02, 1)
 	uninit := cas20Addr(cas20VariantAsset, 2)
 
-	// Mark three tokens as initialized (factory writes a marker code).
 	for _, a := range []common.Address{asset, stable, unknown} {
 		statedb.SetCode(a, CAS20MarkerCode, tracing.CodeChangeContractCreation)
 	}
 
-	// Factory resolves regardless of state.
 	if p, ok := resolveCAS20(CAS20FactoryAddress); !ok {
 		t.Fatal("factory address should resolve")
 	} else if _, ok := p.(*cas20FactoryPrecompile); !ok {
 		t.Fatalf("factory resolved to %T, want *cas20FactoryPrecompile", p)
 	}
 
-	// Initialized Asset / Stablecoin route to the right variant.
 	if p, ok := resolveCAS20(asset); !ok {
 		t.Fatal("initialized asset token should resolve")
 	} else if _, ok := p.(*cas20AssetPrecompile); !ok {
@@ -90,27 +83,21 @@ func TestResolveCAS20(t *testing.T) {
 		t.Fatalf("stablecoin resolved to %T, want *cas20StablecoinPrecompile", p)
 	}
 
-	// Unknown variant byte is not routed even when initialized.
 	if _, ok := resolveCAS20(unknown); ok {
 		t.Error("unknown variant should not resolve")
 	}
-	// An uninitialized address with a recognized variant is still routed:
-	// existence is checked inside the handler, not by dispatch, so a
-	// value-bearing call to it is refused rather than stranded (BEP-702 3.3).
+	// Uninitialized but routed: existence is the handler's check, so a value-bearing
+	// call is refused rather than stranded (BEP-702 3.3).
 	if p, ok := resolveCAS20(uninit); !ok {
 		t.Error("uninitialized recognized-variant address should still route")
 	} else if _, ok := p.(*cas20AssetPrecompile); !ok {
 		t.Errorf("uninitialized asset address resolved to %T, want *cas20AssetPrecompile", p)
 	}
-	// A plain address outside the space is not a CAS20 precompile.
 	if _, ok := resolveCAS20(common.HexToAddress("0x1234")); ok {
 		t.Error("non-CAS20 address should not resolve")
 	}
 }
 
-// TestCAS20VariantOf covers the factory view. It validates the variant byte,
-// unlike isCAS20: the return is an enum, so an unrecognized variant must revert
-// rather than hand back a value the caller's own decoder would reject.
 func TestCAS20VariantOf(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	call := func(to common.Address) ([]byte, error) {
@@ -136,8 +123,7 @@ func TestCAS20VariantOf(t *testing.T) {
 		}
 	}
 
-	// Existence is irrelevant: the answer is derived from the address alone, so
-	// an address no createCAS20 has produced still reports its variant.
+	// Derived from the address alone, so an address never created still reports its variant.
 	if _, err := call(cas20Addr(cas20VariantAsset, 0xfe)); err != nil {
 		t.Errorf("variantOf on an uncreated address err = %v, want success", err)
 	}
@@ -161,11 +147,8 @@ func TestCAS20VariantOf(t *testing.T) {
 	}
 }
 
-// TestCAS20DelegateCallGuard checks that every variant rejects non-direct calls
-// before touching any state, and reverts rather than halting: BEP-702 3.2 says
-// DELEGATECALL and CALLCODE MUST revert, so the caller keeps its gas and can
-// decode the reason. Returning the bare sentinel drained the whole budget and
-// returned nothing.
+// BEP-702 3.2: DELEGATECALL and CALLCODE revert rather than halt, so the caller
+// keeps its gas and can decode the reason.
 func TestCAS20DelegateCallGuard(t *testing.T) {
 	want := revCAS20("DelegateCallNotAllowed()", errSelDelegateCallDenied)
 	wantData, _ := finishCAS20(nil, want)
@@ -184,8 +167,7 @@ func TestCAS20DelegateCallGuard(t *testing.T) {
 	}
 }
 
-// TestCAS20StatelessDispatchGuard checks the defensive backstop on the plain Run
-// path (should never be reached in practice, but must not silently no-op).
+// The plain Run path is never reached in practice, but must not silently no-op.
 func TestCAS20StatelessDispatchGuard(t *testing.T) {
 	var p PrecompiledContract = &cas20AssetPrecompile{}
 	if _, err := p.Run(nil); !errors.Is(err, ErrCAS20StatelessDispatch) {
@@ -193,18 +175,13 @@ func TestCAS20StatelessDispatchGuard(t *testing.T) {
 	}
 }
 
-// TestCAS20UninitializedAddressBehavior pins BEP-702 3.3's dispatch table for a
-// reserved address that holds no token. It is routed to the handler, not left
-// to the ordinary account path, so a value-bearing call is refused instead of
-// being accepted and stranded at an address with no way to withdraw from.
+// BEP-702 3.3: a reserved address holding no token is routed, so value sent to it
+// is refused rather than stranded.
 func TestCAS20UninitializedAddressBehavior(t *testing.T) {
 	_, evm := newCAS20EVM(t)
 	caller := common.HexToAddress("0xca11e5")
-	// A well-formed Asset address nobody has created.
 	empty := cas20Addr(cas20VariantAsset, 0x77)
 
-	// Zero-value call: reaches the handler, which reverts with empty
-	// returndata because no token exists there.
 	ret, _, err := evm.Call(caller, empty, cas20Call(selTotalSupply), NewGasBudget(100_000), uint256.NewInt(0))
 	if !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("call to uninitialized token err = %v, want ErrExecutionReverted", err)
@@ -213,8 +190,6 @@ func TestCAS20UninitializedAddressBehavior(t *testing.T) {
 		t.Fatalf("revert data = %x, want empty", ret)
 	}
 
-	// Value-bearing call: refused with NonPayable before anything else, so the
-	// value never lands.
 	ret, _, err = evm.Call(caller, empty, cas20Call(selTotalSupply), NewGasBudget(100_000), uint256.NewInt(5))
 	if !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("value-bearing call err = %v, want ErrExecutionReverted", err)
@@ -223,8 +198,7 @@ func TestCAS20UninitializedAddressBehavior(t *testing.T) {
 		t.Fatalf("revert data = %x, want NonPayable() = %x", ret, errSelNonPayable)
 	}
 
-	// An unrecognized variant is the other case: not routed at all, so the
-	// ordinary account path applies and the call succeeds trivially.
+	// An unrecognized variant is not routed, so the ordinary account path applies.
 	future := cas20Addr(0x02, 0x77)
 	ret, _, err = evm.Call(caller, future, cas20Call(selTotalSupply), NewGasBudget(100_000), uint256.NewInt(0))
 	if err != nil {
@@ -235,7 +209,6 @@ func TestCAS20UninitializedAddressBehavior(t *testing.T) {
 	}
 }
 
-// TestCAS20GateIsBSCOnly pins that the CAS20 address space is routed only on BSC.
 func TestCAS20GateIsBSCOnly(t *testing.T) {
 	newEVM := func(cfg *params.ChainConfig) *EVM {
 		statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
@@ -260,8 +233,7 @@ func TestCAS20GateIsBSCOnly(t *testing.T) {
 		t.Error("CAS20 must be enabled on a BSC chain past the fork")
 	}
 
-	// Same fork time, no Parlia. IsJenner is where the BSC gate now lives, so the
-	// flag itself must be false — that is the property, not just the routing.
+	// Same fork time, no Parlia: the flag itself must be false, not just the routing.
 	nonBSCCfg := *cas20TestChainConfig()
 	nonBSCCfg.Parlia = nil
 	nonBSC := newEVM(&nonBSCCfg)
@@ -275,7 +247,6 @@ func TestCAS20GateIsBSCOnly(t *testing.T) {
 	if nonBSC.cas20Enabled() {
 		t.Error("CAS20 must not be enabled off BSC, even past the fork")
 	}
-	// And the reserved space must resolve to nothing there.
 	for _, addr := range []common.Address{
 		CAS20FactoryAddress, CAS20PolicyRegistryAddress, CAS20ActivationRegistryAddress,
 		cas20Addr(cas20VariantAsset, 1),
@@ -286,11 +257,8 @@ func TestCAS20GateIsBSCOnly(t *testing.T) {
 	}
 }
 
-// TestCAS20UninitializedExitReportsOutOfGas covers the exit taken when a routed
-// address holds no token. That exit reverts with empty returndata, but the
-// existence check it just performed charged an account access — so when that
-// charge is what exhausted the budget, the call is out of gas and not a revert.
-// The two differ in what the enclosing frame is told and what a tracer records.
+// The existence check charges an account access; when that charge is what
+// exhausted the budget, the exit is out of gas, not a revert.
 func TestCAS20UninitializedExitReportsOutOfGas(t *testing.T) {
 	call := func(budget uint64) (*PrecompileContext, error) {
 		statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
@@ -303,8 +271,7 @@ func TestCAS20UninitializedExitReportsOutOfGas(t *testing.T) {
 		return ctx, err
 	}
 
-	// Enough for the calldata charge but not the cold account access: the
-	// existence check cannot be paid for.
+	// Enough for the calldata charge but not the cold account access.
 	ctx, err := call(params.ColdAccountAccessCostEIP2929 - 1)
 	if !ctx.OutOfGas() {
 		t.Fatal("expected the account access to exhaust this budget")
@@ -313,7 +280,6 @@ func TestCAS20UninitializedExitReportsOutOfGas(t *testing.T) {
 		t.Errorf("err = %v, want ErrOutOfGas — an unaffordable charge is not a revert", err)
 	}
 
-	// With room to pay for it, the same exit is an ordinary empty revert.
 	ctx, err = call(1_000_000)
 	if ctx.OutOfGas() {
 		t.Fatal("did not expect exhaustion with a generous budget")
@@ -323,10 +289,8 @@ func TestCAS20UninitializedExitReportsOutOfGas(t *testing.T) {
 	}
 }
 
-// TestCAS20RoutingFollowsTheFork pins the whole gate: the reserved space is routed
-// exactly when Jenner is active, and behaves as it did before CAS20 existed
-// otherwise. The gate used to have a second half — a usable activation admin in
-// configuration — which governance-held authority removed.
+// The reserved space is routed exactly when Jenner is active, and behaves as it
+// did before CAS20 existed otherwise.
 func TestCAS20RoutingFollowsTheFork(t *testing.T) {
 	token := cas20Addr(cas20VariantAsset, 1)
 	for _, tc := range []struct {

--- a/core/vm/cas20_token.go
+++ b/core/vm/cas20_token.go
@@ -1,0 +1,473 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+)
+
+type cas20Token struct {
+	ctx      *PrecompileContext
+	s        cas20Storage
+	decimals uint8
+
+	// privileged is set on the factory's bootstrap path, where role and
+	// transfer-side policy gates are skipped (anti-revival and MINT_RECEIVER
+	// checks are still enforced). Always false for ordinary calls.
+	privileged bool
+
+	// inAnnounce marks the Asset disclosure window. announce sets it on the
+	// token value it threads into the bundle's internal calls, so a nested
+	// announce sees it and reverts; the enclosing frame's own value is a copy
+	// and needs no reset.
+	inAnnounce bool
+}
+
+func newCAS20Token(ctx *PrecompileContext, decimals uint8) cas20Token {
+	return cas20Token{ctx: ctx, s: newMeteredCAS20Storage(ctx), decimals: decimals}
+}
+
+// newCAS20TokenBootstrap returns a token in the factory's privileged bootstrap
+// mode, where role and transfer-side policy gates are skipped.
+func newCAS20TokenBootstrap(ctx *PrecompileContext, decimals uint8) cas20Token {
+	t := newCAS20Token(ctx, decimals)
+	t.privileged = true
+	return t
+}
+
+// pause feature bits in the paused bitmask (slot 11).
+const (
+	cas20PauseTransfer = 0
+	cas20PauseMint     = 1
+	cas20PauseBurn     = 2
+	cas20PauseSeize    = 3
+)
+
+func selector(sig string) (s [4]byte) {
+	copy(s[:], crypto.Keccak256([]byte(sig)))
+	return s
+}
+
+var (
+	selName         = selector("name()")
+	selSymbol       = selector("symbol()")
+	selDecimals     = selector("decimals()")
+	selTotalSupply  = selector("totalSupply()")
+	selBalanceOf    = selector("balanceOf(address)")
+	selAllowance    = selector("allowance(address,address)")
+	selApprove      = selector("approve(address,uint256)")
+	selTransfer     = selector("transfer(address,uint256)")
+	selTransferFrom = selector("transferFrom(address,address,uint256)")
+
+	cas20TopicTransfer = eventTopic("Transfer(address,address,uint256)")
+	cas20TopicApproval = eventTopic("Approval(address,address,uint256)")
+
+	maxU256 = new(uint256.Int).Not(new(uint256.Int))
+)
+
+// dispatch routes a call by selector. It returns the ABI-encoded result on
+// success. Business-rule failures and unknown selectors revert
+// (ErrExecutionReverted); a write reached in a read-only frame throws
+// (ErrWriteProtection), matching SSTORE-in-STATICCALL semantics.
+func (t cas20Token) dispatch(input []byte) ([]byte, error) {
+	if len(input) < 4 {
+		return nil, ErrExecutionReverted
+	}
+	var sel [4]byte
+	copy(sel[:], input[:4])
+	args := input[4:]
+
+	switch sel {
+	case selName:
+		v, ok := t.s.name()
+		if !ok {
+			return nil, ErrOutOfGas
+		}
+		return encString(v), nil
+	case selSymbol:
+		v, ok := t.s.symbol()
+		if !ok {
+			return nil, ErrOutOfGas
+		}
+		return encString(v), nil
+	case selDecimals:
+		return encU256(uint256.NewInt(uint64(t.decimals))), nil
+	case selTotalSupply:
+		return encU256(t.s.totalSupply()), nil
+	case selBalanceOf:
+		a, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		return encU256(t.s.balanceOf(a)), nil
+	case selAllowance:
+		owner, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		spender, err := readAddress(args, 1)
+		if err != nil {
+			return nil, err
+		}
+		return encU256(t.s.allowance(owner, spender)), nil
+	case selApprove:
+		spender, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		amount, err := readU256(args, 1)
+		if err != nil {
+			return nil, err
+		}
+		return t.approve(t.ctx.Caller, spender, amount)
+	case selTransfer:
+		to, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		amount, err := readU256(args, 1)
+		if err != nil {
+			return nil, err
+		}
+		return t.transfer(t.ctx.Caller, to, amount)
+	case selTransferFrom:
+		from, err := readAddress(args, 0)
+		if err != nil {
+			return nil, err
+		}
+		to, err := readAddress(args, 1)
+		if err != nil {
+			return nil, err
+		}
+		amount, err := readU256(args, 2)
+		if err != nil {
+			return nil, err
+		}
+		return t.transferFrom(t.ctx.Caller, from, to, amount)
+	}
+	// RBAC / pause / mint-burn / configurable selectors.
+	if ret, err, ok := t.dispatchAdmin(sel, args); ok {
+		return ret, err
+	}
+	// Mutable metadata and the configuration views.
+	if ret, err, ok := t.dispatchMetadata(sel, args); ok {
+		return ret, err
+	}
+	// permit (EIP-2612) and the *WithMemo family.
+	if ret, err, ok := t.dispatchPermitMemo(sel, args); ok {
+		return ret, err
+	}
+	return nil, ErrExecutionReverted
+}
+
+// --- ERC-20 core ------------------------------------------------------------
+
+func (t cas20Token) approve(owner, spender common.Address, amount *uint256.Int) ([]byte, error) {
+	if t.ctx.ReadOnly {
+		return nil, ErrWriteProtection
+	}
+	// The approver is checked first. owner is msg.sender, so a zero one only
+	// arises from a frame with no caller, but the check is declared and costs a
+	// comparison.
+	if owner == (common.Address{}) {
+		return nil, revCAS20("InvalidApprover(address)", errSelInvalidApprover, addrKey(owner))
+	}
+	if spender == (common.Address{}) {
+		return nil, revCAS20("InvalidSpender(address)", errSelInvalidSpender, addrKey(spender))
+	}
+	// Not gated by pause or policy, and that follows from the published lists
+	// rather than from intent: PausableFeature is { TRANSFER, MINT, BURN, SEIZE }
+	// (BEP-702 3.9) and the six policy scopes cover transfer sender/receiver/
+	// executor, mint receiver and seize holder/receiver (3.8). Neither names
+	// approve, so there is nothing to consult. A paused token still accepts
+	// approvals; the transfer they authorize is what the pause stops.
+	t.s.setAllowance(owner, spender, amount)
+	if !t.emit(cas20TopicApproval, owner, spender, amount) {
+		return nil, ErrOutOfGas
+	}
+	return encBool(true), nil
+}
+
+func (t cas20Token) transfer(from, to common.Address, amount *uint256.Int) ([]byte, error) {
+	if t.ctx.ReadOnly {
+		return nil, ErrWriteProtection
+	}
+	if t.isPaused(cas20PauseTransfer) {
+		return nil, revCAS20("ContractPaused(uint8)", errSelContractPaused, wU8(cas20PauseTransfer))
+	}
+	if err := t.move(from, to, amount); err != nil {
+		return nil, err
+	}
+	if !t.emit(cas20TopicTransfer, from, to, amount) {
+		return nil, ErrOutOfGas
+	}
+	return encBool(true), nil
+}
+
+func (t cas20Token) transferFrom(spender, from, to common.Address, amount *uint256.Int) ([]byte, error) {
+	if t.ctx.ReadOnly {
+		return nil, ErrWriteProtection
+	}
+	if t.isPaused(cas20PauseTransfer) {
+		return nil, revCAS20("ContractPaused(uint8)", errSelContractPaused, wU8(cas20PauseTransfer))
+	}
+	// The two malformed-argument checks come before the allowance and the
+	// executor policy: a transfer to the zero address is reported as such whatever
+	// the caller's allowance is. move() repeats them for
+	// the direct transfer path; they are comparisons on already-decoded arguments,
+	// so the duplicate costs nothing.
+	if to == (common.Address{}) {
+		return nil, revCAS20("InvalidReceiver(address)", errSelInvalidReceiver, addrKey(to))
+	}
+	if from == (common.Address{}) {
+		return nil, revCAS20("InvalidSender(address)", errSelInvalidSender, addrKey(from))
+	}
+	// The allowance is spent unconditionally — the owner spending their own
+	// balance through transferFrom needs a self-approval, and the factory
+	// bootstrap window carves no exception either. U256::MAX stays infinite.
+	//
+	// Only the executor policy takes the self shortcut, and the privileged one:
+	// the sender policy already covers `from` inside move().
+	slot := t.s.allowanceSlot(from, spender)
+	allowed := t.s.getU256At(slot)
+	infinite := allowed.Eq(maxU256)
+	if !infinite && allowed.Lt(amount) {
+		return nil, revCAS20("InsufficientAllowance(address,uint256,uint256)", errSelInsufficientAllow,
+			addrKey(spender), wU256(allowed), wU256(amount))
+	}
+	// Consulted after the allowance: an unauthorized executor with too little
+	// allowance is told about the allowance.
+	if !t.privileged && spender != from {
+		if _, _, executor := t.s.transferPolicies(); !t.policyAllows(executor, spender) {
+			return nil, revCAS20("PolicyForbids(bytes32,uint64)", errSelPolicyForbids,
+				scopeTransferExecutor, wU64(executor))
+		}
+	}
+	if !infinite {
+		t.s.setU256At(slot, new(uint256.Int).Sub(allowed, amount))
+	}
+	if err := t.move(from, to, amount); err != nil {
+		return nil, err
+	}
+	if !t.emit(cas20TopicTransfer, from, to, amount) {
+		return nil, ErrOutOfGas
+	}
+	return encBool(true), nil
+}
+
+func (t cas20Token) policyAllows(id uint64, account common.Address) bool {
+	if id == 0 {
+		return true
+	}
+	return newPolicyReg(t.ctx).isAuthorized(id, account)
+}
+
+// move debits from and credits to, reverting on insufficient balance.
+func (t cas20Token) move(from, to common.Address, amount *uint256.Int) error {
+	if to == (common.Address{}) {
+		return revCAS20("InvalidReceiver(address)", errSelInvalidReceiver, addrKey(to))
+	}
+	if from == (common.Address{}) {
+		return revCAS20("InvalidSender(address)", errSelInvalidSender, addrKey(from))
+	}
+	// TRANSFER_SENDER / TRANSFER_RECEIVER compliance (skipped when privileged).
+	// Both ids share one slot, and the revert payload reuses the id already read
+	// rather than reading it again.
+	if !t.privileged {
+		sender, receiver, _ := t.s.transferPolicies()
+		if !t.policyAllows(sender, from) {
+			return revCAS20("PolicyForbids(bytes32,uint64)", errSelPolicyForbids,
+				scopeTransferSender, wU64(sender))
+		}
+		if !t.policyAllows(receiver, to) {
+			return revCAS20("PolicyForbids(bytes32,uint64)", errSelPolicyForbids,
+				scopeTransferReceiver, wU64(receiver))
+		}
+	}
+	// Each balance slot is derived once and reused for its read and its write, and
+	// both writes happen unconditionally — including when from == to or amount is
+	// zero. Bytecode performs them anyway, and skipping them would price a native
+	// token below the contract it replaces (BEP-702 3.14).
+	fromSlot := t.s.balanceSlot(from)
+	bal := t.s.getU256At(fromSlot)
+	if bal.Lt(amount) {
+		return revCAS20("InsufficientBalance(address,uint256,uint256)", errSelInsufficientBalance,
+			addrKey(from), wU256(bal), wU256(amount))
+	}
+	t.s.setU256At(fromSlot, new(uint256.Int).Sub(bal, amount))
+	toSlot := t.s.balanceSlot(to)
+	t.s.setU256At(toSlot, new(uint256.Int).Add(t.s.getU256At(toSlot), amount))
+	return nil
+}
+
+func (t cas20Token) isPaused(bit uint) bool {
+	return new(uint256.Int).Rsh(t.s.paused(), bit).Uint64()&1 == 1
+}
+
+func (t cas20Token) emit(topic0 common.Hash, a, b common.Address, value *uint256.Int) bool {
+	v := value.Bytes32()
+	return t.ctx.AddLog([]common.Hash{topic0, addrKey(a), addrKey(b)}, v[:])
+}
+
+// --- ABI helpers ------------------------------------------------------------
+
+func readWord(args []byte, i int) (common.Hash, error) {
+	off := i * 32
+	if len(args) < off+32 {
+		return common.Hash{}, ErrExecutionReverted
+	}
+	return common.BytesToHash(args[off : off+32]), nil
+}
+
+func readAddress(args []byte, i int) (common.Address, error) {
+	w, err := readWord(args, i)
+	if err != nil {
+		return common.Address{}, err
+	}
+	a, ok := addressFromWord(w)
+	if !ok {
+		return common.Address{}, ErrExecutionReverted
+	}
+	return a, nil
+}
+
+// addressFromWord is the strict ABI reading of an address word: the twelve high
+// bytes must be zero. Truncating them instead would accept encodings another
+// client rejects, and address[] elements need the same rule as scalar arguments.
+// u64FromWord decodes a uint64 argument, refusing anything above the low eight
+// bytes — Solidity's external decoder rejects a dirty word rather than
+// truncating it.
+// wordFitsIn reports whether only the low n bytes of w are set, the check
+// Solidity's external decoder makes for every type narrower than a word.
+func wordFitsIn(w common.Hash, n int) bool {
+	for _, b := range w[:32-n] {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func u64FromWord(w common.Hash) (uint64, bool) {
+	if !wordFitsIn(w, 8) {
+		return 0, false
+	}
+	return new(uint256.Int).SetBytes(w.Bytes()).Uint64(), true
+}
+
+func addressFromWord(w common.Hash) (common.Address, bool) {
+	if !wordFitsIn(w, 20) {
+		return common.Address{}, false
+	}
+	return common.BytesToAddress(w.Bytes()), true
+}
+
+// readU64 strictly decodes a uint64 argument (upper 24 bytes must be zero).
+func readU64(args []byte, i int) (uint64, error) {
+	w, err := readWord(args, i)
+	if err != nil {
+		return 0, err
+	}
+	for _, b := range w[:24] {
+		if b != 0 {
+			return 0, ErrExecutionReverted
+		}
+	}
+	return new(uint256.Int).SetBytes(w[24:]).Uint64(), nil
+}
+
+func readU256(args []byte, i int) (*uint256.Int, error) {
+	w, err := readWord(args, i)
+	if err != nil {
+		return nil, err
+	}
+	return new(uint256.Int).SetBytes(w.Bytes()), nil
+}
+
+func encU256(v *uint256.Int) []byte {
+	b := v.Bytes32()
+	return b[:]
+}
+
+func encBool(b bool) []byte {
+	out := make([]byte, 32)
+	if b {
+		out[31] = 1
+	}
+	return out
+}
+
+// encString ABI-encodes a string as a complete return value: one dynamic member
+// in a tuple, so a head offset followed by the length-prefixed data.
+func encString(s string) []byte { return encodeTuple(abiString(s)) }
+
+// --- ABI encoding primitives ------------------------------------------------
+
+// abiPart is one encoded tuple member: a static head word, or a dynamic value
+// whose head is an offset and whose tail carries length-prefixed data.
+type abiPart struct {
+	word    common.Hash
+	dynamic bool
+	tail    []byte
+}
+
+func abiWord(w common.Hash) abiPart { return abiPart{word: w} }
+
+// abiBytes encodes a dynamic byte string: length word then right-padded data.
+func abiBytes(b []byte) abiPart {
+	padded := (len(b) + 31) / 32 * 32
+	tail := make([]byte, 32+padded)
+	l := uint256.NewInt(uint64(len(b))).Bytes32()
+	copy(tail[:32], l[:])
+	copy(tail[32:], b)
+	return abiPart{dynamic: true, tail: tail}
+}
+
+func abiString(s string) abiPart { return abiBytes([]byte(s)) }
+
+// abiWordArray encodes a dynamic array whose members are static words
+// (uint8[], uint256[], address[]): a length word followed by the members.
+func abiWordArray(words []common.Hash) abiPart {
+	tail := make([]byte, 0, 32*(len(words)+1))
+	l := uint256.NewInt(uint64(len(words))).Bytes32()
+	tail = append(tail, l[:]...)
+	for _, w := range words {
+		tail = append(tail, w[:]...)
+	}
+	return abiPart{dynamic: true, tail: tail}
+}
+
+// encodeTuple lays out parts as ABI head/tail: static members inline, dynamic
+// members as an offset into the tail section.
+func encodeTuple(parts ...abiPart) []byte {
+	head := make([]byte, 0, 32*len(parts))
+	tail := make([]byte, 0)
+	tailStart := uint64(32 * len(parts))
+	for _, p := range parts {
+		if !p.dynamic {
+			head = append(head, p.word[:]...)
+			continue
+		}
+		off := uint256.NewInt(tailStart + uint64(len(tail))).Bytes32()
+		head = append(head, off[:]...)
+		tail = append(tail, p.tail...)
+	}
+	return append(head, tail...)
+}
+
+// abiEncodeStruct produces abi.encode(s) for one dynamic struct. Encoding a
+// single value wraps it in a one-element tuple, so the result opens with an
+// offset word (0x20) and only then carries the struct's own head/tail. Getting
+// this wrapper wrong is invisible to a test that encodes and decodes with the
+// same helper, so it is spelled out here once and used everywhere.
+func abiEncodeStruct(members ...abiPart) []byte {
+	return encodeTuple(abiPart{dynamic: true, tail: encodeTuple(members...)})
+}
+
+func readBytesArg(args []byte, argIndex int) ([]byte, error) {
+	s, err := readStringArg(args, argIndex)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(s), nil
+}

--- a/core/vm/cas20_token.go
+++ b/core/vm/cas20_token.go
@@ -11,15 +11,12 @@ type cas20Token struct {
 	s        cas20Storage
 	decimals uint8
 
-	// privileged is set on the factory's bootstrap path, where role and
-	// transfer-side policy gates are skipped (anti-revival and MINT_RECEIVER
-	// checks are still enforced). Always false for ordinary calls.
+	// privileged marks the factory's bootstrap frame: role and transfer-side
+	// policy gates are skipped there, MINT_RECEIVER and the renounce freeze are not.
 	privileged bool
 
-	// inAnnounce marks the Asset disclosure window. announce sets it on the
-	// token value it threads into the bundle's internal calls, so a nested
-	// announce sees it and reverts; the enclosing frame's own value is a copy
-	// and needs no reset.
+	// inAnnounce travels by value into announce's internal calls, so a nested
+	// announce sees it and reverts.
 	inAnnounce bool
 }
 
@@ -27,8 +24,6 @@ func newCAS20Token(ctx *PrecompileContext, decimals uint8) cas20Token {
 	return cas20Token{ctx: ctx, s: newMeteredCAS20Storage(ctx), decimals: decimals}
 }
 
-// newCAS20TokenBootstrap returns a token in the factory's privileged bootstrap
-// mode, where role and transfer-side policy gates are skipped.
 func newCAS20TokenBootstrap(ctx *PrecompileContext, decimals uint8) cas20Token {
 	t := newCAS20Token(ctx, decimals)
 	t.privileged = true
@@ -65,10 +60,6 @@ var (
 	maxU256 = new(uint256.Int).Not(new(uint256.Int))
 )
 
-// dispatch routes a call by selector. It returns the ABI-encoded result on
-// success. Business-rule failures and unknown selectors revert
-// (ErrExecutionReverted); a write reached in a read-only frame throws
-// (ErrWriteProtection), matching SSTORE-in-STATICCALL semantics.
 func (t cas20Token) dispatch(input []byte) ([]byte, error) {
 	if len(input) < 4 {
 		return nil, ErrExecutionReverted
@@ -145,15 +136,12 @@ func (t cas20Token) dispatch(input []byte) ([]byte, error) {
 		}
 		return t.transferFrom(t.ctx.Caller, from, to, amount)
 	}
-	// RBAC / pause / mint-burn / configurable selectors.
 	if ret, err, ok := t.dispatchAdmin(sel, args); ok {
 		return ret, err
 	}
-	// Mutable metadata and the configuration views.
 	if ret, err, ok := t.dispatchMetadata(sel, args); ok {
 		return ret, err
 	}
-	// permit (EIP-2612) and the *WithMemo family.
 	if ret, err, ok := t.dispatchPermitMemo(sel, args); ok {
 		return ret, err
 	}
@@ -166,21 +154,14 @@ func (t cas20Token) approve(owner, spender common.Address, amount *uint256.Int) 
 	if t.ctx.ReadOnly {
 		return nil, ErrWriteProtection
 	}
-	// The approver is checked first. owner is msg.sender, so a zero one only
-	// arises from a frame with no caller, but the check is declared and costs a
-	// comparison.
+	// owner is msg.sender, so this only trips in a frame with no caller; the check is declared anyway.
 	if owner == (common.Address{}) {
 		return nil, revCAS20("InvalidApprover(address)", errSelInvalidApprover, addrKey(owner))
 	}
 	if spender == (common.Address{}) {
 		return nil, revCAS20("InvalidSpender(address)", errSelInvalidSpender, addrKey(spender))
 	}
-	// Not gated by pause or policy, and that follows from the published lists
-	// rather than from intent: PausableFeature is { TRANSFER, MINT, BURN, SEIZE }
-	// (BEP-702 3.9) and the six policy scopes cover transfer sender/receiver/
-	// executor, mint receiver and seize holder/receiver (3.8). Neither names
-	// approve, so there is nothing to consult. A paused token still accepts
-	// approvals; the transfer they authorize is what the pause stops.
+	// Neither the pause features (BEP-702 3.9) nor the policy scopes (3.8) name approve.
 	t.s.setAllowance(owner, spender, amount)
 	if !t.emit(cas20TopicApproval, owner, spender, amount) {
 		return nil, ErrOutOfGas
@@ -211,23 +192,14 @@ func (t cas20Token) transferFrom(spender, from, to common.Address, amount *uint2
 	if t.isPaused(cas20PauseTransfer) {
 		return nil, revCAS20("ContractPaused(uint8)", errSelContractPaused, wU8(cas20PauseTransfer))
 	}
-	// The two malformed-argument checks come before the allowance and the
-	// executor policy: a transfer to the zero address is reported as such whatever
-	// the caller's allowance is. move() repeats them for
-	// the direct transfer path; they are comparisons on already-decoded arguments,
-	// so the duplicate costs nothing.
+	// Zero-address checks before the allowance: a bad receiver is reported as such
+	// whatever the allowance is. move repeats them for the direct path.
 	if to == (common.Address{}) {
 		return nil, revCAS20("InvalidReceiver(address)", errSelInvalidReceiver, addrKey(to))
 	}
 	if from == (common.Address{}) {
 		return nil, revCAS20("InvalidSender(address)", errSelInvalidSender, addrKey(from))
 	}
-	// The allowance is spent unconditionally — the owner spending their own
-	// balance through transferFrom needs a self-approval, and the factory
-	// bootstrap window carves no exception either. U256::MAX stays infinite.
-	//
-	// Only the executor policy takes the self shortcut, and the privileged one:
-	// the sender policy already covers `from` inside move().
 	slot := t.s.allowanceSlot(from, spender)
 	allowed := t.s.getU256At(slot)
 	infinite := allowed.Eq(maxU256)
@@ -235,8 +207,7 @@ func (t cas20Token) transferFrom(spender, from, to common.Address, amount *uint2
 		return nil, revCAS20("InsufficientAllowance(address,uint256,uint256)", errSelInsufficientAllow,
 			addrKey(spender), wU256(allowed), wU256(amount))
 	}
-	// Consulted after the allowance: an unauthorized executor with too little
-	// allowance is told about the allowance.
+	// After the allowance: an unauthorized executor with too little allowance is told about the allowance.
 	if !t.privileged && spender != from {
 		if _, _, executor := t.s.transferPolicies(); !t.policyAllows(executor, spender) {
 			return nil, revCAS20("PolicyForbids(bytes32,uint64)", errSelPolicyForbids,
@@ -262,7 +233,6 @@ func (t cas20Token) policyAllows(id uint64, account common.Address) bool {
 	return newPolicyReg(t.ctx).isAuthorized(id, account)
 }
 
-// move debits from and credits to, reverting on insufficient balance.
 func (t cas20Token) move(from, to common.Address, amount *uint256.Int) error {
 	if to == (common.Address{}) {
 		return revCAS20("InvalidReceiver(address)", errSelInvalidReceiver, addrKey(to))
@@ -270,9 +240,6 @@ func (t cas20Token) move(from, to common.Address, amount *uint256.Int) error {
 	if from == (common.Address{}) {
 		return revCAS20("InvalidSender(address)", errSelInvalidSender, addrKey(from))
 	}
-	// TRANSFER_SENDER / TRANSFER_RECEIVER compliance (skipped when privileged).
-	// Both ids share one slot, and the revert payload reuses the id already read
-	// rather than reading it again.
 	if !t.privileged {
 		sender, receiver, _ := t.s.transferPolicies()
 		if !t.policyAllows(sender, from) {
@@ -284,10 +251,8 @@ func (t cas20Token) move(from, to common.Address, amount *uint256.Int) error {
 				scopeTransferReceiver, wU64(receiver))
 		}
 	}
-	// Each balance slot is derived once and reused for its read and its write, and
-	// both writes happen unconditionally — including when from == to or amount is
-	// zero. Bytecode performs them anyway, and skipping them would price a native
-	// token below the contract it replaces (BEP-702 3.14).
+	// Both writes happen even when from == to or amount is zero: bytecode would
+	// perform them, and skipping them would underprice the native token (BEP-702 3.14).
 	fromSlot := t.s.balanceSlot(from)
 	bal := t.s.getU256At(fromSlot)
 	if bal.Lt(amount) {
@@ -331,14 +296,8 @@ func readAddress(args []byte, i int) (common.Address, error) {
 	return a, nil
 }
 
-// addressFromWord is the strict ABI reading of an address word: the twelve high
-// bytes must be zero. Truncating them instead would accept encodings another
-// client rejects, and address[] elements need the same rule as scalar arguments.
-// u64FromWord decodes a uint64 argument, refusing anything above the low eight
-// bytes — Solidity's external decoder rejects a dirty word rather than
-// truncating it.
-// wordFitsIn reports whether only the low n bytes of w are set, the check
-// Solidity's external decoder makes for every type narrower than a word.
+// wordFitsIn is the check Solidity's external decoder makes for every type
+// narrower than a word: dirty high bytes are a malformed encoding, not a value.
 func wordFitsIn(w common.Hash, n int) bool {
 	for _, b := range w[:32-n] {
 		if b != 0 {
@@ -362,18 +321,16 @@ func addressFromWord(w common.Hash) (common.Address, bool) {
 	return common.BytesToAddress(w.Bytes()), true
 }
 
-// readU64 strictly decodes a uint64 argument (upper 24 bytes must be zero).
 func readU64(args []byte, i int) (uint64, error) {
 	w, err := readWord(args, i)
 	if err != nil {
 		return 0, err
 	}
-	for _, b := range w[:24] {
-		if b != 0 {
-			return 0, ErrExecutionReverted
-		}
+	v, ok := u64FromWord(w)
+	if !ok {
+		return 0, ErrExecutionReverted
 	}
-	return new(uint256.Int).SetBytes(w[24:]).Uint64(), nil
+	return v, nil
 }
 
 func readU256(args []byte, i int) (*uint256.Int, error) {
@@ -397,14 +354,10 @@ func encBool(b bool) []byte {
 	return out
 }
 
-// encString ABI-encodes a string as a complete return value: one dynamic member
-// in a tuple, so a head offset followed by the length-prefixed data.
 func encString(s string) []byte { return encodeTuple(abiString(s)) }
 
 // --- ABI encoding primitives ------------------------------------------------
 
-// abiPart is one encoded tuple member: a static head word, or a dynamic value
-// whose head is an offset and whose tail carries length-prefixed data.
 type abiPart struct {
 	word    common.Hash
 	dynamic bool
@@ -413,7 +366,6 @@ type abiPart struct {
 
 func abiWord(w common.Hash) abiPart { return abiPart{word: w} }
 
-// abiBytes encodes a dynamic byte string: length word then right-padded data.
 func abiBytes(b []byte) abiPart {
 	padded := (len(b) + 31) / 32 * 32
 	tail := make([]byte, 32+padded)
@@ -425,8 +377,6 @@ func abiBytes(b []byte) abiPart {
 
 func abiString(s string) abiPart { return abiBytes([]byte(s)) }
 
-// abiWordArray encodes a dynamic array whose members are static words
-// (uint8[], uint256[], address[]): a length word followed by the members.
 func abiWordArray(words []common.Hash) abiPart {
 	tail := make([]byte, 0, 32*(len(words)+1))
 	l := uint256.NewInt(uint64(len(words))).Bytes32()
@@ -437,8 +387,6 @@ func abiWordArray(words []common.Hash) abiPart {
 	return abiPart{dynamic: true, tail: tail}
 }
 
-// encodeTuple lays out parts as ABI head/tail: static members inline, dynamic
-// members as an offset into the tail section.
 func encodeTuple(parts ...abiPart) []byte {
 	head := make([]byte, 0, 32*len(parts))
 	tail := make([]byte, 0)
@@ -455,11 +403,8 @@ func encodeTuple(parts ...abiPart) []byte {
 	return append(head, tail...)
 }
 
-// abiEncodeStruct produces abi.encode(s) for one dynamic struct. Encoding a
-// single value wraps it in a one-element tuple, so the result opens with an
-// offset word (0x20) and only then carries the struct's own head/tail. Getting
-// this wrapper wrong is invisible to a test that encodes and decodes with the
-// same helper, so it is spelled out here once and used everywhere.
+// abi.encode of one dynamic struct wraps it in a one-element tuple, so the
+// result opens with an offset word (0x20) before the struct's own head/tail.
 func abiEncodeStruct(members ...abiPart) []byte {
 	return encodeTuple(abiPart{dynamic: true, tail: encodeTuple(members...)})
 }

--- a/core/vm/cas20_token.go
+++ b/core/vm/cas20_token.go
@@ -145,6 +145,9 @@ func (t cas20Token) dispatch(input []byte) ([]byte, error) {
 	if ret, err, ok := t.dispatchPermitMemo(sel, args); ok {
 		return ret, err
 	}
+	if ret, err, ok := t.dispatchMemoFormats(sel, args); ok {
+		return ret, err
+	}
 	return nil, ErrExecutionReverted
 }
 

--- a/core/vm/cas20_token_test.go
+++ b/core/vm/cas20_token_test.go
@@ -1,0 +1,289 @@
+package vm
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+func u256hash(n uint64) common.Hash { return common.Hash(uint256.NewInt(n).Bytes32()) }
+
+func cas20Call(sel [4]byte, args ...common.Hash) []byte {
+	out := append([]byte{}, sel[:]...)
+	for _, a := range args {
+		out = append(out, a.Bytes()...)
+	}
+	return out
+}
+
+var (
+	cas20Alice = common.HexToAddress("0xa11ce")
+	cas20Bob   = common.HexToAddress("0xb0b")
+	cas20Carol = common.HexToAddress("0xca401")
+)
+
+func TestCAS20TokenDispatch(t *testing.T) {
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := cas20Addr(cas20VariantAsset, 1)
+
+	// Seed initial state through the unmetered view.
+	view := newUnmeteredCAS20Storage(statedb, token)
+	view.setName("Test Token")
+	view.setSymbol("TT")
+	view.setTotalSupply(uint256.NewInt(1000))
+	view.setBalance(cas20Alice, uint256.NewInt(1000))
+
+	run := func(caller common.Address, ro bool, input []byte) ([]byte, error) {
+		gas := NewGasBudget(1_000_000)
+		ctx := &PrecompileContext{StateDB: statedb, Self: token, Caller: caller, DirectCall: true, ReadOnly: ro, gas: &gas}
+		return newCAS20Token(ctx, 18).dispatch(input)
+	}
+	readU := func(input []byte) uint64 {
+		t.Helper()
+		ret, err := run(cas20Alice, true, input)
+		if err != nil {
+			t.Fatalf("view call err: %v", err)
+		}
+		return new(uint256.Int).SetBytes(ret).Uint64()
+	}
+	wantU := func(label string, got, want uint64) {
+		t.Helper()
+		if got != want {
+			t.Fatalf("%s = %d, want %d", label, got, want)
+		}
+	}
+
+	// views
+	if ret, err := run(cas20Alice, true, cas20Call(selName)); err != nil || string(bytes.TrimRight(ret[64:], "\x00")) != "Test Token" {
+		t.Fatalf("name() = %q, err %v", ret, err)
+	}
+	wantU("decimals", readU(cas20Call(selDecimals)), 18)
+	wantU("totalSupply", readU(cas20Call(selTotalSupply)), 1000)
+	wantU("balanceOf(alice)", readU(cas20Call(selBalanceOf, addrKey(cas20Alice))), 1000)
+
+	// transfer alice -> bob 100
+	if ret, err := run(cas20Alice, false, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(100))); err != nil || !bytes.Equal(ret, encBool(true)) {
+		t.Fatalf("transfer ret %x err %v", ret, err)
+	}
+	wantU("balanceOf(alice)", readU(cas20Call(selBalanceOf, addrKey(cas20Alice))), 900)
+	wantU("balanceOf(bob)", readU(cas20Call(selBalanceOf, addrKey(cas20Bob))), 100)
+
+	// approve alice -> carol 50, then carol transferFrom alice -> bob 30
+	if _, err := run(cas20Alice, false, cas20Call(selApprove, addrKey(cas20Carol), u256hash(50))); err != nil {
+		t.Fatalf("approve err %v", err)
+	}
+	wantU("allowance", readU(cas20Call(selAllowance, addrKey(cas20Alice), addrKey(cas20Carol))), 50)
+	if _, err := run(cas20Carol, false, cas20Call(selTransferFrom, addrKey(cas20Alice), addrKey(cas20Bob), u256hash(30))); err != nil {
+		t.Fatalf("transferFrom err %v", err)
+	}
+	wantU("balanceOf(alice)", readU(cas20Call(selBalanceOf, addrKey(cas20Alice))), 870)
+	wantU("balanceOf(bob)", readU(cas20Call(selBalanceOf, addrKey(cas20Bob))), 130)
+	wantU("allowance", readU(cas20Call(selAllowance, addrKey(cas20Alice), addrKey(cas20Carol))), 20)
+
+	// transferFrom beyond allowance reverts.
+	if _, err := run(cas20Carol, false, cas20Call(selTransferFrom, addrKey(cas20Alice), addrKey(cas20Bob), u256hash(100))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("over-allowance err = %v, want revert", err)
+	}
+	// transfer beyond balance reverts.
+	if _, err := run(cas20Bob, false, cas20Call(selTransfer, addrKey(cas20Alice), u256hash(1e9))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("over-balance err = %v, want revert", err)
+	}
+	// state-mutating call in a read-only frame throws.
+	if _, err := run(cas20Alice, true, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(1))); !errors.Is(err, ErrWriteProtection) {
+		t.Fatalf("readonly transfer err = %v, want write protection", err)
+	}
+	// unknown selector reverts.
+	if _, err := run(cas20Alice, true, []byte{0xde, 0xad, 0xbe, 0xef}); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("unknown selector err = %v, want revert", err)
+	}
+}
+
+func TestCAS20TokenPauseBlocksTransfer(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	token := cas20Addr(cas20VariantAsset, 1)
+	view := newUnmeteredCAS20Storage(statedb, token)
+	view.setBalance(cas20Alice, uint256.NewInt(100))
+	view.setPaused(uint256.NewInt(1 << cas20PauseTransfer))
+
+	gas := NewGasBudget(1_000_000)
+	ctx := &PrecompileContext{StateDB: statedb, Self: token, Caller: cas20Alice, DirectCall: true, gas: &gas}
+	if _, err := newCAS20Token(ctx, 18).dispatch(cas20Call(selTransfer, addrKey(cas20Bob), u256hash(1))); !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("paused transfer err = %v, want revert", err)
+	}
+}
+
+// TestCAS20EndToEndTransfer drives a transfer through the full EVM Call path:
+// address resolution, the stateful precompile host, dispatch, state mutation
+// and the Transfer log.
+func TestCAS20EndToEndTransfer(t *testing.T) {
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := cas20Addr(cas20VariantAsset, 1)
+	// Simulate factory creation: initialization marker + seed balance.
+	statedb.SetCode(token, CAS20MarkerCode, 0)
+	newUnmeteredCAS20Storage(statedb, token).setBalance(cas20Alice, uint256.NewInt(1000))
+
+	cfg := *cas20TestChainConfig()
+
+	txHash := common.HexToHash("0x1234")
+	statedb.SetTxContext(txHash, 0)
+
+	bc := cas20BlockContext(1)
+	evm := NewEVM(bc, statedb, &cfg, Config{})
+	if !evm.cas20Enabled() {
+		t.Fatal("CAS20 must be enabled for the precompile to resolve")
+	}
+
+	input := cas20Call(selTransfer, addrKey(cas20Bob), u256hash(250))
+	ret, _, err := evm.Call(cas20Alice, token, input, NewGasBudget(1_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("evm.Call transfer err: %v", err)
+	}
+	if !bytes.Equal(ret, encBool(true)) {
+		t.Fatalf("transfer returned %x, want true", ret)
+	}
+
+	view := newUnmeteredCAS20Storage(statedb, token)
+	if got := view.balanceOf(cas20Alice).Uint64(); got != 750 {
+		t.Errorf("alice balance = %d, want 750", got)
+	}
+	if got := view.balanceOf(cas20Bob).Uint64(); got != 250 {
+		t.Errorf("bob balance = %d, want 250", got)
+	}
+
+	logs := statedb.GetLogs(txHash, 1, common.Hash{}, 1)
+	if len(logs) != 1 {
+		t.Fatalf("got %d logs, want 1", len(logs))
+	}
+	log := logs[0]
+	if log.Address != token || log.Topics[0] != cas20TopicTransfer {
+		t.Errorf("unexpected log: addr %s topic %s", log.Address.Hex(), log.Topics[0].Hex())
+	}
+	if log.Topics[1] != addrKey(cas20Alice) || log.Topics[2] != addrKey(cas20Bob) {
+		t.Errorf("Transfer topics from/to mismatch")
+	}
+}
+
+// TestCAS20CalldataStrictnessProfile pins which malformed encodings are refused and
+// which are not, so the profile is a decision rather than an accident.
+func TestCAS20CalldataStrictnessProfile(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	creator := common.HexToAddress("0xdec0de")
+	ret, _, err := evm.Call(creator, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0x57"), creator, [][]byte{
+			cas20Call(selGrantRole, roleMint, addrKey(creator)),
+			cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
+		}), NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+	call := func(caller common.Address, input []byte) ([]byte, error) {
+		r, _, e := evm.Call(caller, token, input, NewGasBudget(1_000_000), uint256.NewInt(0))
+		return r, e
+	}
+
+	// Refused: one byte short of the second argument.
+	short := cas20Call(selTransfer, addrKey(cas20Bob), u256hash(1))
+	if _, err := call(cas20Alice, short[:len(short)-1]); !errors.Is(err, ErrExecutionReverted) {
+		t.Errorf("truncated transfer args: err = %v, want a revert", err)
+	}
+	// Refused: an address word with bits above the low 20 bytes.
+	dirty := addrKey(cas20Bob)
+	dirty[0] = 0x01
+	if _, err := call(cas20Alice, cas20Call(selTransfer, dirty, u256hash(1))); !errors.Is(err, ErrExecutionReverted) {
+		t.Errorf("dirty address high bits: err = %v, want a revert", err)
+	}
+
+	// Accepted: a whole extra word after a complete argument list, as Solidity
+	// accepts it. The transfer must go through, not merely fail to revert.
+	before := newUnmeteredCAS20Storage(statedb, token).balanceOf(cas20Bob).Uint64()
+	trailing := append(cas20Call(selTransfer, addrKey(cas20Bob), u256hash(7)), u256hash(0xdead).Bytes()...)
+	if r, err := call(cas20Alice, trailing); err != nil || !bytes.Equal(r, encBool(true)) {
+		t.Fatalf("transfer with trailing data: ret %x err %v, want success — Solidity ignores "+
+			"extra calldata, so refusing it would diverge from the contract this replaces", r, err)
+	}
+	if got := newUnmeteredCAS20Storage(statedb, token).balanceOf(cas20Bob).Uint64(); got != before+7 {
+		t.Errorf("bob's balance = %d, want %d; the trailing word changed how the args decoded",
+			got, before+7)
+	}
+}
+
+// TestCAS20TransferFromSelfSpendsAllowance covers the owner moving their own balance
+// through transferFrom: the allowance is spent, the executor policy is not
+// consulted.
+func TestCAS20TransferFromSelfSpendsAllowance(t *testing.T) {
+	statedb, evm := newCAS20EVM(t)
+	admin := cas20TestCaller
+
+	// A policy authorizing nobody, bound as the executor scope, so the shortcut is
+	// observable: without it the self transfer would be refused too.
+	ret, _, err := evm.Call(admin, CAS20PolicyRegistryAddress,
+		cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyAllowlist)),
+		NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createPolicy: %v", err)
+	}
+	empty := new(uint256.Int).SetBytes(ret).Uint64()
+
+	ret, _, err = evm.Call(admin, CAS20FactoryAddress,
+		encodeCreateCAS20(cas20VariantAsset, common.HexToHash("0x5e1f"), admin, [][]byte{
+			cas20Call(selGrantRole, roleMint, addrKey(admin)),
+			cas20Call(selMint, addrKey(cas20Alice), u256hash(1000)),
+			cas20Call(selUpdatePolicy, scopeTransferExecutor, wU64(empty)),
+		}), NewGasBudget(9_000_000), uint256.NewInt(0))
+	if err != nil {
+		t.Fatalf("createCAS20: %v", err)
+	}
+	token := common.BytesToAddress(ret)
+	view := newUnmeteredCAS20Storage(statedb, token)
+	send := func(caller common.Address, input []byte) ([]byte, error) {
+		r, _, e := evm.Call(caller, token, input, NewGasBudget(1_000_000), uint256.NewInt(0))
+		return r, e
+	}
+
+	// No self-approval yet: the allowance is consumed unconditionally, so this is
+	// InsufficientAllowance and not a free pass.
+	out, err := send(cas20Alice, cas20Call(selTransferFrom, addrKey(cas20Alice), addrKey(cas20Bob), u256hash(40)))
+	if !errors.Is(err, ErrExecutionReverted) {
+		t.Fatalf("self transferFrom without an approval: err = %v, want a revert", err)
+	}
+	if len(out) < 4 || [4]byte(out[:4]) != errSelInsufficientAllow {
+		t.Errorf("revert = %x, want InsufficientAllowance", out[:min(4, len(out))])
+	}
+
+	// With one, it goes through and the allowance decrements — the executor policy
+	// authorizes nobody, so reaching the transfer at all is the self shortcut.
+	if _, err := send(cas20Alice, cas20Call(selApprove, addrKey(cas20Alice), u256hash(100))); err != nil {
+		t.Fatalf("self approve: %v", err)
+	}
+	if out, err := send(cas20Alice, cas20Call(selTransferFrom, addrKey(cas20Alice), addrKey(cas20Bob), u256hash(40))); err != nil ||
+		!bytes.Equal(out, encBool(true)) {
+		t.Fatalf("self transferFrom with an approval: ret %x err %v", out, err)
+	}
+	if got := view.allowance(cas20Alice, cas20Alice).Uint64(); got != 60 {
+		t.Errorf("self-allowance = %d, want 60 — it must be spent like any other", got)
+	}
+	if got := view.balanceOf(cas20Bob).Uint64(); got != 40 {
+		t.Errorf("bob's balance = %d, want 40", got)
+	}
+
+	// And the contrast: a third party with a full allowance is still refused by the
+	// executor policy, so the shortcut above is the executor check and nothing else.
+	if _, err := send(admin, cas20Call(selApprove, addrKey(cas20Carol), u256hash(100))); err != nil {
+		t.Fatalf("approve carol: %v", err)
+	}
+	if _, err := send(cas20Carol, cas20Call(selTransferFrom, addrKey(admin), addrKey(cas20Bob), u256hash(1))); !errors.Is(err, ErrExecutionReverted) {
+		t.Errorf("a delegated transfer under a deny-all executor policy err = %v, want a revert", err)
+	}
+}

--- a/core/vm/cas20_token_test.go
+++ b/core/vm/cas20_token_test.go
@@ -34,7 +34,6 @@ func TestCAS20TokenDispatch(t *testing.T) {
 	}
 	token := cas20Addr(cas20VariantAsset, 1)
 
-	// Seed initial state through the unmetered view.
 	view := newUnmeteredCAS20Storage(statedb, token)
 	view.setName("Test Token")
 	view.setSymbol("TT")
@@ -61,7 +60,6 @@ func TestCAS20TokenDispatch(t *testing.T) {
 		}
 	}
 
-	// views
 	if ret, err := run(cas20Alice, true, cas20Call(selName)); err != nil || string(bytes.TrimRight(ret[64:], "\x00")) != "Test Token" {
 		t.Fatalf("name() = %q, err %v", ret, err)
 	}
@@ -69,14 +67,12 @@ func TestCAS20TokenDispatch(t *testing.T) {
 	wantU("totalSupply", readU(cas20Call(selTotalSupply)), 1000)
 	wantU("balanceOf(alice)", readU(cas20Call(selBalanceOf, addrKey(cas20Alice))), 1000)
 
-	// transfer alice -> bob 100
 	if ret, err := run(cas20Alice, false, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(100))); err != nil || !bytes.Equal(ret, encBool(true)) {
 		t.Fatalf("transfer ret %x err %v", ret, err)
 	}
 	wantU("balanceOf(alice)", readU(cas20Call(selBalanceOf, addrKey(cas20Alice))), 900)
 	wantU("balanceOf(bob)", readU(cas20Call(selBalanceOf, addrKey(cas20Bob))), 100)
 
-	// approve alice -> carol 50, then carol transferFrom alice -> bob 30
 	if _, err := run(cas20Alice, false, cas20Call(selApprove, addrKey(cas20Carol), u256hash(50))); err != nil {
 		t.Fatalf("approve err %v", err)
 	}
@@ -88,19 +84,15 @@ func TestCAS20TokenDispatch(t *testing.T) {
 	wantU("balanceOf(bob)", readU(cas20Call(selBalanceOf, addrKey(cas20Bob))), 130)
 	wantU("allowance", readU(cas20Call(selAllowance, addrKey(cas20Alice), addrKey(cas20Carol))), 20)
 
-	// transferFrom beyond allowance reverts.
 	if _, err := run(cas20Carol, false, cas20Call(selTransferFrom, addrKey(cas20Alice), addrKey(cas20Bob), u256hash(100))); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("over-allowance err = %v, want revert", err)
 	}
-	// transfer beyond balance reverts.
 	if _, err := run(cas20Bob, false, cas20Call(selTransfer, addrKey(cas20Alice), u256hash(1e9))); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("over-balance err = %v, want revert", err)
 	}
-	// state-mutating call in a read-only frame throws.
 	if _, err := run(cas20Alice, true, cas20Call(selTransfer, addrKey(cas20Bob), u256hash(1))); !errors.Is(err, ErrWriteProtection) {
 		t.Fatalf("readonly transfer err = %v, want write protection", err)
 	}
-	// unknown selector reverts.
 	if _, err := run(cas20Alice, true, []byte{0xde, 0xad, 0xbe, 0xef}); !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("unknown selector err = %v, want revert", err)
 	}
@@ -120,16 +112,12 @@ func TestCAS20TokenPauseBlocksTransfer(t *testing.T) {
 	}
 }
 
-// TestCAS20EndToEndTransfer drives a transfer through the full EVM Call path:
-// address resolution, the stateful precompile host, dispatch, state mutation
-// and the Transfer log.
 func TestCAS20EndToEndTransfer(t *testing.T) {
 	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	if err != nil {
 		t.Fatal(err)
 	}
 	token := cas20Addr(cas20VariantAsset, 1)
-	// Simulate factory creation: initialization marker + seed balance.
 	statedb.SetCode(token, CAS20MarkerCode, 0)
 	newUnmeteredCAS20Storage(statedb, token).setBalance(cas20Alice, uint256.NewInt(1000))
 
@@ -174,8 +162,7 @@ func TestCAS20EndToEndTransfer(t *testing.T) {
 	}
 }
 
-// TestCAS20CalldataStrictnessProfile pins which malformed encodings are refused and
-// which are not, so the profile is a decision rather than an accident.
+// Which malformed encodings are refused and which are not is a decision, not an accident.
 func TestCAS20CalldataStrictnessProfile(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	creator := common.HexToAddress("0xdec0de")
@@ -193,20 +180,17 @@ func TestCAS20CalldataStrictnessProfile(t *testing.T) {
 		return r, e
 	}
 
-	// Refused: one byte short of the second argument.
 	short := cas20Call(selTransfer, addrKey(cas20Bob), u256hash(1))
 	if _, err := call(cas20Alice, short[:len(short)-1]); !errors.Is(err, ErrExecutionReverted) {
 		t.Errorf("truncated transfer args: err = %v, want a revert", err)
 	}
-	// Refused: an address word with bits above the low 20 bytes.
 	dirty := addrKey(cas20Bob)
 	dirty[0] = 0x01
 	if _, err := call(cas20Alice, cas20Call(selTransfer, dirty, u256hash(1))); !errors.Is(err, ErrExecutionReverted) {
 		t.Errorf("dirty address high bits: err = %v, want a revert", err)
 	}
 
-	// Accepted: a whole extra word after a complete argument list, as Solidity
-	// accepts it. The transfer must go through, not merely fail to revert.
+	// Accepted, as Solidity accepts it: a whole extra word after a complete argument list.
 	before := newUnmeteredCAS20Storage(statedb, token).balanceOf(cas20Bob).Uint64()
 	trailing := append(cas20Call(selTransfer, addrKey(cas20Bob), u256hash(7)), u256hash(0xdead).Bytes()...)
 	if r, err := call(cas20Alice, trailing); err != nil || !bytes.Equal(r, encBool(true)) {
@@ -219,15 +203,11 @@ func TestCAS20CalldataStrictnessProfile(t *testing.T) {
 	}
 }
 
-// TestCAS20TransferFromSelfSpendsAllowance covers the owner moving their own balance
-// through transferFrom: the allowance is spent, the executor policy is not
-// consulted.
 func TestCAS20TransferFromSelfSpendsAllowance(t *testing.T) {
 	statedb, evm := newCAS20EVM(t)
 	admin := cas20TestCaller
 
-	// A policy authorizing nobody, bound as the executor scope, so the shortcut is
-	// observable: without it the self transfer would be refused too.
+	// A deny-all executor policy, so the self shortcut is observable.
 	ret, _, err := evm.Call(admin, CAS20PolicyRegistryAddress,
 		cas20Call(selCreatePolicy, addrKey(admin), u256hash(cas20PolicyAllowlist)),
 		NewGasBudget(9_000_000), uint256.NewInt(0))
@@ -252,8 +232,6 @@ func TestCAS20TransferFromSelfSpendsAllowance(t *testing.T) {
 		return r, e
 	}
 
-	// No self-approval yet: the allowance is consumed unconditionally, so this is
-	// InsufficientAllowance and not a free pass.
 	out, err := send(cas20Alice, cas20Call(selTransferFrom, addrKey(cas20Alice), addrKey(cas20Bob), u256hash(40)))
 	if !errors.Is(err, ErrExecutionReverted) {
 		t.Fatalf("self transferFrom without an approval: err = %v, want a revert", err)
@@ -262,8 +240,6 @@ func TestCAS20TransferFromSelfSpendsAllowance(t *testing.T) {
 		t.Errorf("revert = %x, want InsufficientAllowance", out[:min(4, len(out))])
 	}
 
-	// With one, it goes through and the allowance decrements — the executor policy
-	// authorizes nobody, so reaching the transfer at all is the self shortcut.
 	if _, err := send(cas20Alice, cas20Call(selApprove, addrKey(cas20Alice), u256hash(100))); err != nil {
 		t.Fatalf("self approve: %v", err)
 	}
@@ -278,8 +254,7 @@ func TestCAS20TransferFromSelfSpendsAllowance(t *testing.T) {
 		t.Errorf("bob's balance = %d, want 40", got)
 	}
 
-	// And the contrast: a third party with a full allowance is still refused by the
-	// executor policy, so the shortcut above is the executor check and nothing else.
+	// The contrast: a third party with a full allowance is still refused by the executor policy.
 	if _, err := send(admin, cas20Call(selApprove, addrKey(cas20Carol), u256hash(100))); err != nil {
 		t.Fatalf("approve carol: %v", err)
 	}

--- a/core/vm/contracts_stateful.go
+++ b/core/vm/contracts_stateful.go
@@ -172,12 +172,10 @@ func (ctx *PrecompileContext) meteredGasUsed() uint64 {
 // gasLeft reports the regular gas remaining in the budget.
 func (ctx *PrecompileContext) gasLeft() uint64 { return ctx.gas.RegularGas }
 
-// BlockTime returns the timestamp of the block being executed (used e.g. by
-// EIP-2612 permit deadline checks).
+// BlockTime returns the timestamp of the block being executed.
 func (ctx *PrecompileContext) BlockTime() uint64 { return ctx.evm.Context.Time }
 
-// ChainID returns the active chain id (used e.g. by the EIP-712 domain
-// separator).
+// ChainID returns the active chain id.
 func (ctx *PrecompileContext) ChainID() *uint256.Int {
 	id, _ := uint256.FromBig(ctx.evm.chainConfig.ChainID)
 	return id

--- a/core/vm/contracts_stateful.go
+++ b/core/vm/contracts_stateful.go
@@ -1,0 +1,245 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+// StatefulPrecompiledContract is a precompile that reads and writes consensus
+// state. Unlike the plain PrecompiledContract, whose Run is a pure function of
+// its input, a stateful precompile is handed a PrecompileContext carrying the
+// StateDB, the caller, the call mode, and dynamic gas metering. It is the host
+// primitive the CAS20 token family is built on.
+type StatefulPrecompiledContract interface {
+	// RequiredGas returns the flat gas charged up-front, before RunStateful.
+	// Additional, data-dependent cost is charged inside RunStateful via
+	// PrecompileContext.UseGas.
+	RequiredGas(input []byte) uint64
+
+	// RunStateful executes the precompile against ctx. Returning a non-nil error
+	// reverts every state mutation performed during the call (the enclosing
+	// Call/StaticCall frame is already wrapped in a StateDB snapshot).
+	RunStateful(ctx *PrecompileContext, input []byte) ([]byte, error)
+}
+
+// PrecompileContext is the execution environment handed to a stateful
+// precompile. It exposes exactly the host capabilities a native token needs —
+// state access, caller identity, call-mode guards, log emission and dynamic
+// gas — without leaking the whole *EVM.
+type PrecompileContext struct {
+	evm *EVM
+
+	// StateDB is the live state; mutations are journalled and revert with the
+	// enclosing call frame's snapshot when RunStateful returns an error.
+	StateDB StateDB
+
+	// Self is the address the precompile is bound to. For the CAS20 dynamic
+	// family this is the token address, and is the storage root for its state.
+	Self common.Address
+
+	// Caller is msg.sender for this frame.
+	Caller common.Address
+
+	// ReadOnly is true inside a STATICCALL (or any read-only ancestor frame);
+	// a precompile must reject state mutation when set.
+	ReadOnly bool
+
+	// DirectCall is true for CALL and STATICCALL, false for CALLCODE and
+	// DELEGATECALL. Stateful token precompiles reject non-direct calls so that
+	// Self is always the genuine callee and can be trusted as the storage root.
+	DirectCall bool
+
+	// Value is the wei attached to the frame (nil means zero). Every CAS20 entry
+	// point is nonpayable and rejects a non-zero value with NonPayable
+	// (BEP-702 section 3.2).
+	Value *uint256.Int
+
+	// gas points at the caller's remaining budget so UseGas can meter
+	// data-dependent cost in place.
+	gas *GasBudget
+
+	// adminRenounced records that a token gave up its last admin during this
+	// frame, so a bootstrap bundle cannot renounce and then grant again (BEP-702
+	// 3.4). Per-frame rather than stored: outside the bootstrap window the zero
+	// admin count freezes role mutation on its own.
+	adminRenounced bool
+
+	// frame holds accounting shared by every context in this EVM frame, so a
+	// spawned child's exhaustion and charges are not lost. Lazily allocated.
+	frame *frameAccounting
+}
+
+// frameAccounting is shared by every context in one EVM frame, so a child's gas
+// exhaustion and state-gas charges cannot be lost on the way back.
+type frameAccounting struct {
+	// outOfGas is set sticky once a charge cannot be covered; the dispatcher
+	// checks it and returns ErrOutOfGas.
+	outOfGas bool
+
+	// writeProtected is set sticky when a metered write is attempted in a
+	// read-only frame. It outranks outOfGas at the exit: the frame had no business
+	// writing at all, whatever it could afford.
+	writeProtected bool
+
+	meteredGasUsed uint64
+}
+
+// UseGas charges cost against the remaining budget. It returns false and
+// exhausts the budget when the charge cannot be covered, mirroring the EVM's
+// out-of-gas semantics; callers should propagate ErrOutOfGas on false.
+func (ctx *PrecompileContext) UseGas(cost GasCosts) bool {
+	prior, ok := ctx.gas.Charge(cost)
+	if !ok {
+		ctx.gas.Exhaust()
+		return false
+	}
+	if ctx.evm != nil && ctx.evm.Config.Tracer != nil && ctx.evm.Config.Tracer.OnGasChange != nil {
+		ctx.evm.Config.Tracer.OnGasChange(prior, ctx.gas.RegularGas, tracing.GasChangeCallPrecompiledContract)
+	}
+	return true
+}
+
+// spawnBootstrap derives a context bound to a different self address, sharing
+// this frame's state, gas budget and accounting. ReadOnly is carried
+// across: dropping it would let initCalls write during a STATICCALL.
+func (ctx *PrecompileContext) spawnBootstrap(self, caller common.Address) *PrecompileContext {
+	return &PrecompileContext{
+		evm:        ctx.evm,
+		StateDB:    ctx.StateDB,
+		Self:       self,
+		Caller:     caller,
+		DirectCall: true,
+		ReadOnly:   ctx.ReadOnly,
+		gas:        ctx.gas,
+		frame:      ctx.frameGas(),
+	}
+}
+
+// frameGas returns the shared frame accounting, allocating it on first use so a
+// context built as a plain struct literal needs no initialisation.
+func (ctx *PrecompileContext) frameGas() *frameAccounting {
+	if ctx.frame == nil {
+		ctx.frame = new(frameAccounting)
+	}
+	return ctx.frame
+}
+
+// markOutOfGas records exhaustion. Every context spawned from this one — and the
+// one it was spawned from — observes it, because they hold the same accounting.
+func (ctx *PrecompileContext) markOutOfGas() { ctx.frameGas().outOfGas = true }
+
+// chargeGas charges cost against the frame and reports whether it may continue.
+// Every CAS20 charge arrives here, state access and computation alike.
+//
+// False means stop: the caller must return before the operation this charge pays
+// for, the way the interpreter checks UseGas before executing an opcode rather
+// than after. A charge that cannot be covered marks the frame, and an already
+// marked frame refuses every later charge, so one failure ends the call rather
+// than letting the rest of the handler run on an exhausted budget.
+func (ctx *PrecompileContext) chargeGas(cost uint64) bool {
+	if ctx.OutOfGas() {
+		return false
+	}
+	if !ctx.UseGas(GasCosts{RegularGas: cost}) {
+		ctx.markOutOfGas()
+		return false
+	}
+	ctx.frameGas().meteredGasUsed += cost
+	return true
+}
+
+// OutOfGas reports whether a charge has failed during this call. The
+// dispatcher must check it after driving the token logic and return
+// ErrOutOfGas so the frame reverts.
+func (ctx *PrecompileContext) OutOfGas() bool { return ctx.frame != nil && ctx.frame.outOfGas }
+
+// meteredGasUsed returns every charge this frame levied, a bootstrap child's
+// included: state access and equally the calldata copy, the keccaks, the logs and
+// permit's ecrecover. Read only by the metering tests.
+//
+// It is not GasCosts.StateGas, which is a separate dimension — half of what is
+// counted here is computation. Wiring it there means dividing these charges by
+// dimension first.
+func (ctx *PrecompileContext) meteredGasUsed() uint64 {
+	if ctx.frame == nil {
+		return 0
+	}
+	return ctx.frame.meteredGasUsed
+}
+
+// gasLeft reports the regular gas remaining in the budget.
+func (ctx *PrecompileContext) gasLeft() uint64 { return ctx.gas.RegularGas }
+
+// BlockTime returns the timestamp of the block being executed (used e.g. by
+// EIP-2612 permit deadline checks).
+func (ctx *PrecompileContext) BlockTime() uint64 { return ctx.evm.Context.Time }
+
+// ChainID returns the active chain id (used e.g. by the EIP-712 domain
+// separator).
+func (ctx *PrecompileContext) ChainID() *uint256.Int {
+	id, _ := uint256.FromBig(ctx.evm.chainConfig.ChainID)
+	return id
+}
+
+// markWriteProtected records an attempted write in a read-only frame, the way
+// geth's gas functions return ErrWriteProtection before pricing anything
+// (gasSStoreEIP2200, gasSelfdestruct, gasCallIntrinsic). The handlers each check
+// ReadOnly first and none is known to be missing; this is what makes a missing
+// one fail closed instead of writing state inside a STATICCALL.
+func (ctx *PrecompileContext) markWriteProtected() { ctx.frameGas().writeProtected = true }
+
+// writeProtectionViolated reports whether any write was attempted in a read-only
+// frame during this call.
+func (ctx *PrecompileContext) writeProtectionViolated() bool {
+	return ctx.frame != nil && ctx.frame.writeProtected
+}
+
+// AddLog emits a log, or does nothing and reports false when the charge for it
+// cannot be covered. Dropping that result let a handler whose write had already
+// been refused still append its event: approve's Approval log costs 1,756 gas,
+// which fits inside the 2,300 the EIP-2200 sentry leaves behind.
+func (ctx *PrecompileContext) AddLog(topics []common.Hash, data []byte) bool {
+	if ctx.ReadOnly {
+		ctx.markWriteProtected()
+		return false
+	}
+	if !ctx.chargeLog(len(topics), len(data)) {
+		return false
+	}
+	ctx.StateDB.AddLog(&types.Log{
+		Address: ctx.Self,
+		Topics:  topics,
+		Data:    data,
+	})
+	return true
+}
+
+func runStatefulPrecompiledContract(evm *EVM, p StatefulPrecompiledContract, caller, self common.Address, input []byte, gas GasBudget, readOnly, directCall bool, value *uint256.Int) (ret []byte, remaining GasBudget, err error) {
+	gasCost := p.RequiredGas(input)
+	prior, ok := gas.Charge(GasCosts{RegularGas: gasCost})
+	if !ok {
+		gas.Exhaust()
+		return nil, gas, ErrOutOfGas
+	}
+	if evm.Config.Tracer != nil && evm.Config.Tracer.OnGasChange != nil {
+		evm.Config.Tracer.OnGasChange(prior, gas.RegularGas, tracing.GasChangeCallPrecompiledContract)
+	}
+	// Mirror the access-list touch performed for plain precompiles.
+	if evm.chainRules.IsAmsterdam {
+		evm.StateDB.Touch(self)
+	}
+	ctx := &PrecompileContext{
+		evm:        evm,
+		StateDB:    evm.StateDB,
+		Self:       self,
+		Caller:     caller,
+		ReadOnly:   readOnly,
+		DirectCall: directCall,
+		Value:      value,
+		gas:        &gas,
+	}
+	output, err := p.RunStateful(ctx, input)
+	return output, gas, err
+}

--- a/core/vm/contracts_stateful.go
+++ b/core/vm/contracts_stateful.go
@@ -98,6 +98,14 @@ func (ctx *PrecompileContext) frameGas() *frameAccounting {
 
 func (ctx *PrecompileContext) markOutOfGas() { ctx.frameGas().outOfGas = true }
 
+// traceStorageRead announces a native slot access to a tracer, which would
+// otherwise learn of it only through the SLOAD it did not see.
+func (ctx *PrecompileContext) traceStorageRead(addr common.Address, slot common.Hash) {
+	if ctx.evm != nil && ctx.evm.Config.Tracer != nil && ctx.evm.Config.Tracer.OnStorageRead != nil {
+		ctx.evm.Config.Tracer.OnStorageRead(addr, slot)
+	}
+}
+
 // chargeGas is where every CAS20 charge arrives. False means stop before the
 // operation the charge pays for, as the interpreter checks gas before an opcode.
 func (ctx *PrecompileContext) chargeGas(cost uint64) bool {

--- a/core/vm/contracts_stateful.go
+++ b/core/vm/contracts_stateful.go
@@ -8,87 +8,61 @@ import (
 )
 
 // StatefulPrecompiledContract is a precompile that reads and writes consensus
-// state. Unlike the plain PrecompiledContract, whose Run is a pure function of
-// its input, a stateful precompile is handed a PrecompileContext carrying the
-// StateDB, the caller, the call mode, and dynamic gas metering. It is the host
-// primitive the CAS20 token family is built on.
+// state through a PrecompileContext, unlike PrecompiledContract, whose Run is a
+// pure function of its input.
 type StatefulPrecompiledContract interface {
-	// RequiredGas returns the flat gas charged up-front, before RunStateful.
-	// Additional, data-dependent cost is charged inside RunStateful via
-	// PrecompileContext.UseGas.
+	// RequiredGas is the flat charge taken before RunStateful; data-dependent
+	// cost is charged inside it.
 	RequiredGas(input []byte) uint64
 
-	// RunStateful executes the precompile against ctx. Returning a non-nil error
-	// reverts every state mutation performed during the call (the enclosing
-	// Call/StaticCall frame is already wrapped in a StateDB snapshot).
+	// RunStateful's error reverts every state mutation of the call.
 	RunStateful(ctx *PrecompileContext, input []byte) ([]byte, error)
 }
 
-// PrecompileContext is the execution environment handed to a stateful
-// precompile. It exposes exactly the host capabilities a native token needs —
-// state access, caller identity, call-mode guards, log emission and dynamic
-// gas — without leaking the whole *EVM.
+// PrecompileContext is the execution environment handed to a stateful precompile.
 type PrecompileContext struct {
 	evm *EVM
 
-	// StateDB is the live state; mutations are journalled and revert with the
-	// enclosing call frame's snapshot when RunStateful returns an error.
 	StateDB StateDB
 
-	// Self is the address the precompile is bound to. For the CAS20 dynamic
-	// family this is the token address, and is the storage root for its state.
+	// Self is the callee address and the storage root of its state.
 	Self common.Address
 
 	// Caller is msg.sender for this frame.
 	Caller common.Address
 
-	// ReadOnly is true inside a STATICCALL (or any read-only ancestor frame);
-	// a precompile must reject state mutation when set.
+	// ReadOnly is true inside a STATICCALL or any read-only ancestor frame.
 	ReadOnly bool
 
-	// DirectCall is true for CALL and STATICCALL, false for CALLCODE and
-	// DELEGATECALL. Stateful token precompiles reject non-direct calls so that
-	// Self is always the genuine callee and can be trusted as the storage root.
+	// DirectCall is false for CALLCODE and DELEGATECALL, which would make Self
+	// something other than the genuine callee.
 	DirectCall bool
 
-	// Value is the wei attached to the frame (nil means zero). Every CAS20 entry
-	// point is nonpayable and rejects a non-zero value with NonPayable
-	// (BEP-702 section 3.2).
+	// Value is the wei attached to the frame; nil means zero.
 	Value *uint256.Int
 
-	// gas points at the caller's remaining budget so UseGas can meter
-	// data-dependent cost in place.
 	gas *GasBudget
 
-	// adminRenounced records that a token gave up its last admin during this
-	// frame, so a bootstrap bundle cannot renounce and then grant again (BEP-702
-	// 3.4). Per-frame rather than stored: outside the bootstrap window the zero
-	// admin count freezes role mutation on its own.
+	// adminRenounced is per-frame, not stored: outside the bootstrap window the zero
+	// admin count freezes role mutation on its own (BEP-702 3.4).
 	adminRenounced bool
 
-	// frame holds accounting shared by every context in this EVM frame, so a
-	// spawned child's exhaustion and charges are not lost. Lazily allocated.
+	// frame is shared with every context spawned in this EVM frame, so a child's
+	// exhaustion and charges are not lost. Lazily allocated.
 	frame *frameAccounting
 }
 
-// frameAccounting is shared by every context in one EVM frame, so a child's gas
-// exhaustion and state-gas charges cannot be lost on the way back.
 type frameAccounting struct {
-	// outOfGas is set sticky once a charge cannot be covered; the dispatcher
-	// checks it and returns ErrOutOfGas.
 	outOfGas bool
 
-	// writeProtected is set sticky when a metered write is attempted in a
-	// read-only frame. It outranks outOfGas at the exit: the frame had no business
+	// writeProtected outranks outOfGas at the exit: the frame had no business
 	// writing at all, whatever it could afford.
 	writeProtected bool
 
 	meteredGasUsed uint64
 }
 
-// UseGas charges cost against the remaining budget. It returns false and
-// exhausts the budget when the charge cannot be covered, mirroring the EVM's
-// out-of-gas semantics; callers should propagate ErrOutOfGas on false.
+// UseGas exhausts the budget when the charge cannot be covered, as the EVM does.
 func (ctx *PrecompileContext) UseGas(cost GasCosts) bool {
 	prior, ok := ctx.gas.Charge(cost)
 	if !ok {
@@ -101,9 +75,7 @@ func (ctx *PrecompileContext) UseGas(cost GasCosts) bool {
 	return true
 }
 
-// spawnBootstrap derives a context bound to a different self address, sharing
-// this frame's state, gas budget and accounting. ReadOnly is carried
-// across: dropping it would let initCalls write during a STATICCALL.
+// ReadOnly is carried across: dropping it would let initCalls write during a STATICCALL.
 func (ctx *PrecompileContext) spawnBootstrap(self, caller common.Address) *PrecompileContext {
 	return &PrecompileContext{
 		evm:        ctx.evm,
@@ -117,8 +89,6 @@ func (ctx *PrecompileContext) spawnBootstrap(self, caller common.Address) *Preco
 	}
 }
 
-// frameGas returns the shared frame accounting, allocating it on first use so a
-// context built as a plain struct literal needs no initialisation.
 func (ctx *PrecompileContext) frameGas() *frameAccounting {
 	if ctx.frame == nil {
 		ctx.frame = new(frameAccounting)
@@ -126,18 +96,10 @@ func (ctx *PrecompileContext) frameGas() *frameAccounting {
 	return ctx.frame
 }
 
-// markOutOfGas records exhaustion. Every context spawned from this one — and the
-// one it was spawned from — observes it, because they hold the same accounting.
 func (ctx *PrecompileContext) markOutOfGas() { ctx.frameGas().outOfGas = true }
 
-// chargeGas charges cost against the frame and reports whether it may continue.
-// Every CAS20 charge arrives here, state access and computation alike.
-//
-// False means stop: the caller must return before the operation this charge pays
-// for, the way the interpreter checks UseGas before executing an opcode rather
-// than after. A charge that cannot be covered marks the frame, and an already
-// marked frame refuses every later charge, so one failure ends the call rather
-// than letting the rest of the handler run on an exhausted budget.
+// chargeGas is where every CAS20 charge arrives. False means stop before the
+// operation the charge pays for, as the interpreter checks gas before an opcode.
 func (ctx *PrecompileContext) chargeGas(cost uint64) bool {
 	if ctx.OutOfGas() {
 		return false
@@ -150,18 +112,10 @@ func (ctx *PrecompileContext) chargeGas(cost uint64) bool {
 	return true
 }
 
-// OutOfGas reports whether a charge has failed during this call. The
-// dispatcher must check it after driving the token logic and return
-// ErrOutOfGas so the frame reverts.
 func (ctx *PrecompileContext) OutOfGas() bool { return ctx.frame != nil && ctx.frame.outOfGas }
 
-// meteredGasUsed returns every charge this frame levied, a bootstrap child's
-// included: state access and equally the calldata copy, the keccaks, the logs and
-// permit's ecrecover. Read only by the metering tests.
-//
-// It is not GasCosts.StateGas, which is a separate dimension — half of what is
-// counted here is computation. Wiring it there means dividing these charges by
-// dimension first.
+// meteredGasUsed is read only by the metering tests. It is not GasCosts.StateGas:
+// half of what it counts is computation.
 func (ctx *PrecompileContext) meteredGasUsed() uint64 {
 	if ctx.frame == nil {
 		return 0
@@ -169,35 +123,25 @@ func (ctx *PrecompileContext) meteredGasUsed() uint64 {
 	return ctx.frame.meteredGasUsed
 }
 
-// gasLeft reports the regular gas remaining in the budget.
 func (ctx *PrecompileContext) gasLeft() uint64 { return ctx.gas.RegularGas }
 
-// BlockTime returns the timestamp of the block being executed.
 func (ctx *PrecompileContext) BlockTime() uint64 { return ctx.evm.Context.Time }
 
-// ChainID returns the active chain id.
 func (ctx *PrecompileContext) ChainID() *uint256.Int {
 	id, _ := uint256.FromBig(ctx.evm.chainConfig.ChainID)
 	return id
 }
 
-// markWriteProtected records an attempted write in a read-only frame, the way
-// geth's gas functions return ErrWriteProtection before pricing anything
-// (gasSStoreEIP2200, gasSelfdestruct, gasCallIntrinsic). The handlers each check
-// ReadOnly first and none is known to be missing; this is what makes a missing
-// one fail closed instead of writing state inside a STATICCALL.
+// The handlers each check ReadOnly first; this is what makes a missing check fail
+// closed instead of writing inside a STATICCALL.
 func (ctx *PrecompileContext) markWriteProtected() { ctx.frameGas().writeProtected = true }
 
-// writeProtectionViolated reports whether any write was attempted in a read-only
-// frame during this call.
 func (ctx *PrecompileContext) writeProtectionViolated() bool {
 	return ctx.frame != nil && ctx.frame.writeProtected
 }
 
-// AddLog emits a log, or does nothing and reports false when the charge for it
-// cannot be covered. Dropping that result let a handler whose write had already
-// been refused still append its event: approve's Approval log costs 1,756 gas,
-// which fits inside the 2,300 the EIP-2200 sentry leaves behind.
+// AddLog's result must be honoured: an Approval log fits inside the 2,300 gas the
+// EIP-2200 sentry leaves behind, so a refused write could still emit its event.
 func (ctx *PrecompileContext) AddLog(topics []common.Hash, data []byte) bool {
 	if ctx.ReadOnly {
 		ctx.markWriteProtected()

--- a/core/vm/contracts_stateful.go
+++ b/core/vm/contracts_stateful.go
@@ -106,6 +106,13 @@ func (ctx *PrecompileContext) traceStorageRead(addr common.Address, slot common.
 	}
 }
 
+// traceAccountRead announces a native account access the same way.
+func (ctx *PrecompileContext) traceAccountRead(addr common.Address) {
+	if ctx.evm != nil && ctx.evm.Config.Tracer != nil && ctx.evm.Config.Tracer.OnAccountRead != nil {
+		ctx.evm.Config.Tracer.OnAccountRead(addr)
+	}
+}
+
 // chargeGas is where every CAS20 charge arrives. False means stop before the
 // operation the charge pays for, as the interpreter checks gas before an opcode.
 func (ctx *PrecompileContext) chargeGas(cost uint64) bool {

--- a/core/vm/contracts_stateful_test.go
+++ b/core/vm/contracts_stateful_test.go
@@ -1,0 +1,118 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// probePrecompile records the context it was handed instead of doing work.
+type probePrecompile struct {
+	cas20StatefulBase
+	got PrecompileContext
+}
+
+func (p *probePrecompile) Name() string { return "Probe" }
+
+func (p *probePrecompile) RunStateful(ctx *PrecompileContext, _ []byte) ([]byte, error) {
+	p.got = *ctx
+	return nil, nil
+}
+
+// TestStatefulPrecompileCallContext pins the msg.sender and msg.value a stateful
+// precompile is handed on each of the four call opcodes.
+func TestStatefulPrecompileCallContext(t *testing.T) {
+	var (
+		probeAddr = common.HexToAddress("0x0b0be0")
+		caller    = common.HexToAddress("0xca11e5")
+		origin    = common.HexToAddress("0x0416019")
+	)
+
+	run := func(t *testing.T, invoke func(*EVM, *probePrecompile)) PrecompileContext {
+		t.Helper()
+		statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+		if err != nil {
+			t.Fatal(err)
+		}
+		evm := NewEVM(BlockContext{
+			CanTransfer: func(StateDB, common.Address, *uint256.Int) bool { return true },
+			Transfer:    func(StateDB, common.Address, common.Address, *uint256.Int, *params.Rules) {},
+			BlockNumber: common.Big1,
+		}, statedb, params.TestChainConfig, Config{})
+
+		probe := &probePrecompile{}
+		evm.SetPrecompiles(PrecompiledContracts{probeAddr: probe})
+		invoke(evm, probe)
+		return probe.got
+	}
+
+	const value = 7
+
+	for _, tc := range []struct {
+		name       string
+		invoke     func(*EVM, *probePrecompile)
+		wantCaller common.Address
+		wantValue  uint64
+		wantDirect bool
+		wantRead   bool
+	}{
+		{
+			name: "CALL",
+			invoke: func(evm *EVM, _ *probePrecompile) {
+				evm.Call(caller, probeAddr, nil, NewGasBudget(100_000), uint256.NewInt(value))
+			},
+			wantCaller: caller, wantValue: value, wantDirect: true,
+		},
+		{
+			name: "STATICCALL",
+			invoke: func(evm *EVM, _ *probePrecompile) {
+				evm.StaticCall(caller, probeAddr, nil, NewGasBudget(100_000))
+			},
+			wantCaller: caller, wantValue: 0, wantDirect: true, wantRead: true,
+		},
+		{
+			// CALLCODE transfers value to the caller itself, so the frame is
+			// value-bearing and msg.sender is the immediate caller.
+			name: "CALLCODE",
+			invoke: func(evm *EVM, _ *probePrecompile) {
+				evm.CallCode(caller, probeAddr, nil, NewGasBudget(100_000), uint256.NewInt(value))
+			},
+			wantCaller: caller, wantValue: value, wantDirect: false,
+		},
+		{
+			// DELEGATECALL preserves the parent's msg.sender and inherits its
+			// msg.value; neither is the immediate caller's.
+			name: "DELEGATECALL",
+			invoke: func(evm *EVM, _ *probePrecompile) {
+				evm.DelegateCall(origin, caller, probeAddr, nil, NewGasBudget(100_000), uint256.NewInt(value))
+			},
+			wantCaller: origin, wantValue: value, wantDirect: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := run(t, tc.invoke)
+			if got.Self != probeAddr {
+				t.Errorf("Self = %s, want %s", got.Self.Hex(), probeAddr.Hex())
+			}
+			if got.Caller != tc.wantCaller {
+				t.Errorf("Caller = %s, want %s", got.Caller.Hex(), tc.wantCaller.Hex())
+			}
+			switch {
+			case got.Value == nil && tc.wantValue != 0:
+				t.Errorf("Value = nil, want %d", tc.wantValue)
+			case got.Value != nil && got.Value.Uint64() != tc.wantValue:
+				t.Errorf("Value = %s, want %d", got.Value, tc.wantValue)
+			}
+			if got.DirectCall != tc.wantDirect {
+				t.Errorf("DirectCall = %v, want %v", got.DirectCall, tc.wantDirect)
+			}
+			if got.ReadOnly != tc.wantRead {
+				t.Errorf("ReadOnly = %v, want %v", got.ReadOnly, tc.wantRead)
+			}
+		})
+	}
+}

--- a/core/vm/contracts_stateful_test.go
+++ b/core/vm/contracts_stateful_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// probePrecompile records the context it was handed instead of doing work.
 type probePrecompile struct {
 	cas20StatefulBase
 	got PrecompileContext
@@ -23,8 +22,6 @@ func (p *probePrecompile) RunStateful(ctx *PrecompileContext, _ []byte) ([]byte,
 	return nil, nil
 }
 
-// TestStatefulPrecompileCallContext pins the msg.sender and msg.value a stateful
-// precompile is handed on each of the four call opcodes.
 func TestStatefulPrecompileCallContext(t *testing.T) {
 	var (
 		probeAddr = common.HexToAddress("0x0b0be0")
@@ -75,8 +72,7 @@ func TestStatefulPrecompileCallContext(t *testing.T) {
 			wantCaller: caller, wantValue: 0, wantDirect: true, wantRead: true,
 		},
 		{
-			// CALLCODE transfers value to the caller itself, so the frame is
-			// value-bearing and msg.sender is the immediate caller.
+			// CALLCODE transfers value to the caller itself.
 			name: "CALLCODE",
 			invoke: func(evm *EVM, _ *probePrecompile) {
 				evm.CallCode(caller, probeAddr, nil, NewGasBudget(100_000), uint256.NewInt(value))
@@ -84,8 +80,7 @@ func TestStatefulPrecompileCallContext(t *testing.T) {
 			wantCaller: caller, wantValue: value, wantDirect: false,
 		},
 		{
-			// DELEGATECALL preserves the parent's msg.sender and inherits its
-			// msg.value; neither is the immediate caller's.
+			// DELEGATECALL preserves the parent's msg.sender and msg.value.
 			name: "DELEGATECALL",
 			invoke: func(evm *EVM, _ *probePrecompile) {
 				evm.DelegateCall(origin, caller, probeAddr, nil, NewGasBudget(100_000), uint256.NewInt(value))

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -44,8 +44,40 @@ type (
 )
 
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
-	p, ok := evm.precompiles[addr]
-	return p, ok
+	if p, ok := evm.precompiles[addr]; ok {
+		return p, ok
+	}
+	// CAS20 native token family: the factory has a fixed address and every token
+	// address is resolved dynamically from its prefix (there is no fixed-address
+	// entry for tokens, so they cannot live in the static precompiles map).
+	if evm.cas20Enabled() {
+		return resolveCAS20(addr)
+	}
+	return nil, false
+}
+
+// cas20Enabled reports whether the CAS20 native token family is active for the
+// current block.
+//
+// Jenner (BEP-706) is the fork that ships it. IsJenner embeds the IsInBSC gate,
+// so no separate check is needed: a non-BSC config that set jennerTime would
+// still not route the reserved address space, and its registries would never be
+// seeded either.
+func (evm *EVM) cas20Enabled() bool {
+	return evm.chainRules.IsJenner
+}
+
+// runPrecompile dispatches a resolved precompile, routing stateful precompiles
+// (the CAS20 family) through runStatefulPrecompiledContract and everything else
+// through the plain, stateless RunPrecompiledContract.
+//
+// readOnly is the read-only state of the current frame; directCall is true for
+// CALL/STATICCALL and false for CALLCODE/DELEGATECALL.
+func (evm *EVM) runPrecompile(p PrecompiledContract, caller, self common.Address, input []byte, gas GasBudget, readOnly, directCall bool, value *uint256.Int) ([]byte, GasBudget, error) {
+	if sp, ok := p.(StatefulPrecompiledContract); ok {
+		return runStatefulPrecompiledContract(evm, sp, caller, self, input, gas, readOnly, directCall, value)
+	}
+	return RunPrecompiledContract(evm.StateDB, p, self, input, gas, evm.Config.Tracer, evm.chainRules, evm.Context)
 }
 
 // BlockContext provides the EVM with auxiliary information. Once provided
@@ -316,7 +348,7 @@ func (evm *EVM) Call(caller common.Address, addr common.Address, input []byte, g
 	}
 
 	if isPrecompile {
-		ret, gas, err = RunPrecompiledContract(evm.StateDB, p, addr, input, gas, evm.Config.Tracer, evm.chainRules, evm.Context)
+		ret, gas, err = evm.runPrecompile(p, caller, addr, input, gas, evm.readOnly, true, value)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		code := evm.resolveCode(addr)
@@ -382,7 +414,7 @@ func (evm *EVM) CallCode(caller common.Address, addr common.Address, input []byt
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunPrecompiledContract(evm.StateDB, p, addr, input, gas, evm.Config.Tracer, evm.chainRules, evm.Context)
+		ret, gas, err = evm.runPrecompile(p, caller, addr, input, gas, evm.readOnly, false, value)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
@@ -427,7 +459,7 @@ func (evm *EVM) DelegateCall(originCaller common.Address, caller common.Address,
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunPrecompiledContract(evm.StateDB, p, addr, input, gas, evm.Config.Tracer, evm.chainRules, evm.Context)
+		ret, gas, err = evm.runPrecompile(p, originCaller, addr, input, gas, evm.readOnly, false, value)
 	} else {
 		// Initialise a new contract and make initialise the delegate values
 		contract := GetContract(originCaller, caller, value, gas, evm.jumpDests)
@@ -479,7 +511,7 @@ func (evm *EVM) StaticCall(caller common.Address, addr common.Address, input []b
 	evm.StateDB.AddBalance(addr, new(uint256.Int), tracing.BalanceChangeTouchAccount)
 
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunPrecompiledContract(evm.StateDB, p, addr, input, gas, evm.Config.Tracer, evm.chainRules, evm.Context)
+		ret, gas, err = evm.runPrecompile(p, caller, addr, input, gas, true, true, nil)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -47,20 +47,16 @@ func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	if p, ok := evm.precompiles[addr]; ok {
 		return p, ok
 	}
-	// CAS20 native token family: the factory has a fixed address and every token
-	// address is resolved dynamically from its prefix (there is no fixed-address
-	// entry for tokens, so they cannot live in the static precompiles map).
+	// CAS20 tokens have no fixed address, so they cannot live in the static map:
+	// they are resolved from the address prefix instead.
 	if evm.cas20Enabled() {
 		return resolveCAS20(addr)
 	}
 	return nil, false
 }
 
-// cas20Enabled reports whether the CAS20 native token family is active for the
-// current block.
-//
-// Jenner (BEP-706) is the fork that ships it. IsJenner embeds the IsInBSC gate,
-// so no separate check is needed: a non-BSC config that set jennerTime would
+// cas20Enabled gates the family on Jenner (BEP-706). IsJenner embeds the IsInBSC
+// gate, so no separate check is needed: a non-BSC config that set jennerTime would
 // still not route the reserved address space, and its registries would never be
 // seeded either.
 func (evm *EVM) cas20Enabled() bool {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -45,6 +45,9 @@ type (
 
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	if p, ok := evm.precompiles[addr]; ok {
+		if p == DisabledPrecompile {
+			return nil, false
+		}
 		return p, ok
 	}
 	// CAS20 tokens have no fixed address, so they cannot live in the static map:

--- a/core/vm/testdata/cas20_layout.json
+++ b/core/vm/testdata/cas20_layout.json
@@ -1,0 +1,331 @@
+{
+  "_comment": "Authoritative CAS20 storage layout, and consensus-critical: a slot number decides the state root, so two implementations that disagree here diverge on the first token operation that touches it. TestCAS20LayoutFixtureFollowsTheCode holds every namespace, root and slot against the Go constants in both directions, so this file cannot drift from the implementation. BEP-702 3.17 is rendered from it \u2014 the namespace table, the field table, the derivation rules, the packed-word lanes and the not-persisted list, in that order \u2014 so a change here has to be carried into that section in the same commit.",
+  "erc7201": "keccak256(abi.encode(uint256(keccak256(namespace)) - 1)) & ~bytes32(uint256(0xff))",
+  "derivation": {
+    "fixed_field": "root + offset",
+    "mapping_value_key": "keccak256(pad32(key) ++ slot)",
+    "mapping_string_key": "keccak256(bytes(key) ++ slot)   // unpadded, unlike a value key",
+    "nested_mapping": "outer key first: members[id][account] = keccak256(pad32(account) ++ keccak256(pad32(id) ++ slot))",
+    "string_short": "content in the high bytes, low byte = 2*len",
+    "string_long": "slot = 2*len+1, data at keccak256(slot)",
+    "string_malformed": "a length word no write could have produced reads as the empty string; an implementation MUST NOT fault on it",
+    "string_max_len": 16777216,
+    "dynamic_array": "slot = element count, data at keccak256(slot)"
+  },
+  "namespaces": [
+    {
+      "name": "bsc.cas20",
+      "held_by": "every token, both variants",
+      "root": "0x562aafeb82006b6968827b59606253289ba8bc22c7d434d71765d5b3a068af00",
+      "fields": [
+        {
+          "slot": 0,
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "slot": 1,
+          "name": "symbol",
+          "type": "string"
+        },
+        {
+          "slot": 2,
+          "name": "contractURI",
+          "type": "string"
+        },
+        {
+          "slot": 3,
+          "name": "totalSupply",
+          "type": "uint256"
+        },
+        {
+          "slot": 4,
+          "name": "balances",
+          "type": "mapping(address => uint256)"
+        },
+        {
+          "slot": 5,
+          "name": "allowances",
+          "type": "mapping(address => mapping(address => uint256))"
+        },
+        {
+          "slot": 6,
+          "name": "roles",
+          "type": "mapping(bytes32 => mapping(address => bool))"
+        },
+        {
+          "slot": 7,
+          "name": "roleAdmins",
+          "type": "mapping(bytes32 => bytes32)"
+        },
+        {
+          "slot": 8,
+          "name": "adminCount",
+          "type": "uint256"
+        },
+        {
+          "slot": 9,
+          "name": "transferPolicies",
+          "type": "packed 4x uint64"
+        },
+        {
+          "slot": 10,
+          "name": "mintPolicy",
+          "type": "packed 4x uint64"
+        },
+        {
+          "slot": 11,
+          "name": "paused",
+          "type": "uint256 bitmask"
+        },
+        {
+          "slot": 12,
+          "name": "supplyCap",
+          "type": "uint256"
+        },
+        {
+          "slot": 13,
+          "name": "nonces",
+          "type": "mapping(address => uint256)"
+        },
+        {
+          "slot": 14,
+          "name": "seizePolicies",
+          "type": "packed 4x uint64"
+        }
+      ]
+    },
+    {
+      "name": "bsc.cas20.asset",
+      "held_by": "the Asset variant",
+      "root": "0xff1f981cfcfd1795c7002397f3fa439537651c7544b1d579931b62466060ae00",
+      "fields": [
+        {
+          "slot": 0,
+          "name": "decimals",
+          "type": "uint8"
+        },
+        {
+          "slot": 1,
+          "name": "multiplier",
+          "type": "uint256"
+        },
+        {
+          "slot": 2,
+          "name": "announcements",
+          "type": "mapping(string => bool)"
+        },
+        {
+          "slot": 3,
+          "name": "extraMetadata",
+          "type": "mapping(string => string)"
+        },
+        {
+          "slot": 4,
+          "name": "pendingMultiplier",
+          "type": "packed uint128 + uint64"
+        }
+      ]
+    },
+    {
+      "name": "bsc.cas20.stablecoin",
+      "held_by": "the Stablecoin variant",
+      "root": "0xd88f59ff5f54ab199d582c5de9fd2a11ddf31b4380c891c97fe80c42868a1600",
+      "fields": [
+        {
+          "slot": 0,
+          "name": "currency",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "bsc.policy_registry",
+      "held_by": "the PolicyRegistry singleton",
+      "root": "0x2e7731329603a38e578303ba37c039549397ad42853922c474dfc3cb33d7b000",
+      "fields": [
+        {
+          "slot": 0,
+          "name": "policies",
+          "type": "mapping(uint64 => packed word)"
+        },
+        {
+          "slot": 1,
+          "name": "members",
+          "type": "mapping(uint64 => mapping(address => bool))"
+        },
+        {
+          "slot": 2,
+          "name": "pendingAdmins",
+          "type": "mapping(uint64 => address)"
+        },
+        {
+          "slot": 3,
+          "name": "counter",
+          "type": "uint64"
+        },
+        {
+          "slot": 4,
+          "name": "children",
+          "type": "mapping(uint64 => uint64[])"
+        }
+      ]
+    },
+    {
+      "name": "bsc.activation_registry",
+      "held_by": "the ActivationRegistry singleton",
+      "root": "0xa8970030726ea4c1e5fe64bf3ba11683da0b59f818265a7369e5570e9fc0bd00",
+      "fields": [
+        {
+          "slot": 0,
+          "name": "features",
+          "type": "mapping(bytes32 => bool)"
+        },
+        {
+          "slot": 1,
+          "name": "admin",
+          "type": "address"
+        }
+      ]
+    }
+  ],
+  "packed_words": [
+    {
+      "where": "bsc.cas20 slot 9",
+      "lanes": [
+        {
+          "name": "transferSenderPolicy",
+          "bit_offset": 0,
+          "width": 64
+        },
+        {
+          "name": "transferReceiverPolicy",
+          "bit_offset": 64,
+          "width": 64
+        },
+        {
+          "name": "transferExecutorPolicy",
+          "bit_offset": 128,
+          "width": 64
+        },
+        {
+          "name": "reserved",
+          "bit_offset": 192,
+          "width": 64
+        }
+      ]
+    },
+    {
+      "where": "bsc.cas20 slot 10",
+      "lanes": [
+        {
+          "name": "mintReceiverPolicy",
+          "bit_offset": 0,
+          "width": 64
+        },
+        {
+          "name": "reserved",
+          "bit_offset": 64,
+          "width": 64
+        },
+        {
+          "name": "reserved",
+          "bit_offset": 128,
+          "width": 64
+        },
+        {
+          "name": "reserved",
+          "bit_offset": 192,
+          "width": 64
+        }
+      ],
+      "note": "the free lanes belong to future mint-side policy types, which is why seize takes a slot of its own"
+    },
+    {
+      "where": "bsc.cas20 slot 14",
+      "lanes": [
+        {
+          "name": "seizeHolderPolicy",
+          "bit_offset": 0,
+          "width": 64
+        },
+        {
+          "name": "seizeReceiverPolicy",
+          "bit_offset": 64,
+          "width": 64
+        },
+        {
+          "name": "reserved",
+          "bit_offset": 128,
+          "width": 64
+        },
+        {
+          "name": "reserved",
+          "bit_offset": 192,
+          "width": 64
+        }
+      ]
+    },
+    {
+      "where": "bsc.cas20.asset slot 4",
+      "lanes": [
+        {
+          "bit_offset": 0,
+          "width": 128,
+          "name": "pendingMultiplier"
+        },
+        {
+          "bit_offset": 128,
+          "width": 64,
+          "name": "effectiveAt"
+        }
+      ],
+      "note": "a zero effectiveAt means no schedule is recorded"
+    },
+    {
+      "where": "bsc.policy_registry slot 0, the mapping value",
+      "lanes": [
+        {
+          "bit_offset": 255,
+          "width": 1,
+          "name": "exists"
+        },
+        {
+          "bit_offset": 0,
+          "width": 160,
+          "name": "admin"
+        }
+      ],
+      "note": "the exists bit survives renouncing, so a renounced policy stays distinguishable from one never created"
+    },
+    {
+      "where": "bsc.policy_registry slot 4, the array data words",
+      "lanes": [
+        {
+          "bit_offset": 0,
+          "width": 64,
+          "name": "child[4k+0]"
+        },
+        {
+          "bit_offset": 64,
+          "width": 64,
+          "name": "child[4k+1]"
+        },
+        {
+          "bit_offset": 128,
+          "width": 64,
+          "name": "child[4k+2]"
+        },
+        {
+          "bit_offset": 192,
+          "width": 64,
+          "name": "child[4k+3]"
+        }
+      ],
+      "note": "a shrink rewrites the whole word, so orphaned lanes are zeroed"
+    }
+  ],
+  "not_storage": [
+    "`adminRenounced` is per-frame only, so a bootstrap bundle cannot renounce the last admin and then grant again (\u00a73.4)"
+  ]
+}

--- a/core/vm/testdata/cas20_layout.json
+++ b/core/vm/testdata/cas20_layout.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Authoritative CAS20 storage layout, and consensus-critical: a slot number decides the state root, so two implementations that disagree here diverge on the first token operation that touches it. TestCAS20LayoutFixtureFollowsTheCode holds every namespace, root and slot against the Go constants in both directions, so this file cannot drift from the implementation. BEP-702 3.17 is rendered from it \u2014 the namespace table, the field table, the derivation rules, the packed-word lanes and the not-persisted list, in that order \u2014 so a change here has to be carried into that section in the same commit.",
+  "_comment": "Authoritative CAS20 storage layout, and consensus-critical: a slot number decides the state root, so two implementations that disagree here diverge on the first token operation that touches it. TestCAS20LayoutFixtureFollowsTheCode holds every namespace, root and slot against the Go constants in both directions, so this file cannot drift from the implementation. BEP-702 3.17 is rendered from it — the namespace table, the field table, the derivation rules, the packed-word lanes and the not-persisted list, in that order — so a change here has to be carried into that section in the same commit.",
   "erc7201": "keccak256(abi.encode(uint256(keccak256(namespace)) - 1)) & ~bytes32(uint256(0xff))",
   "derivation": {
     "fixed_field": "root + offset",
@@ -92,6 +92,11 @@
           "slot": 14,
           "name": "seizePolicies",
           "type": "packed 4x uint64"
+        },
+        {
+          "slot": 15,
+          "name": "expectedMemoFormats",
+          "type": "uint64[]"
         }
       ]
     },
@@ -185,6 +190,28 @@
           "slot": 1,
           "name": "admin",
           "type": "address"
+        }
+      ]
+    },
+    {
+      "name": "bsc.memo_registry",
+      "held_by": "the MemoFormatRegistry singleton",
+      "root": "0x5a6c5f5e6cf79d21be49b950b0b58ab5e8436ce422b034de12307bc971a5d000",
+      "fields": [
+        {
+          "slot": 0,
+          "name": "formats",
+          "type": "mapping(uint64 => packed word)"
+        },
+        {
+          "slot": 1,
+          "name": "fields",
+          "type": "mapping(uint64 => uint64[])"
+        },
+        {
+          "slot": 2,
+          "name": "counters",
+          "type": "mapping(uint8 => uint64)"
         }
       ]
     }
@@ -323,9 +350,66 @@
         }
       ],
       "note": "a shrink rewrites the whole word, so orphaned lanes are zeroed"
+    },
+    {
+      "where": "bsc.memo_registry slot 0, the mapping value",
+      "lanes": [
+        {
+          "name": "creator",
+          "bit_offset": 0,
+          "width": 160
+        },
+        {
+          "name": "category",
+          "bit_offset": 160,
+          "width": 8
+        },
+        {
+          "name": "fieldCount",
+          "bit_offset": 168,
+          "width": 16
+        },
+        {
+          "name": "totalLen",
+          "bit_offset": 184,
+          "width": 16
+        },
+        {
+          "name": "exists",
+          "bit_offset": 255,
+          "width": 1
+        }
+      ],
+      "note": "format 0, UNSTRUCTURED, exists without a word; the exists bit is what a read consults for every other id"
+    },
+    {
+      "where": "bsc.memo_registry slot 1, each array lane",
+      "lanes": [
+        {
+          "name": "offset",
+          "bit_offset": 0,
+          "width": 16
+        },
+        {
+          "name": "length",
+          "bit_offset": 16,
+          "width": 16
+        },
+        {
+          "name": "kind",
+          "bit_offset": 32,
+          "width": 8
+        },
+        {
+          "name": "required",
+          "bit_offset": 40,
+          "width": 8
+        }
+      ],
+      "note": "one FieldSpec per uint64 lane, four lanes per word, LSB-first"
     }
   ],
   "not_storage": [
-    "`adminRenounced` is per-frame only, so a bootstrap bundle cannot renounce the last admin and then grant again (\u00a73.4)"
+    "`adminRenounced` is per-frame only, so a bootstrap bundle cannot renounce the last admin and then grant again (§3.4)"
   ]
 }

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -128,8 +128,15 @@ func NewAccessListTracer(acl types.AccessList, addressesToExclude map[common.Add
 
 func (a *AccessListTracer) Hooks() *tracing.Hooks {
 	return &tracing.Hooks{
-		OnOpcode: a.OnOpcode,
+		OnOpcode:      a.OnOpcode,
+		OnStorageRead: a.OnStorageRead,
 	}
+}
+
+// OnStorageRead records a slot a stateful precompile touched outside the
+// interpreter, where no opcode announced it.
+func (a *AccessListTracer) OnStorageRead(addr common.Address, slot common.Hash) {
+	a.list.addSlot(addr, slot)
 }
 
 // OnOpcode captures all opcodes that touch storage or addresses and adds them to the accesslist.

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -130,6 +130,15 @@ func (a *AccessListTracer) Hooks() *tracing.Hooks {
 	return &tracing.Hooks{
 		OnOpcode:      a.OnOpcode,
 		OnStorageRead: a.OnStorageRead,
+		OnAccountRead: a.OnAccountRead,
+	}
+}
+
+// OnAccountRead records an account a stateful precompile read outside the
+// interpreter.
+func (a *AccessListTracer) OnAccountRead(addr common.Address) {
+	if _, ok := a.excl[addr]; !ok {
+		a.list.addAddress(addr)
 	}
 }
 

--- a/eth/tracers/logger/cas20_access_list_test.go
+++ b/eth/tracers/logger/cas20_access_list_test.go
@@ -1,0 +1,68 @@
+package logger
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// A CAS20 transfer touches storage through native code, not SLOAD/SSTORE, so the
+// slots reach the access list through OnStorageRead.
+func TestAccessListTracerSeesCAS20Storage(t *testing.T) {
+	alice, bob := common.HexToAddress("0x111111"), common.HexToAddress("0x222222")
+	token := common.HexToAddress("0xca52000000000000000000000000000000000001")
+	slot := func(a common.Address) common.Hash {
+		x := new(uint256.Int).SetBytes(crypto.Keccak256([]byte("bsc.cas20")))
+		x.SubUint64(x, 1)
+		root := crypto.Keccak256Hash(x.Bytes())
+		root[31] = 0
+		base := new(uint256.Int).SetBytes(root[:])
+		base.AddUint64(base, 4)
+		return crypto.Keccak256Hash(common.LeftPadBytes(a.Bytes(), 32), base.Bytes())
+	}
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	statedb.SetCode(token, vm.CAS20MarkerCode, tracing.CodeChangeContractCreation)
+	statedb.SetState(token, slot(alice), common.BigToHash(big.NewInt(100)))
+	statedb.SetBalance(alice, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
+	statedb.Finalise(false)
+
+	cfg := *params.TestChainConfig
+	cfg.JennerTime = new(uint64)
+	cfg.Parlia = &params.ParliaConfig{}
+	tr := NewAccessListTracer(nil, nil)
+	input := append(crypto.Keccak256([]byte("transfer(address,uint256)"))[:4], common.LeftPadBytes(bob.Bytes(), 32)...)
+	input = append(input, common.LeftPadBytes([]byte{7}, 32)...)
+	blockCtx := vm.BlockContext{CanTransfer: core.CanTransfer, Transfer: core.Transfer, BlockNumber: big.NewInt(1), Time: 1, Difficulty: big.NewInt(1), BaseFee: big.NewInt(0), GasLimit: 30_000_000}
+	evm := vm.NewEVM(blockCtx, state.NewHookedState(statedb, tr.Hooks()), &cfg, vm.Config{Tracer: tr.Hooks()})
+	tx := types.NewTx(&types.LegacyTx{To: &token, Gas: 100_000, GasPrice: big.NewInt(1), Data: input})
+	msg := &core.Message{From: alice, To: &token, GasLimit: tx.Gas(), GasPrice: uint256.NewInt(1), GasFeeCap: uint256.NewInt(1), GasTipCap: uint256.NewInt(1), Value: new(uint256.Int), Data: input}
+	statedb.SetTxContext(tx.Hash(), 0)
+	receipt, err := core.ApplyTransactionWithEVM(msg, core.NewGasPool(tx.Gas()), statedb, blockCtx.BlockNumber, common.Hash{}, blockCtx.Time, tx, evm)
+	evm.Release()
+	if err != nil || receipt.Status != types.ReceiptStatusSuccessful {
+		t.Fatalf("transfer: err %v status %d", err, receipt.Status)
+	}
+
+	var tokenSlots []common.Hash
+	for _, e := range tr.AccessList() {
+		if e.Address == token {
+			tokenSlots = e.StorageKeys
+		}
+	}
+	want := map[common.Hash]bool{slot(alice): true, slot(bob): true}
+	for _, s := range tokenSlots {
+		delete(want, s)
+	}
+	if len(want) != 0 {
+		t.Errorf("access list for the token lacks %v; got %v", want, tokenSlots)
+	}
+}

--- a/eth/tracers/native/cas20_prestate_test.go
+++ b/eth/tracers/native/cas20_prestate_test.go
@@ -3,8 +3,10 @@ package native
 import (
 	"encoding/json"
 	"math/big"
+	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -17,80 +19,218 @@ import (
 	"github.com/holiman/uint256"
 )
 
+var (
+	cas20Alice = common.HexToAddress("0x111111")
+	cas20Bob   = common.HexToAddress("0x222222")
+	cas20Token = common.HexToAddress("0xca52000000000000000000000000000000000001")
+)
+
+// ERC-7201 root of a namespace, as BEP-702 §3.17 derives it.
+func cas20Root(namespace string) *uint256.Int {
+	x := new(uint256.Int).SetBytes(crypto.Keccak256([]byte(namespace)))
+	x.SubUint64(x, 1)
+	root := crypto.Keccak256Hash(x.Bytes())
+	root[31] = 0
+	return new(uint256.Int).SetBytes(root[:])
+}
+
+// balances is slot 4 of bsc.cas20.
+func cas20BalanceSlot(a common.Address) common.Hash {
+	base := cas20Root("bsc.cas20")
+	base.AddUint64(base, 4)
+	return crypto.Keccak256Hash(common.LeftPadBytes(a.Bytes(), 32), base.Bytes())
+}
+
+func cas20JennerConfig() *params.ChainConfig {
+	cfg := *params.TestChainConfig
+	cfg.JennerTime = new(uint64)
+	cfg.Parlia = &params.ParliaConfig{}
+	return &cfg
+}
+
+// cas20Run applies one transaction from alice to `to` under the given tracer.
+func cas20Run(t *testing.T, statedb *state.StateDB, cfg *params.ChainConfig, hooks *tracing.Hooks, to common.Address, input []byte) *types.Receipt {
+	t.Helper()
+	blockCtx := vm.BlockContext{CanTransfer: core.CanTransfer, Transfer: core.Transfer, BlockNumber: big.NewInt(1), Time: 1, Difficulty: big.NewInt(1), BaseFee: big.NewInt(0), GasLimit: 30_000_000}
+	evm := vm.NewEVM(blockCtx, state.NewHookedState(statedb, hooks), cfg, vm.Config{Tracer: hooks})
+	defer evm.Release()
+	tx := types.NewTx(&types.LegacyTx{To: &to, Gas: 2_000_000, GasPrice: big.NewInt(1), Data: input})
+	msg := &core.Message{From: cas20Alice, To: &to, GasLimit: tx.Gas(), GasPrice: uint256.NewInt(1), GasFeeCap: uint256.NewInt(1), GasTipCap: uint256.NewInt(1), Value: new(uint256.Int), Data: input}
+	statedb.SetTxContext(tx.Hash(), 0)
+	receipt, err := core.ApplyTransactionWithEVM(msg, core.NewGasPool(tx.Gas()), statedb, blockCtx.BlockNumber, common.Hash{}, blockCtx.Time, tx, evm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return receipt
+}
+
+// A token holding 100 for alice, and the transfer(bob, 7) calldata.
+func cas20TransferFixture(t *testing.T) (*state.StateDB, []byte) {
+	t.Helper()
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	statedb.SetCode(cas20Token, vm.CAS20MarkerCode, tracing.CodeChangeContractCreation)
+	statedb.SetState(cas20Token, cas20BalanceSlot(cas20Alice), common.BigToHash(big.NewInt(100)))
+	statedb.SetBalance(cas20Alice, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
+	statedb.Finalise(false)
+	input := append(crypto.Keccak256([]byte("transfer(address,uint256)"))[:4], common.LeftPadBytes(cas20Bob.Bytes(), 32)...)
+	return statedb, append(input, common.LeftPadBytes([]byte{7}, 32)...)
+}
+
+type prestateDiff struct {
+	Pre  map[common.Address]account `json:"pre"`
+	Post map[common.Address]account `json:"post"`
+}
+
 // A CAS20 transfer touches storage through native code, not SLOAD/SSTORE, so the
 // tracer has to learn of the slots through OnStorageRead.
 func TestPrestateSeesCAS20Storage(t *testing.T) {
-	alice, bob := common.HexToAddress("0x111111"), common.HexToAddress("0x222222")
-	token := common.HexToAddress("0xca52000000000000000000000000000000000001")
-	aliceSlot, bobSlot := cas20BalanceSlot(alice), cas20BalanceSlot(bob)
-
+	aliceSlot, bobSlot := cas20BalanceSlot(cas20Alice), cas20BalanceSlot(cas20Bob)
 	for _, diffMode := range []bool{false, true} {
-		statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
-		statedb.SetCode(token, vm.CAS20MarkerCode, tracing.CodeChangeContractCreation)
-		statedb.SetState(token, aliceSlot, common.BigToHash(big.NewInt(100)))
-		statedb.SetBalance(alice, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
-		statedb.Finalise(false)
-
-		cfg := *params.TestChainConfig
-		cfg.JennerTime = new(uint64)
-		cfg.Parlia = &params.ParliaConfig{}
-		tr, err := newPrestateTracer(&tracers.Context{}, json.RawMessage(`{"diffMode":`+map[bool]string{false: "false", true: "true"}[diffMode]+`}`), &cfg)
+		statedb, input := cas20TransferFixture(t)
+		cfg := cas20JennerConfig()
+		tr, err := newPrestateTracer(&tracers.Context{}, json.RawMessage(`{"diffMode":`+map[bool]string{false: "false", true: "true"}[diffMode]+`}`), cfg)
 		if err != nil {
 			t.Fatal(err)
 		}
-		input := append(crypto.Keccak256([]byte("transfer(address,uint256)"))[:4], common.LeftPadBytes(bob.Bytes(), 32)...)
-		input = append(input, common.LeftPadBytes([]byte{7}, 32)...)
-		blockCtx := vm.BlockContext{CanTransfer: core.CanTransfer, Transfer: core.Transfer, BlockNumber: big.NewInt(1), Time: 1, Difficulty: big.NewInt(1), BaseFee: big.NewInt(0), GasLimit: 30_000_000}
-		evm := vm.NewEVM(blockCtx, state.NewHookedState(statedb, tr.Hooks), &cfg, vm.Config{Tracer: tr.Hooks})
-		tx := types.NewTx(&types.LegacyTx{To: &token, Gas: 100_000, GasPrice: big.NewInt(1), Data: input})
-		msg := &core.Message{From: alice, To: &token, GasLimit: tx.Gas(), GasPrice: uint256.NewInt(1), GasFeeCap: uint256.NewInt(1), GasTipCap: uint256.NewInt(1), Value: new(uint256.Int), Data: input}
-		statedb.SetTxContext(tx.Hash(), 0)
-		receipt, err := core.ApplyTransactionWithEVM(msg, core.NewGasPool(tx.Gas()), statedb, blockCtx.BlockNumber, common.Hash{}, blockCtx.Time, tx, evm)
-		evm.Release()
-		if err != nil || receipt.Status != types.ReceiptStatusSuccessful {
-			t.Fatalf("transfer: err %v status %d", err, receipt.Status)
+		if r := cas20Run(t, statedb, cfg, tr.Hooks, cas20Token, input); r.Status != types.ReceiptStatusSuccessful {
+			t.Fatal("transfer failed")
 		}
 		res, err := tr.GetResult()
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		if !diffMode {
 			var pre map[common.Address]account
 			if err := json.Unmarshal(res, &pre); err != nil {
 				t.Fatal(err)
 			}
-			if got := pre[token].Storage[aliceSlot]; got != common.BigToHash(big.NewInt(100)) {
-				t.Errorf("prestate: alice's slot = %s, want 100; storage %v", got.Hex(), pre[token].Storage)
+			if got := pre[cas20Token].Storage[aliceSlot]; got != common.BigToHash(big.NewInt(100)) {
+				t.Errorf("prestate: alice's slot = %s, want 100; storage %v", got.Hex(), pre[cas20Token].Storage)
 			}
-			if _, ok := pre[token].Storage[bobSlot]; !ok {
+			if _, ok := pre[cas20Token].Storage[bobSlot]; !ok {
 				t.Errorf("prestate lacks bob's slot, which the transfer read before writing")
 			}
 			continue
 		}
-		var diff struct {
-			Pre  map[common.Address]account `json:"pre"`
-			Post map[common.Address]account `json:"post"`
-		}
+		var diff prestateDiff
 		if err := json.Unmarshal(res, &diff); err != nil {
 			t.Fatal(err)
 		}
-		if got := diff.Pre[token].Storage[aliceSlot]; got != common.BigToHash(big.NewInt(100)) {
+		if got := diff.Pre[cas20Token].Storage[aliceSlot]; got != common.BigToHash(big.NewInt(100)) {
 			t.Errorf("diff pre: alice's slot = %s, want 100", got.Hex())
 		}
-		if got := diff.Post[token].Storage[bobSlot]; got != common.BigToHash(big.NewInt(7)) {
-			t.Errorf("diff post: bob's slot = %s, want 7; post %v", got.Hex(), diff.Post[token].Storage)
+		if got := diff.Post[cas20Token].Storage[bobSlot]; got != common.BigToHash(big.NewInt(7)) {
+			t.Errorf("diff post: bob's slot = %s, want 7; post %v", got.Hex(), diff.Post[cas20Token].Storage)
 		}
 	}
 }
 
-// balances is slot 4 of the bsc.cas20 ERC-7201 namespace (BEP-702 §3.17).
-func cas20BalanceSlot(a common.Address) common.Hash {
-	x := new(uint256.Int).SetBytes(crypto.Keccak256([]byte("bsc.cas20")))
-	x.SubUint64(x, 1)
-	root := crypto.Keccak256Hash(x.Bytes())
-	root[31] = 0
-	base := new(uint256.Int).SetBytes(root[:])
-	base.AddUint64(base, 4)
-	return crypto.Keccak256Hash(common.LeftPadBytes(a.Bytes(), 32), base.Bytes())
+// The mux tracer has to forward the native-access hooks, or a prestate tracer
+// requested alongside a call tracer loses every CAS20 slot again.
+func TestMuxForwardsCAS20StorageReads(t *testing.T) {
+	statedb, input := cas20TransferFixture(t)
+	cfg := cas20JennerConfig()
+	pre, err := newPrestateTracer(&tracers.Context{}, json.RawMessage(`{"diffMode":true}`), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	call, err := newCallTracer(&tracers.Context{}, json.RawMessage(`{}`), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux, err := NewMuxTracer([]string{"prestateTracer", "callTracer"}, []*tracers.Tracer{pre, call})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := cas20Run(t, statedb, cfg, mux.Hooks, cas20Token, input); r.Status != types.ReceiptStatusSuccessful {
+		t.Fatal("transfer failed")
+	}
+	res, err := mux.GetResult()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(res, &out); err != nil {
+		t.Fatalf("%v: %q", err, res)
+	}
+	var diff prestateDiff
+	if err := json.Unmarshal(out["prestateTracer"], &diff); err != nil {
+		t.Fatal(err)
+	}
+	if got := diff.Post[cas20Token].Storage[cas20BalanceSlot(cas20Bob)]; got != common.BigToHash(big.NewInt(7)) {
+		t.Errorf("through the mux, diff post: bob's slot = %s, want 7", got.Hex())
+	}
+}
+
+// createCAS20 reads the target account before it plants the sentinel, and the
+// prestate has to capture it then: no code before, the sentinel after.
+func TestPrestateSeesCAS20Creation(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	// The ActivationRegistry with the Asset feature open, as the fork and governance would leave it.
+	statedb.SetCode(vm.CAS20ActivationRegistryAddress, vm.CAS20MarkerCode, tracing.CodeChangeContractCreation)
+	featuresSlot := cas20Root("bsc.activation_registry") // slot 0 of the namespace
+	featureKey := crypto.Keccak256Hash(crypto.Keccak256([]byte("bsc.cas20_asset")), featuresSlot.Bytes())
+	statedb.SetState(vm.CAS20ActivationRegistryAddress, featureKey, common.Hash{31: 1})
+	statedb.SetBalance(cas20Alice, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
+	statedb.Finalise(false)
+
+	// createCAS20(ASSET, salt, abi.encode(CAS20AssetCreateParams{1, "N", "S", alice, 18}), [])
+	def, err := abi.JSON(strings.NewReader(`[{"type":"function","name":"createCAS20","inputs":[{"name":"variant","type":"uint8"},{"name":"salt","type":"bytes32"},{"name":"params","type":"bytes"},{"name":"initCalls","type":"bytes[]"}]}]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	paramsT, _ := abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "version", Type: "uint8"}, {Name: "name", Type: "string"}, {Name: "symbol", Type: "string"},
+		{Name: "initialAdmin", Type: "address"}, {Name: "decimals", Type: "uint8"},
+	})
+	params, err := abi.Arguments{{Type: paramsT}}.Pack(struct {
+		Version      uint8
+		Name         string
+		Symbol       string
+		InitialAdmin common.Address
+		Decimals     uint8
+	}{1, "N", "S", cas20Alice, 18})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := def.Pack("createCAS20", uint8(0), [32]byte{0xa1}, params, [][]byte{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := cas20JennerConfig()
+	tr, err := newPrestateTracer(&tracers.Context{}, json.RawMessage(`{"diffMode":true}`), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := cas20Run(t, statedb, cfg, tr.Hooks, vm.CAS20FactoryAddress, input); r.Status != types.ReceiptStatusSuccessful {
+		t.Fatal("createCAS20 failed")
+	}
+	res, err := tr.GetResult()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var diff prestateDiff
+	if err := json.Unmarshal(res, &diff); err != nil {
+		t.Fatal(err)
+	}
+	var created common.Address
+	for addr, acc := range diff.Post {
+		if vm.IsCAS20Address(addr) && acc.Code != nil {
+			created = addr
+		}
+	}
+	if created == (common.Address{}) {
+		t.Fatalf("no created token in the post-state: %v", diff.Post)
+	}
+	// The account did not exist before the transaction, so it is absent from the
+	// pre-state and its whole post-state is reported; had it been captured only
+	// after the sentinel was written, the code would have looked unchanged and the
+	// token would not appear in the post-state at all.
+	if pre, ok := diff.Pre[created]; ok {
+		t.Errorf("pre-state lists the new token as %+v, want no entry", pre)
+	}
+	if got := *diff.Post[created].Code; string(got) != string(vm.CAS20MarkerCode) {
+		t.Errorf("post-state code = %x, want the sentinel", got)
+	}
 }

--- a/eth/tracers/native/cas20_prestate_test.go
+++ b/eth/tracers/native/cas20_prestate_test.go
@@ -1,0 +1,96 @@
+package native
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// A CAS20 transfer touches storage through native code, not SLOAD/SSTORE, so the
+// tracer has to learn of the slots through OnStorageRead.
+func TestPrestateSeesCAS20Storage(t *testing.T) {
+	alice, bob := common.HexToAddress("0x111111"), common.HexToAddress("0x222222")
+	token := common.HexToAddress("0xca52000000000000000000000000000000000001")
+	aliceSlot, bobSlot := cas20BalanceSlot(alice), cas20BalanceSlot(bob)
+
+	for _, diffMode := range []bool{false, true} {
+		statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+		statedb.SetCode(token, vm.CAS20MarkerCode, tracing.CodeChangeContractCreation)
+		statedb.SetState(token, aliceSlot, common.BigToHash(big.NewInt(100)))
+		statedb.SetBalance(alice, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
+		statedb.Finalise(false)
+
+		cfg := *params.TestChainConfig
+		cfg.JennerTime = new(uint64)
+		cfg.Parlia = &params.ParliaConfig{}
+		tr, err := newPrestateTracer(&tracers.Context{}, json.RawMessage(`{"diffMode":`+map[bool]string{false: "false", true: "true"}[diffMode]+`}`), &cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		input := append(crypto.Keccak256([]byte("transfer(address,uint256)"))[:4], common.LeftPadBytes(bob.Bytes(), 32)...)
+		input = append(input, common.LeftPadBytes([]byte{7}, 32)...)
+		blockCtx := vm.BlockContext{CanTransfer: core.CanTransfer, Transfer: core.Transfer, BlockNumber: big.NewInt(1), Time: 1, Difficulty: big.NewInt(1), BaseFee: big.NewInt(0), GasLimit: 30_000_000}
+		evm := vm.NewEVM(blockCtx, state.NewHookedState(statedb, tr.Hooks), &cfg, vm.Config{Tracer: tr.Hooks})
+		tx := types.NewTx(&types.LegacyTx{To: &token, Gas: 100_000, GasPrice: big.NewInt(1), Data: input})
+		msg := &core.Message{From: alice, To: &token, GasLimit: tx.Gas(), GasPrice: uint256.NewInt(1), GasFeeCap: uint256.NewInt(1), GasTipCap: uint256.NewInt(1), Value: new(uint256.Int), Data: input}
+		statedb.SetTxContext(tx.Hash(), 0)
+		receipt, err := core.ApplyTransactionWithEVM(msg, core.NewGasPool(tx.Gas()), statedb, blockCtx.BlockNumber, common.Hash{}, blockCtx.Time, tx, evm)
+		evm.Release()
+		if err != nil || receipt.Status != types.ReceiptStatusSuccessful {
+			t.Fatalf("transfer: err %v status %d", err, receipt.Status)
+		}
+		res, err := tr.GetResult()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !diffMode {
+			var pre map[common.Address]account
+			if err := json.Unmarshal(res, &pre); err != nil {
+				t.Fatal(err)
+			}
+			if got := pre[token].Storage[aliceSlot]; got != common.BigToHash(big.NewInt(100)) {
+				t.Errorf("prestate: alice's slot = %s, want 100; storage %v", got.Hex(), pre[token].Storage)
+			}
+			if _, ok := pre[token].Storage[bobSlot]; !ok {
+				t.Errorf("prestate lacks bob's slot, which the transfer read before writing")
+			}
+			continue
+		}
+		var diff struct {
+			Pre  map[common.Address]account `json:"pre"`
+			Post map[common.Address]account `json:"post"`
+		}
+		if err := json.Unmarshal(res, &diff); err != nil {
+			t.Fatal(err)
+		}
+		if got := diff.Pre[token].Storage[aliceSlot]; got != common.BigToHash(big.NewInt(100)) {
+			t.Errorf("diff pre: alice's slot = %s, want 100", got.Hex())
+		}
+		if got := diff.Post[token].Storage[bobSlot]; got != common.BigToHash(big.NewInt(7)) {
+			t.Errorf("diff post: bob's slot = %s, want 7; post %v", got.Hex(), diff.Post[token].Storage)
+		}
+	}
+}
+
+// balances is slot 4 of the bsc.cas20 ERC-7201 namespace (BEP-702 §3.17).
+func cas20BalanceSlot(a common.Address) common.Hash {
+	x := new(uint256.Int).SetBytes(crypto.Keccak256([]byte("bsc.cas20")))
+	x.SubUint64(x, 1)
+	root := crypto.Keccak256Hash(x.Bytes())
+	root[31] = 0
+	base := new(uint256.Int).SetBytes(root[:])
+	base.AddUint64(base, 4)
+	return crypto.Keccak256Hash(common.LeftPadBytes(a.Bytes(), 32), base.Bytes())
+}

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -84,6 +84,8 @@ func NewMuxTracer(names []string, objects []*tracers.Tracer) (*tracers.Tracer, e
 			OnNonceChangeV2:           t.OnNonceChangeV2,
 			OnCodeChangeV2:            t.OnCodeChangeV2,
 			OnStorageChange:           t.OnStorageChange,
+			OnStorageRead:             t.OnStorageRead,
+			OnAccountRead:             t.OnAccountRead,
 			OnLog:                     t.OnLog,
 			OnSystemTxFixIntrinsicGas: t.OnSystemTxFixIntrinsicGas,
 			OnSystemCallStartV2:       t.OnSystemCallStart,
@@ -182,6 +184,22 @@ func (t *muxTracer) OnStorageChange(a common.Address, k, prev, new common.Hash) 
 	for _, t := range t.tracers {
 		if t.OnStorageChange != nil {
 			t.OnStorageChange(a, k, prev, new)
+		}
+	}
+}
+
+func (t *muxTracer) OnStorageRead(a common.Address, k common.Hash) {
+	for _, t := range t.tracers {
+		if t.OnStorageRead != nil {
+			t.OnStorageRead(a, k)
+		}
+	}
+}
+
+func (t *muxTracer) OnAccountRead(a common.Address) {
+	for _, t := range t.tracers {
+		if t.OnAccountRead != nil {
+			t.OnAccountRead(a)
 		}
 	}
 }

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -104,13 +104,24 @@ func newPrestateTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *p
 	}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
-			OnTxStart: t.OnTxStart,
-			OnTxEnd:   t.OnTxEnd,
-			OnOpcode:  t.OnOpcode,
+			OnTxStart:     t.OnTxStart,
+			OnTxEnd:       t.OnTxEnd,
+			OnOpcode:      t.OnOpcode,
+			OnStorageRead: t.OnStorageRead,
 		},
 		GetResult: t.GetResult,
 		Stop:      t.Stop,
 	}, nil
+}
+
+// OnStorageRead records a slot a stateful precompile touched outside the
+// interpreter, where no opcode announced it.
+func (t *prestateTracer) OnStorageRead(addr common.Address, slot common.Hash) {
+	if t.interrupt.Load() {
+		return
+	}
+	t.lookupAccount(addr)
+	t.lookupStorage(addr, slot)
 }
 
 // OnOpcode implements the EVMLogger interface to trace a single step of VM execution.

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -108,10 +108,20 @@ func newPrestateTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *p
 			OnTxEnd:       t.OnTxEnd,
 			OnOpcode:      t.OnOpcode,
 			OnStorageRead: t.OnStorageRead,
+			OnAccountRead: t.OnAccountRead,
 		},
 		GetResult: t.GetResult,
 		Stop:      t.Stop,
 	}, nil
+}
+
+// OnAccountRead records an account a stateful precompile read outside the
+// interpreter, before it can have changed it.
+func (t *prestateTracer) OnAccountRead(addr common.Address) {
+	if t.interrupt.Load() {
+		return
+	}
+	t.lookupAccount(addr)
 }
 
 // OnStorageRead records a slot a stateful precompile touched outside the

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1925,8 +1925,11 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	// Apply state overrides immediately after StateAndHeaderByNumberOrHash.
 	// If not applied here, there could be cases where user-specified overrides (e.g., nonce)
 	// may conflict with default values from the database, leading to inconsistencies.
+	// The overrides may disable a CAS20 address's native routing, which the
+	// simulated EVM has to see, so the precompile set is built here and handed on.
+	precompileContracts := vm.ActivePrecompiledContracts(b.ChainConfig().Rules(header.Number, header.Difficulty.Sign() == 0, header.Time))
 	if stateOverrides != nil {
-		if err := stateOverrides.Apply(db, nil); err != nil {
+		if err := stateOverrides.Apply(db, precompileContracts); err != nil {
 			return nil, 0, nil, err
 		}
 	}
@@ -2000,6 +2003,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		tracer := logger.NewAccessListTracer(accessList, addressesToExclude)
 		config := vm.Config{Tracer: tracer.Hooks(), NoBaseFee: true}
 		evm := b.GetEVM(ctx, statedb, header, &config, nil)
+		evm.SetPrecompiles(precompileContracts)
 
 		// Lower the basefee to 0 to avoid breaking EVM
 		// invariants (basefee < feecap).

--- a/internal/ethapi/api_cas20.go
+++ b/internal/ethapi/api_cas20.go
@@ -1,0 +1,80 @@
+package ethapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// cas20BatchLimit bounds one cas20_getTokenInfoBatch request.
+const cas20BatchLimit = 20
+
+// CAS20API reads CAS20 token configuration straight from state, so a wallet gets
+// in one call, at one block, what would otherwise take a dozen eth_calls. It is
+// not in the default module list; enable it with --http.api or --ws.api.
+type CAS20API struct {
+	b Backend
+}
+
+func NewCAS20API(b Backend) *CAS20API {
+	return &CAS20API{b: b}
+}
+
+// GetTokenInfo returns a CAS20 token's configuration as of the given block
+// (latest when omitted). It errors for an address that holds no token there.
+func (api *CAS20API) GetTokenInfo(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*vm.CAS20TokenInfo, error) {
+	infos, err := api.tokenInfos(ctx, []common.Address{address}, blockNrOrHash)
+	if err != nil {
+		return nil, err
+	}
+	if infos[0] == nil {
+		return nil, vm.ErrNotCAS20Token
+	}
+	return infos[0], nil
+}
+
+// GetTokenInfoBatch is GetTokenInfo over a list, answering null for an address
+// that holds no token so one stranger does not fail the whole portfolio.
+func (api *CAS20API) GetTokenInfoBatch(ctx context.Context, addresses []common.Address, blockNrOrHash *rpc.BlockNumberOrHash) ([]*vm.CAS20TokenInfo, error) {
+	if len(addresses) > cas20BatchLimit {
+		return nil, fmt.Errorf("batch of %d exceeds the limit of %d", len(addresses), cas20BatchLimit)
+	}
+	return api.tokenInfos(ctx, addresses, blockNrOrHash)
+}
+
+func (api *CAS20API) tokenInfos(ctx context.Context, addresses []common.Address, blockNrOrHash *rpc.BlockNumberOrHash) ([]*vm.CAS20TokenInfo, error) {
+	at := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+	if blockNrOrHash != nil {
+		at = *blockNrOrHash
+	}
+	state, header, err := api.b.StateAndHeaderByNumberOrHash(ctx, at)
+	if err != nil {
+		return nil, err
+	}
+	if state == nil || header == nil {
+		return nil, errors.New("block state unavailable")
+	}
+	config := api.b.ChainConfig()
+	if !config.IsJenner(header.Number, header.Time) {
+		return nil, errors.New("CAS20 is not active at this block")
+	}
+	out := make([]*vm.CAS20TokenInfo, len(addresses))
+	for i, addr := range addresses {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		info, err := vm.CAS20TokenInfoAt(state, config.ChainID, addr, header.Time)
+		if errors.Is(err, vm.ErrNotCAS20Token) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		out[i] = info
+	}
+	return out, state.Error()
+}

--- a/internal/ethapi/api_cas20.go
+++ b/internal/ethapi/api_cas20.go
@@ -10,24 +10,14 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-// cas20BatchLimit bounds one cas20_getTokenInfoBatch request.
+// cas20BatchLimit bounds one eth_getCAS20TokenInfoBatch request.
 const cas20BatchLimit = 20
 
-// CAS20API reads CAS20 token configuration straight from state, so a wallet gets
-// in one call, at one block, what would otherwise take a dozen eth_calls. It is
-// not in the default module list; enable it with --http.api or --ws.api.
-type CAS20API struct {
-	b Backend
-}
-
-func NewCAS20API(b Backend) *CAS20API {
-	return &CAS20API{b: b}
-}
-
-// GetTokenInfo returns a CAS20 token's configuration as of the given block
-// (latest when omitted). It errors for an address that holds no token there.
-func (api *CAS20API) GetTokenInfo(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*vm.CAS20TokenInfo, error) {
-	infos, err := api.tokenInfos(ctx, []common.Address{address}, blockNrOrHash)
+// GetCAS20TokenInfo returns a CAS20 token's configuration as of the given block
+// (latest when omitted), read straight from state: in one call what would
+// otherwise take a dozen eth_calls. It errors for an address that holds no token.
+func (api *BlockChainAPI) GetCAS20TokenInfo(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*vm.CAS20TokenInfo, error) {
+	infos, err := api.cas20TokenInfos(ctx, []common.Address{address}, blockNrOrHash)
 	if err != nil {
 		return nil, err
 	}
@@ -37,16 +27,16 @@ func (api *CAS20API) GetTokenInfo(ctx context.Context, address common.Address, b
 	return infos[0], nil
 }
 
-// GetTokenInfoBatch is GetTokenInfo over a list, answering null for an address
-// that holds no token so one stranger does not fail the whole portfolio.
-func (api *CAS20API) GetTokenInfoBatch(ctx context.Context, addresses []common.Address, blockNrOrHash *rpc.BlockNumberOrHash) ([]*vm.CAS20TokenInfo, error) {
+// GetCAS20TokenInfoBatch is GetCAS20TokenInfo over a list, answering null for an
+// address that holds no token so one stranger does not fail the whole portfolio.
+func (api *BlockChainAPI) GetCAS20TokenInfoBatch(ctx context.Context, addresses []common.Address, blockNrOrHash *rpc.BlockNumberOrHash) ([]*vm.CAS20TokenInfo, error) {
 	if len(addresses) > cas20BatchLimit {
 		return nil, fmt.Errorf("batch of %d exceeds the limit of %d", len(addresses), cas20BatchLimit)
 	}
-	return api.tokenInfos(ctx, addresses, blockNrOrHash)
+	return api.cas20TokenInfos(ctx, addresses, blockNrOrHash)
 }
 
-func (api *CAS20API) tokenInfos(ctx context.Context, addresses []common.Address, blockNrOrHash *rpc.BlockNumberOrHash) ([]*vm.CAS20TokenInfo, error) {
+func (api *BlockChainAPI) cas20TokenInfos(ctx context.Context, addresses []common.Address, blockNrOrHash *rpc.BlockNumberOrHash) ([]*vm.CAS20TokenInfo, error) {
 	at := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	if blockNrOrHash != nil {
 		at = *blockNrOrHash

--- a/internal/ethapi/api_cas20_test.go
+++ b/internal/ethapi/api_cas20_test.go
@@ -19,26 +19,26 @@ import (
 // this covers the plumbing: block resolution, the fork gate, and the batch shape.
 func TestCAS20GetTokenInfoPlumbing(t *testing.T) {
 	t.Parallel()
-	api := NewCAS20API(newJennerBSCBackend(t))
+	api := NewBlockChainAPI(newJennerBSCBackend(t))
 	ctx := context.Background()
 	stranger := common.HexToAddress("0x5714a9e7")
 
-	if _, err := api.GetTokenInfo(ctx, stranger, nil); !errors.Is(err, vm.ErrNotCAS20Token) {
+	if _, err := api.GetCAS20TokenInfo(ctx, stranger, nil); !errors.Is(err, vm.ErrNotCAS20Token) {
 		t.Errorf("stranger: err = %v, want ErrNotCAS20Token", err)
 	}
-	if _, err := api.GetTokenInfo(ctx, vm.CAS20FactoryAddress, nil); !errors.Is(err, vm.ErrNotCAS20Token) {
+	if _, err := api.GetCAS20TokenInfo(ctx, vm.CAS20FactoryAddress, nil); !errors.Is(err, vm.ErrNotCAS20Token) {
 		t.Errorf("factory: err = %v, want ErrNotCAS20Token", err)
 	}
 
-	got, err := api.GetTokenInfoBatch(ctx, []common.Address{stranger, vm.CAS20FactoryAddress}, nil)
+	got, err := api.GetCAS20TokenInfoBatch(ctx, []common.Address{stranger, vm.CAS20FactoryAddress}, nil)
 	if err != nil || len(got) != 2 || got[0] != nil || got[1] != nil {
 		t.Errorf("batch of non-tokens = %v, %v; want two nulls", got, err)
 	}
-	if _, err := api.GetTokenInfoBatch(ctx, make([]common.Address, cas20BatchLimit+1), nil); err == nil {
+	if _, err := api.GetCAS20TokenInfoBatch(ctx, make([]common.Address, cas20BatchLimit+1), nil); err == nil {
 		t.Error("a batch past the limit was accepted")
 	}
 	unknown := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(1 << 40))
-	if _, err := api.GetTokenInfo(ctx, stranger, &unknown); err == nil || errors.Is(err, vm.ErrNotCAS20Token) {
+	if _, err := api.GetCAS20TokenInfo(ctx, stranger, &unknown); err == nil || errors.Is(err, vm.ErrNotCAS20Token) {
 		t.Errorf("unknown block: err = %v, want a lookup error", err)
 	}
 }
@@ -50,8 +50,8 @@ func TestCAS20GetTokenInfoBeforeJenner(t *testing.T) {
 		Config: params.TestChainConfig,
 		Alloc:  types.GenesisAlloc{acc.addr: {Balance: big.NewInt(params.Ether)}},
 	}
-	api := NewCAS20API(newTestBackend(t, 1, gspec, ethash.NewFaker(), func(i int, b *core.BlockGen) {}))
-	if _, err := api.GetTokenInfo(context.Background(), common.HexToAddress("0x5714a9e7"), nil); err == nil || errors.Is(err, vm.ErrNotCAS20Token) {
+	api := NewBlockChainAPI(newTestBackend(t, 1, gspec, ethash.NewFaker(), func(i int, b *core.BlockGen) {}))
+	if _, err := api.GetCAS20TokenInfo(context.Background(), common.HexToAddress("0x5714a9e7"), nil); err == nil || errors.Is(err, vm.ErrNotCAS20Token) {
 		t.Errorf("before the fork: err = %v, want the not-active error", err)
 	}
 }

--- a/internal/ethapi/api_cas20_test.go
+++ b/internal/ethapi/api_cas20_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/internal/ethapi/override"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -53,5 +55,23 @@ func TestCAS20GetTokenInfoBeforeJenner(t *testing.T) {
 	api := NewBlockChainAPI(newTestBackend(t, 1, gspec, ethash.NewFaker(), func(i int, b *core.BlockGen) {}))
 	if _, err := api.GetCAS20TokenInfo(context.Background(), common.HexToAddress("0x5714a9e7"), nil); err == nil || errors.Is(err, vm.ErrNotCAS20Token) {
 		t.Errorf("before the fork: err = %v, want the not-active error", err)
+	}
+}
+
+// eth_createAccessList applies the overrides before it builds its EVM, so a code
+// override on a CAS20 address has to reach that EVM's precompile set too.
+func TestCAS20CreateAccessListWithCodeOverride(t *testing.T) {
+	t.Parallel()
+	api := NewBlockChainAPI(newJennerBSCBackend(t))
+	token := common.HexToAddress("0xca52000000000000000000000000000000000001")
+	returns42 := hexutil.Bytes(common.FromHex("602a60005260206000f3"))
+	overrides := &override.StateOverride{token: override.OverrideAccount{Code: &returns42}}
+	from := common.HexToAddress("0xf00d")
+	res, err := api.CreateAccessList(context.Background(), TransactionArgs{From: &from, To: &token}, nil, overrides)
+	if err != nil {
+		t.Fatalf("eth_createAccessList with a CAS20 code override: %v", err)
+	}
+	if res.Error != "" {
+		t.Errorf("the overridden code did not run: %s", res.Error)
 	}
 }

--- a/internal/ethapi/api_cas20_test.go
+++ b/internal/ethapi/api_cas20_test.go
@@ -1,0 +1,57 @@
+package ethapi
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// The token-level answers are covered where a token can be created, in core/vm;
+// this covers the plumbing: block resolution, the fork gate, and the batch shape.
+func TestCAS20GetTokenInfoPlumbing(t *testing.T) {
+	t.Parallel()
+	api := NewCAS20API(newJennerBSCBackend(t))
+	ctx := context.Background()
+	stranger := common.HexToAddress("0x5714a9e7")
+
+	if _, err := api.GetTokenInfo(ctx, stranger, nil); !errors.Is(err, vm.ErrNotCAS20Token) {
+		t.Errorf("stranger: err = %v, want ErrNotCAS20Token", err)
+	}
+	if _, err := api.GetTokenInfo(ctx, vm.CAS20FactoryAddress, nil); !errors.Is(err, vm.ErrNotCAS20Token) {
+		t.Errorf("factory: err = %v, want ErrNotCAS20Token", err)
+	}
+
+	got, err := api.GetTokenInfoBatch(ctx, []common.Address{stranger, vm.CAS20FactoryAddress}, nil)
+	if err != nil || len(got) != 2 || got[0] != nil || got[1] != nil {
+		t.Errorf("batch of non-tokens = %v, %v; want two nulls", got, err)
+	}
+	if _, err := api.GetTokenInfoBatch(ctx, make([]common.Address, cas20BatchLimit+1), nil); err == nil {
+		t.Error("a batch past the limit was accepted")
+	}
+	unknown := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(1 << 40))
+	if _, err := api.GetTokenInfo(ctx, stranger, &unknown); err == nil || errors.Is(err, vm.ErrNotCAS20Token) {
+		t.Errorf("unknown block: err = %v, want a lookup error", err)
+	}
+}
+
+func TestCAS20GetTokenInfoBeforeJenner(t *testing.T) {
+	t.Parallel()
+	acc := newTestAccount()
+	gspec := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc:  types.GenesisAlloc{acc.addr: {Balance: big.NewInt(params.Ether)}},
+	}
+	api := NewCAS20API(newTestBackend(t, 1, gspec, ethash.NewFaker(), func(i int, b *core.BlockGen) {}))
+	if _, err := api.GetTokenInfo(context.Background(), common.HexToAddress("0x5714a9e7"), nil); err == nil || errors.Is(err, vm.ErrNotCAS20Token) {
+		t.Errorf("before the fork: err = %v, want the not-active error", err)
+	}
+}

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -159,6 +159,9 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 		}, {
 			Namespace: "mev",
 			Service:   NewMevAPI(apiBackend),
+		}, {
+			Namespace: "cas20",
+			Service:   NewCAS20API(apiBackend),
 		},
 	}
 }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -159,9 +159,6 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 		}, {
 			Namespace: "mev",
 			Service:   NewMevAPI(apiBackend),
-		}, {
-			Namespace: "cas20",
-			Service:   NewCAS20API(apiBackend),
 		},
 	}
 }

--- a/internal/ethapi/override/override.go
+++ b/internal/ethapi/override/override.go
@@ -72,6 +72,14 @@ func (diff *StateOverride) Apply(statedb *state.StateDB, precompiles vm.Precompi
 			return fmt.Errorf("account %s has already been overridden by a precompile", addr.Hex())
 		}
 		p, isPrecompile := precompiles[addr]
+		if p == vm.DisabledPrecompile {
+			isPrecompile = false
+		}
+		// A CAS20 address is routed to native code by prefix, not through this map,
+		// so a code override has to disable that routing explicitly.
+		if account.Code != nil && vm.IsCAS20Routed(addr) {
+			precompiles[addr] = vm.DisabledPrecompile
+		}
 		// The MoveTo feature makes it possible to move a precompile
 		// code to another address. If the target address is another precompile
 		// the code for the latter is lost for this session.

--- a/internal/ethapi/override/override.go
+++ b/internal/ethapi/override/override.go
@@ -77,7 +77,7 @@ func (diff *StateOverride) Apply(statedb *state.StateDB, precompiles vm.Precompi
 		}
 		// A CAS20 address is routed to native code by prefix, not through this map,
 		// so a code override has to disable that routing explicitly.
-		if account.Code != nil && vm.IsCAS20Routed(addr) {
+		if account.Code != nil && precompiles != nil && vm.IsCAS20Routed(addr) {
 			precompiles[addr] = vm.DisabledPrecompile
 		}
 		// The MoveTo feature makes it possible to move a precompile

--- a/internal/ethapi/override/override_cas20_test.go
+++ b/internal/ethapi/override/override_cas20_test.go
@@ -1,0 +1,82 @@
+package override
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// A code override on a CAS20 address has to disable the prefix routing, or the
+// call would still reach native code whatever code the override installed.
+func TestCAS20CodeOverrideRunsTheOverride(t *testing.T) {
+	returns42 := hexutil.Bytes(common.FromHex("602a60005260206000f3"))
+	for _, tc := range []struct {
+		name string
+		addr common.Address
+		code []byte // what the account holds before the override
+	}{
+		{"a static precompile, for contrast", common.HexToAddress("0x1"), nil},
+		{"an initialized token", common.HexToAddress("0xca52000000000000000000000000000000000001"), vm.CAS20MarkerCode},
+		{"a reserved address holding no token", common.HexToAddress("0xca52000000000000000000000000000000000002"), nil},
+		{"the factory", vm.CAS20FactoryAddress, vm.CAS20MarkerCode},
+		{"the ActivationRegistry", vm.CAS20ActivationRegistryAddress, vm.CAS20MarkerCode},
+		{"the PolicyRegistry", vm.CAS20PolicyRegistryAddress, vm.CAS20MarkerCode},
+	} {
+		statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+		if tc.code != nil {
+			statedb.SetCode(tc.addr, tc.code, tracing.CodeChangeContractCreation)
+		}
+		cfg := *params.TestChainConfig
+		cfg.JennerTime = new(uint64)
+		cfg.Parlia = &params.ParliaConfig{}
+		precompiles := vm.ActivePrecompiledContracts(cfg.Rules(big.NewInt(1), false, 1))
+		over := StateOverride{tc.addr: OverrideAccount{Code: &returns42}}
+		if err := over.Apply(statedb, precompiles); err != nil {
+			t.Fatalf("%s: Apply: %v", tc.name, err)
+		}
+		blockCtx := vm.BlockContext{BlockNumber: big.NewInt(1), Time: 1,
+			CanTransfer: func(vm.StateDB, common.Address, *uint256.Int) bool { return true },
+			Transfer:    func(vm.StateDB, common.Address, common.Address, *uint256.Int, *params.Rules) {}}
+		evm := vm.NewEVM(blockCtx, statedb, &cfg, vm.Config{})
+		evm.SetPrecompiles(precompiles)
+		ret, _, err := evm.Call(common.Address{19: 9}, tc.addr, nil, vm.NewGasBudget(100_000), new(uint256.Int))
+		evm.Release()
+		if err != nil || new(uint256.Int).SetBytes(ret).Uint64() != 42 {
+			t.Errorf("%s: override not executed: ret %x err %v", tc.name, ret, err)
+		}
+	}
+}
+
+// Without an override the routing is untouched: the same call reaches native code.
+func TestCAS20RoutingWithoutOverride(t *testing.T) {
+	token := common.HexToAddress("0xca52000000000000000000000000000000000001")
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	statedb.SetCode(token, vm.CAS20MarkerCode, tracing.CodeChangeContractCreation)
+	cfg := *params.TestChainConfig
+	cfg.JennerTime = new(uint64)
+	cfg.Parlia = &params.ParliaConfig{}
+	precompiles := vm.ActivePrecompiledContracts(cfg.Rules(big.NewInt(1), false, 1))
+	if err := (&StateOverride{}).Apply(statedb, precompiles); err != nil {
+		t.Fatal(err)
+	}
+	blockCtx := vm.BlockContext{BlockNumber: big.NewInt(1), Time: 1,
+		CanTransfer: func(vm.StateDB, common.Address, *uint256.Int) bool { return true },
+		Transfer:    func(vm.StateDB, common.Address, common.Address, *uint256.Int, *params.Rules) {}}
+	evm := vm.NewEVM(blockCtx, statedb, &cfg, vm.Config{})
+	evm.SetPrecompiles(precompiles)
+	// Empty calldata is an unknown selector to the token: an empty revert, not the
+	// 0xEF sentinel executing as bytecode.
+	ret, _, err := evm.Call(common.Address{19: 9}, token, nil, vm.NewGasBudget(100_000), new(uint256.Int))
+	evm.Release()
+	if err != vm.ErrExecutionReverted || len(ret) != 0 {
+		t.Errorf("unoverridden token: ret %x err %v, want an empty revert from native code", ret, err)
+	}
+}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -19,7 +19,6 @@ package web3ext
 
 var Modules = map[string]string{
 	"admin":  AdminJs,
-	"cas20":  CAS20Js,
 	"parlia": ParliaJs,
 	"debug":  DebugJs,
 	"eth":    EthJs,
@@ -531,6 +530,18 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
+			name: 'getCAS20TokenInfo',
+			call: 'eth_getCAS20TokenInfo',
+			params: 2,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'getCAS20TokenInfoBatch',
+			call: 'eth_getCAS20TokenInfoBatch',
+			params: 2,
+			inputFormatter: [null, web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
 			name: 'getBlockByNumber',
 			call: 'eth_getBlockByNumber',
 			params: 2,
@@ -770,25 +781,5 @@ web3._extend({
 			params: 1
 		}),
 	],
-});
-`
-
-const CAS20Js = `
-web3._extend({
-	property: 'cas20',
-	methods: [
-		new web3._extend.Method({
-			name: 'getTokenInfo',
-			call: 'cas20_getTokenInfo',
-			params: 2,
-			inputFormatter: [web3._extend.formatters.inputAddressFormatter, web3._extend.formatters.inputBlockNumberFormatter]
-		}),
-		new web3._extend.Method({
-			name: 'getTokenInfoBatch',
-			call: 'cas20_getTokenInfoBatch',
-			params: 2,
-			inputFormatter: [null, web3._extend.formatters.inputBlockNumberFormatter]
-		}),
-	]
 });
 `

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -19,6 +19,7 @@ package web3ext
 
 var Modules = map[string]string{
 	"admin":  AdminJs,
+	"cas20":  CAS20Js,
 	"parlia": ParliaJs,
 	"debug":  DebugJs,
 	"eth":    EthJs,
@@ -769,5 +770,25 @@ web3._extend({
 			params: 1
 		}),
 	],
+});
+`
+
+const CAS20Js = `
+web3._extend({
+	property: 'cas20',
+	methods: [
+		new web3._extend.Method({
+			name: 'getTokenInfo',
+			call: 'cas20_getTokenInfo',
+			params: 2,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'getTokenInfoBatch',
+			call: 'cas20_getTokenInfoBatch',
+			params: 2,
+			inputFormatter: [null, web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+	]
 });
 `

--- a/params/bsc_fork_schedule_test.go
+++ b/params/bsc_fork_schedule_test.go
@@ -1,0 +1,96 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package params
+
+import (
+	"strings"
+	"testing"
+)
+
+var bscConfigs = []struct {
+	name string
+	cfg  *ChainConfig
+}{
+	{"bsc", BSCChainConfig},
+	{"chapel", ChapelChainConfig},
+	{"rialto", RialtoChainConfig},
+}
+
+// TestBSCForksAreSchedulable pins that every timestamp fork BSC is ready to ship
+// can actually be scheduled. CheckConfigForkOrder refuses a configuration that
+// sets a fork's timestamp without a blobSchedule entry for it, so a missing entry
+// does not surface until a node is started with that fork enabled — at which
+// point it is a fatal error at service registration, not a test failure.
+func TestBSCForksAreSchedulable(t *testing.T) {
+	ts := uint64(1) << 40
+
+	for _, tc := range bscConfigs {
+		// Schedule the forks still unset, in order, so the ordering check passes and
+		// the blobSchedule check is what is actually exercised. Rialto leaves
+		// MendelTime unset, so Pasteur cannot be scheduled there on its own.
+		cfg := *tc.cfg
+		for _, f := range []*(*uint64){
+			&cfg.FermiTime, &cfg.OsakaTime, &cfg.MendelTime, &cfg.PasteurTime,
+		} {
+			if *f == nil {
+				*f = &ts
+			}
+		}
+		if err := cfg.CheckConfigForkOrder(); err != nil {
+			t.Errorf("%s: scheduling every shippable fork failed: %v", tc.name, err)
+		}
+	}
+}
+
+// TestBSCAmsterdamIsNotSchedulable is a tripwire, not an invariant we want to
+// keep. Amsterdam brings EIP-7928 block access lists, and this tree carries only
+// the scaffolding: headers are validated for BlockAccessListHash but never built
+// with one. Scheduling Amsterdam therefore halts block production at the fork
+// block — the first Amsterdam block is rejected by its own peers with
+//
+//	rlp: input string too short for common.Hash, decoding into
+//	(types.Header).BlockAccessListHash
+//
+// and sealing stops with "unknown ancestor". The missing blobSchedule entry is
+// what currently stands between an operator and that halt, so it stays missing
+// until BAL block production is wired up.
+//
+// If this test starts failing, the entry has been added. That is the right move
+// once headers carry a real BlockAccessListHash — verify that they do, then
+// delete this test rather than working around it.
+func TestBSCAmsterdamIsNotSchedulable(t *testing.T) {
+	ts := uint64(1) << 40
+
+	for _, tc := range bscConfigs {
+		cfg := *tc.cfg
+		for _, f := range []*(*uint64){
+			&cfg.FermiTime, &cfg.OsakaTime, &cfg.MendelTime, &cfg.PasteurTime,
+			&cfg.AmsterdamTime,
+		} {
+			if *f == nil {
+				*f = &ts
+			}
+		}
+		// Assert on the reason, not just on failure: an ordering error would let
+		// this pass while Amsterdam was in fact schedulable.
+		err := cfg.CheckConfigForkOrder()
+		if err == nil || !strings.Contains(err.Error(), `missing entry for fork "amsterdam" in blobSchedule`) {
+			t.Errorf("%s: Amsterdam is now schedulable (err = %v) — confirm block "+
+				"production fills in header.BlockAccessListHash before allowing it", tc.name, err)
+		}
+	}
+}

--- a/params/config.go
+++ b/params/config.go
@@ -733,7 +733,8 @@ type ChainConfig struct {
 	BPO4Time       *uint64 `json:"bpo4Time,omitempty"`       // BPO4 switch time (nil = no fork, 0 = already on bpo4)
 	BPO5Time       *uint64 `json:"bpo5Time,omitempty"`       // BPO5 switch time (nil = no fork, 0 = already on bpo5)
 	AmsterdamTime  *uint64 `json:"amsterdamTime,omitempty"`  // Amsterdam switch time (nil = no fork, 0 = already on amsterdam)
-	UBTTime        *uint64 `json:"ubtTime,omitempty"`        // UBT switch time (nil = no fork, 0 = already on UBT)
+
+	UBTTime *uint64 `json:"ubtTime,omitempty"` // UBT switch time (nil = no fork, 0 = already on UBT)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -1457,6 +1458,29 @@ func (c *ChainConfig) IsOnMendel(currentBlockNumber *big.Int, lastBlockTime uint
 // IsPasteur returns whether time is either equal to the Pasteur fork time or greater.
 func (c *ChainConfig) IsPasteur(num *big.Int, time uint64) bool {
 	return c.IsLondon(num) && isTimestampForked(c.PasteurTime, time)
+}
+
+// IsOnJenner reports whether this block is the one that crosses into Jenner, the
+// single block on which the fork's state changes are applied.
+//
+// Block 1 counts as that block on a chain whose genesis is already Jenner-active,
+// where no false-to-true transition exists to find. Without it such a chain would
+// never plant the registries' account sentinels, and because GovHub refuses a
+// target carrying no code, the activation admin could then never be appointed —
+// leaving the reserved address space routed to precompiles that nothing can ever
+// open, correctable only by another fork.
+func (c *ChainConfig) IsOnJenner(currentBlockNumber *big.Int, lastBlockTime uint64, currentBlockTime uint64) bool {
+	if !c.IsJenner(currentBlockNumber, currentBlockTime) {
+		return false
+	}
+	if currentBlockNumber.Cmp(big.NewInt(1)) == 0 {
+		return true
+	}
+	lastBlockNumber := new(big.Int)
+	if currentBlockNumber.Cmp(big.NewInt(1)) >= 0 {
+		lastBlockNumber.Sub(currentBlockNumber, big.NewInt(1))
+	}
+	return !c.IsJenner(lastBlockNumber, lastBlockTime)
 }
 
 // IsOnPasteur eturns whether currentBlockTime is either equal to the Pasteur fork time or greater firstly.

--- a/params/config.go
+++ b/params/config.go
@@ -733,8 +733,7 @@ type ChainConfig struct {
 	BPO4Time       *uint64 `json:"bpo4Time,omitempty"`       // BPO4 switch time (nil = no fork, 0 = already on bpo4)
 	BPO5Time       *uint64 `json:"bpo5Time,omitempty"`       // BPO5 switch time (nil = no fork, 0 = already on bpo5)
 	AmsterdamTime  *uint64 `json:"amsterdamTime,omitempty"`  // Amsterdam switch time (nil = no fork, 0 = already on amsterdam)
-
-	UBTTime *uint64 `json:"ubtTime,omitempty"` // UBT switch time (nil = no fork, 0 = already on UBT)
+	UBTTime        *uint64 `json:"ubtTime,omitempty"`        // UBT switch time (nil = no fork, 0 = already on UBT)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -1460,29 +1459,6 @@ func (c *ChainConfig) IsPasteur(num *big.Int, time uint64) bool {
 	return c.IsLondon(num) && isTimestampForked(c.PasteurTime, time)
 }
 
-// IsOnJenner reports whether this block is the one that crosses into Jenner, the
-// single block on which the fork's state changes are applied.
-//
-// Block 1 counts as that block on a chain whose genesis is already Jenner-active,
-// where no false-to-true transition exists to find. Without it such a chain would
-// never plant the registries' account sentinels, and because GovHub refuses a
-// target carrying no code, the activation admin could then never be appointed —
-// leaving the reserved address space routed to precompiles that nothing can ever
-// open, correctable only by another fork.
-func (c *ChainConfig) IsOnJenner(currentBlockNumber *big.Int, lastBlockTime uint64, currentBlockTime uint64) bool {
-	if !c.IsJenner(currentBlockNumber, currentBlockTime) {
-		return false
-	}
-	if currentBlockNumber.Cmp(big.NewInt(1)) == 0 {
-		return true
-	}
-	lastBlockNumber := new(big.Int)
-	if currentBlockNumber.Cmp(big.NewInt(1)) >= 0 {
-		lastBlockNumber.Sub(currentBlockNumber, big.NewInt(1))
-	}
-	return !c.IsJenner(lastBlockNumber, lastBlockTime)
-}
-
 // IsOnPasteur eturns whether currentBlockTime is either equal to the Pasteur fork time or greater firstly.
 func (c *ChainConfig) IsOnPasteur(currentBlockNumber *big.Int, lastBlockTime uint64, currentBlockTime uint64) bool {
 	lastBlockNumber := new(big.Int)
@@ -1502,6 +1478,15 @@ func (c *ChainConfig) IsOnPasteur(currentBlockNumber *big.Int, lastBlockTime uin
 // path sets JennerTime on it.
 func (c *ChainConfig) IsJenner(num *big.Int, time uint64) bool {
 	return c.IsInBSC() && c.IsLondon(num) && isTimestampForked(c.JennerTime, time)
+}
+
+// IsOnJenner returns whether currentBlockTime is either equal to the Jenner fork time or greater firstly.
+func (c *ChainConfig) IsOnJenner(currentBlockNumber *big.Int, lastBlockTime uint64, currentBlockTime uint64) bool {
+	lastBlockNumber := new(big.Int)
+	if currentBlockNumber.Cmp(big.NewInt(1)) >= 0 {
+		lastBlockNumber.Sub(currentBlockNumber, big.NewInt(1))
+	}
+	return !c.IsJenner(lastBlockNumber, lastBlockTime) && c.IsJenner(currentBlockNumber, currentBlockTime)
 }
 
 // IsBPO1 returns whether time is either equal to the BPO1 fork time or greater.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -242,7 +242,18 @@ var (
 
 	// EIP-2935 - Serve historical block hashes from state
 	HistoryStorageAddress = common.HexToAddress("0x0000F90827F1C53a10cb7A02335B175320002935")
-	HistoryStorageCode    = common.FromHex("3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500")
+
+	// CAS20GovHubAddress is BSC's GovHub, the only account the CAS20 ActivationRegistry
+	// accepts a parameter change from (BEP-702 3.15). It is duplicated from
+	// core/systemcontracts, which imports core/vm and so cannot be imported back.
+	//
+	// A governance proposal cannot name the registry directly: BSCGovernor's
+	// whitelist of proposal targets holds GovHub alone and has no setter. GovHub's
+	// own updateParam(key, value, target) takes an arbitrary target, though, and
+	// forwards to updateParam(key, value) on it — which is how every system
+	// contract is configured and how this registry is reached.
+	CAS20GovHubAddress = common.HexToAddress("0x0000000000000000000000000000000000001007")
+	HistoryStorageCode = common.FromHex("3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500")
 
 	// EIP-7002 - Execution layer triggerable withdrawals
 	WithdrawalQueueAddress = common.HexToAddress("0x00000961Ef480Eb55e80D19ad83579A64c007002")


### PR DESCRIPTION
### Description

Stacked on #3813 — only the last commit is new. Draft until #3813 lands.

Spec context: [BEP-702](https://github.com/bnb-chain/BEPs/blob/new_token/BEPs/BEP-702.md); the §3.6 memo paragraph follows once the implementation settles.

A CAS20 memo is a 32-byte hash, and a hash carries no information about how the payload behind it is encoded. An indexer cannot tell which message format a transfer claims to follow, and a receiving institution that gets the payload out of band has no deterministic way to know which bytes are which field. This PR adds two token entry points that let a transfer declare it:

```
transferWithMemoFormat(to, amount, memo, formatId)
transferFromWithMemoFormat(from, to, amount, memo, formatId)
event MemoFormatDeclared(address indexed declarer, bytes32 indexed memo, bytes32 indexed formatId)
```

`formatId` is one `bytes32` naming a format definition maintained off chain; how the id is derived from the definition and where definitions are published is an interoperability convention the spec will fix separately. The event is emitted right after `Memo`, so an indexer ties the declaration to its transfer by log position rather than by a memo hash two transfers may share.

### Rationale

The chain records the declaration and nothing more: it never sees the payload, so it never verifies the claim — the same trust posture `currency()` already has. What the declaration buys is that the claim is queryable per transaction, and that a receiver holding the payload has a deterministic key to the format definition that parses it.

There is deliberately **no on-chain registry**. A registry would store layouts the chain never reads to make a decision, and an existence check catches a typo, not a lie; a content-addressed `formatId` is unique without a coordinator and lets the receiver verify the definition it fetched. Composing several standards (payment + identity + local reporting) is the definition's business — a top-level format references its parts by their own ids — so a transfer declares one id, not a list, which removes duplicate-id, ordering and conflict questions from the protocol. A zero `formatId` is refused: the existing memo methods are how a transfer declares nothing.

Recommended SDK convention, not enforced on chain: `memo = keccak256(abi.encode(domain, formatId, salt, payload))`, so a receiver recomputing the memo also verifies the format the payload is bound to, and a random salt keeps low-entropy business data from being enumerated.

### Example

```
formatId = keccak256(PaymentEnvelopeV1)        // references PaymentFormatV3, IdentityFormatV2, ...
token.transferWithMemoFormat(to, amount, memo, formatId)
   // Transfer, Memo(memo), MemoFormatDeclared(caller, memo, formatId)
```

### Changes

- `core/vm/cas20_memo.go` — the two entry points and the event; the check order is the entry point's own transfer after the zero-format refusal; the `transferFrom` form is `transferFrom` whoever calls it.
- `core/vm/cas20_errors.go` — `InvalidFormatId()`.
- Tests: event order and topics, the zero refusal and its position against pause, the static-frame refusal, the `transferFrom` form spending the allowance with the spender as declarer, and a holder's self-approval being spent through it.

No new address, feature, storage slot or registry: no existing selector changes behaviour or gas.
